### PR TITLE
docs: require user-facing changes to be documented in docs/to-doc-site

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -257,4 +257,15 @@ The tool can install and manage Chrome/Firefox browsers via `@puppeteer/browsers
 - Do not edit generated artifacts or dependencies (e.g. `node_modules/`, `build/`, `coverage/`, `sea-prep.blob`, `build.cjs`) unless the task explicitly requires it.
 - Run `npm run format` before committing to keep formatting consistent.
 
+## Documenting user-facing changes
+
+If a change adds, alters, or removes behaviour a Butler Sheet Icons user can observe — CLI commands or flags, environment variables, defaults, output, or error messages they are expected to act on — stage a page in `docs/to-doc-site/` as part of the same change.
+
+- Write for **Qlik Sense administrators**, not Node developers.
+- `docs/to-doc-site/README.md` defines the workflow: unprefixed means pending publication; rename with a `done_` prefix once published.
+- The published site is [butler-sheet-icons.ptarmiganlabs.com](https://butler-sheet-icons.ptarmiganlabs.com), built from [ptarmiganlabs/butler-sheet-icons-docs](https://github.com/ptarmiganlabs/butler-sheet-icons-docs).
+- Verify the text against the implementation before publishing rather than trusting the staged draft.
+
+Internal-only changes — refactors, test changes, build or lint tooling — need no doc page.
+
 **CRITICAL REMINDER**: **NEVER CANCEL** long-running builds or tests. Build may take several minutes, tests take 15-20+ minutes. Always use appropriate timeouts (5+ minutes for builds, 30+ minutes for tests).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,7 @@ This project is indexed by GitNexus as **butler-sheet-icons**. Use the GitNexus 
 - **Config-driven** — many runtime options come from env vars (`BSI_HOST`, `BSI_CERT_FILE`, `BSI_CLOUD_*`, etc.) or a YAML config; avoid hard-coding new env-var reads
 - **Dependencies** — Docker/SEA builds use `--omit=dev`; runtime deps must be in `dependencies`, not `devDependencies`
 - **Repo hygiene** — do not edit `node_modules/`, `build/`, `coverage/`, `sea-prep.blob`, `build.cjs`, or other generated artifacts. No drive-by formatting/indentation changes — keep diffs focused on the requested change.
+- **Document user-facing changes** — if a change adds, alters, or removes behaviour a BSI user can observe (CLI commands or flags, environment variables, defaults, output, or error messages they are expected to act on), stage a page in `docs/to-doc-site/` as part of the same change. Write for Qlik Sense administrators, not Node developers. See `docs/to-doc-site/README.md` for the staging and `done_` publication workflow; the published site is [butler-sheet-icons.ptarmiganlabs.com](https://butler-sheet-icons.ptarmiganlabs.com), built from [ptarmiganlabs/butler-sheet-icons-docs](https://github.com/ptarmiganlabs/butler-sheet-icons-docs). Internal-only changes (refactors, test changes, tooling) need no doc page.
 
 ## Browser / Puppeteer
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,3 +52,16 @@ This project is indexed by GitNexus as **butler-sheet-icons**. Use the GitNexus 
 | Work in the Util area | `.claude/skills/generated/util/SKILL.md` |
 
 <!-- gitnexus:end -->
+
+## Documenting user-facing changes
+
+If a change adds, alters, or removes behaviour a Butler Sheet Icons user can observe — CLI commands or flags, environment variables, defaults, output, or error messages they are expected to act on — stage a page in `docs/to-doc-site/` as part of the same change.
+
+- Write for **Qlik Sense administrators**, not Node developers.
+- `docs/to-doc-site/README.md` defines the workflow: unprefixed means pending publication; rename with a `done_` prefix once published.
+- The published site is [butler-sheet-icons.ptarmiganlabs.com](https://butler-sheet-icons.ptarmiganlabs.com), built from [ptarmiganlabs/butler-sheet-icons-docs](https://github.com/ptarmiganlabs/butler-sheet-icons-docs). Verify with `npm run docs:build` there — it fails on dead links.
+- Verify the text against the implementation before publishing rather than trusting the staged draft.
+
+Internal-only changes — refactors, test changes, build or lint tooling — need no doc page.
+
+See `AGENTS.md` for the full set of repository conventions.


### PR DESCRIPTION
Records a convention that already existed but was written down nowhere an agent or contributor would find it.

## Why

`docs/to-doc-site/` and its `done_` publication workflow were defined in `docs/to-doc-site/README.md`, but no instruction file referenced them. The rule was discoverable only by opening that README — and the `done_` convention had **never been applied to any file**.

The cost was real: crash dumps and log redaction both shipped in #813 and reached users with nothing on the doc site explaining either. They were only published later, under #820, after the gap was noticed by accident.

## What

The same rule in the three places these get read:

| File | Where |
|---|---|
| `AGENTS.md` | In the existing Conventions list, beside Logging / JSDoc / Repo hygiene |
| `CLAUDE.md` | After the `gitnexus:end` marker, so a re-index cannot remove it |
| `.github/copilot-instructions.md` | Its own section, after Repo Hygiene |

Scoped deliberately to **behaviour a user can observe** — CLI commands and flags, environment variables, defaults, output, error messages they are expected to act on. Refactors, test changes and tooling are explicitly excluded, so the rule stays meaningful instead of becoming boilerplate everyone learns to skip.

## Verified

`npm run gitnexus:index` leaves `CLAUDE.md` byte-identical, confirming the new section sits outside the managed block and survives re-indexing. Lint clean.

## Flagged, not fixed

There is a **second, diverged `copilot-instructions.md` at the repo root**. It was last touched in Nov 2025 (`a109179`) and has not tracked any of the changes since made to `.github/copilot-instructions.md` — which is the copy GitHub Copilot actually reads. An agent reading the root file gets stale rules.

I have not touched it, since deleting or gutting it is outside this change. Worth deciding separately whether to delete it or reduce it to a one-line pointer at the `.github/` copy.