### PR TITLE
Fix browserPageTimeout default value

### DIFF
--- a/src/butler-sheet-icons.js
+++ b/src/butler-sheet-icons.js
@@ -333,7 +333,7 @@ const program = new Command();
                 '--browser-page-timeout <version>',
                 'Timeout (seconds) for the browser to load a page. Default is 90 seconds. This is the time that the browser will wait for a page to load before giving up.'
             )
-                .default('latest')
+                .default(90)
                 .env('BSI_BROWSER_PAGE_TIMEOUT')
         );
 


### PR DESCRIPTION
Doesnt look like this throws any error because 'latest' is not greater than 0.
https://github.com/ptarmiganlabs/butler-sheet-icons/blob/ec39b76d54c326fa05eef3fc57d933612599f3c8/src/lib/qseow/qseow-process-app.js#L88-L91