### PR TITLE
fix: detect cached browsers instead of re-downloading on every run

### DIFF
--- a/docs/to-doc-site/browser-cache-reuse.md
+++ b/docs/to-doc-site/browser-cache-reuse.md
@@ -1,0 +1,57 @@
+# Cached browser reuse (doc site update)
+
+Target page: `docs/guide/concepts/browser-detection-and-environment-variables.md` on the doc site
+(section **"### 2. Cached browser (medium priority)"**).
+
+This is an edit to an existing page, not a new page. The page already describes step 2 correctly as
+an intention — but until Butler Sheet Icons 3.12.0 the step never actually ran, so no reader could
+have observed the behaviour the page describes. From 3.12.0 the description becomes true, and the
+version-matching rule below needs stating because the page currently only says "a compatible
+browser" without defining compatible.
+
+## Replacement text for section 2
+
+> ### 2. Cached browser (medium priority)
+>
+> If no system browser is configured, Butler Sheet Icons looks in the Puppeteer cache directory
+> (for example `C:\Users\<user>\.cache\puppeteer` on Windows, or `~/.cache/puppeteer` on macOS and
+> Linux).
+>
+> A cached browser is used when it matches both of these:
+>
+> - **Browser type** — the browser requested with `--browser` (`chrome` or `firefox`).
+> - **Version** — if you specify an exact `--browser-version`, only a cached browser with exactly
+>   that build is used. If a different version is cached, Butler Sheet Icons treats it as no match
+>   and downloads the version you asked for. If `--browser-version` is `latest`, any cached build of
+>   the requested browser type is accepted.
+>
+> When a cached browser matches, it is used as-is and nothing is downloaded. This is what makes
+> repeat runs fast: the browser is downloaded once and reused on every later run, with no network
+> access needed for the browser itself.
+>
+> Use `butler-sheet-icons browser list-installed` to see which browsers are currently cached, and
+> `browser install` to add one deliberately — for example when preparing a machine that will later
+> run without internet access.
+
+## Why this matters to administrators
+
+Before version 3.12.0 a defect prevented Butler Sheet Icons from ever finding a cached browser. In
+practice it re-downloaded a browser on **every run** unless `PUPPETEER_EXECUTABLE_PATH` was set.
+
+From 3.12.0 onwards:
+
+- Repeat runs no longer re-download a browser, so they start faster and use far less bandwidth.
+- Preparing a machine in advance with `browser install` now works as intended: the browser you
+  installed is actually picked up on later runs.
+- An environment with no internet access can be prepared by installing a browser once while
+  connectivity is available.
+
+Nothing needs to be reconfigured — the improvement applies automatically.
+
+## Note for the reviewer publishing this
+
+If a "what's new in 3.12.0" note exists, the bandwidth and startup-time improvement is worth
+mentioning there too. Administrators who worked around the old behaviour by setting
+`PUPPETEER_EXECUTABLE_PATH` purely to avoid repeated downloads can now drop that workaround if they
+prefer, although keeping it remains perfectly valid and is still the recommended approach for
+Docker and centrally managed browsers.

--- a/src/lib/browser/__tests__/browser_detect.test.js
+++ b/src/lib/browser/__tests__/browser_detect.test.js
@@ -1,0 +1,164 @@
+import { jest, test, expect, describe, beforeEach, afterEach } from '@jest/globals';
+
+jest.unstable_mockModule('@puppeteer/browsers', () => ({
+    getInstalledBrowsers: jest.fn(),
+}));
+const { getInstalledBrowsers } = await import('@puppeteer/browsers');
+
+jest.unstable_mockModule('../../../globals.js', () => ({
+    logger: {
+        info: jest.fn(),
+        verbose: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+    },
+}));
+const { logger } = await import('../../../globals.js');
+
+jest.unstable_mockModule('fs', () => ({
+    default: { existsSync: jest.fn() },
+    existsSync: jest.fn(),
+}));
+const fs = (await import('fs')).default;
+
+const { detectAvailableBrowser } = await import('../browser-detect.js');
+
+// PUPPETEER_EXECUTABLE_PATH is ambient and leaks between test files, so capture and
+// restore it around every test rather than assuming it starts unset.
+let savedExecutablePath;
+
+beforeEach(() => {
+    savedExecutablePath = process.env.PUPPETEER_EXECUTABLE_PATH;
+    delete process.env.PUPPETEER_EXECUTABLE_PATH;
+});
+
+afterEach(() => {
+    if (savedExecutablePath === undefined) {
+        delete process.env.PUPPETEER_EXECUTABLE_PATH;
+    } else {
+        process.env.PUPPETEER_EXECUTABLE_PATH = savedExecutablePath;
+    }
+});
+
+/**
+ * Builds an InstalledBrowser-shaped entry as returned by `@puppeteer/browsers`.
+ *
+ * @param {string} browser - Browser type, e.g. `chrome`.
+ * @param {string} buildId - Build id, e.g. `138.0.7204.94`.
+ *
+ * @returns {object} Entry with `browser`, `buildId` and `executablePath`.
+ */
+function cachedBrowser(browser, buildId) {
+    return {
+        browser,
+        buildId,
+        executablePath: `/cache/${browser}/${buildId}/${browser}`,
+    };
+}
+
+describe('detectAvailableBrowser — cached browsers', () => {
+    test('returns a cached browser when one matches', async () => {
+        // Regression test for the missing `await` on getInstalledBrowsers(). Without it the
+        // value is a Promise: truthy, but `.length` is undefined and `undefined > 0` is
+        // false, so the whole cache block was skipped and this returned null.
+        getInstalledBrowsers.mockResolvedValue([cachedBrowser('chrome', '138.0.7204.94')]);
+
+        const result = await detectAvailableBrowser({ browser: 'chrome' });
+
+        expect(result).toEqual({
+            executablePath: '/cache/chrome/138.0.7204.94/chrome',
+            source: 'cache',
+            browser: 'chrome',
+            buildId: '138.0.7204.94',
+        });
+    });
+
+    test('returns null when the cache is empty', async () => {
+        getInstalledBrowsers.mockResolvedValue([]);
+
+        expect(await detectAvailableBrowser({ browser: 'chrome' })).toBeNull();
+    });
+
+    test('ignores cached browsers of a different type', async () => {
+        getInstalledBrowsers.mockResolvedValue([cachedBrowser('firefox', '130.0')]);
+
+        expect(await detectAvailableBrowser({ browser: 'chrome' })).toBeNull();
+    });
+});
+
+describe('detectAvailableBrowser — browser version matching', () => {
+    test('honours an exact version pin', async () => {
+        getInstalledBrowsers.mockResolvedValue([cachedBrowser('chrome', '138.0.7204.94')]);
+
+        const result = await detectAvailableBrowser({
+            browser: 'chrome',
+            browserVersion: '138.0.7204.94',
+        });
+
+        expect(result.buildId).toBe('138.0.7204.94');
+    });
+
+    test('falls through to download when no cached build matches the pin', async () => {
+        getInstalledBrowsers.mockResolvedValue([cachedBrowser('chrome', '138.0.7204.94')]);
+
+        const result = await detectAvailableBrowser({
+            browser: 'chrome',
+            browserVersion: '121.0.6167.85',
+        });
+
+        expect(result).toBeNull();
+    });
+
+    test('"latest" accepts any cached build of the requested type', async () => {
+        getInstalledBrowsers.mockResolvedValue([cachedBrowser('chrome', '138.0.7204.94')]);
+
+        const result = await detectAvailableBrowser({
+            browser: 'chrome',
+            browserVersion: 'latest',
+        });
+
+        expect(result.buildId).toBe('138.0.7204.94');
+    });
+});
+
+describe('detectAvailableBrowser — system browser', () => {
+    test('prefers PUPPETEER_EXECUTABLE_PATH and does not consult the cache', async () => {
+        process.env.PUPPETEER_EXECUTABLE_PATH = '/usr/bin/chromium-browser';
+        fs.existsSync.mockReturnValue(true);
+
+        const result = await detectAvailableBrowser({ browser: 'chrome' });
+
+        expect(result).toEqual({
+            executablePath: '/usr/bin/chromium-browser',
+            source: 'system',
+            browser: 'chrome',
+            buildId: 'system-installed',
+        });
+        expect(getInstalledBrowsers).not.toHaveBeenCalled();
+    });
+
+    test('warns and falls back to the cache when the configured path does not exist', async () => {
+        process.env.PUPPETEER_EXECUTABLE_PATH = '/nope/chromium';
+        fs.existsSync.mockReturnValue(false);
+        getInstalledBrowsers.mockResolvedValue([cachedBrowser('chrome', '138.0.7204.94')]);
+
+        const result = await detectAvailableBrowser({ browser: 'chrome' });
+
+        expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('/nope/chromium'));
+        expect(result.source).toBe('cache');
+    });
+});
+
+describe('detectAvailableBrowser — failure handling', () => {
+    test('returns null and logs when the cache lookup rejects', async () => {
+        // Before the missing `await` was added the rejection escaped the surrounding
+        // try/catch entirely and surfaced as an unhandled rejection.
+        getInstalledBrowsers.mockRejectedValue(new Error('cache unreadable'));
+
+        const result = await detectAvailableBrowser({ browser: 'chrome' });
+
+        expect(result).toBeNull();
+        expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('cache unreadable'));
+    });
+});

--- a/src/lib/browser/browser-detect.js
+++ b/src/lib/browser/browser-detect.js
@@ -46,7 +46,7 @@ export const detectAvailableBrowser = async (options) => {
         const browserPath = path.join(homedir(), '.cache/puppeteer');
         logger.debug(`Checking for cached browsers in: ${browserPath}`);
 
-        const installedBrowsers = getInstalledBrowsers({
+        const installedBrowsers = await getInstalledBrowsers({
             cacheDir: browserPath,
         });
 
@@ -56,11 +56,21 @@ export const detectAvailableBrowser = async (options) => {
             // Filter by requested browser type if specified
             let matchingBrowsers = installedBrowsers;
             if (options.browser) {
-                matchingBrowsers = installedBrowsers.filter((b) => b.browser === options.browser);
+                matchingBrowsers = matchingBrowsers.filter((b) => b.browser === options.browser);
+            }
+
+            // browserVersion is part of this function's documented contract but was never
+            // applied, because the block was unreachable until the missing `await` above was
+            // fixed. Honour it now: 'latest' means any cached build of the requested type,
+            // anything else is a pin, and a cache miss correctly falls through to download.
+            if (options.browserVersion && options.browserVersion !== 'latest') {
+                matchingBrowsers = matchingBrowsers.filter(
+                    (b) => b.buildId === options.browserVersion
+                );
             }
 
             if (matchingBrowsers.length > 0) {
-                // Use the first matching browser
+                // Any matching build is acceptable; this is filesystem order, not newest-first.
                 const browser = matchingBrowsers[0];
                 logger.info(`Using cached browser: ${browser.browser} ${browser.buildId}`);
 


### PR DESCRIPTION
Refs #828. The one finding in that batch that is a genuine user-facing bug rather than an expression-correctness cleanup.

## The bug

`src/lib/browser/browser-detect.js` called the **async** `getInstalledBrowsers()` without awaiting it:

```js
const installedBrowsers = getInstalledBrowsers({ cacheDir: browserPath });
if (installedBrowsers && installedBrowsers.length > 0) {   // Promise: truthy, .length undefined
```

`undefined > 0` is false, so the entire cached-browser block was skipped and the function **always returned `null`**. Every sibling call site awaits correctly (`browser-installed.js`, `browser-uninstall.js`), so this was an omission.

**What users experienced:** BSI never found an already-cached browser and re-downloaded one on *every run*, unless `PUPPETEER_EXECUTABLE_PATH` was set. The doc site has described this cache step as working all along — good evidence it was never meant to behave this way.

## Demonstrated, not just reasoned about

Against the real `~/.cache/puppeteer` on a machine with two cached Chrome builds, with `PUPPETEER_EXECUTABLE_PATH` unset:

| | any cached chrome | pinned to a cached version | pinned to an uncached version |
|---|---|---|---|
| **before** | `null` | `null` | `null` |
| **after** | `source: 'cache'`, `146.0.7680.153` | `149.0.7827.22` | `null` (correctly downloads) |

The caller then logs `Browser ready from cache: chrome 146.0.7680.153` instead of `No local browser found. Downloading and installing browser...`.

## Two behaviours had to be decided, not inherited

The block had never executed, so it could not simply be switched on:

1. **`options.browserVersion` was documented in the JSDoc but never read.** It is now applied — an exact version is a pin and a cache miss falls through to download; `latest` accepts any cached build of the requested type. Without this, `--browser-version 121` could silently reuse a cached 138.
2. **Selection stays first-match**, now with a comment noting that is filesystem order, not newest-first. Sorting was considered and left out as scope creep.

## Second fix in the same line

The `await` also pulls a rejected `getInstalledBrowsers()` into the surrounding `try/catch`. Previously the rejection escaped it entirely — the new test for that case **crashed the whole Jest process** before the fix, which is how I confirmed it.

## Tests

Adds `src/lib/browser/__tests__/browser_detect.test.js`. The module had **no tests at all**, which is why this survived. 9 cases: cache hit, cache miss, browser-type filter, version pin honoured, version pin missed, `latest`, system browser winning without consulting the cache, configured-but-missing system path, and the rejection case.

The cache-hit test was written first and confirmed failing on `main` (`Received: null`) before the fix went in.

`npm run test:unit`: **172 passed** (up from 163). Lint and prettier clean.

## Docs

User-facing, so per the convention added in #831 the doc-site update is staged in `docs/to-doc-site/browser-cache-reuse.md`. It is an edit to the existing "Cached browser (medium priority)" section, which currently says only that "a compatible browser" is used without defining compatible — now that version matching is applied, that needs stating.

**Do not publish it until this ships in a release**, otherwise the page describes behaviour no user has yet.

## Possible relevance to #785 / #809

Not claimed as a fix for either, but worth noting while triaging them: this bug meant BSI attempted a download on every run regardless of what was cached, which is exactly the failure mode those offline / air-gapped issues describe. Pre-caching a browser now actually works.
