### PR TITLE
refactor: extract shared browser launch sequence from the process-app modules

### DIFF
--- a/src/lib/browser/__tests__/browser_launch.test.js
+++ b/src/lib/browser/__tests__/browser_launch.test.js
@@ -1,0 +1,187 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+jest.unstable_mockModule('puppeteer-core', () => ({
+    default: { launch: jest.fn() },
+}));
+const puppeteer = (await import('puppeteer-core')).default;
+
+jest.unstable_mockModule('@puppeteer/browsers', () => ({
+    computeExecutablePath: jest.fn().mockReturnValue('/downloaded/chrome'),
+}));
+const { computeExecutablePath } = await import('@puppeteer/browsers');
+
+jest.unstable_mockModule('../../../globals.js', () => ({
+    logger: {
+        info: jest.fn(),
+        verbose: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+    },
+}));
+const { logger } = await import('../../../globals.js');
+
+jest.unstable_mockModule('../browser-detect.js', () => ({
+    detectAvailableBrowser: jest.fn(),
+}));
+const { detectAvailableBrowser } = await import('../browser-detect.js');
+
+jest.unstable_mockModule('../browser-install.js', () => ({
+    browserInstall: jest.fn(),
+}));
+const { browserInstall } = await import('../browser-install.js');
+
+// Docker detection imports fs dynamically; existsSync drives which branch is taken.
+jest.unstable_mockModule('fs', () => ({
+    default: { existsSync: jest.fn() },
+    existsSync: jest.fn().mockReturnValue(false),
+}));
+const fs = await import('fs');
+
+const { launchBrowserForApp, buildBrowserArgs, resolveBrowserExecutablePath } =
+    await import('../browser-launch.js');
+
+/** Stand-in typed error, matching the (message, { cause }) shape of the real ones. */
+class TestError extends Error {
+    /**
+     * Construct a test error carrying an optional cause.
+     *
+     * @param {string} message - Error message.
+     * @param {object} [options] - Error options, including `cause`.
+     */
+    constructor(message, options) {
+        super(message, options);
+        this.name = 'TestError';
+    }
+}
+
+const CONTEXT = {
+    appId: 'test-app-id',
+    logPrefix: 'TEST:',
+    appLabel: 'test app',
+    ErrorClass: TestError,
+};
+
+const OPTIONS = { browser: 'chrome', browserVersion: 'latest', headless: true };
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    fs.existsSync.mockReturnValue(false);
+});
+
+describe('buildBrowserArgs', () => {
+    test('includes the shared Chromium flags', async () => {
+        const args = await buildBrowserArgs();
+
+        expect(args).toEqual(expect.arrayContaining(['--no-sandbox', '--disable-gpu']));
+    });
+
+    test('adds --single-process outside Windows and Docker', async () => {
+        // The unit test hosts (macOS locally, Ubuntu in CI) are both non-Windows.
+        expect(await buildBrowserArgs()).toContain('--single-process');
+    });
+
+    test('omits --single-process in Docker, where it crashes Chromium', async () => {
+        fs.existsSync.mockImplementation((p) => p === '/.dockerenv');
+
+        expect(await buildBrowserArgs()).not.toContain('--single-process');
+    });
+});
+
+describe('resolveBrowserExecutablePath', () => {
+    test('uses a detected browser without installing', async () => {
+        detectAvailableBrowser.mockResolvedValue({
+            executablePath: '/cached/chrome',
+            source: 'cache',
+            browser: 'chrome',
+            buildId: '138.0.0.1',
+        });
+
+        expect(await resolveBrowserExecutablePath(OPTIONS)).toBe('/cached/chrome');
+        expect(browserInstall).not.toHaveBeenCalled();
+    });
+
+    test('installs when no browser is available', async () => {
+        detectAvailableBrowser.mockResolvedValue(null);
+        browserInstall.mockResolvedValue({ browser: 'chrome', buildId: '138.0.0.1' });
+
+        expect(await resolveBrowserExecutablePath(OPTIONS)).toBe('/downloaded/chrome');
+        expect(browserInstall).toHaveBeenCalledTimes(1);
+        expect(computeExecutablePath).toHaveBeenCalledWith(
+            expect.objectContaining({ browser: 'chrome', buildId: '138.0.0.1' })
+        );
+    });
+});
+
+describe('launchBrowserForApp', () => {
+    test('launches with the v25-compatible option shape', async () => {
+        detectAvailableBrowser.mockResolvedValue({
+            executablePath: '/cached/chrome',
+            source: 'cache',
+            browser: 'chrome',
+            buildId: '138.0.0.1',
+        });
+        const fakeBrowser = { id: 'browser' };
+        puppeteer.launch.mockResolvedValue(fakeBrowser);
+
+        const browser = await launchBrowserForApp(OPTIONS, CONTEXT);
+
+        expect(browser).toBe(fakeBrowser);
+        expect(puppeteer.launch).toHaveBeenCalledWith(
+            expect.objectContaining({
+                executablePath: '/cached/chrome',
+                headless: true,
+                ignoreHTTPSErrors: true,
+            })
+        );
+        expect(puppeteer.launch).not.toHaveBeenCalledWith(
+            expect.objectContaining({ acceptInsecureCerts: expect.anything() })
+        );
+    });
+
+    test('wraps an install failure in the caller-supplied error, with app context', async () => {
+        detectAvailableBrowser.mockResolvedValue(null);
+        const cause = new Error('network unreachable');
+        browserInstall.mockRejectedValue(cause);
+
+        await expect(launchBrowserForApp(OPTIONS, CONTEXT)).rejects.toThrow(TestError);
+        await expect(launchBrowserForApp(OPTIONS, CONTEXT)).rejects.toThrow(
+            'Failed to install a browser for test app test-app-id'
+        );
+        expect(puppeteer.launch).not.toHaveBeenCalled();
+    });
+
+    test('wraps a launch failure, preserving the original as cause', async () => {
+        detectAvailableBrowser.mockResolvedValue({
+            executablePath: '/cached/chrome',
+            source: 'cache',
+            browser: 'chrome',
+            buildId: '138.0.0.1',
+        });
+        const cause = new Error('no display');
+        puppeteer.launch.mockRejectedValue(cause);
+
+        const err = await launchBrowserForApp(OPTIONS, CONTEXT).catch((e) => e);
+
+        expect(err).toBeInstanceOf(TestError);
+        expect(err.message).toBe('Failed to launch virtual browser for test app test-app-id');
+        expect(err.cause).toBe(cause);
+        expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('TEST:'));
+    });
+
+    test('logs the thrown value itself when it is not an Error', async () => {
+        detectAvailableBrowser.mockResolvedValue({
+            executablePath: '/cached/chrome',
+            source: 'cache',
+            browser: 'chrome',
+            buildId: '138.0.0.1',
+        });
+        // A bare string has neither .stack nor .message; without a final fallback the log
+        // line would read "... : undefined" and lose the only diagnostic available.
+        puppeteer.launch.mockRejectedValue('no display available');
+
+        await launchBrowserForApp(OPTIONS, CONTEXT).catch(() => undefined);
+
+        expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('no display available'));
+    });
+});

--- a/src/lib/browser/__tests__/browser_launch.test.js
+++ b/src/lib/browser/__tests__/browser_launch.test.js
@@ -32,11 +32,11 @@ jest.unstable_mockModule('../browser-install.js', () => ({
 const { browserInstall } = await import('../browser-install.js');
 
 // Docker detection imports fs dynamically; existsSync drives which branch is taken.
-jest.unstable_mockModule('fs', () => ({
+jest.unstable_mockModule('node:fs', () => ({
     default: { existsSync: jest.fn() },
     existsSync: jest.fn().mockReturnValue(false),
 }));
-const fs = await import('fs');
+const fs = await import('node:fs');
 
 const { launchBrowserForApp, buildBrowserArgs, resolveBrowserExecutablePath } =
     await import('../browser-launch.js');

--- a/src/lib/browser/browser-launch.js
+++ b/src/lib/browser/browser-launch.js
@@ -1,0 +1,172 @@
+import puppeteer from 'puppeteer-core';
+import path from 'path';
+import { homedir } from 'os';
+import { computeExecutablePath } from '@puppeteer/browsers';
+
+import { logger } from '../../globals.js';
+import { detectAvailableBrowser } from './browser-detect.js';
+import { browserInstall } from './browser-install.js';
+import { parseHeadlessOption } from '../util/headless-option.js';
+
+/**
+ * Chromium flags used for every Butler Sheet Icons browser launch.
+ *
+ * Copied verbatim from the two process-app modules this was extracted from; the list was
+ * already identical in both.
+ */
+const BASE_BROWSER_ARGS = [
+    '--proxy-bypass-list=*',
+    '--disable-gpu',
+    '--disable-dev-shm-usage',
+    '--disable-setuid-sandbox',
+    '--no-first-run',
+    '--no-sandbox',
+    '--no-zygote',
+    '--ignore-certificate-errors',
+    '--ignore-certificate-errors-spki-list',
+    '--enable-features=NetworkService',
+];
+
+/**
+ * Detects whether the process is running inside a container.
+ *
+ * `--single-process` is needed on Windows to avoid crashes but causes crashes in Docker, so the
+ * two cases have to be told apart.
+ *
+ * @returns {Promise<boolean>} `true` when a container environment is detected.
+ */
+const detectDocker = async () => {
+    try {
+        const fs = await import('fs');
+        // Check for .dockerenv file (common Docker indicator)
+        if (fs.existsSync('/.dockerenv')) return true;
+        // Check if running as PID 1 with tini/node (Docker entrypoint pattern)
+        if (process.pid === 1) return true;
+        // Check for Alpine Linux
+        if (fs.existsSync('/etc/alpine-release')) return true;
+        return false;
+    } catch {
+        return false;
+    }
+};
+
+/**
+ * Builds the Chromium argument list for the current platform.
+ *
+ * @returns {Promise<string[]>} Browser arguments, including `--single-process` where safe.
+ */
+export const buildBrowserArgs = async () => {
+    const browserArgs = [...BASE_BROWSER_ARGS];
+
+    const isDocker = await detectDocker();
+
+    if (process.platform !== 'win32' && !isDocker) {
+        browserArgs.push('--single-process');
+        logger.debug('Added --single-process flag for non-Windows native environment');
+    } else if (isDocker) {
+        logger.debug('Skipping --single-process flag in Docker/containerized environment');
+    } else {
+        logger.debug('Skipping --single-process flag on Windows to keep Chromium stable');
+    }
+
+    return browserArgs;
+};
+
+/**
+ * Resolves a usable browser executable, downloading one only if neither a system nor a cached
+ * browser is available.
+ *
+ * @param {object} options - Options object, passed through to browser detection and install.
+ *
+ * @returns {Promise<string>} Path to the browser executable.
+ *
+ * @throws {Error} If no browser is available and the install fails. Callers are expected to wrap
+ * this in a platform-specific typed error carrying the app id.
+ */
+export const resolveBrowserExecutablePath = async (options) => {
+    const browserPath = path.join(homedir(), '.cache/puppeteer');
+    logger.debug(`Browser cache path: ${browserPath}`);
+
+    logger.info(`Checking for available browsers...`);
+    const browserInfo = await detectAvailableBrowser(options);
+
+    if (browserInfo) {
+        // Found system or cached browser
+        logger.info(
+            `Browser ready from ${browserInfo.source}: ${browserInfo.browser} ${browserInfo.buildId}`
+        );
+        return browserInfo.executablePath;
+    }
+
+    // No browser found - download required
+    logger.info(`No local browser found. Downloading and installing browser...`);
+
+    // browserInstall() signals failure by throwing - see its JSDoc. The throw propagates to the
+    // caller, which attaches the app context.
+    const browserInstallResult = await browserInstall(options);
+
+    const executablePath = computeExecutablePath({
+        browser: browserInstallResult.browser,
+        buildId: browserInstallResult.buildId,
+        cacheDir: browserPath,
+    });
+
+    logger.info(`Browser downloaded successfully`);
+
+    return executablePath;
+};
+
+/**
+ * Resolves a browser and launches it, ready for page work.
+ *
+ * Extracted from `process-cloud-app.js` and `qseow-process-app.js`, which carried this sequence
+ * as ~90 lines of duplicated code differing only in log prefix and error type (see issue #834).
+ *
+ * @param {object} options - Options object. `headless` is parsed here; the rest is passed through
+ * to browser detection and install.
+ * @param {object} context - Platform-specific labelling and error construction.
+ * @param {string} context.appId - App being processed, used in error messages.
+ * @param {string} context.logPrefix - Log line prefix, e.g. `QSEOW` or `CLOUD APP:`.
+ * @param {string} context.appLabel - Human-readable app description, e.g. `QSEoW app`.
+ * @param {Function} context.ErrorClass - Typed error to throw, e.g. `QseowError` or `CloudError`.
+ *
+ * @returns {Promise<object>} The launched Puppeteer browser instance.
+ *
+ * @throws {Error} An instance of `context.ErrorClass` if the browser cannot be installed or
+ * launched, with the original error attached as `cause`.
+ */
+export const launchBrowserForApp = async (options, { appId, logPrefix, appLabel, ErrorClass }) => {
+    let executablePath;
+    try {
+        executablePath = await resolveBrowserExecutablePath(options);
+    } catch (err) {
+        throw new ErrorClass(`Failed to install a browser for ${appLabel} ${appId}`, {
+            cause: err,
+        });
+    }
+
+    logger.info(`Browser setup complete. Launching browser...`);
+    logger.verbose(`Using browser at ${executablePath}`);
+
+    const headless = parseHeadlessOption(options.headless);
+    const browserArgs = await buildBrowserArgs();
+
+    try {
+        return await puppeteer.launch({
+            executablePath,
+            headless,
+            ignoreHTTPSErrors: true,
+            args: browserArgs,
+        });
+    } catch (err) {
+        // Falls back to the value itself so a non-Error throw still logs something useful
+        // rather than "undefined".
+        logger.error(
+            `${logPrefix} Could not launch virtual browser: ${err.stack ?? err.message ?? err}`
+        );
+
+        throw new ErrorClass(`Failed to launch virtual browser for ${appLabel} ${appId}`, {
+            cause: err,
+        });
+    }
+};

--- a/src/lib/browser/browser-launch.js
+++ b/src/lib/browser/browser-launch.js
@@ -1,6 +1,6 @@
 import puppeteer from 'puppeteer-core';
-import path from 'path';
-import { homedir } from 'os';
+import path from 'node:path';
+import { homedir } from 'node:os';
 import { computeExecutablePath } from '@puppeteer/browsers';
 
 import { logger } from '../../globals.js';
@@ -41,7 +41,7 @@ const BASE_BROWSER_ARGS = [
  */
 const detectDocker = async () => {
     try {
-        const fs = await import('fs');
+        const fs = await import('node:fs');
         // Check for .dockerenv file (common Docker indicator)
         if (fs.existsSync('/.dockerenv')) return true;
         // Check if running as PID 1 with tini/node (Docker entrypoint pattern)

--- a/src/lib/browser/browser-launch.js
+++ b/src/lib/browser/browser-launch.js
@@ -30,8 +30,12 @@ const BASE_BROWSER_ARGS = [
 /**
  * Detects whether the process is running inside a container.
  *
- * `--single-process` is needed on Windows to avoid crashes but causes crashes in Docker, so the
- * two cases have to be told apart.
+ * `--single-process` helps on native Linux and macOS but crashes Chromium both in containers and
+ * on Windows, so those two cases have to be told apart from a plain native run.
+ *
+ * The Windows half is not theoretical: it caused issue #742, "Updating thumbnails in QS Cloud
+ * fails on Windows, works on macOS", and was fixed in 482559c by skipping the flag there. Do not
+ * reintroduce it for Windows.
  *
  * @returns {Promise<boolean>} `true` when a container environment is detected.
  */

--- a/src/lib/cloud/process-cloud-app.js
+++ b/src/lib/cloud/process-cloud-app.js
@@ -1,19 +1,13 @@
 import enigma from 'enigma.js';
-import puppeteer from 'puppeteer-core';
 import fs from 'fs';
-import path from 'path';
-import { homedir } from 'os';
-import { computeExecutablePath } from '@puppeteer/browsers';
 import { setupEnigmaConnection } from './cloud-enigma.js';
 import { logger, sleep } from '../../globals.js';
 import { qscloudUploadToApp } from './cloud-upload.js';
 import { qscloudUpdateSheetThumbnails } from './cloud-updatesheets.js';
-import { browserInstall } from '../browser/browser-install.js';
-import { detectAvailableBrowser } from '../browser/browser-detect.js';
 import { deleteCloudAppThumbnail } from './cloud-delete-thumbnails.js';
 import { takeSheetScreenshot } from './sheet-screenshot.js';
-import { parseHeadlessOption } from '../util/headless-option.js';
 import { CloudError } from '../util/errors.js';
+import { launchBrowserForApp } from '../browser/browser-launch.js';
 
 // Selector paths to elements on login page
 const selectorLoginPageUserName = '[id="\u0031-email"]';
@@ -149,115 +143,13 @@ export const processCloudApp = async (appId, saasInstance, options) => {
             logger.info(`Number of sheets in app: ${sheetListObj.qAppObjectList.qItems.length}`);
             let iSheetNum = 1;
 
-            // Get browser cache path
-            const browserPath = path.join(homedir(), '.cache/puppeteer');
-            logger.debug(`Browser cache path: ${browserPath}`);
+            const browser = await launchBrowserForApp(options, {
+                appId,
+                logPrefix: 'CLOUD APP:',
+                appLabel: 'Qlik Sense Cloud app',
+                ErrorClass: CloudError,
+            });
 
-            // Detect available browser (system, cached, or download)
-            logger.info(`Checking for available browsers...`);
-            let executablePath;
-            let browserInfo = await detectAvailableBrowser(options);
-
-            if (browserInfo) {
-                // Found system or cached browser
-                executablePath = browserInfo.executablePath;
-                logger.info(
-                    `Browser ready from ${browserInfo.source}: ${browserInfo.browser} ${browserInfo.buildId}`
-                );
-            } else {
-                // No browser found - download required
-                logger.info(`No local browser found. Downloading and installing browser...`);
-
-                let browserInstallResult;
-                try {
-                    browserInstallResult = await browserInstall(options);
-                } catch (err) {
-                    // browserInstall() signals failure by throwing - see its JSDoc.
-                    throw new CloudError(
-                        `Failed to install a browser for Qlik Sense Cloud app ${appId}`,
-                        { cause: err }
-                    );
-                }
-
-                executablePath = computeExecutablePath({
-                    browser: browserInstallResult.browser,
-                    buildId: browserInstallResult.buildId,
-                    cacheDir: browserPath,
-                });
-
-                logger.info(`Browser downloaded successfully`);
-            }
-
-            logger.info(`Browser setup complete. Launching browser...`);
-            logger.verbose(`Using browser at ${executablePath}`);
-
-            // Parse --headless option
-            const headless = parseHeadlessOption(options.headless);
-            // Make sure browser is launched ok
-            const browserArgs = [
-                '--proxy-bypass-list=*',
-                '--disable-gpu',
-                '--disable-dev-shm-usage',
-                '--disable-setuid-sandbox',
-                '--no-first-run',
-                '--no-sandbox',
-                '--no-zygote',
-                '--ignore-certificate-errors',
-                '--ignore-certificate-errors-spki-list',
-                '--enable-features=NetworkService',
-            ];
-
-            // Detect if running in Docker/Alpine (where --single-process crashes Chromium)
-            const isDocker = await (async () => {
-                try {
-                    const fs = await import('fs');
-                    // Check for .dockerenv file (common Docker indicator)
-                    if (fs.existsSync('/.dockerenv')) return true;
-                    // Check if running as PID 1 with tini/node (Docker entrypoint pattern)
-                    if (process.pid === 1) return true;
-                    // Check for Alpine Linux
-                    if (fs.existsSync('/etc/alpine-release')) return true;
-                    return false;
-                } catch {
-                    return false;
-                }
-            })();
-
-            // --single-process is needed on Windows to avoid crashes, but causes crashes in Docker
-            if (process.platform !== 'win32' && !isDocker) {
-                browserArgs.push('--single-process');
-                logger.debug('Added --single-process flag for non-Windows native environment');
-            } else if (isDocker) {
-                logger.debug('Skipping --single-process flag in Docker/containerized environment');
-            } else {
-                logger.debug('Skipping --single-process flag on Windows to keep Chromium stable');
-            }
-
-            let browser;
-            try {
-                browser = await puppeteer.launch({
-                    executablePath,
-                    headless,
-                    ignoreHTTPSErrors: true,
-                    args: browserArgs,
-                });
-            } catch (err) {
-                if (err.stack) {
-                    logger.error(
-                        `CLOUD APP: Could not launch virtual browser (stack): ${err.stack}`
-                    );
-                } else if (err.message) {
-                    logger.error(
-                        `CLOUD APP: Could not launch virtual browser (message): ${err.message}`
-                    );
-                } else {
-                    logger.error(`CLOUD APP: Could not launch virtual browser: ${err}. Exiting.`);
-                }
-                throw new CloudError(
-                    `Failed to launch virtual browser for Qlik Sense Cloud app ${appId}`,
-                    { cause: err }
-                );
-            }
             const page = await browser.newPage();
             // Thumbnails should be 410x270 pixels, so set the viewport to a multiple of this.
             await page.setViewport({

--- a/src/lib/qseow/qseow-process-app.js
+++ b/src/lib/qseow/qseow-process-app.js
@@ -1,10 +1,6 @@
 import enigma from 'enigma.js';
-import puppeteer from 'puppeteer-core';
 import fs from 'fs';
 import qrsInteract from 'qrs-interact';
-import path from 'path';
-import { homedir } from 'os';
-import { computeExecutablePath } from '@puppeteer/browsers';
 import { Jimp } from 'jimp';
 
 import { setupEnigmaConnection } from './qseow-enigma.js';
@@ -12,11 +8,9 @@ import { logger, sleep } from '../../globals.js';
 import { qseowUploadToContentLibrary } from './qseow-upload.js';
 import { qseowUpdateSheetThumbnails } from './qseow-updatesheets.js';
 import { setupQseowQrsConnection } from './qseow-qrs.js';
-import { browserInstall } from '../browser/browser-install.js';
-import { detectAvailableBrowser } from '../browser/browser-detect.js';
 import { determineSheetExcludeStatus } from './determine-sheet-exclude-status.js';
-import { parseHeadlessOption } from '../util/headless-option.js';
 import { QseowError } from '../util/errors.js';
+import { launchBrowserForApp } from '../browser/browser-launch.js';
 
 const selectorLoginPageUserName = '#username-input';
 const selectorLoginPageUserPwd = '#password-input';
@@ -257,113 +251,12 @@ export const qseowProcessApp = async (appId, options) => {
 
             let iSheetNum = 1;
 
-            // Get browser cache path
-            const browserPath = path.join(homedir(), '.cache/puppeteer');
-            logger.debug(`Browser cache path: ${browserPath}`);
-
-            // Detect available browser (system, cached, or download)
-            logger.info(`Checking for available browsers...`);
-            let executablePath;
-            let browserInfo = await detectAvailableBrowser(options);
-
-            if (browserInfo) {
-                // Found system or cached browser
-                executablePath = browserInfo.executablePath;
-                logger.info(
-                    `Browser ready from ${browserInfo.source}: ${browserInfo.browser} ${browserInfo.buildId}`
-                );
-            } else {
-                // No browser found - download required
-                logger.info(`No local browser found. Downloading and installing browser...`);
-
-                let browserInstallResult;
-                try {
-                    browserInstallResult = await browserInstall(options);
-                } catch (err) {
-                    // browserInstall() signals failure by throwing - see its JSDoc.
-                    throw new QseowError(`Failed to install a browser for QSEoW app ${appId}`, {
-                        cause: err,
-                    });
-                }
-
-                executablePath = computeExecutablePath({
-                    browser: browserInstallResult.browser,
-                    buildId: browserInstallResult.buildId,
-                    cacheDir: browserPath,
-                });
-
-                logger.info(`Browser downloaded successfully`);
-            }
-
-            logger.info(`Browser setup complete. Launching browser...`);
-            logger.verbose(`Using browser at ${executablePath}`);
-
-            // Parse --headless option
-            const headless = parseHeadlessOption(options.headless);
-
-            const browserArgs = [
-                '--proxy-bypass-list=*',
-                '--disable-gpu',
-                '--disable-dev-shm-usage',
-                '--disable-setuid-sandbox',
-                '--no-first-run',
-                '--no-sandbox',
-                '--no-zygote',
-                '--ignore-certificate-errors',
-                '--ignore-certificate-errors-spki-list',
-                '--enable-features=NetworkService',
-            ];
-
-            // Detect if running in Docker/Alpine (where --single-process crashes Chromium)
-            const isDocker = await (async () => {
-                try {
-                    const fs = await import('fs');
-                    // Check for .dockerenv file (common Docker indicator)
-                    if (fs.existsSync('/.dockerenv')) return true;
-                    // Check if running as PID 1 with tini/node (Docker entrypoint pattern)
-                    if (process.pid === 1) return true;
-                    // Check for Alpine Linux
-                    if (fs.existsSync('/etc/alpine-release')) return true;
-                    return false;
-                } catch {
-                    return false;
-                }
-            })();
-
-            // --single-process is needed on Windows to avoid crashes, but causes crashes in Docker
-            if (process.platform !== 'win32' && !isDocker) {
-                browserArgs.push('--single-process');
-                logger.debug('Added --single-process flag for non-Windows native environment');
-            } else if (isDocker) {
-                logger.debug('Skipping --single-process flag in Docker/containerized environment');
-            } else {
-                logger.debug('Skipping --single-process flag on Windows to keep Chromium stable');
-            }
-
-            // Make sure browser is launched ok
-            let browser;
-            try {
-                browser = await puppeteer.launch({
-                    executablePath,
-                    headless,
-                    ignoreHTTPSErrors: true,
-                    args: browserArgs,
-                });
-            } catch (err) {
-                if (err.stack) {
-                    logger.error(`QSEOW Could not launch virtual browser (stack): ${err.stack}`);
-                } else if (err.message) {
-                    logger.error(
-                        `QSEOW Could not launch virtual browser (message): ${err.message}`
-                    );
-                } else {
-                    logger.error(`QSEOW Could not launch virtual browser: ${err}. Exiting.`);
-                }
-
-                throw new QseowError(`Failed to launch virtual browser for QSEoW app ${appId}`, {
-                    cause: err,
-                });
-            }
+            const browser = await launchBrowserForApp(options, {
+                appId,
+                logPrefix: 'QSEOW',
+                appLabel: 'QSEoW app',
+                ErrorClass: QseowError,
+            });
 
             const page = await browser.newPage();
 


### PR DESCRIPTION
Closes #834.

## The problem

`process-cloud-app.js` and `qseow-process-app.js` were copy-paste twins across most of their browser setup. Sonar measured three duplicated blocks between them — 15, 54 and 67 lines — and rated the files **25.8%** and **20.0%** duplicated overall.

The practical cost is that a fix has to be applied twice, by hand, with nothing enforcing that the halves stay in step. The 2025-May logout XPath corrected in #775 was exactly that kind of drift. It also meant any change touching both halves failed the `new_duplicated_lines_density` gate — #833 and #835 both did.

## What was extracted

New module `src/lib/browser/browser-launch.js`:

| Export | What it covers |
|---|---|
| `buildBrowserArgs()` | Chromium flags plus the Docker and Windows handling for `--single-process`. This part was **character-identical** in both files. |
| `resolveBrowserExecutablePath()` | Detect a system or cached browser; install one only if neither is available; compute the executable path. |
| `launchBrowserForApp()` | The whole sequence through to a launched browser. |

`launchBrowserForApp` is parameterised by `{ appId, logPrefix, appLabel, ErrorClass }` — the only respect in which the two platforms actually differed.

Each caller's ~107-line block collapses to a six-line call, and seven now-unreferenced imports come out of each file. **Net 229 lines removed, 14 added.**

Confirmed there is no third launch site: `grep` for `puppeteer.launch`, `proxy-bypass-list` and `single-process` across `src/` finds nothing outside the new module and its tests. The duplication is gone, not relocated.

## What was deliberately left

**Block 1, the ~14-line enigma session setup.** It produces five values (`configEnigma`, `session`, `global`, `engineVersion`, `imgDir`), so extracting it means a clumsy multi-value interface for the smallest of the three payoffs. Worth a follow-up, not this change.

## Behaviour

Error messages are preserved **byte for byte** — same text, same typed error, same `cause`.

One deliberate difference: the launch-failure log collapses the three-branch `err.stack` / `else if (err.message)` / `else` idiom to a single line, since a real `Error` always has both and two arms were unreachable. The final fallback is kept as `?? err` so a non-Error throw still logs its value rather than `undefined` — with a regression test for exactly that.

The second commit corrects a comment that stated the **inverse** of the `--single-process` rule: the JSDoc claimed the flag "is needed on Windows", while the code skips it there. Git history settles it — the Windows skip came from 482559c fixing #742, *"Updating thumbnails in QS Cloud fails on Windows, works on macOS"*. The wording was already wrong on `main`; this PR moved it into a shared module and promoted it to JSDoc, so it is corrected here with the issue and commit cited.

## Tests

9 new tests for the module (**97.6% coverage**): both Docker branches, cache-hit versus install, and the install and launch failure paths including `cause` preservation and the non-Error throw.

The **pre-existing process-app tests pass unchanged** — including those asserting the puppeteer v25 launch option shape (`headless: true`, `ignoreHTTPSErrors: true`, no `acceptInsecureCerts`), which now exercise the extracted module. That is the main evidence the extraction is faithful.

`npm run test:unit`: **211 passed across 21 suites.** Lint and prettier clean.

## Expected gate results

- **`new_duplicated_lines_density` should improve markedly** — that is the point of the change, and the reason this needs a PR analysis to confirm.
- **`new_coverage` will probably still fail.** The diff touches callers sitting at 64% and 77% coverage. That is #821, which this change cannot fix.

## Verification limit, stated plainly

Everything above is unit-level, with Puppeteer and Enigma mocked. **Nothing here has been exercised against a live Qlik Sense environment**, and browser launch is precisely the kind of code where mocks can agree while reality does not. The integration suites in `ci.yaml` cover this path but need real credentials and a running Sense server. Worth a live run before this reaches a release.
