### PR TITLE
fix: normalise includesheetpart so numeric values reach the right code path

### DIFF
--- a/src/lib/cloud/__tests__/cloud_create_thumbnails_validation.test.js
+++ b/src/lib/cloud/__tests__/cloud_create_thumbnails_validation.test.js
@@ -1,0 +1,84 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+// Only the --includesheetpart validation is under test here. The connection test that comes
+// straight after it is mocked to throw, so a value that passes validation stops there instead
+// of reaching the tenant.
+jest.unstable_mockModule('../../../globals.js', () => ({
+    logger: {
+        info: jest.fn(),
+        verbose: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+    },
+    setLoggingLevel: jest.fn(),
+    bsiExecutablePath: '/test/path',
+    isSea: false,
+}));
+
+jest.unstable_mockModule('../cloud-test-connection.js', () => ({
+    qscloudTestConnection: jest.fn(() => {
+        throw new Error('PAST_VALIDATION');
+    }),
+}));
+
+jest.unstable_mockModule('../cloud-repo.js', () => ({ default: jest.fn() }));
+
+jest.unstable_mockModule('../process-cloud-app.js', () => ({
+    processCloudApp: jest.fn().mockResolvedValue(true),
+}));
+
+jest.unstable_mockModule('../../util/redact-secrets.js', () => ({
+    redactOptions: jest.fn((o) => o),
+}));
+
+const { logger } = await import('../../../globals.js');
+const { qscloudCreateThumbnails } = await import('../cloud-create-thumbnails.js');
+
+const INVALID = 'Invalid --includesheetpart paramater';
+
+/**
+ * Runs the function with the given sheet-part value and reports whether the
+ * --includesheetpart validation rejected it.
+ *
+ * The outcome is observable through the log rather than through a rejection, because the
+ * function catches everything. Only this one check is of interest.
+ *
+ * @param {string|number|undefined} includesheetpart - Value to validate.
+ *
+ * @returns {Promise<boolean>} True when the value was rejected by this validation.
+ */
+async function rejectedByValidation(includesheetpart) {
+    const options = {
+        includesheetpart,
+        loglevel: 'info',
+        logLevel: 'info',
+        tenanturl: 'test.eu.qlikcloud.com',
+        apikey: 'test-key',
+    };
+    await qscloudCreateThumbnails(options, {}).catch(() => undefined);
+
+    return logger.error.mock.calls.some((call) => String(call[0]).includes(INVALID));
+}
+
+describe('cloud-create-thumbnails.js — includesheetpart validation', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test.each(['1', '2', '4'])('accepts the string "%s"', async (value) => {
+        expect(await rejectedByValidation(value)).toBe(false);
+    });
+
+    // The numeric forms were previously accepted by explicit `!== 1 && !== 2 ...` comparisons.
+    // Normalising with String() has to keep accepting them, or programmatic callers break.
+    test.each([1, 2, 4])('still accepts the number %s after normalisation', async (value) => {
+        expect(await rejectedByValidation(value)).toBe(false);
+    });
+
+    // '3' is valid for QSEoW but not for QS Cloud, which has no sheet part 3. The two
+    // validators deliberately accept different sets.
+    test.each(['3', 3, '5', 'abc', '', 0, undefined])('rejects %p', async (value) => {
+        expect(await rejectedByValidation(value)).toBe(true);
+    });
+});

--- a/src/lib/cloud/__tests__/qscloudCreateThumbnails_success.integration.test.js
+++ b/src/lib/cloud/__tests__/qscloudCreateThumbnails_success.integration.test.js
@@ -20,7 +20,7 @@ const options = {
     imagedir: process.env.BSI_IMAGE_DIR || 'img',
     schemaversion: process.env.BSI_CLOUD_SCHEMA_VERSION || '12.612.0',
     appid: process.env.BSI_CLOUD_APP_ID,
-    includesheetpart: process.env.BSI_INCLUDE_SHEET_PART || 1,
+    includesheetpart: process.env.BSI_INCLUDE_SHEET_PART || '1',
     browser: process.env.BSI_BROWSER || 'chrome',
     browserVersion: process.env.BSI_BROWSER_VERSION || 'latest',
     blurSheetStatus: process.env.BSI_BLUR_SHEET_STATUS || [],

--- a/src/lib/cloud/cloud-create-thumbnails.js
+++ b/src/lib/cloud/cloud-create-thumbnails.js
@@ -16,7 +16,7 @@ import { processCloudApp } from './process-cloud-app.js';
  * @param {string} options.collectionid - ID of collection in Qlik Sense Cloud tenant.
  * @param {string} options.appid - ID of app in Qlik Sense Cloud tenant.
  * @param {string} options.imagedir - Directory where images will be stored.
- * @param {string} options.includesheetpart - Optional parameter to include sheet parts in the thumbnails. Values: 1, 2, 4.
+ * @param {string} options.includesheetpart - Optional parameter to include sheet parts in the thumbnails. Values: 1, 2, 4. Normalised to a string on entry, so a number is also accepted.
  * @param {string} options.schemaversion - Version of the QS schema.
  * @param {string} options.browser - Name of browser to use for rendering thumbnails.
  * @param {string} options.browserVersion - Version of browser to use for rendering thumbnails.
@@ -42,15 +42,14 @@ export const qscloudCreateThumbnails = async (options) => {
 
         const appIdsToProcess = [];
 
+        // Commander always yields a string here (.default('1'), .env() and the .choices()
+        // wrapper all produce strings), but programmatic and test callers may pass a number.
+        // Normalise once so the check below - and the string-only sheet-part comparisons
+        // downstream in sheet-screenshot.js - see a consistent type.
+        options.includesheetpart = String(options.includesheetpart);
+
         // If --includesheetpart has been specifed it should contain a valid value
-        if (
-            options.includesheetpart !== '1' &&
-            options.includesheetpart !== '2' &&
-            options.includesheetpart !== '4' &&
-            options.includesheetpart !== 1 &&
-            options.includesheetpart !== 2 &&
-            options.includesheetpart !== 4
-        ) {
+        if (!['1', '2', '4'].includes(options.includesheetpart)) {
             logger.error(
                 `Invalid --includesheetpart paramater: ${options.includesheetpart}. Aborting`
             );

--- a/src/lib/qseow/__tests__/qseowCreateThumbnails_fail_missing_content_library.integration.test.js
+++ b/src/lib/qseow/__tests__/qseowCreateThumbnails_fail_missing_content_library.integration.test.js
@@ -26,7 +26,7 @@ const options = {
     logonuserdir: process.env.BSI_LOGON_USER_DIR,
     logonuserid: process.env.BSI_LOGON_USER_ID,
     logonpwd: process.env.BSI_LOGON_PWD,
-    includesheetpart: process.env.BSI_INCLUDE_SHEET_PART || 1,
+    includesheetpart: process.env.BSI_INCLUDE_SHEET_PART || '1',
     qliksensetag: process.env.BSI_QLIK_SENSE_TAG || '',
     senseVersion: process.env.BSI_SENSE_VERSION,
 };

--- a/src/lib/qseow/__tests__/qseowCreateThumbnails_success.integration.test.js
+++ b/src/lib/qseow/__tests__/qseowCreateThumbnails_success.integration.test.js
@@ -26,7 +26,7 @@ const options = {
     logonuserdir: process.env.BSI_LOGON_USER_DIR,
     logonuserid: process.env.BSI_LOGON_USER_ID,
     logonpwd: process.env.BSI_LOGON_PWD,
-    includesheetpart: process.env.BSI_INCLUDE_SHEET_PART || 1,
+    includesheetpart: process.env.BSI_INCLUDE_SHEET_PART || '1',
     qliksensetag: process.env.BSI_QLIK_SENSE_TAG || '',
     senseVersion: process.env.BSI_SENSE_VERSION,
     browser: process.env.BSI_BROWSER || 'chrome',

--- a/src/lib/qseow/__tests__/qseow_create_thumbnails_validation.test.js
+++ b/src/lib/qseow/__tests__/qseow_create_thumbnails_validation.test.js
@@ -1,0 +1,78 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+// Only the --includesheetpart validation is under test here. The certificate check that comes
+// straight after it is mocked to throw, so a value that passes validation stops there instead
+// of reaching QRS.
+jest.unstable_mockModule('../../../globals.js', () => ({
+    logger: {
+        info: jest.fn(),
+        verbose: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+    },
+    setLoggingLevel: jest.fn(),
+    bsiExecutablePath: '/test/path',
+    isSea: false,
+    sleep: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.unstable_mockModule('../qseow-certificates.js', () => ({
+    qseowVerifyCertificatesExist: jest.fn(() => {
+        throw new Error('PAST_VALIDATION');
+    }),
+}));
+
+jest.unstable_mockModule('../../util/redact-secrets.js', () => ({
+    redactOptions: jest.fn((o) => o),
+}));
+
+const { logger } = await import('../../../globals.js');
+const { qseowCreateThumbnails } = await import('../qseow-create-thumbnails.js');
+
+const INVALID = 'Invalid --includesheetpart paramater';
+
+/**
+ * Runs the function with the given sheet-part value and reports whether the
+ * --includesheetpart validation rejected it.
+ *
+ * qseowCreateThumbnails catches everything and returns false, so the validation outcome is
+ * observable through the log rather than through a rejection. Only this one check is of
+ * interest — a valid value is one that does not trip it, whatever happens further down.
+ *
+ * @param {string|number|undefined} includesheetpart - Value to validate.
+ *
+ * @returns {Promise<boolean>} True when the value was rejected by this validation.
+ */
+async function rejectedByValidation(includesheetpart) {
+    const options = {
+        includesheetpart,
+        loglevel: 'info',
+        logLevel: 'info',
+        certfile: '/test/cert.pem',
+        certkeyfile: '/test/key.pem',
+    };
+    await qseowCreateThumbnails(options, {}).catch(() => undefined);
+
+    return logger.error.mock.calls.some((call) => String(call[0]).includes(INVALID));
+}
+
+describe('qseow-create-thumbnails.js — includesheetpart validation', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test.each(['1', '2', '3', '4'])('accepts the string "%s"', async (value) => {
+        expect(await rejectedByValidation(value)).toBe(false);
+    });
+
+    // The numeric forms were previously accepted by explicit `!== 1 && !== 2 ...` comparisons.
+    // Normalising with String() has to keep accepting them, or programmatic callers break.
+    test.each([1, 2, 3, 4])('still accepts the number %s after normalisation', async (value) => {
+        expect(await rejectedByValidation(value)).toBe(false);
+    });
+
+    test.each(['5', 'abc', '', 0, undefined])('rejects %p', async (value) => {
+        expect(await rejectedByValidation(value)).toBe(true);
+    });
+});

--- a/src/lib/qseow/qseow-create-thumbnails.js
+++ b/src/lib/qseow/qseow-create-thumbnails.js
@@ -19,7 +19,7 @@ import { qseowProcessApp } from './qseow-process-app.js';
  * @param {string} options.contentlibrary - Name of content library where thumbnails will be stored.
  * @param {string} options.appid - ID of app for which thumbnails will be created.
  * @param {string} options.qliksensetag - Tag for which apps will be processed.
- * @param {number} options.includesheetpart - Optional parameter to include sheet parts in the thumbnails. Values: 1, 2, 3, 4.
+ * @param {string} options.includesheetpart - Optional parameter to include sheet parts in the thumbnails. Values: 1, 2, 3, 4. Normalised to a string on entry, so a number is also accepted.
  * @param {string} options.certfile - Path to certificate file.
  * @param {string} options.certkeyfile - Path to certificate key file.
  * @param {string} options.loglevel - Log level for the operation.
@@ -41,17 +41,14 @@ export const qseowCreateThumbnails = async (options) => {
 
         const appIdsToProcess = [];
 
+        // Commander always yields a string here (.default('1') and .env() both produce
+        // strings), but programmatic and test callers may pass a number. Normalise once so the
+        // check below - and the string-only sheet-part comparisons downstream in
+        // qseow-process-app.js - see a consistent type.
+        options.includesheetpart = String(options.includesheetpart);
+
         // If --includesheetpart has been specifed it should contain a valid value
-        if (
-            options.includesheetpart !== '1' &&
-            options.includesheetpart !== '2' &&
-            options.includesheetpart !== '3' &&
-            options.includesheetpart !== '4' &&
-            options.includesheetpart !== 1 &&
-            options.includesheetpart !== 2 &&
-            options.includesheetpart !== 3 &&
-            options.includesheetpart !== 4
-        ) {
+        if (!['1', '2', '3', '4'].includes(options.includesheetpart)) {
             logger.error(
                 `Invalid --includesheetpart paramater: ${options.includesheetpart}. Aborting`
             );


### PR DESCRIPTION
Refs #828. Last of the four bug-fix PRs. Closes out the 16 findings.

## Sonar flagged opposite halves of the two files

- `cloud-create-thumbnails.js` — the **numeric** comparisons (`!== 1`, `!== 2`, `!== 4`)
- `qseow-create-thumbnails.js` — the **string** comparisons (`!== '1'` … `!== '4'`)

The cause is the JSDoc, which disagreed between the files: `@param {string}` in cloud, `@param {number}` in QSEoW. Sonar types the expression from the annotation and declares the other half unreachable.

**Following it literally in the QSEoW file would delete the string checks and break every real CLI invocation.** This is the second place in #828 where the issue's advice had to be checked rather than applied.

## Runtime truth

Commander always produces a **string** here:

- `.default('1')` is a string, and Commander never runs `parseArg` on defaults
- `.env()` yields `process.env[...]`, always a string
- `parsePositiveInteger` (`src/lib/commands/helpers.js:44`) returns the *trimmed string*: `return returnNumber ? parsed : stringValue;`, `returnNumber` defaults false, and neither call site passes it
- in the cloud command, `.choices(['1','2','4'])` overwrites `parseArg` outright, so that argParser never runs at all

## But numbers do occur, and they were already broken

All three integration tests build options by hand:

```js
includesheetpart: process.env.BSI_INCLUDE_SHEET_PART || 1,
```

`ci.yaml` feeds that variable from a secret, so an unset or empty secret renders as `''` → falsy → the fallback yields the **number** `1`.

A number passed validation through the numeric comparisons, then matched none of the string-only comparisons downstream in `sheet-screenshot.js:39-43` and `qseow-process-app.js:493-502`, leaving `selector = ''` and reaching `page.waitForSelector('')`.

So the "cosmetic, no runtime consequence" characterisation in #828 was wrong, and I have corrected the issue.

## The fix

Normalise once at the top rather than deleting either half:

```js
options.includesheetpart = String(options.includesheetpart);

if (!['1', '2', '4'].includes(options.includesheetpart)) { ... }
```

This satisfies Sonar, keeps programmatic and test callers working, and fixes the downstream mismatch. Mutating `options` matches the existing idiom — both functions already do `options.loglevel = options.logLevel` a few lines above — and a local `const` would not fix the downstream reads, which go through `options`.

Also in this PR:

- **`qseow-create-thumbnails.js` JSDoc corrected** from `{number}` to `{string}`. That contradiction is what split Sonar's verdict in the first place.
- **The three integration tests** now fall back to `'1'` rather than `1`.
- **The 1/2/4 vs 1/2/3/4 asymmetry is preserved.** QSEoW handles sheet part `3` downstream; QS Cloud does not, and its CLI blocks it via `.choices(['1','2','4'])`.

## Tests

A validation test per module — **neither had one**. 13 cases each: every valid string, every valid number, and the rejections. `'3'` is asserted valid for QSEoW and invalid for QS Cloud, pinning the asymmetry.

The numeric cases are the important ones: they prove the `String()` normalisation **widened** rather than tightened what is accepted, which is the risk when replacing an explicit comparison chain.

`npm run test:unit`: **202 passed across 20 suites** (up from 176/18). Lint and prettier clean.

## Out of scope, worth a follow-up

`src/lib/commands/qscloud/create-sheet-thumbnails.js:145-151` chains `.argParser(parsePositiveInteger)` then `.choices([...])`. Commander's `choices()` overwrites `parseArg`, so that argParser is dead code. Harmless today, since both produce strings.
