### PR TITLE
fix: attach app context when browser installation fails

### DIFF
--- a/src/lib/browser/browser-install.js
+++ b/src/lib/browser/browser-install.js
@@ -14,6 +14,10 @@ import { getMostRecentUsableChromeBuildId } from './browser-list-available.js';
  * downloads and unpacks the browser while showing a progress bar, and returns the installed
  * browser metadata on success.
  *
+ * Failure is signalled by throwing, never by a falsy return value: the single `return` is
+ * guarded by `if (!browser) throw lastError;`. Callers that need to add context to a failure
+ * must therefore wrap the call in try/catch rather than test the result.
+ *
  * @param {object} options - Options object.
  * @param {string} options.browser - Browser to install (`chrome` or `firefox`).
  * @param {string} options.browserVersion - Browser version to install, or `latest` for Chrome to auto-pick the newest stable build.

--- a/src/lib/cloud/__tests__/process_cloud_app.test.js
+++ b/src/lib/cloud/__tests__/process_cloud_app.test.js
@@ -327,4 +327,22 @@ describe('process-cloud-app.js — puppeteer launch and click options', () => {
             expect(opts).not.toHaveProperty('clickCount');
         }
     });
+
+    test('reports the app context when browser installation fails', async () => {
+        setupHappyPath();
+        // Force the download branch, then make the install fail. browserInstall() signals
+        // failure by throwing, never by returning false.
+        detectAvailableBrowser.mockResolvedValue(null);
+        browserInstall.mockRejectedValue(new Error('network unreachable'));
+
+        // processCloudApp catches and logs rather than rethrowing, so callers can continue to
+        // the next app. Assert it resolves; `rejects.toThrow` would fail here.
+        await processCloudApp('test-app-id', defaultSaasInstance, defaultOptions);
+
+        const logged = logger.error.mock.calls.map((call) => String(call[0])).join('\n');
+        expect(logged).toContain(
+            'Failed to install a browser for Qlik Sense Cloud app test-app-id'
+        );
+        expect(puppeteer.launch).not.toHaveBeenCalled();
+    });
 });

--- a/src/lib/cloud/process-cloud-app.js
+++ b/src/lib/cloud/process-cloud-app.js
@@ -168,11 +168,17 @@ export const processCloudApp = async (appId, saasInstance, options) => {
                 // No browser found - download required
                 logger.info(`No local browser found. Downloading and installing browser...`);
 
-                const browserInstallResult = await browserInstall(options);
-                if (browserInstallResult === false) {
-                    logger.error(`CLOUD: Error installing browser for app ${appId}.`);
+                let browserInstallResult;
+                try {
+                    browserInstallResult = await browserInstall(options);
+                } catch (err) {
+                    // browserInstall() returns browser metadata or throws; it never returns a
+                    // falsy sentinel. The app context therefore has to be attached here rather
+                    // than by testing the return value, which is what the previous
+                    // `=== false` check attempted and could never reach.
                     throw new CloudError(
-                        `Failed to install a browser for Qlik Sense Cloud app ${appId}`
+                        `Failed to install a browser for Qlik Sense Cloud app ${appId}`,
+                        { cause: err }
                     );
                 }
 

--- a/src/lib/cloud/process-cloud-app.js
+++ b/src/lib/cloud/process-cloud-app.js
@@ -172,10 +172,7 @@ export const processCloudApp = async (appId, saasInstance, options) => {
                 try {
                     browserInstallResult = await browserInstall(options);
                 } catch (err) {
-                    // browserInstall() returns browser metadata or throws; it never returns a
-                    // falsy sentinel. The app context therefore has to be attached here rather
-                    // than by testing the return value, which is what the previous
-                    // `=== false` check attempted and could never reach.
+                    // browserInstall() signals failure by throwing - see its JSDoc.
                     throw new CloudError(
                         `Failed to install a browser for Qlik Sense Cloud app ${appId}`,
                         { cause: err }

--- a/src/lib/qseow/__tests__/qseow_process_app.test.js
+++ b/src/lib/qseow/__tests__/qseow_process_app.test.js
@@ -348,4 +348,20 @@ describe('qseow-process-app.js — puppeteer launch and click options', () => {
             expect(opts).not.toHaveProperty('clickCount');
         }
     });
+
+    test('reports the app context when browser installation fails', async () => {
+        setupHappyPath();
+        // Force the download branch, then make the install fail. browserInstall() signals
+        // failure by throwing, never by returning false.
+        detectAvailableBrowser.mockResolvedValue(null);
+        browserInstall.mockRejectedValue(new Error('network unreachable'));
+
+        // qseowProcessApp catches and logs rather than rethrowing, so callers can continue
+        // to the next app. Assert it resolves; `rejects.toThrow` would fail here.
+        await qseowProcessApp('test-app-id', defaultOptions);
+
+        const logged = logger.error.mock.calls.map((call) => String(call[0])).join('\n');
+        expect(logged).toContain('Failed to install a browser for QSEoW app test-app-id');
+        expect(puppeteer.launch).not.toHaveBeenCalled();
+    });
 });

--- a/src/lib/qseow/qseow-process-app.js
+++ b/src/lib/qseow/qseow-process-app.js
@@ -280,10 +280,7 @@ export const qseowProcessApp = async (appId, options) => {
                 try {
                     browserInstallResult = await browserInstall(options);
                 } catch (err) {
-                    // browserInstall() returns browser metadata or throws; it never returns a
-                    // falsy sentinel. The app context therefore has to be attached here rather
-                    // than by testing the return value, which is what the previous
-                    // `=== false` check attempted and could never reach.
+                    // browserInstall() signals failure by throwing - see its JSDoc.
                     throw new QseowError(`Failed to install a browser for QSEoW app ${appId}`, {
                         cause: err,
                     });

--- a/src/lib/qseow/qseow-process-app.js
+++ b/src/lib/qseow/qseow-process-app.js
@@ -276,10 +276,17 @@ export const qseowProcessApp = async (appId, options) => {
                 // No browser found - download required
                 logger.info(`No local browser found. Downloading and installing browser...`);
 
-                const browserInstallResult = await browserInstall(options);
-                if (browserInstallResult === false) {
-                    logger.error(`QSEoW APP: Error installing browser for app ${appId}.`);
-                    throw new QseowError(`Failed to install a browser for QSEoW app ${appId}`);
+                let browserInstallResult;
+                try {
+                    browserInstallResult = await browserInstall(options);
+                } catch (err) {
+                    // browserInstall() returns browser metadata or throws; it never returns a
+                    // falsy sentinel. The app context therefore has to be attached here rather
+                    // than by testing the return value, which is what the previous
+                    // `=== false` check attempted and could never reach.
+                    throw new QseowError(`Failed to install a browser for QSEoW app ${appId}`, {
+                        cause: err,
+                    });
                 }
 
                 executablePath = computeExecutablePath({


### PR DESCRIPTION
Refs #828. This is the half of the issue's "Group 1" where Sonar is **correct** — see #830's sibling PR for the six sites where it is not.

## The dead branch

```js
const browserInstallResult = await browserInstall(options);
if (browserInstallResult === false) {
    logger.error(`... Error installing browser for app ${appId}.`);
    throw new CloudError(`Failed to install a browser for ... app ${appId}`);
}
```

`browserInstall()` has exactly one `return browser;`, guarded immediately above by `if (!browser) throw lastError;`, and throws on every failure path — missing options, unresolvable build id, undownloadable build, and all three install attempts exhausted. Its own JSDoc says `@returns {Promise<object>}` / `@throws {Error}`. **It can never return `false`.**

So the branch was unreachable, and the typed error naming the app could never be constructed. Install failures propagated as the raw underlying error instead, losing exactly the context the author was trying to add.

## The fix

try/catch, with `cause` preserving the original:

```js
let browserInstallResult;
try {
    browserInstallResult = await browserInstall(options);
} catch (err) {
    throw new CloudError(`Failed to install a browser for Qlik Sense Cloud app ${appId}`, {
        cause: err,
    });
}
```

## Three things deliberately left out

- **No `logger.error` in the catch.** `browserInstall()` already logs message and stack, and the outer catch logs the wrapped error — a third line would just duplicate.
- **No `instanceof BsiError` re-throw guard.** The precedent at `enigma-util.js:97-100` is reachable because that function throws `EnigmaError` from inside its own `try`. `browserInstall` throws only raw `Error`, so the same guard here would be a brand-new always-false branch — the exact defect class this PR removes.
- **No `if (err.stack) / else if (err.message) / else` logging idiom**, used widely elsewhere in these files. A real `Error` always has both, so two of its three arms are dead. Not adding more.

## What actually changes for users

**The log text, and nothing else.** Both `processCloudApp` and `qseowProcessApp` catch and return rather than rethrow, and their callers continue to the next app — so a failed app is still logged and skipped, and the exit code is unchanged. What improves is that the log now names the app that failed.

## Tests

One failure test per suite. Both force the download branch (`detectAvailableBrowser` → `null`), reject `browserInstall`, then assert the app-context message reaches `logger.error` and that `puppeteer.launch` is never called.

They assert the call **resolves** rather than using `rejects.toThrow` — which would fail, because the outer catch swallows. That asymmetry is worth knowing about when adding further tests to these files.

`npm run test:unit`: **174 passed** (up from 172). Lint and prettier clean.
