### PR TITLE
fix: stop branching on the resolved value of enigma session.close()

### DIFF
--- a/src/lib/cloud/__tests__/process_cloud_app.test.js
+++ b/src/lib/cloud/__tests__/process_cloud_app.test.js
@@ -328,6 +328,20 @@ describe('process-cloud-app.js — puppeteer launch and click options', () => {
         }
     });
 
+    test('closes the enigma session without branching on its resolved value', async () => {
+        setupHappyPath();
+
+        await processCloudApp('test-app-id', defaultSaasInstance, defaultOptions);
+
+        const session = await enigma.create.mock.results[0].value;
+        expect(session.close).toHaveBeenCalled();
+
+        // The removed `else` branch logged this on any non-true resolution. enigma.js always
+        // resolves close() truthy, so it only ever fired on a misreading of the contract.
+        const logged = logger.error.mock.calls.map((call) => String(call[0])).join('\n');
+        expect(logged).not.toContain('Error closing session');
+    });
+
     test('reports the app context when browser installation fails', async () => {
         setupHappyPath();
         // Force the download branch, then make the install fail. browserInstall() signals

--- a/src/lib/cloud/cloud-remove-sheet-icons.js
+++ b/src/lib/cloud/cloud-remove-sheet-icons.js
@@ -126,13 +126,11 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
                 iSheetNum += 1;
             }
 
-            if ((await session.close()) === true) {
-                logger.verbose(
-                    `Closed session after updating sheet thumbnail images in QS Cloud app ${appId} on host ${options.host}`
-                );
-            } else {
-                logger.error(`Error closing session for QS Cloud app ${appId}`);
-            }
+            // enigma.js always resolves close() truthy; a real failure rejects into the catch below.
+            await session.close();
+            logger.verbose(
+                `Closed session after updating sheet thumbnail images in QS Cloud app ${appId} on host ${options.host}`
+            );
         }
 
         logger.info(`Done processing app ${appId}`);

--- a/src/lib/cloud/cloud-updatesheets.js
+++ b/src/lib/cloud/cloud-updatesheets.js
@@ -185,13 +185,11 @@ export const qscloudUpdateSheetThumbnails = async (createdFiles, appId, options)
             }
         }
 
-        if ((await session.close()) === true) {
-            logger.verbose(
-                `Closed session after updating sheet thumbnail images in QS Cloud app ${appId} on host ${options.host}`
-            );
-        } else {
-            logger.error(`Error closing session for QS Cloud app ${appId}`);
-        }
+        // enigma.js always resolves close() truthy; a real failure rejects into the catch below.
+        await session.close();
+        logger.verbose(
+            `Closed session after updating sheet thumbnail images in QS Cloud app ${appId} on host ${options.host}`
+        );
     } catch (err) {
         if (err.stack) {
             logger.error(`CLOUD UPDATE SHEETS (stack): ${err.stack}`);

--- a/src/lib/cloud/process-cloud-app.js
+++ b/src/lib/cloud/process-cloud-app.js
@@ -472,15 +472,11 @@ export const processCloudApp = async (appId, saasInstance, options) => {
                 }
             }
         }
-        if ((await session.close()) === true) {
-            logger.verbose(
-                `Closed session after generating sheet thumbnail images for all sheets in QS Cloud app ${appId} on tenant ${options.tenanturl}`
-            );
-        } else {
-            logger.error(
-                `Error closing session for QS Cloud app ${appId} on host ${options.tenanturl}`
-            );
-        }
+        // enigma.js always resolves close() truthy; a real failure rejects into the catch below.
+        await session.close();
+        logger.verbose(
+            `Closed session after generating sheet thumbnail images for all sheets in QS Cloud app ${appId} on tenant ${options.tenanturl}`
+        );
 
         // Upload to QS Cloud app
         await qscloudUploadToApp(createdFiles, appId, options);

--- a/src/lib/qseow/__tests__/qseow_process_app.test.js
+++ b/src/lib/qseow/__tests__/qseow_process_app.test.js
@@ -349,6 +349,20 @@ describe('qseow-process-app.js — puppeteer launch and click options', () => {
         }
     });
 
+    test('closes the enigma session without branching on its resolved value', async () => {
+        setupHappyPath();
+
+        await qseowProcessApp('test-app-id', defaultOptions);
+
+        const session = await enigma.create.mock.results[0].value;
+        expect(session.close).toHaveBeenCalled();
+
+        // The removed `else` branch logged this on any non-true resolution. enigma.js always
+        // resolves close() truthy, so it only ever fired on a misreading of the contract.
+        const logged = logger.error.mock.calls.map((call) => String(call[0])).join('\n');
+        expect(logged).not.toContain('Error closing session');
+    });
+
     test('reports the app context when browser installation fails', async () => {
         setupHappyPath();
         // Force the download branch, then make the install fail. browserInstall() signals

--- a/src/lib/qseow/qseow-process-app.js
+++ b/src/lib/qseow/qseow-process-app.js
@@ -650,13 +650,11 @@ export const qseowProcessApp = async (appId, options) => {
             }
         }
 
-        if ((await session.close()) === true) {
-            logger.verbose(
-                `Closed session after generating sheet thumbnail images for all sheets in QSEoW app ${appId} on host ${options.host}`
-            );
-        } else {
-            logger.error(`Error closing session for QSEoW app ${appId} on host ${options.host}`);
-        }
+        // enigma.js always resolves close() truthy; a real failure rejects into the catch below.
+        await session.close();
+        logger.verbose(
+            `Closed session after generating sheet thumbnail images for all sheets in QSEoW app ${appId} on host ${options.host}`
+        );
 
         // Upload to QSEoW content library
         await qseowUploadToContentLibrary(createdFiles, appId, options);

--- a/src/lib/qseow/qseow-remove-sheet-icons.js
+++ b/src/lib/qseow/qseow-remove-sheet-icons.js
@@ -98,15 +98,11 @@ const removeSheetIconsQSEoWApp = async (appId, g, options) => {
                 iSheetNum += 1;
             }
 
-            if ((await session.close()) === true) {
-                logger.verbose(
-                    `Closed session after generating sheet thumbnail images for all sheets in QSEoW app ${appId} on host ${options.host}`
-                );
-            } else {
-                logger.error(
-                    `Error closing session for QSEoW app ${appId} on host ${options.host}`
-                );
-            }
+            // enigma.js always resolves close() truthy; a real failure rejects into the catch below.
+            await session.close();
+            logger.verbose(
+                `Closed session after generating sheet thumbnail images for all sheets in QSEoW app ${appId} on host ${options.host}`
+            );
         }
 
         logger.info(`Done processing app ${appId}`);

--- a/src/lib/qseow/qseow-updatesheets.js
+++ b/src/lib/qseow/qseow-updatesheets.js
@@ -180,13 +180,11 @@ export const qseowUpdateSheetThumbnails = async (createdFiles, appId, options) =
             }
         }
 
-        if ((await session.close()) === true) {
-            logger.verbose(
-                `Closed session after updating sheet thumbnail images in QSEoW app ${appId} on host ${options.host}`
-            );
-        } else {
-            logger.error(`Error closing session for QSEoW app ${appId} on host ${options.host}`);
-        }
+        // enigma.js always resolves close() truthy; a real failure rejects into the catch below.
+        await session.close();
+        logger.verbose(
+            `Closed session after updating sheet thumbnail images in QSEoW app ${appId} on host ${options.host}`
+        );
     } catch (err) {
         if (err.stack) {
             logger.error(`QSEOW UPDATE SHEETS (stack): ${err.stack}`);


### PR DESCRIPTION
Refs #828. **This is the half of that issue where Sonar is wrong**, and following its advice would introduce a bug. Read this before reviewing.

## What the six sites look like

`process-cloud-app.js`, `qseow-process-app.js`, `cloud-remove-sheet-icons.js`, `qseow-remove-sheet-icons.js`, `cloud-updatesheets.js`, `qseow-updatesheets.js` — all identical in shape:

```js
if ((await session.close()) === true) {
    logger.verbose('Closed session after ...');
} else {
    logger.error('Error closing session for ...');
}
```

Sonar reports the comparison as always false and suggests removing the check. **Doing that literally would delete the `if` and leave the `else`, so every successful session close would log `Error closing session`.**

## What enigma.js actually does

`Session.close()` returns:

```js
return this.rpc.close(code, reason).then(function (evt) {
  return _this7.emit('closed', evt);
});
```

so it resolves with `emit`'s return value. `emit` returns `false` only when no listener is registered — and the `Session` constructor unconditionally registers one:

```js
session.on('closed', function () {
  return session.onSessionClosed();
});
```

`onSessionClosed` calls `removeAllListeners()` on the generated **API instances**, never on the session itself, so that listener is never removed. `close()` therefore always resolves `true`, and **the dead branch is the `else`, not the `if`**.

Sonar's inference comes from `enigma.d.ts`, which declares `close(): Promise<void>`. That contradicts the shipped implementation — awaiting `Promise<void>` gives `undefined`, and `undefined === true` is statically false. Correct against the declared type, wrong against the code.

## The fix

```js
// enigma.js always resolves close() truthy; a real failure rejects into the catch below.
await session.close();
logger.verbose('Closed session after ...');
```

This removes both the always-true comparison Sonar objects to and the genuinely unreachable `else`, without inverting anything.

A real close failure **rejects** rather than resolving falsy — `rpc.close()`'s promise rejects if the socket close errors. All six sites already sit inside a `try` with a `catch` (verified individually), so failures were handled there before this change and still are. Nothing is being made less safe.

## Comment length

The explanation is one line per site rather than the four-line block I would normally write. #833 showed that identical multi-line comments repeated across the cloud/QSEoW mirror pairs count against the `new_duplicated_lines` gate. The full reasoning lives in the commit message and here, where it is not duplicated six times.

## Tests

Existing tests already mock `close: jest.fn().mockResolvedValue(true)` and pass unchanged. Added one test per process-app suite asserting the session is closed and that no close-failure error is logged — pinning the removed `else`.

`npm run test:unit`: **176 passed** (up from 174). Lint and prettier clean.

## Worth flagging

`src/lib/qseow/__tests__/qseow_remove_sheet_icons.test._js` contains a test named "should handle session close failure gracefully" built on `close.mockResolvedValue(false)` — encoding exactly the misconception removed here. It is parked as `.test._js` and not collected by Jest, so it does not break the build, but **if anyone revives that suite this test must be rewritten as a rejection case.**

Also expect the duplication gate to fire again, for the reasons in #834 — these are the same mirror-pair files.
