### PR TITLE
chore: enable ESLint correctness rules, and fix the crash they found

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,9 +1,14 @@
+import js from '@eslint/js';
 import prettier from 'eslint-plugin-prettier';
 import prettierConfig from 'eslint-config-prettier/flat';
 import globals from 'globals';
 import jsdoc from 'eslint-plugin-jsdoc';
 
 export default [
+    // Correctness rules - no-undef, no-unused-vars and friends. Without these the lint step
+    // checks formatting and JSDoc only, so an undefined variable or a stale import passes
+    // silently; enabling them caught a real crash on `--blur-sheet-tag` (issue #840).
+    js.configs.recommended,
     prettierConfig,
     {
         ignores: ['src/lib/util/import-meta-url.js'],
@@ -32,6 +37,16 @@ export default [
 
         rules: {
             'prettier/prettier': 'error',
+            // Underscore marks a binding that is deliberately unused - typically a Commander
+            // `_command` argument kept for symmetry with the other command handlers.
+            'no-unused-vars': [
+                'error',
+                {
+                    argsIgnorePattern: '^_',
+                    varsIgnorePattern: '^_',
+                    caughtErrorsIgnorePattern: '^_',
+                },
+            ],
             // JSDoc rules
             'jsdoc/tag-lines': ['error', 'any', { startLines: 1 }],
             'jsdoc/require-jsdoc': [

--- a/src/__tests__/butler-sheet-icons.test.js
+++ b/src/__tests__/butler-sheet-icons.test.js
@@ -1,8 +1,8 @@
 // filepath: /Users/goran/code/butler-sheet-icons/src/__tests__/butler-sheet-icons.test.js
-import { test, expect, describe, jest, beforeEach, afterEach } from '@jest/globals';
+import { test, expect, describe, jest, beforeEach } from '@jest/globals';
 import 'dotenv/config';
-import { Command } from 'commander';
-import { logger } from '../globals.js';
+import {} from 'commander';
+import {} from '../globals.js';
 import childProcess from 'child_process';
 import path from 'path';
 import { fileURLToPath } from 'url';

--- a/src/globals.js
+++ b/src/globals.js
@@ -16,7 +16,7 @@ const LEVEL = Symbol.for('level');
 let sea;
 try {
     sea = require('node:sea');
-} catch (error) {
+} catch {
     sea = {
         /**
          * Shim for `node:sea`'s `isSea()`. Always returns `false` because `node:sea`
@@ -236,7 +236,7 @@ const chromiumRevisionMac = '1097624';
  */
 const getChromiumRevision = () => {
     const { platform } = process;
-    let revision = '';
+    let revision;
 
     if (platform === 'linux') {
         revision = chromiumRevisionLinux;

--- a/src/lib/browser/__tests__/browser_complex_scenarios.integration.test.js
+++ b/src/lib/browser/__tests__/browser_complex_scenarios.integration.test.js
@@ -1,4 +1,4 @@
-import { test, expect, describe } from '@jest/globals';
+import { test, expect, describe, beforeAll } from '@jest/globals';
 import 'dotenv/config';
 
 import { browserInstalled } from '../browser-installed.js';

--- a/src/lib/browser/__tests__/browser_install_uninstall.integration.test.js
+++ b/src/lib/browser/__tests__/browser_install_uninstall.integration.test.js
@@ -1,4 +1,4 @@
-import { test, expect, describe } from '@jest/globals';
+import { test, expect, describe, beforeAll } from '@jest/globals';
 import 'dotenv/config';
 
 import { browserInstalled } from '../browser-installed.js';

--- a/src/lib/browser/__tests__/browser_uninstall.integration.test.js
+++ b/src/lib/browser/__tests__/browser_uninstall.integration.test.js
@@ -1,4 +1,4 @@
-import { jest, test, expect, describe } from '@jest/globals';
+import { jest, test, expect, describe, beforeEach } from '@jest/globals';
 import fs from 'fs-extra';
 import 'dotenv/config';
 
@@ -20,7 +20,7 @@ jest.unstable_mockModule('../../../globals', () => ({
     bsiExecutablePath: '/test/path',
     isSea: false,
 }));
-const { logger, setLoggingLevel, bsiExecutablePath, isSea } = await import('../../../globals.js');
+const { logger, setLoggingLevel } = await import('../../../globals.js');
 
 // Import functions under test after mocks are set up
 const { browserUninstall, browserUninstallAll } = await import('../browser-uninstall.js');
@@ -229,7 +229,7 @@ describe('browserUninstallAll function', () => {
 
         // Mock the implementation of the browserUninstallAll function to catch errors
         // by spying on the logger.error method
-        const errorSpy = jest.spyOn(logger, 'error');
+        jest.spyOn(logger, 'error');
 
         // Mock successful emptyDir
         fs.emptyDir.mockResolvedValue(undefined);

--- a/src/lib/cloud/__tests__/process_cloud_app.test.js
+++ b/src/lib/cloud/__tests__/process_cloud_app.test.js
@@ -86,19 +86,10 @@ const mockSheetScreenshot = jest.unstable_mockModule('../sheet-screenshot.js', (
 
 let processCloudApp;
 let puppeteer;
-let computeExecutablePath;
-let fs;
-let Jimp;
 let enigma;
 let logger;
-let sleep;
-let setupEnigmaConnection;
-let qscloudUploadToApp;
-let qscloudUpdateSheetThumbnails;
 let browserInstall;
 let detectAvailableBrowser;
-let deleteCloudAppThumbnail;
-let takeSheetScreenshot;
 
 beforeAll(async () => {
     await Promise.all([
@@ -118,18 +109,10 @@ beforeAll(async () => {
     ]);
 
     puppeteer = (await import('puppeteer-core')).default;
-    ({ computeExecutablePath } = await import('@puppeteer/browsers'));
-    fs = (await import('fs')).default;
-    ({ Jimp } = await import('jimp'));
     enigma = (await import('enigma.js')).default;
-    ({ logger, sleep } = await import('../../../globals.js'));
-    ({ setupEnigmaConnection } = await import('../cloud-enigma.js'));
-    ({ qscloudUploadToApp } = await import('../cloud-upload.js'));
-    ({ qscloudUpdateSheetThumbnails } = await import('../cloud-updatesheets.js'));
+    ({ logger } = await import('../../../globals.js'));
     ({ browserInstall } = await import('../../browser/browser-install.js'));
     ({ detectAvailableBrowser } = await import('../../browser/browser-detect.js'));
-    ({ deleteCloudAppThumbnail } = await import('../cloud-delete-thumbnails.js'));
-    ({ takeSheetScreenshot } = await import('../sheet-screenshot.js'));
     ({ processCloudApp } = await import('../process-cloud-app.js'));
 });
 

--- a/src/lib/cloud/cloud-collections.js
+++ b/src/lib/cloud/cloud-collections.js
@@ -187,6 +187,6 @@ export const qscloudVerifyCollectionExists = async (options) => {
             logger.error(`CLOUD COLLECTION EXISTS 1: ${err}`);
         }
 
-        throw new Error(`COLLECTION EXISTS 1: ${err}`);
+        throw new Error(`COLLECTION EXISTS 1: ${err}`, { cause: err });
     }
 };

--- a/src/lib/cloud/cloud-delete-thumbnails.js
+++ b/src/lib/cloud/cloud-delete-thumbnails.js
@@ -27,6 +27,6 @@ export async function deleteCloudAppThumbnail(thumbnailImg, appId, saasInstance,
         } else {
             logger.error(`CREATE THUMBNAILS 3: Error deleting existing thumbnail: ${err}`);
         }
-        throw Error('Error deleting existing thumbnail');
+        throw new Error('Error deleting existing thumbnail', { cause: err });
     }
 }

--- a/src/lib/cloud/cloud-enigma.js
+++ b/src/lib/cloud/cloud-enigma.js
@@ -12,11 +12,11 @@ import { getEnigmaSchema } from '../util/enigma-util.js';
  * @param {string} options.schemaversion - The version of the Enigma schema to use.
  * @param {string} options.tenanturl - The URL of the Qlik Sense SaaS tenant.
  * @param {string} options.apikey - The API key to use for authentication.
- * @param {object} command - Command options, used for logging.
+ * @param {object} _command - Command options, used for logging. Unused; kept for symmetry with the other handlers.
  *
  * @returns {object} An object with `schema`, `url`, and `createSocket(url)` to be used when creating an Enigma session.
  */
-export const setupEnigmaConnection = (appId, options, command) => {
+export const setupEnigmaConnection = (appId, options, _command) => {
     logger.debug(`Prepping for cloud Enigma connection for app ${appId}`);
 
     // Set up enigma.js configuration

--- a/src/lib/cloud/process-cloud-app.js
+++ b/src/lib/cloud/process-cloud-app.js
@@ -42,7 +42,7 @@ export const processCloudApp = async (appId, saasInstance, options) => {
         } else {
             logger.error(`CREATE THUMBNAILS 1: Error creating cloud image directory: ${err}`);
         }
-        throw Error('Error creating cloud image directory');
+        throw new Error('Error creating cloud image directory', { cause: err });
     }
     try {
         // Does the app have a thumbnail folder in its media library?
@@ -74,7 +74,7 @@ export const processCloudApp = async (appId, saasInstance, options) => {
                 } else {
                     logger.error(`CREATE THUMBNAILS 2: Error getting existing thumbnails: ${err}`);
                 }
-                throw Error('Error getting existing thumbnails');
+                throw new Error('Error getting existing thumbnails', { cause: err });
             }
 
             for (const thumbnailImg of existingThumbnails) {

--- a/src/lib/commands/__tests__/commands.test.js
+++ b/src/lib/commands/__tests__/commands.test.js
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, jest } from '@jest/globals';
+import { describe, test, expect, beforeEach, jest, beforeAll } from '@jest/globals';
 import { InvalidArgumentError } from 'commander';
 
 const loggerMock = {

--- a/src/lib/qseow/__tests__/qseowCreateThumbnails_fail_missing_content_library.integration.test.js
+++ b/src/lib/qseow/__tests__/qseowCreateThumbnails_fail_missing_content_library.integration.test.js
@@ -1,4 +1,4 @@
-import { test, expect, describe } from '@jest/globals';
+import { test, expect } from '@jest/globals';
 import 'dotenv/config';
 
 import { qseowCreateThumbnails } from '../qseow-create-thumbnails.js';

--- a/src/lib/qseow/__tests__/qseowCreateThumbnails_success.integration.test.js
+++ b/src/lib/qseow/__tests__/qseowCreateThumbnails_success.integration.test.js
@@ -1,4 +1,4 @@
-import { test, expect, describe } from '@jest/globals';
+import { test, expect } from '@jest/globals';
 import 'dotenv/config';
 
 import { qseowCreateThumbnails } from '../qseow-create-thumbnails.js';

--- a/src/lib/qseow/__tests__/qseow_process_app.test.js
+++ b/src/lib/qseow/__tests__/qseow_process_app.test.js
@@ -93,20 +93,11 @@ const mockDetermineSheetExcludeStatus = jest.unstable_mockModule(
 
 let qseowProcessApp;
 let puppeteer;
-let computeExecutablePath;
-let fs;
-let Jimp;
 let enigma;
 let qrsInteract;
 let logger;
-let sleep;
-let setupEnigmaConnection;
-let qseowUploadToContentLibrary;
-let qseowUpdateSheetThumbnails;
-let setupQseowQrsConnection;
 let browserInstall;
 let detectAvailableBrowser;
-let determineSheetExcludeStatus;
 
 beforeAll(async () => {
     await Promise.all([
@@ -127,19 +118,11 @@ beforeAll(async () => {
     ]);
 
     puppeteer = (await import('puppeteer-core')).default;
-    ({ computeExecutablePath } = await import('@puppeteer/browsers'));
-    fs = (await import('fs')).default;
-    ({ Jimp } = await import('jimp'));
     enigma = (await import('enigma.js')).default;
     qrsInteract = (await import('qrs-interact')).default;
-    ({ logger, sleep } = await import('../../../globals.js'));
-    ({ setupEnigmaConnection } = await import('../qseow-enigma.js'));
-    ({ qseowUploadToContentLibrary } = await import('../qseow-upload.js'));
-    ({ qseowUpdateSheetThumbnails } = await import('../qseow-updatesheets.js'));
-    ({ setupQseowQrsConnection } = await import('../qseow-qrs.js'));
+    ({ logger } = await import('../../../globals.js'));
     ({ browserInstall } = await import('../../browser/browser-install.js'));
     ({ detectAvailableBrowser } = await import('../../browser/browser-detect.js'));
-    ({ determineSheetExcludeStatus } = await import('../determine-sheet-exclude-status.js'));
     ({ qseowProcessApp } = await import('../qseow-process-app.js'));
 });
 

--- a/src/lib/qseow/__tests__/qseow_updatesheets.test.js
+++ b/src/lib/qseow/__tests__/qseow_updatesheets.test.js
@@ -1,0 +1,184 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+jest.unstable_mockModule('enigma.js', () => ({
+    default: { create: jest.fn() },
+}));
+const enigma = (await import('enigma.js')).default;
+
+jest.unstable_mockModule('../qseow-enigma.js', () => ({
+    setupEnigmaConnection: jest.fn().mockReturnValue({ url: 'wss://test' }),
+}));
+
+jest.unstable_mockModule('../../../globals.js', () => ({
+    logger: {
+        info: jest.fn(),
+        verbose: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+    },
+}));
+const { logger } = await import('../../../globals.js');
+
+const { qseowUpdateSheetThumbnails } = await import('../qseow-updatesheets.js');
+
+const BLUR_TAG_WARNING = '--blur-sheet-tag is not yet implemented';
+
+/**
+ * Wires the enigma mock chain so the function walks its full sheet-update path over a single
+ * sheet, and returns the sheet object so tests can inspect the thumbnail URL that was set.
+ *
+ * @param {string} sheetId - Engine object id to give the single sheet.
+ *
+ * @returns {object} The mock sheet object, exposing `setProperties` and the props it received.
+ */
+function wireEnigmaWithOneSheet(sheetId = 'engine-sheet-1') {
+    const sheetProperties = {
+        thumbnail: { qStaticContentUrlDef: { qUrl: '' } },
+    };
+    const sheetObj = {
+        getProperties: jest.fn().mockResolvedValue(sheetProperties),
+        setProperties: jest.fn().mockResolvedValue({ ok: true }),
+        _props: sheetProperties,
+    };
+
+    const app = {
+        createSessionObject: jest.fn().mockResolvedValue({
+            getLayout: jest.fn().mockResolvedValue({
+                qAppObjectList: {
+                    qItems: [
+                        {
+                            qInfo: { qId: sheetId },
+                            qMeta: { title: 'Sheet 1', description: 'first' },
+                            qData: { rank: 1 },
+                        },
+                    ],
+                },
+            }),
+        }),
+        getObject: jest.fn().mockResolvedValue(sheetObj),
+        doSave: jest.fn().mockResolvedValue(true),
+    };
+
+    const globalObj = {
+        engineVersion: jest.fn().mockResolvedValue({ qComponentVersion: '12.0.0' }),
+        openDoc: jest.fn().mockResolvedValue(app),
+    };
+
+    enigma.create.mockResolvedValue({
+        open: jest.fn().mockResolvedValue(globalObj),
+        close: jest.fn().mockResolvedValue(true),
+        on: jest.fn(),
+    });
+
+    return sheetObj;
+}
+
+const CREATED_FILES = [{ sheetPos: 1, fileNameShort: 'thumbnail-1.png' }];
+
+const BASE_OPTIONS = {
+    host: 'test-server.example.com',
+    contentlibrary: 'test-library',
+    loglevel: 'info',
+};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('qseowUpdateSheetThumbnails — --blur-sheet-tag handling (issue #840)', () => {
+    test('does not throw when blurSheetTag is set and no tag metadata is supplied', async () => {
+        // Before the fix this threw `ReferenceError: tagSheetAppMetadata is not defined`,
+        // because the identifier did not exist in the function at all.
+        wireEnigmaWithOneSheet();
+
+        await expect(
+            qseowUpdateSheetThumbnails(CREATED_FILES, 'test-app-id', {
+                ...BASE_OPTIONS,
+                blurSheetTag: 'some-tag',
+            })
+        ).resolves.toBeUndefined();
+    });
+
+    test('warns that the option is ignored rather than silently dropping it', async () => {
+        wireEnigmaWithOneSheet();
+
+        await qseowUpdateSheetThumbnails(CREATED_FILES, 'test-app-id', {
+            ...BASE_OPTIONS,
+            blurSheetTag: 'some-tag',
+        });
+
+        const warned = logger.warn.mock.calls.map((call) => String(call[0])).join('\n');
+        expect(warned).toContain(BLUR_TAG_WARNING);
+    });
+
+    test('warns once per call, not once per sheet', async () => {
+        wireEnigmaWithOneSheet();
+
+        await qseowUpdateSheetThumbnails(CREATED_FILES, 'test-app-id', {
+            ...BASE_OPTIONS,
+            blurSheetTag: 'some-tag',
+        });
+
+        const blurTagWarnings = logger.warn.mock.calls.filter((call) =>
+            String(call[0]).includes(BLUR_TAG_WARNING)
+        );
+        expect(blurTagWarnings).toHaveLength(1);
+    });
+
+    test('stays silent when blurSheetTag is not set', async () => {
+        wireEnigmaWithOneSheet();
+
+        await qseowUpdateSheetThumbnails(CREATED_FILES, 'test-app-id', { ...BASE_OPTIONS });
+
+        const warned = logger.warn.mock.calls.map((call) => String(call[0])).join('\n');
+        expect(warned).not.toContain(BLUR_TAG_WARNING);
+    });
+
+    test('leaves the sheet unblurred when the tag rule matches nothing', async () => {
+        const sheetObj = wireEnigmaWithOneSheet();
+
+        await qseowUpdateSheetThumbnails(CREATED_FILES, 'test-app-id', {
+            ...BASE_OPTIONS,
+            blurSheetTag: 'some-tag',
+        });
+
+        expect(sheetObj.setProperties).toHaveBeenCalledTimes(1);
+        expect(sheetObj._props.thumbnail.qStaticContentUrlDef.qUrl).toBe(
+            '/content/test-library/thumbnail-test-app-id-1.png'
+        );
+    });
+
+    test('blurs the sheet when supplied metadata matches its engine object id, and does not warn', async () => {
+        // The parameter exists so a caller that has looked the tag up can drive the rule.
+        // Nothing does that yet (#840), but the plumbing has to work for the fix to be real.
+        const sheetObj = wireEnigmaWithOneSheet('engine-sheet-1');
+
+        await qseowUpdateSheetThumbnails(
+            CREATED_FILES,
+            'test-app-id',
+            { ...BASE_OPTIONS, blurSheetTag: 'some-tag' },
+            [{ engineObjectId: 'engine-sheet-1' }]
+        );
+
+        expect(sheetObj._props.thumbnail.qStaticContentUrlDef.qUrl).toBe(
+            '/content/test-library/thumbnail-test-app-id-1-blurred.png'
+        );
+
+        const warned = logger.warn.mock.calls.map((call) => String(call[0])).join('\n');
+        expect(warned).not.toContain(BLUR_TAG_WARNING);
+    });
+
+    test('only logs the "via tags" line when the sheet is actually blurred', async () => {
+        // The log used to fire unconditionally, claiming a blur that had not happened.
+        wireEnigmaWithOneSheet();
+
+        await qseowUpdateSheetThumbnails(CREATED_FILES, 'test-app-id', {
+            ...BASE_OPTIONS,
+            blurSheetTag: 'some-tag',
+        });
+
+        const verbose = logger.verbose.mock.calls.map((call) => String(call[0])).join('\n');
+        expect(verbose).not.toContain('via tags');
+    });
+});

--- a/src/lib/qseow/qseow-contentlibrary.js
+++ b/src/lib/qseow/qseow-contentlibrary.js
@@ -47,6 +47,6 @@ export const qseowVerifyContentLibraryExists = async (options) => {
             logger.error(`QSEOW CONTENT LIBRARY 1: ${err}`);
         }
 
-        throw new Error(`CONTENT LIBRARY 1: ${err}`);
+        throw new Error(`CONTENT LIBRARY 1: ${err}`, { cause: err });
     }
 };

--- a/src/lib/qseow/qseow-create-thumbnails.js
+++ b/src/lib/qseow/qseow-create-thumbnails.js
@@ -1,6 +1,6 @@
 import qrsInteract from 'qrs-interact';
 
-import { logger, setLoggingLevel, bsiExecutablePath, isSea, sleep } from '../../globals.js';
+import { logger, setLoggingLevel, bsiExecutablePath, isSea } from '../../globals.js';
 import { redactOptions } from '../util/redact-secrets.js';
 import { qseowVerifyContentLibraryExists } from './qseow-contentlibrary.js';
 import { qseowVerifyCertificatesExist } from './qseow-certificates.js';

--- a/src/lib/qseow/qseow-enigma.js
+++ b/src/lib/qseow/qseow-enigma.js
@@ -30,11 +30,11 @@ const readCert = (filename) => fs.readFileSync(filename);
  * @param {string} options.certkeyfile - Path to the certificate key file to use for authentication.
  * @param {boolean|string} [options.rejectUnauthorized] - Whether to reject unauthorized certificates. Defaults to `false`.
  * @param {string} options.schemaversion - The version of the Enigma schema to use.
- * @param {object} command - Command options, used for logging.
+ * @param {object} _command - Command options, used for logging. Unused; kept for symmetry with the other handlers.
  *
  * @returns {object} An object with `schema`, `url`, and `createSocket(url)` to be used when creating an Enigma session.
  */
-export const setupEnigmaConnection = (appId, options, command) => {
+export const setupEnigmaConnection = (appId, options, _command) => {
     logger.debug(`Prepping for QSEoW Enigma connection for app ${appId}`);
 
     // Set up enigma.js configuration

--- a/src/lib/qseow/qseow-process-app.js
+++ b/src/lib/qseow/qseow-process-app.js
@@ -101,8 +101,8 @@ export const qseowProcessApp = async (appId, options) => {
 
     // Get correct XPaths to UI elements (user menu, logout button etc) in the Sense web UI
     // As Qlik update their Sense web client these xpaths may/will change.
-    let xpathHubUserPageButton = null;
-    let xpathLogoutButton = null;
+    let xpathHubUserPageButton;
+    let xpathLogoutButton;
 
     if (options.senseVersion === 'pre-2022-Nov') {
         xpathHubUserPageButton = xpathHubUserPageButtonPre2022Nov;
@@ -157,7 +157,7 @@ export const qseowProcessApp = async (appId, options) => {
             logger.error(`QSEOW CREATE THUMBNAILS 1 (stack): ${err.stack}`);
         }
 
-        throw Error('Error creating QSEoW image directory');
+        throw new Error('Error creating QSEoW image directory', { cause: err });
     }
 
     try {
@@ -553,6 +553,9 @@ export const qseowProcessApp = async (appId, options) => {
         await qseowUploadToContentLibrary(createdFiles, appId, options);
 
         // Update sheets in app
+        // tagSheetAppMetadata is deliberately not passed: it is queried on options.excludeSheetTag,
+        // so handing it to the blur-by-tag rule would blur sheets carrying the *exclude* tag. See
+        // issue #840 - --blur-sheet-tag needs its own QRS lookup before it can work.
         await qseowUpdateSheetThumbnails(createdFiles, appId, options);
 
         logger.info(`Done processing app ${appId}`);

--- a/src/lib/qseow/qseow-updatesheets.js
+++ b/src/lib/qseow/qseow-updatesheets.js
@@ -11,12 +11,28 @@ import { QseowError } from '../util/errors.js';
  * that were created during the previous step in the process.
  * @param {string} appId - The ID of the QSEoW app to process.
  * @param {object} options - Configuration options for processing the app.
+ * @param {Array<object>} [tagSheetAppMetadata] - Sheet metadata from QRS for sheets carrying the
+ * tag named by `--blur-sheet-tag`, each entry exposing `engineObjectId`. Defaults to empty so the
+ * tag rule simply matches nothing when the caller has not looked it up.
  *
  * @returns {Promise<void>} Resolves when the sheet thumbnails have been updated in the QSEoW app.
  */
-export const qseowUpdateSheetThumbnails = async (createdFiles, appId, options) => {
+export const qseowUpdateSheetThumbnails = async (
+    createdFiles,
+    appId,
+    options,
+    tagSheetAppMetadata = []
+) => {
     try {
         logger.verbose(`Starting update of sheet icons for app ${appId}`);
+
+        // Warn rather than silently ignore: --blur-sheet-tag is accepted by the CLI but nothing
+        // looks the tag up yet, so the rule below can never match. See issue #840.
+        if (options.blurSheetTag && tagSheetAppMetadata.length === 0) {
+            logger.warn(
+                '--blur-sheet-tag is not yet implemented for QSEoW and will be ignored. See https://github.com/ptarmiganlabs/butler-sheet-icons/issues/840'
+            );
+        }
 
         // Configure Enigma.js
         const configEnigma = setupEnigmaConnection(appId, options);
@@ -114,17 +130,18 @@ export const qseowUpdateSheetThumbnails = async (createdFiles, appId, options) =
                     }
 
                     // Should this sheet be blurred based on tags?
-                    // options.blurSheetTag is an array of strings
-                    // tagSheetAppMetadata is an array of sheet objects, with the id property being the sheet id
+                    // tagSheetAppMetadata is an array of sheet objects, each exposing engineObjectId.
+                    // It arrives empty unless the caller looked the tag up, which nothing does yet -
+                    // see issue #840. Until then the rule matches nothing rather than throwing.
                     if (options.blurSheetTag && blurSheet === false) {
-                        // Does the sheet id match any of the ids in tagSheetAppMetadata array?
-                        // Set blurSheet to true/false based on the result
                         blurSheet = tagSheetAppMetadata.some(
                             (element) => element.engineObjectId === sheet.qInfo.qId
                         );
-                        logger.verbose(
-                            `Blurred sheet thumbnail (via tags): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
-                        );
+                        if (blurSheet) {
+                            logger.verbose(
+                                `Blurred sheet thumbnail (via tags): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
+                            );
+                        }
                     }
 
                     // Should this sheet be blurred based on its position/sheet number?

--- a/src/lib/util/__tests__/errors.test.js
+++ b/src/lib/util/__tests__/errors.test.js
@@ -56,6 +56,7 @@ describe('Subclasses', () => {
         expect(ce).not.toBeInstanceOf(QseowError);
         expect(ee).not.toBeInstanceOf(CloudError);
         expect(cle).not.toBeInstanceOf(QseowError);
+        expect(qe).not.toBeInstanceOf(CloudError);
     });
 
     test('subclasses preserve a stack trace', () => {

--- a/src/lib/util/enigma-util.js
+++ b/src/lib/util/enigma-util.js
@@ -14,7 +14,7 @@ const require = createRequire(import.meta.url);
 let getSeaAsset;
 try {
     ({ getAsset: getSeaAsset } = require('node:sea'));
-} catch (error) {
+} catch {
     /**
      * Fallback SEA `getAsset` shim used when the `node:sea` module is not available
      * (i.e. in tests and plain Node.js runs). Always throws because SEA assets can


### PR DESCRIPTION
Closes #838. Also fixes a real crash the change uncovered — see #840.

## The problem

`npm run lint --max-warnings 0` is listed as a required quality gate in `AGENTS.md` and `.github/copilot-instructions.md`, but it enforced **no correctness properties at all**. `eslint.config.js` composed only `prettierConfig` and `jsdoc/flat-recommended`, with an explicit rules block holding `prettier/prettier` plus ten `jsdoc/*` rules — no `@eslint/js` recommended set, so `no-undef` and `no-unused-vars` were both off.

Demonstrated before the change — `npx eslint` **passed** on a file containing:

```js
export const canary = () => thisVariableDoesNotExistAnywhere;
const alsoUnused = 42;
```

After it, both are errors.

That matters most for refactors, which is exactly what this repo has been doing: #839 deleted ~230 lines and 7 imports per file with no static safety net, and the two process-app files sit below full coverage so tests are not a dependable backstop either.

## It found a real crash

`qseow-updatesheets.js` referenced `tagSheetAppMetadata`, which existed nowhere in the file. ESM is strict mode, so:

```
ReferenceError: tagSheetAppMetadata is not defined
```

**Reachable**: `--blur-sheet-tag` is a real CLI option (`commands/qseow/index.js:299`), so any QSEoW user passing it hits this.

I deliberately did **not** fix it by passing the value that is in scope at the call site. That array is queried on `options.excludeSheetTag`, so handing it to the blur rule would blur sheets carrying the *exclude* tag — trading a loud crash for a silent wrong answer. No query filtered on `blurSheetTag` exists anywhere. So the parameter gets an empty default, and the function now **warns** that the flag is ignored rather than pretending to honour it. Implementing it properly needs its own QRS lookup: #840.

Also made the "Blurred via tags" verbose log conditional — it previously fired even when the rule matched nothing.

## Violations resolved (48)

| Rule | Count | Treatment |
|---|---|---|
| `no-unused-vars` | 33 | Unused imports and test bindings removed; `argsIgnorePattern: '^_'` for the deliberate Commander `_command` args; missing `@jest/globals` imports added |
| `preserve-caught-error` | 6 | Attached `{ cause: err }` so the original stack survives the rethrow |
| `no-undef` | 6 | **1 real crash** (above) + 5 missing Jest global imports |
| `no-useless-assignment` | 3 | Dead initialisers before exhaustive if/else chains that throw |

`@eslint/js` was already a devDependency, so no packages are added. `js.configs.recommended` is placed first so `prettierConfig` still wins on the stylistic rules it disables.

## Tests

Adds the **first tests for `qseow-updatesheets.js`**, which had 9.72% coverage and 0% of its functions executed — the reason the bug survived. Coverage now **77.31%**.

They were checked against the old code rather than assumed useful: stashing the fix gives **6 failed, 1 passed**. The one that passes either way covers the flag being unset, where the buggy line is never reached.

`npm run test:unit`: **218 passed across 22 suites**. Lint and prettier clean.

## Commits

Three, each independently lint-clean (verified by checking out each and running lint):

- `65c518f` `fix:` the `--blur-sheet-tag` crash — user-facing, patch bump
- `ec2b85f` `refactor:` resolve the violations
- `0f9c6ed` `chore:` enable the rules

Split deliberately so a real crash fix is not buried inside a lint change, and so the changelog reflects it.

## Verification limits, stated plainly

- **Five `*.integration.test.js` files are touched, and `npm run test:unit` excludes that pattern** — so the 218 passing tests did not exercise those edits. Verified as far as possible statically: all five pass `node --check`, and their `@jest/globals` import lists now match usage exactly (`describe` confirmed unused at 0 call sites in both qseow files; `beforeAll`/`beforeEach` confirmed used where added). CI is the first place they actually run.
- The `--blur-sheet-tag` mitigation is unit-tested but has **not** been exercised against a live QSEoW environment.
