### PR TITLE
docs: correct inaccuracies in staged log redaction page

### DIFF
--- a/docs/to-doc-site/log-redaction.md
+++ b/docs/to-doc-site/log-redaction.md
@@ -16,6 +16,7 @@ The allow-list covers the property names most likely to contain a credential, in
 
 - `logonpwd`
 - `apikey`, `apiKey`, `api_key`
+- `apiToken`, `api_token`
 - `password`, `pwd`, `passwd`
 - `passphrase`
 - `secret`, `token`
@@ -28,11 +29,11 @@ If you add a new option that carries a credential, add the property name to the 
 
 ### Patterns that are always redacted in text
 
-The redaction also matches common patterns in free text, so log messages and stack traces that mention secrets in passing are cleaned up as well. The text `***[REDACTED]***` is substituted for the matched value. The following patterns are recognised:
+The redaction also matches common patterns in free text, so log messages and stack traces that mention secrets in passing are cleaned up as well. The text `[REDACTED]` is substituted for the matched value. The following patterns are recognised:
 
 - **URLs with embedded credentials** — `https://user:secret@host/...` becomes `https://[REDACTED]@host/...`
 - **Authorization headers** — `Authorization: Bearer eyJhbGciOi…` becomes `Authorization: Bearer [REDACTED]`. The same applies to `Basic …` and `Token …` schemes.
-- **`key=value` and `key:value` patterns** — `password=hunter2`, `api_key=abcdef`, `clientSecret: topsecret`, and similar. Recognised key names are the same as the property-name allow-list above.
+- **`key=value` and `key:value` patterns** — `password=hunter2`, `api_key=abcdef`, `clientSecret: topsecret`, and similar. The recognised key names are close to the property-name allow-list above, but not identical: this pattern also matches a bare `auth`, and it does not match the `BSI_*` environment variable names. Note that a match written with a colon is rewritten using `=`, so `clientSecret: topsecret` appears in the log as `clientSecret=[REDACTED]`.
 - **JSON-style quoted secrets** — `"password": "mysecret"` becomes `"password": "[REDACTED]"`.
 
 ## Where does the redaction happen?


### PR DESCRIPTION
Refs #820.

While publishing the staged pages to the doc site (ptarmiganlabs/butler-sheet-icons-docs#30) I verified the text against the merged implementation in `src/lib/util/redact-secrets.js` rather than publishing it as-is. That turned up three errors in `docs/to-doc-site/log-redaction.md`.

The corrections are already applied in the doc-site PR. This PR keeps the staging copy — which `docs/to-doc-site/README.md` describes as the source of truth — in sync, so the next person to read it does not inherit the same errors.

## What was wrong

1. **Wrong placeholder.** The page said text-pattern matches are replaced with `***[REDACTED]***`. The code uses `[REDACTED]`. The `***redacted***` form is the separate placeholder used for object properties, and the examples further down the same page already used the correct form — so the page contradicted itself.
2. **Incomplete allow-list.** `apiToken` and `api_token` are in `BSI_SECRET_KEYS` but were not in the documented list.
3. **Overstated equivalence.** The page claimed the `key=value` pattern recognises "the same" key names as the property allow-list. It does not: the text pattern also matches a bare `auth`, and does not match the `BSI_*` environment variable names. Also documented that a colon-form match is rewritten using `=`, so `clientSecret: topsecret` appears as `clientSecret=[REDACTED]`.

`crash-dump-files.md` was checked the same way and needed no changes — environment variables, defaults, the two-file output, filename pattern and local-time timestamps all match `src/lib/util/crash-dump.js`.

## Follow-up not included here

`docs/to-doc-site/README.md` documents a convention where a published file is renamed with a `done_` prefix for traceability. That convention exists but has never been applied to these two files. I have deliberately **not** renamed them yet, since the doc-site PR is still open — renaming now would claim a publication that has not happened. Once ptarmiganlabs/butler-sheet-icons-docs#30 merges, both files should become `done_crash-dump-files.md` and `done_log-redaction.md`.
