### PR TITLE
fix: guard the shared axios interceptor, and make offline browser commands explain themselves

### DIFF
--- a/.claude/skills/generated/browser/SKILL.md
+++ b/.claude/skills/generated/browser/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: browser
-description: "Skill for the Browser area of butler-sheet-icons. 10 symbols across 8 files."
+description: "Skill for the Browser area of butler-sheet-icons. 18 symbols across 10 files."
 ---
 
 # Browser
 
-10 symbols | 8 files | Cohesion: 90%
+18 symbols | 10 files | Cohesion: 96%
 
 ## When to Use
 
@@ -17,43 +17,60 @@ description: "Skill for the Browser area of butler-sheet-icons. 10 symbols acros
 
 | File | Symbols |
 |------|---------|
-| `src/lib/browser/browser-list-available.js` | mapPlatformToChrome, browserListAvailable, getMostRecentUsableChromeBuildId |
+| `src/lib/browser/browser-list-available.js` | markReported, alreadyReported, logVersionHistoryFailure, extractVersions, mapPlatformToChrome (+2) |
+| `src/lib/util/error-categorizer.js` | getErrorCategory, getErrorMetadata |
+| `src/lib/browser/browser-launch.js` | detectDocker, buildBrowserArgs |
+| `src/lib/browser/browser-install.js` | browserInstall |
 | `src/lib/commands/browser/index.js` | buildBrowserCommand |
 | `src/lib/commands/browser/install.js` | buildBrowserInstallCommand |
 | `src/lib/commands/browser/list-available.js` | buildBrowserListAvailableCommand |
 | `src/lib/commands/browser/list-installed.js` | buildBrowserListInstalledCommand |
 | `src/lib/commands/browser/uninstall-all.js` | buildBrowserUninstallAllCommand |
 | `src/lib/commands/browser/uninstall.js` | buildBrowserUninstallCommand |
-| `src/lib/browser/browser-install.js` | browserInstall |
 
 ## Entry Points
 
 Start here when exploring this area:
 
-- **`browserInstall`** (Function) — `src/lib/browser/browser-install.js:26`
-- **`browserListAvailable`** (Function) — `src/lib/browser/browser-list-available.js:46`
-- **`getMostRecentUsableChromeBuildId`** (Function) — `src/lib/browser/browser-list-available.js:199`
+- **`browserInstall`** (Function) — `src/lib/browser/browser-install.js:30`
+- **`browserListAvailable`** (Function) — `src/lib/browser/browser-list-available.js:168`
+- **`getMostRecentUsableChromeBuildId`** (Function) — `src/lib/browser/browser-list-available.js:335`
+- **`getErrorCategory`** (Function) — `src/lib/util/error-categorizer.js:32`
+- **`getErrorMetadata`** (Function) — `src/lib/util/error-categorizer.js:81`
 
 ## Key Symbols
 
 | Symbol | Type | File | Line |
 |--------|------|------|------|
-| `browserInstall` | Function | `src/lib/browser/browser-install.js` | 26 |
-| `browserListAvailable` | Function | `src/lib/browser/browser-list-available.js` | 46 |
-| `getMostRecentUsableChromeBuildId` | Function | `src/lib/browser/browser-list-available.js` | 199 |
+| `browserInstall` | Function | `src/lib/browser/browser-install.js` | 30 |
+| `browserListAvailable` | Function | `src/lib/browser/browser-list-available.js` | 168 |
+| `getMostRecentUsableChromeBuildId` | Function | `src/lib/browser/browser-list-available.js` | 335 |
+| `getErrorCategory` | Function | `src/lib/util/error-categorizer.js` | 32 |
+| `getErrorMetadata` | Function | `src/lib/util/error-categorizer.js` | 81 |
+| `buildBrowserArgs` | Function | `src/lib/browser/browser-launch.js` | 61 |
+| `markReported` | Function | `src/lib/browser/browser-list-available.js` | 40 |
+| `alreadyReported` | Function | `src/lib/browser/browser-list-available.js` | 53 |
+| `logVersionHistoryFailure` | Function | `src/lib/browser/browser-list-available.js` | 73 |
+| `extractVersions` | Function | `src/lib/browser/browser-list-available.js` | 110 |
+| `mapPlatformToChrome` | Function | `src/lib/browser/browser-list-available.js` | 139 |
 | `buildBrowserCommand` | Function | `src/lib/commands/browser/index.js` | 12 |
 | `buildBrowserInstallCommand` | Function | `src/lib/commands/browser/install.js` | 44 |
-| `buildBrowserListAvailableCommand` | Function | `src/lib/commands/browser/list-available.js` | 34 |
+| `buildBrowserListAvailableCommand` | Function | `src/lib/commands/browser/list-available.js` | 33 |
 | `buildBrowserListInstalledCommand` | Function | `src/lib/commands/browser/list-installed.js` | 35 |
 | `buildBrowserUninstallAllCommand` | Function | `src/lib/commands/browser/uninstall-all.js` | 34 |
 | `buildBrowserUninstallCommand` | Function | `src/lib/commands/browser/uninstall.js` | 34 |
-| `mapPlatformToChrome` | Function | `src/lib/browser/browser-list-available.js` | 17 |
+| `detectDocker` | Function | `src/lib/browser/browser-launch.js` | 41 |
 
 ## Execution Flows
 
 | Flow | Type | Steps |
 |------|------|-------|
+| `BrowserInstall → GetErrorCategory` | intra_community | 4 |
+| `BrowserInstall → MarkReported` | intra_community | 4 |
+| `BrowserListAvailable → GetErrorCategory` | intra_community | 3 |
+| `BrowserListAvailable → MarkReported` | intra_community | 3 |
 | `BrowserInstall → MapPlatformToChrome` | intra_community | 3 |
+| `BrowserInstall → AlreadyReported` | intra_community | 3 |
 
 ## Connected Areas
 

--- a/.claude/skills/generated/cloud/SKILL.md
+++ b/.claude/skills/generated/cloud/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: cloud
-description: "Skill for the Cloud area of butler-sheet-icons. 23 symbols across 17 files."
+description: "Skill for the Cloud area of butler-sheet-icons. 24 symbols across 18 files."
 ---
 
 # Cloud
 
-23 symbols | 17 files | Cohesion: 92%
+24 symbols | 18 files | Cohesion: 94%
 
 ## When to Use
 
@@ -42,26 +42,26 @@ Start here when exploring this area:
 
 | Symbol | Type | File | Line |
 |--------|------|------|------|
-| `CloudError` | Class | `src/lib/util/errors.js` | 75 |
+| `QseowError` | Class | `src/lib/util/errors.js` | 91 |
 | `browserInstalled` | Function | `src/lib/browser/browser-installed.js` | 16 |
 | `browserUninstall` | Function | `src/lib/browser/browser-uninstall.js` | 20 |
 | `browserUninstallAll` | Function | `src/lib/browser/browser-uninstall.js` | 85 |
 | `qscloudListCollections` | Function | `src/lib/cloud/cloud-collections.js` | 19 |
 | `qscloudCreateThumbnails` | Function | `src/lib/cloud/cloud-create-thumbnails.js` | 29 |
-| `qscloudRemoveSheetIcons` | Function | `src/lib/cloud/cloud-remove-sheet-icons.js` | 161 |
+| `qscloudRemoveSheetIcons` | Function | `src/lib/cloud/cloud-remove-sheet-icons.js` | 159 |
 | `qscloudUploadToApp` | Function | `src/lib/cloud/cloud-upload.js` | 25 |
 | `qseowCreateThumbnails` | Function | `src/lib/qseow/qseow-create-thumbnails.js` | 28 |
-| `qseowRemoveSheetIcons` | Function | `src/lib/qseow/qseow-remove-sheet-icons.js` | 137 |
+| `qseowRemoveSheetIcons` | Function | `src/lib/qseow/qseow-remove-sheet-icons.js` | 133 |
 | `qseowUploadToContentLibrary` | Function | `src/lib/qseow/qseow-upload.js` | 27 |
 | `deleteCloudAppThumbnail` | Function | `src/lib/cloud/cloud-delete-thumbnails.js` | 10 |
-| `qscloudUpdateSheetThumbnails` | Function | `src/lib/cloud/cloud-updatesheets.js` | 24 |
-| `processCloudApp` | Function | `src/lib/cloud/process-cloud-app.js` | 31 |
+| `processCloudApp` | Function | `src/lib/cloud/process-cloud-app.js` | 25 |
 | `takeSheetScreenshot` | Function | `src/lib/cloud/sheet-screenshot.js` | 18 |
+| `qseowProcessApp` | Function | `src/lib/qseow/qseow-process-app.js` | 94 |
+| `qseowUpdateSheetThumbnails` | Function | `src/lib/qseow/qseow-updatesheets.js` | 19 |
 | `setLoggingLevel` | Function | `src/globals.js` | 265 |
 | `removeSheetIconsCloudApp` | Function | `src/lib/cloud/cloud-remove-sheet-icons.js` | 20 |
 | `removeSheetIconsQSEoWApp` | Function | `src/lib/qseow/qseow-remove-sheet-icons.js` | 22 |
 | `sleep` | Function | `src/globals.js` | 282 |
-| `bufferToStream` | Function | `src/lib/cloud/cloud-repo-request.js` | 38 |
 
 ## Execution Flows
 

--- a/.claude/skills/generated/util/SKILL.md
+++ b/.claude/skills/generated/util/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: util
-description: "Skill for the Util area of butler-sheet-icons. 33 symbols across 11 files."
+description: "Skill for the Util area of butler-sheet-icons. 30 symbols across 9 files."
 ---
 
 # Util
 
-33 symbols | 11 files | Cohesion: 94%
+30 symbols | 9 files | Cohesion: 95%
 
 ## When to Use
 
 - Working with code in `src/`
-- Understanding how qseowProcessApp, qseowUpdateSheetThumbnails, getCertFilePaths work
+- Understanding how qscloudUpdateSheetThumbnails, getCertFilePaths, getEnigmaSchema work
 - Modifying util-related functionality
 
 ## Key Files
@@ -20,23 +20,22 @@ description: "Skill for the Util area of butler-sheet-icons. 33 symbols across 1
 | `src/lib/util/log-error.js` | logErrorWithLevel, logError, logWarn, logInfo, logVerbose (+1) |
 | `src/lib/util/env-check.js` | isMissing, present, toHex, formatSecret, checkEnv (+1) |
 | `src/lib/util/crash-dump.js` | envBool, buildTimestampForFilename, sanitizeStackTrace, resolveCrashDir, writeCrashDump |
-| `src/lib/util/errors.js` | BsiError, CertError, EnigmaError, QseowError |
+| `src/lib/util/errors.js` | BsiError, CertError, EnigmaError, CloudError |
 | `src/lib/util/redact-secrets.js` | isSecretKey, redactValue, redactOptions, redactSensitivePatterns |
 | `src/globals.js` | sanitizeLogValue, sanitizeFormat |
-| `src/lib/util/error-categorizer.js` | getErrorCategory, getErrorMetadata |
-| `src/lib/qseow/qseow-process-app.js` | qseowProcessApp |
-| `src/lib/qseow/qseow-updatesheets.js` | qseowUpdateSheetThumbnails |
+| `src/lib/cloud/cloud-updatesheets.js` | qscloudUpdateSheetThumbnails |
 | `src/lib/util/cert.js` | getCertFilePaths |
+| `src/lib/util/enigma-util.js` | getEnigmaSchema |
 
 ## Entry Points
 
 Start here when exploring this area:
 
-- **`qseowProcessApp`** (Function) — `src/lib/qseow/qseow-process-app.js:100`
-- **`qseowUpdateSheetThumbnails`** (Function) — `src/lib/qseow/qseow-updatesheets.js:16`
+- **`qscloudUpdateSheetThumbnails`** (Function) — `src/lib/cloud/cloud-updatesheets.js:24`
 - **`getCertFilePaths`** (Function) — `src/lib/util/cert.js:18`
 - **`getEnigmaSchema`** (Function) — `src/lib/util/enigma-util.js:45`
 - **`redactValue`** (Function) — `src/lib/util/redact-secrets.js:89`
+- **`redactOptions`** (Function) — `src/lib/util/redact-secrets.js:126`
 
 ## Key Symbols
 
@@ -45,9 +44,8 @@ Start here when exploring this area:
 | `BsiError` | Class | `src/lib/util/errors.js` | 26 |
 | `CertError` | Class | `src/lib/util/errors.js` | 43 |
 | `EnigmaError` | Class | `src/lib/util/errors.js` | 59 |
-| `QseowError` | Class | `src/lib/util/errors.js` | 91 |
-| `qseowProcessApp` | Function | `src/lib/qseow/qseow-process-app.js` | 100 |
-| `qseowUpdateSheetThumbnails` | Function | `src/lib/qseow/qseow-updatesheets.js` | 16 |
+| `CloudError` | Class | `src/lib/util/errors.js` | 75 |
+| `qscloudUpdateSheetThumbnails` | Function | `src/lib/cloud/cloud-updatesheets.js` | 24 |
 | `getCertFilePaths` | Function | `src/lib/util/cert.js` | 18 |
 | `getEnigmaSchema` | Function | `src/lib/util/enigma-util.js` | 45 |
 | `redactValue` | Function | `src/lib/util/redact-secrets.js` | 89 |
@@ -62,6 +60,7 @@ Start here when exploring this area:
 | `present` | Function | `src/lib/util/env-check.js` | 167 |
 | `formatSecret` | Function | `src/lib/util/env-check.js` | 106 |
 | `checkEnv` | Function | `src/lib/util/env-check.js` | 129 |
+| `render` | Function | `src/lib/util/env-check.js` | 150 |
 
 ## Execution Flows
 
@@ -71,14 +70,8 @@ Start here when exploring this area:
 | `RedactOptions → IsSecretKey` | intra_community | 3 |
 | `SanitizeFormat → RedactSensitivePatterns` | intra_community | 3 |
 
-## Connected Areas
-
-| Area | Connections |
-|------|-------------|
-| Cloud | 1 calls |
-
 ## How to Explore
 
-1. `gitnexus_context({name: "qseowProcessApp"})` — see callers and callees
+1. `gitnexus_context({name: "qscloudUpdateSheetThumbnails"})` — see callers and callees
 2. `gitnexus_query({query: "util"})` — find related execution flows
 3. Read key files listed above for implementation details

--- a/docs/to-doc-site/browser-commands-without-internet.md
+++ b/docs/to-doc-site/browser-commands-without-internet.md
@@ -1,0 +1,65 @@
+# Using browser commands without internet access
+
+Target page: `docs/guide/concepts/browser-detection-and-environment-variables.md` on the doc site,
+as a new section after "### 3. Download browser (lowest priority)". Alternatively
+`docs/guide/troubleshooting.md`, if a troubleshooting entry reads better there.
+
+This documents behaviour that changes in the next release. Before it, running
+`browser list-available` on a machine with no internet access produced an unhelpful error:
+
+```
+error: Error checking for available browsers: TypeError: Cannot read properties of undefined (reading 'status')
+error: BROWSER MAIN 10: TypeError: Cannot read properties of undefined (reading 'status')
+error: BROWSER MAIN 10 (message): Cannot read properties of undefined (reading 'status')
+error: BROWSER MAIN 10 (stack): TypeError: ...
+    at ./build/build.cjs:172381:26
+    ...
+```
+
+Nothing in that output said "this machine cannot reach the internet".
+
+## Suggested new section
+
+> ### Which browser commands need internet access?
+>
+> Only some of the `browser` commands reach out to the internet:
+>
+> | Command | Needs internet? |
+> |---|---|
+> | `browser list-installed` | No. Reads the local Puppeteer cache only. |
+> | `browser uninstall` / `uninstall-all` | No. Removes browsers from the local cache. |
+> | `browser list-available` | **Yes.** Asks Google's Chrome version history service which versions exist. |
+> | `browser install` | **Yes**, unless the requested version is already in the cache. |
+>
+> On a machine with no internet access — an air-gapped server, or one behind a proxy that blocks
+> outbound HTTPS — the two commands that need it will report:
+>
+> ```
+> error: Could not reach versionhistory.googleapis.com to look up available browser versions.
+> error: Butler Sheet Icons needs internet access for this command. If this machine is offline or
+>        behind a proxy, use "butler-sheet-icons browser list-installed" to see the browsers already
+>        available locally.
+> ```
+>
+> This is expected, not a fault in Butler Sheet Icons. Use `browser list-installed` to see what is
+> already available on the machine.
+>
+> To prepare an offline machine, run `browser install` once while it still has internet access. The
+> browser is stored in the Puppeteer cache and reused on later runs, so thumbnail creation itself
+> works without connectivity. Setting `PUPPETEER_EXECUTABLE_PATH` to a browser installed by other
+> means works too, and is the usual approach for Docker and centrally managed environments.
+
+## Why this matters to administrators
+
+The previous output was a stack trace referencing line numbers inside the bundled binary, which is
+not something an administrator can act on. Several support questions have started this way.
+
+If the service is reachable but returns an error, the message now says so explicitly and quotes the
+HTTP status, so a proxy returning 403 is distinguishable from no connectivity at all.
+
+## Note for the reviewer publishing this
+
+Check whether the air-gapped guidance already exists elsewhere on the site before adding a new
+section — issues #809 and #810 cover air-gapped support more broadly, and it would be better to
+have one place describing it than two. If a dedicated air-gapped page lands from that work, this
+content belongs there instead.

--- a/src/lib/browser/__tests__/browser_install_offline.test.js
+++ b/src/lib/browser/__tests__/browser_install_offline.test.js
@@ -1,0 +1,118 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+// `browser install --browser-version latest` resolves the build id through
+// getMostRecentUsableChromeBuildId, so an offline install fails on the same code path as
+// `browser list-available`. These tests cover the install side of issue #785.
+
+jest.unstable_mockModule('axios', () => ({ default: jest.fn() }));
+const axios = (await import('axios')).default;
+
+jest.unstable_mockModule('@puppeteer/browsers', () => ({
+    detectBrowserPlatform: jest.fn().mockResolvedValue('mac_arm'),
+    canDownload: jest.fn().mockResolvedValue(true),
+    install: jest.fn(),
+    resolveBuildId: jest.fn(),
+}));
+
+jest.unstable_mockModule('../../../globals.js', () => ({
+    logger: {
+        info: jest.fn(),
+        verbose: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+    },
+    setLoggingLevel: jest.fn(),
+    bsiExecutablePath: '/test/path',
+    isSea: false,
+}));
+const { logger } = await import('../../../globals.js');
+
+/** Inert progress bar so the install path does not write to a TTY. */
+class FakeSingleBar {
+    /**
+     * No-op stub for cli-progress SingleBar.start.
+     *
+     * @returns {void}
+     */
+    start() {}
+
+    /**
+     * No-op stub for cli-progress SingleBar.update.
+     *
+     * @returns {void}
+     */
+    update() {}
+
+    /**
+     * No-op stub for cli-progress SingleBar.stop.
+     *
+     * @returns {void}
+     */
+    stop() {}
+}
+
+jest.unstable_mockModule('cli-progress', () => ({
+    default: { SingleBar: FakeSingleBar, Presets: { shades_classic: {} } },
+}));
+
+const { browserInstall } = await import('../browser-install.js');
+
+/**
+ * Collects everything logged at error level during a run.
+ *
+ * @returns {string} Concatenated error-level output.
+ */
+function errorOutput() {
+    return logger.error.mock.calls.map((call) => String(call[0])).join('\n');
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('browserInstall — offline (issue #785)', () => {
+    test('does not repeat the failure or print a stack at error level', async () => {
+        // The first version of this fix kept the already-reported marker private to
+        // browser-list-available.js, so browserInstall logged the raw message and a full stack
+        // trace on top of the explanation - reproducing the very symptom #785 reports.
+        axios.mockRejectedValue(
+            Object.assign(new Error('getaddrinfo ENOTFOUND'), { code: 'ENOTFOUND' })
+        );
+
+        await browserInstall({ browser: 'chrome', browserVersion: 'latest' }).catch(
+            () => undefined
+        );
+
+        const out = errorOutput();
+        expect(out).toContain('Could not reach versionhistory.googleapis.com');
+        expect(out).not.toContain('Error installing browser');
+        expect(out).not.toContain('at ');
+    });
+
+    test('propagates a non-Error throw unchanged instead of masking it', async () => {
+        // `err.message.includes(...)` was unguarded, so a non-Error throw raised a second
+        // TypeError from inside the handler, replacing the original cause with a confusing
+        // message about `includes`.
+        //
+        // Asserting the identity of the rejected value, not merely that it rejects: on the old
+        // code it still rejected, just with the wrong error. A `toBeDefined()` assertion passed
+        // either way and would have proved nothing.
+        axios.mockRejectedValue('a bare string, not an Error');
+
+        const rejection = await browserInstall({
+            browser: 'chrome',
+            browserVersion: 'latest',
+        }).catch((err) => err);
+
+        expect(rejection).toBe('a bare string, not an Error');
+        expect(String(rejection)).not.toContain('Cannot read properties');
+    });
+
+    test('still reports an install failure that nothing else has explained', async () => {
+        // Missing options fail before any network call, so no other layer has described this.
+        await browserInstall({}).catch(() => undefined);
+
+        expect(errorOutput()).toContain('Error installing browser');
+    });
+});

--- a/src/lib/browser/__tests__/browser_list_available_offline.test.js
+++ b/src/lib/browser/__tests__/browser_list_available_offline.test.js
@@ -1,0 +1,143 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+jest.unstable_mockModule('axios', () => ({ default: jest.fn() }));
+const axios = (await import('axios')).default;
+
+jest.unstable_mockModule('@puppeteer/browsers', () => ({
+    detectBrowserPlatform: jest.fn().mockResolvedValue('mac_arm'),
+    canDownload: jest.fn().mockResolvedValue(true),
+}));
+
+jest.unstable_mockModule('../../../globals.js', () => ({
+    logger: {
+        info: jest.fn(),
+        verbose: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+    },
+    setLoggingLevel: jest.fn(),
+    bsiExecutablePath: '/test/path',
+    isSea: false,
+}));
+const { logger } = await import('../../../globals.js');
+
+const { browserListAvailable } = await import('../browser-list-available.js');
+
+const OPTIONS = { browser: 'chrome', channel: 'stable', loglevel: 'info' };
+
+/**
+ * Runs the command with axios rejecting, and returns everything logged at error level.
+ *
+ * @param {unknown} rejection - Value axios should reject with.
+ *
+ * @returns {Promise<string>} Concatenated error-level log output.
+ */
+async function errorOutputWhenAxiosRejects(rejection) {
+    axios.mockRejectedValue(rejection);
+    await browserListAvailable({ ...OPTIONS }).catch(() => undefined);
+    return logger.error.mock.calls.map((call) => String(call[0])).join('\n');
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('browserListAvailable — no internet connectivity (issue #785)', () => {
+    test('explains a DNS failure instead of surfacing a raw error', async () => {
+        const out = await errorOutputWhenAxiosRejects(
+            Object.assign(new Error('getaddrinfo ENOTFOUND versionhistory.googleapis.com'), {
+                code: 'ENOTFOUND',
+            })
+        );
+
+        expect(out).toContain('Could not reach versionhistory.googleapis.com');
+        expect(out).toContain('browser list-installed');
+    });
+
+    test('handles the exact TypeError reported from inside axios', async () => {
+        // The reported symptom was `TypeError: Cannot read properties of undefined (reading
+        // 'status')` thrown by axios itself, carrying no error code at all. Detection therefore
+        // keys off the absent HTTP response rather than off `err.code`.
+        const out = await errorOutputWhenAxiosRejects(
+            new TypeError("Cannot read properties of undefined (reading 'status')")
+        );
+
+        expect(out).toContain('Could not reach versionhistory.googleapis.com');
+        expect(out).not.toContain('TypeError');
+    });
+
+    test('reports the failure exactly twice, leaking none of the raw error text', async () => {
+        // Asserting the precise set of lines, because an earlier version of this fix explained
+        // the failure correctly and *then* let the rethrown error fall through to a generic
+        // handler, which re-logged "Cannot read properties of undefined (reading 'status')" -
+        // the exact string from the bug report. Checking only for the absence of the word
+        // "TypeError" missed that, since the generic handler logs err.message.
+        axios.mockRejectedValue(
+            new TypeError("Cannot read properties of undefined (reading 'status')")
+        );
+        await browserListAvailable({ ...OPTIONS }).catch(() => undefined);
+
+        const lines = logger.error.mock.calls.map((call) => String(call[0]));
+
+        expect(lines).toHaveLength(2);
+        expect(lines[0]).toContain('Could not reach versionhistory.googleapis.com');
+        expect(lines[1]).toContain('needs internet access');
+        expect(lines.join('\n')).not.toContain('Cannot read properties');
+        expect(lines.join('\n')).not.toContain('Error checking for available browsers');
+    });
+
+    test('explains an intercepted 200 response instead of throwing on a missing body', async () => {
+        // A captive portal answering 200 with an HTML login page used to leave `versions`
+        // undefined, then throw "Cannot read properties of undefined (reading 'length')".
+        axios.mockResolvedValue({ data: '<html>Sign in to the network</html>' });
+        await browserListAvailable({ ...OPTIONS }).catch(() => undefined);
+
+        const out = logger.error.mock.calls.map((call) => String(call[0])).join('\n');
+
+        expect(out).toContain('Unexpected response from versionhistory.googleapis.com');
+        expect(out).toContain('captive portal');
+        expect(out).not.toContain('Cannot read properties');
+    });
+
+    test.each([
+        ['connection refused', 'ECONNREFUSED'],
+        ['timeout', 'ETIMEDOUT'],
+        ['connection reset', 'ECONNRESET'],
+    ])('explains a %s failure', async (_label, code) => {
+        const out = await errorOutputWhenAxiosRejects(Object.assign(new Error(code), { code }));
+
+        expect(out).toContain('Could not reach versionhistory.googleapis.com');
+    });
+
+    test('never writes a stack trace at error level', async () => {
+        const err = Object.assign(new Error('getaddrinfo ENOTFOUND'), { code: 'ENOTFOUND' });
+        const out = await errorOutputWhenAxiosRejects(err);
+
+        // The original defect logged the message three times over plus a full stack trace.
+        expect(out).not.toContain('at ');
+        expect(logger.debug).toHaveBeenCalled();
+    });
+
+    test('reports an HTTP failure differently from an unreachable host', async () => {
+        // The service answered, so the "you may be offline" advice would be actively misleading.
+        const out = await errorOutputWhenAxiosRejects(
+            Object.assign(new Error('Request failed with status code 503'), {
+                response: { status: 503 },
+            })
+        );
+
+        expect(out).toContain('returned HTTP 503');
+        expect(out).not.toContain('Butler Sheet Icons needs internet access');
+    });
+
+    test('does not mislabel a local validation error as a connectivity problem', async () => {
+        // Thrown before any request is made, so it must not attract network advice.
+        await browserListAvailable({ ...OPTIONS, browser: 'not-a-browser' }).catch(() => undefined);
+
+        const out = logger.error.mock.calls.map((call) => String(call[0])).join('\n');
+        expect(out).toContain('Invalid browser');
+        expect(out).not.toContain('Could not reach');
+        expect(axios).not.toHaveBeenCalled();
+    });
+});

--- a/src/lib/browser/browser-install.js
+++ b/src/lib/browser/browser-install.js
@@ -6,6 +6,7 @@ import cliProgress from 'cli-progress';
 import { logger, setLoggingLevel, bsiExecutablePath, isSea } from '../../globals.js';
 import { redactOptions } from '../util/redact-secrets.js';
 import { getMostRecentUsableChromeBuildId } from './browser-list-available.js';
+import { alreadyReported } from '../util/reported-error.js';
 
 /**
  * Install a browser into the Puppeteer cache directory.
@@ -170,15 +171,19 @@ export const browserInstall = async (options, _command) => {
 
         return browser;
     } catch (err) {
-        // Check if error is due to browser version missing
-        if (err.message.includes('Download failed: server returned code 404.')) {
+        // Optional chaining because a catch cannot assume it was handed an Error. Reading
+        // `.message` unguarded here previously turned a non-Error throw - such as the code-less
+        // TypeError axios has been seen to produce offline - into a second, more confusing
+        // TypeError raised from inside the error handler, losing the original cause (issue #785).
+        if (err?.message?.includes('Download failed: server returned code 404.')) {
             logger.error(`Browser version "${options.browserVersion}" not found`);
-        } else {
-            logger.error(`Error installing browser: ${err.message}`);
-
-            if (err.stack) {
-                logger.error(err.stack);
-            }
+        } else if (!alreadyReported(err)) {
+            // Only report what nothing else has explained. Resolving "latest" goes through
+            // getMostRecentUsableChromeBuildId, which already describes connectivity failures in
+            // detail; repeating the raw message and a stack trace on top is what made an offline
+            // run unreadable. The stack stays available at debug.
+            logger.error(`Error installing browser: ${err?.message ?? err}`);
+            logger.debug(err?.stack ?? String(err));
         }
 
         throw err;

--- a/src/lib/browser/browser-list-available.js
+++ b/src/lib/browser/browser-list-available.js
@@ -5,6 +5,128 @@ import axios from 'axios';
 
 import { logger, setLoggingLevel, bsiExecutablePath, isSea } from '../../globals.js';
 import { redactOptions } from '../util/redact-secrets.js';
+import { getErrorCategory } from '../util/error-categorizer.js';
+
+/** Host queried for the list of published Chrome versions. */
+const CHROME_VERSION_HISTORY_HOST = 'versionhistory.googleapis.com';
+
+/**
+ * Error categories that mean "the request never reached the server".
+ *
+ * Kept separate from HTTP-level failures (4xx/5xx), which indicate the service was reached but
+ * refused or failed the request - a different problem, with different advice.
+ */
+const CONNECTIVITY_CATEGORIES = new Set([
+    'timeout',
+    'connection_refused',
+    'host_not_found',
+    'connection_reset',
+]);
+
+/**
+ * Marks an error whose cause has already been explained to the user.
+ *
+ * A Symbol rather than a plain property so it never shows up in `JSON.stringify` output or in
+ * anything that enumerates the error's own keys.
+ */
+const FAILURE_REPORTED = Symbol('butler-sheet-icons.failureReported');
+
+/**
+ * Records that a failure has been reported, so outer handlers do not repeat it.
+ *
+ * @param {Error|unknown} err - The error to mark. Non-objects are ignored.
+ *
+ * @returns {void}
+ */
+function markReported(err) {
+    if (err && typeof err === 'object') {
+        err[FAILURE_REPORTED] = true;
+    }
+}
+
+/**
+ * Reports whether an error has already been explained by a more specific handler.
+ *
+ * @param {Error|unknown} err - The error to test.
+ *
+ * @returns {boolean} `true` when the failure has already been logged for the user.
+ */
+function alreadyReported(err) {
+    return Boolean(err && typeof err === 'object' && err[FAILURE_REPORTED]);
+}
+
+/**
+ * Logs an actionable message for a failure returned by the Chrome version history service.
+ *
+ * Only call this for errors thrown by the HTTP request itself, so that Butler Sheet Icons' own
+ * validation errors are never mistaken for connectivity problems.
+ *
+ * Two shapes have to be handled. A well-formed network failure carries a code such as
+ * `ENOTFOUND`. But an offline run has also been seen to surface as
+ * `TypeError: Cannot read properties of undefined (reading 'status')` thrown from inside axios
+ * itself, with no code at all (issue #785). The reliable signal common to both is the **absence
+ * of an HTTP response**: if there is no `response`, the service was never reached.
+ *
+ * @param {Error|unknown} err - The error thrown while contacting the service.
+ *
+ * @returns {void}
+ */
+function logVersionHistoryFailure(err) {
+    const category = getErrorCategory(err);
+    const gotHttpResponse = Boolean(err?.response);
+
+    if (!gotHttpResponse || CONNECTIVITY_CATEGORIES.has(category)) {
+        logger.error(
+            `Could not reach ${CHROME_VERSION_HISTORY_HOST} to look up available browser versions.`
+        );
+        logger.error(
+            'Butler Sheet Icons needs internet access for this command. If this machine is offline or behind a proxy, use "butler-sheet-icons browser list-installed" to see the browsers already available locally.'
+        );
+        logger.verbose(`Connectivity failure category: ${category}`);
+    } else {
+        // The service answered, but not with success - a different problem, different advice.
+        logger.error(
+            `${CHROME_VERSION_HISTORY_HOST} returned HTTP ${err.response.status} while listing available browser versions.`
+        );
+    }
+
+    logger.debug(err?.stack ?? String(err));
+    markReported(err);
+}
+
+/**
+ * Extracts the version array from a version history response, rejecting anything unexpected.
+ *
+ * The response body is not assumed to be well formed. A captive portal or intercepting proxy can
+ * answer HTTP 200 with an HTML login page, and reading `.versions` off that yields `undefined` -
+ * which then throws `Cannot read properties of undefined (reading 'length')` further down, the
+ * same class of unhelpful error this module already had (issue #785).
+ *
+ * @param {object} response - Axios response for the version history request.
+ *
+ * @returns {Array<object>} The `versions` array from the response body.
+ *
+ * @throws {Error} If the body does not contain a `versions` array.
+ */
+function extractVersions(response) {
+    const versions = response?.data?.versions;
+
+    if (!Array.isArray(versions)) {
+        logger.error(
+            `Unexpected response from ${CHROME_VERSION_HISTORY_HOST} when listing available browser versions.`
+        );
+        logger.error(
+            'This can happen when a proxy or captive portal intercepts the request. Check that this machine can reach the internet directly.'
+        );
+        logger.debug(`Response body: ${JSON.stringify(response?.data)}`);
+
+        const err = new Error(`Unexpected response from ${CHROME_VERSION_HISTORY_HOST}`);
+        markReported(err);
+        throw err;
+    }
+
+    return versions;
+}
 
 /**
  * Maps Puppeteer's platform values to corresponding Chrome version history API platform values.
@@ -125,8 +247,16 @@ export async function browserListAvailable(options) {
                 url: `https://versionhistory.googleapis.com/v1/chrome/platforms/${chromePlatform}/channels/${options.channel}/versions`,
             };
 
-            const response = await axios(axiosConfig);
-            browsersAvailable = response.data.versions;
+            let response;
+            try {
+                response = await axios(axiosConfig);
+            } catch (err) {
+                // Scoped to the request so that this module's own validation errors, thrown
+                // earlier in the same try, are never reported as connectivity problems.
+                logVersionHistoryFailure(err);
+                throw err;
+            }
+            browsersAvailable = extractVersions(response);
             logger.debug(`Chrome versions: ${JSON.stringify(browsersAvailable, null, 2)}`);
 
             // Output Chrome versions and names to info log
@@ -185,7 +315,13 @@ export async function browserListAvailable(options) {
         }
         return browsersAvailable;
     } catch (err) {
-        logger.error(`Error checking for available browsers: ${err}`);
+        // Only report failures nothing else has explained. Request and response problems are
+        // already described in detail above; repeating them here is what left the reported
+        // `Cannot read properties of undefined` text in the output (issue #785).
+        if (!alreadyReported(err)) {
+            logger.error(`Error checking for available browsers: ${err.message ?? err}`);
+            logger.debug(err?.stack ?? String(err));
+        }
         throw err;
     }
 }
@@ -236,8 +372,15 @@ export async function getMostRecentUsableChromeBuildId(channel) {
             url: `https://versionhistory.googleapis.com/v1/chrome/platforms/${chromePlatform}/channels/${channel}/versions`,
         };
 
-        const response = await axios(axiosConfig);
-        const browsersAvailable = response.data.versions;
+        let response;
+        try {
+            response = await axios(axiosConfig);
+        } catch (err) {
+            // Scoped to the request, as in browserListAvailable above.
+            logVersionHistoryFailure(err);
+            throw err;
+        }
+        const browsersAvailable = extractVersions(response);
         logger.debug(`Chrome versions: ${JSON.stringify(browsersAvailable, null, 2)}`);
 
         // Output Chrome versions and names to info log
@@ -260,10 +403,10 @@ export async function getMostRecentUsableChromeBuildId(channel) {
         logger.info('No Chrome versions available');
         return false;
     } catch (err) {
-        logger.error(`Error getting most recent usable Chrome build ID: ${err.message}`);
-
-        if (err.stack) {
-            logger.error(err.stack);
+        // As above: only report what has not already been explained.
+        if (!alreadyReported(err)) {
+            logger.error(`Error getting most recent usable Chrome build ID: ${err.message ?? err}`);
+            logger.debug(err?.stack ?? String(err));
         }
 
         throw err;

--- a/src/lib/browser/browser-list-available.js
+++ b/src/lib/browser/browser-list-available.js
@@ -6,6 +6,7 @@ import axios from 'axios';
 import { logger, setLoggingLevel, bsiExecutablePath, isSea } from '../../globals.js';
 import { redactOptions } from '../util/redact-secrets.js';
 import { getErrorCategory } from '../util/error-categorizer.js';
+import { markReported, alreadyReported } from '../util/reported-error.js';
 
 /** Host queried for the list of published Chrome versions. */
 const CHROME_VERSION_HISTORY_HOST = 'versionhistory.googleapis.com';
@@ -22,38 +23,6 @@ const CONNECTIVITY_CATEGORIES = new Set([
     'host_not_found',
     'connection_reset',
 ]);
-
-/**
- * Marks an error whose cause has already been explained to the user.
- *
- * A Symbol rather than a plain property so it never shows up in `JSON.stringify` output or in
- * anything that enumerates the error's own keys.
- */
-const FAILURE_REPORTED = Symbol('butler-sheet-icons.failureReported');
-
-/**
- * Records that a failure has been reported, so outer handlers do not repeat it.
- *
- * @param {Error|unknown} err - The error to mark. Non-objects are ignored.
- *
- * @returns {void}
- */
-function markReported(err) {
-    if (err && typeof err === 'object') {
-        err[FAILURE_REPORTED] = true;
-    }
-}
-
-/**
- * Reports whether an error has already been explained by a more specific handler.
- *
- * @param {Error|unknown} err - The error to test.
- *
- * @returns {boolean} `true` when the failure has already been logged for the user.
- */
-function alreadyReported(err) {
-    return Boolean(err && typeof err === 'object' && err[FAILURE_REPORTED]);
-}
 
 /**
  * Logs an actionable message for a failure returned by the Chrome version history service.

--- a/src/lib/cloud/__tests__/cloud_repo_request.test.js
+++ b/src/lib/cloud/__tests__/cloud_repo_request.test.js
@@ -213,3 +213,50 @@ describe('interceptor rejection shape is what downstream classification expects'
         expect(rejection.response).toEqual({ status: 403 });
     });
 });
+
+describe('multipart form-data path matching', () => {
+    /**
+     * Issues a multipart request and returns the axios config it produced.
+     *
+     * @param {string} path - Repository API path.
+     *
+     * @returns {Promise<object>} The config axios was called with.
+     */
+    async function multipartConfigFor(path) {
+        axios.mockResolvedValueOnce({ status: 200, data: { data: [] } });
+        await request(
+            MAIN_CONFIG,
+            path,
+            'post',
+            undefined,
+            'multipart/form-data',
+            Buffer.from('zip-bytes'),
+            'ext.zip'
+        );
+        return axios.mock.calls[0][0];
+    }
+
+    test('builds form-data for a path containing "extensions"', async () => {
+        const config = await multipartConfigFor('apps/123/media/extensions');
+
+        // FormData sets its own multipart boundary header.
+        expect(String(config.headers['content-type'] ?? '')).toContain('multipart/form-data');
+    });
+
+    test('builds form-data when "extensions" is at the start of the path', async () => {
+        // indexOf returns 0 here, which is falsy, so the old check skipped the one case it was
+        // written for and sent the raw buffer with a multipart content type.
+        const config = await multipartConfigFor('extensions/upload');
+
+        expect(String(config.headers['content-type'] ?? '')).toContain('multipart/form-data');
+    });
+
+    test('leaves a path without "extensions" alone', async () => {
+        // indexOf returns -1 here, which is truthy, so the old check wrapped unrelated paths in
+        // a FormData body labelled extension.zip.
+        const config = await multipartConfigFor('apps/123/media/list');
+
+        expect(String(config.headers['content-type'] ?? '')).not.toContain('boundary');
+        expect(Buffer.isBuffer(config.data) || config.data === undefined).toBe(true);
+    });
+});

--- a/src/lib/cloud/__tests__/cloud_repo_request.test.js
+++ b/src/lib/cloud/__tests__/cloud_repo_request.test.js
@@ -1,0 +1,215 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+// The module registers a response interceptor on the shared axios instance at import time, so
+// the mock has to expose that surface. The registered handlers are captured rather than
+// discarded, because the error handler is itself under test.
+const interceptors = { fulfilled: undefined, rejected: undefined };
+
+jest.unstable_mockModule('axios', () => {
+    const mockAxios = jest.fn();
+    mockAxios.interceptors = {
+        response: {
+            use: jest.fn((onFulfilled, onRejected) => {
+                interceptors.fulfilled = onFulfilled;
+                interceptors.rejected = onRejected;
+            }),
+        },
+    };
+    return { default: mockAxios };
+});
+const axios = (await import('axios')).default;
+
+jest.unstable_mockModule('../../../globals.js', () => ({
+    logger: {
+        info: jest.fn(),
+        verbose: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+    },
+}));
+
+const request = (await import('../cloud-repo-request.js')).default;
+
+const MAIN_CONFIG = { baseURL: 'https://tenant.eu.qlikcloud.com', version: '1', token: 'tkn' };
+
+/**
+ * Calls the module's default export with the fixed config used throughout these tests.
+ *
+ * @returns {Promise<object|Array>} Whatever the request resolves to.
+ */
+function get() {
+    return request(MAIN_CONFIG, 'items', 'get');
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('cloud-repo-request pagination', () => {
+    test('follows a lowercase links.next.href across pages', async () => {
+        axios
+            .mockResolvedValueOnce({
+                status: 200,
+                data: { data: [{ id: 1 }], links: { next: { href: '/page2' } } },
+            })
+            .mockResolvedValueOnce({ status: 200, data: { data: [{ id: 2 }] } });
+
+        expect(await get()).toEqual([{ id: 1 }, { id: 2 }]);
+        expect(axios).toHaveBeenCalledTimes(2);
+        expect(axios.mock.calls[1][0].url).toBe('/page2');
+    });
+
+    test('follows a capitalised links.Next.Href', async () => {
+        // The guard has always accepted `Next`, but the line after it read `next.href`
+        // unconditionally, so a response using only the capitalised form threw
+        // `TypeError: Cannot read properties of undefined (reading 'href')`.
+        axios
+            .mockResolvedValueOnce({
+                status: 200,
+                data: { data: [{ id: 1 }], links: { Next: { Href: '/page2' } } },
+            })
+            .mockResolvedValueOnce({ status: 200, data: { data: [{ id: 2 }] } });
+
+        expect(await get()).toEqual([{ id: 1 }, { id: 2 }]);
+        expect(axios.mock.calls[1][0].url).toBe('/page2');
+    });
+
+    test('stops when links is present but carries no next page', async () => {
+        axios.mockResolvedValueOnce({ status: 200, data: { data: [{ id: 1 }], links: {} } });
+
+        expect(await get()).toEqual([{ id: 1 }]);
+        expect(axios).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not throw on a response with no body', async () => {
+        // `response.data` is optional - the module's own debug logging guards it - so reading
+        // `.data` off it unguarded threw on an empty response.
+        axios.mockResolvedValueOnce({ status: 204 });
+
+        await expect(get()).resolves.toEqual({ data: undefined, status: 204 });
+    });
+
+    test('returns status and body when the payload is not a data array', async () => {
+        axios.mockResolvedValueOnce({ status: 200, data: { id: 'single-object' } });
+
+        expect(await get()).toEqual({ id: 'single-object' });
+    });
+
+    test('propagates a request failure to the caller', async () => {
+        const boom = Object.assign(new Error('getaddrinfo ENOTFOUND'), { code: 'ENOTFOUND' });
+        axios.mockRejectedValueOnce(boom);
+
+        await expect(get()).rejects.toBe(boom);
+    });
+});
+
+describe('axios error interceptor (root cause of issue #785)', () => {
+    test('does not throw when the request never reached the server', async () => {
+        // `e.response` is undefined offline. Reading `.status` off it raised
+        // `TypeError: Cannot read properties of undefined (reading 'status')` from inside axios
+        // - verbatim the error in the bug report. Because this interceptor is installed on the
+        // shared axios instance, it affected every HTTP call in the process.
+        const offline = Object.assign(new Error('getaddrinfo ENOTFOUND'), { code: 'ENOTFOUND' });
+
+        const rejection = await interceptors.rejected(offline).catch((e) => e);
+
+        expect(rejection.message).toBe('getaddrinfo ENOTFOUND');
+        expect(rejection.status).toBeUndefined();
+        expect(String(rejection.message)).not.toContain('Cannot read properties');
+    });
+
+    test('preserves code and response so the failure can still be classified', async () => {
+        // getErrorCategory keys off `code` and `response.status`; dropping them left every
+        // failure looking identical to callers.
+        const offline = Object.assign(new Error('connect ECONNREFUSED'), {
+            code: 'ECONNREFUSED',
+        });
+
+        const rejection = await interceptors.rejected(offline).catch((e) => e);
+
+        expect(rejection.code).toBe('ECONNREFUSED');
+    });
+
+    test('still surfaces HTTP status and statusText when the server did answer', async () => {
+        const httpError = Object.assign(new Error('Request failed with status code 403'), {
+            response: { status: 403, statusText: 'Forbidden' },
+        });
+
+        const rejection = await interceptors.rejected(httpError).catch((e) => e);
+
+        expect(rejection.status).toBe(403);
+        expect(rejection.statusText).toBe('Forbidden');
+        expect(rejection.message).toBe('Request failed with status code 403');
+    });
+
+    test('survives a non-Error rejection', async () => {
+        const rejection = await interceptors.rejected('a bare string').catch((e) => e);
+
+        expect(rejection.message).toBe('a bare string');
+    });
+});
+
+describe('interceptor rejection shape is what downstream classification expects', () => {
+    // The interceptor is installed on the *shared* axios instance, so every HTTP request in the
+    // process - including the Chrome version lookup in browser-list-available.js - receives its
+    // rejections in this shape rather than as raw axios errors.
+    //
+    // Those consumers mock axios wholesale in their own tests, which means the interceptor never
+    // runs there and the coupling goes unchecked. That gap already hid a real defect: before the
+    // interceptor passed `response` through, an HTTP 503 arrived with no `response` field and
+    // browser-list-available reported it as "could not reach the host", while its own test
+    // asserted the opposite and passed. These tests pin the contract from this side.
+
+    /**
+     * Runs an error through the real interceptor and returns the rejected value.
+     *
+     * @param {unknown} err - Error to feed the interceptor.
+     *
+     * @returns {Promise<object>} The transformed rejection.
+     */
+    const throughInterceptor = (err) => interceptors.rejected(err).catch((e) => e);
+
+    test('an offline failure stays classifiable and reads as "no response"', async () => {
+        const { getErrorCategory } = await import('../../util/error-categorizer.js');
+
+        const rejection = await throughInterceptor(
+            Object.assign(new Error('getaddrinfo ENOTFOUND'), { code: 'ENOTFOUND' })
+        );
+
+        // browser-list-available treats an absent `response` as "never reached the server".
+        expect(Boolean(rejection.response)).toBe(false);
+        expect(getErrorCategory(rejection)).toBe('host_not_found');
+    });
+
+    test('an HTTP failure keeps its status so it is not misreported as offline', async () => {
+        const { getErrorCategory } = await import('../../util/error-categorizer.js');
+
+        const rejection = await throughInterceptor(
+            Object.assign(new Error('Request failed with status code 503'), {
+                response: { status: 503, statusText: 'Service Unavailable' },
+            })
+        );
+
+        expect(Boolean(rejection.response)).toBe(true);
+        expect(rejection.response.status).toBe(503);
+        expect(getErrorCategory(rejection)).toBe('http_5xx');
+    });
+
+    test('does not carry the API token into the rejected value', async () => {
+        // config.headers.Authorization holds the bearer token, and several callers log errors
+        // with JSON.stringify(err). Only the status is passed through, never the response object.
+        const rejection = await throughInterceptor(
+            Object.assign(new Error('Request failed with status code 403'), {
+                response: {
+                    status: 403,
+                    config: { headers: { Authorization: 'Bearer SUPER-SECRET-TOKEN' } },
+                    data: { detail: 'nope' },
+                },
+            })
+        );
+
+        expect(JSON.stringify(rejection)).not.toContain('SUPER-SECRET-TOKEN');
+        expect(rejection.response).toEqual({ status: 403 });
+    });
+});

--- a/src/lib/cloud/cloud-repo-request.js
+++ b/src/lib/cloud/cloud-repo-request.js
@@ -22,10 +22,31 @@ axios.interceptors.response.use(
         return response;
     },
     (e) =>
+        // `e.response` is absent whenever the request never reached the server - offline, DNS
+        // failure, connection refused, TLS rejection. Reading `.status` off it unguarded turned
+        // every such failure into `TypeError: Cannot read properties of undefined (reading
+        // 'status')` raised from inside axios, which is the error reported in issue #785.
+        //
+        // This interceptor is registered on the shared axios instance, so it applied to every
+        // HTTP request in the process - including the Chrome version lookup in
+        // browser-list-available.js, which is where the report came from rather than from any
+        // Qlik Cloud call.
+        //
+        // `code` and the response *status* are carried through so callers can still classify the
+        // failure - getErrorCategory reads `err.code` and `err.response?.status`, and without
+        // either it cannot tell "offline" from "the server said no".
+        //
+        // Only the status, never the response object itself: that carries `config`, and
+        // `config.headers.Authorization` is the Qlik Cloud API token. Several callers log errors
+        // with `JSON.stringify(err)`, so attaching the whole response would put the token on the
+        // path to the log. The winston sanitiser would most likely catch it, but there is no
+        // reason to depend on that.
         Promise.reject({
-            status: e.response.status,
-            statusText: e.response.statusText,
-            message: e.message,
+            status: e?.response?.status,
+            statusText: e?.response?.statusText,
+            message: e?.message ?? String(e),
+            code: e?.code,
+            response: e?.response ? { status: e.response.status } : undefined,
         })
 );
 
@@ -68,13 +89,25 @@ async function makeRequest(config, data = []) {
                 `CLOUD Got response 1 (headers): ${JSON.stringify(response.headers, null, 2)}`
             );
 
-        if (response.data.data) returnData = [...returnData, ...response.data.data];
-        if (!response.data.data) returnData = { data: response.data, status: response.status };
+        // `response.data` is optional - the debug logging above already treats it as such - so
+        // reading `.data` off it unguarded would throw on a response with no body.
+        const body = response.data;
 
-        if (response.data.links && (response.data.links.next || response.data.links.Next)) {
-            config.url = response.data.links.next.href
-                ? response.data.links.next.href
-                : response.data.links.Next.Href;
+        if (body?.data) {
+            returnData = [...returnData, ...body.data];
+        } else {
+            returnData = { data: body, status: response.status };
+        }
+
+        // Qlik Cloud has been seen to use both `links.next` and `links.Next`, which is why the
+        // guard here accepts either. Reading `next.href` unconditionally afterwards meant a
+        // response carrying only the capital form threw
+        // `TypeError: Cannot read properties of undefined (reading 'href')` - the guard admitted
+        // a shape the next line could not handle.
+        const nextPageUrl = body?.links?.next?.href || body?.links?.Next?.Href;
+
+        if (nextPageUrl) {
+            config.url = nextPageUrl;
             return makeRequest(config, returnData);
         }
     } catch (err) {

--- a/src/lib/cloud/cloud-repo-request.js
+++ b/src/lib/cloud/cloud-repo-request.js
@@ -162,7 +162,11 @@ const request = async (
     };
 
     if (contentType === 'multipart/form-data') {
-        if (path.toLowerCase().indexOf('extensions')) {
+        // `.includes` rather than the previous `.indexOf(...)` used as a boolean: indexOf returns
+        // -1 when the substring is absent, which is truthy, and 0 when it is at the very start,
+        // which is falsy. The test was therefore inverted for both edge cases - it ran for paths
+        // with no "extensions" in them, and skipped paths beginning with "extensions".
+        if (path.toLowerCase().includes('extensions')) {
             const formData = new FormData();
             formData.append('file', bufferToStream(file), {
                 contentType: 'application/x-zip-compressed',

--- a/src/lib/commands/__tests__/commands.test.js
+++ b/src/lib/commands/__tests__/commands.test.js
@@ -304,7 +304,14 @@ describe('browser commands', () => {
 
         browserListAvailable.mockRejectedValueOnce(new Error('bad'));
         await handleBrowserListAvailable(options, {});
-        expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('BROWSER MAIN 10'));
+
+        // The handler used to log the same failure three times, prefixed "BROWSER MAIN 10",
+        // including a full stack trace. browserListAvailable has already explained the cause by
+        // this point, so the handler now adds one line and puts the stack at debug (issue #785).
+        const errors = logger.error.mock.calls.map((call) => String(call[0]));
+        expect(errors).toContain('Could not list available browsers.');
+        expect(errors.join('\n')).not.toContain('BROWSER MAIN 10');
+        expect(errors.join('\n')).not.toContain('at ');
     });
 
     test('install delegates to browserInstall after normalizing chrome defaults', async () => {

--- a/src/lib/commands/browser/list-available.js
+++ b/src/lib/commands/browser/list-available.js
@@ -17,13 +17,12 @@ const handleBrowserListAvailable = async (options = {}, cmd) => {
         const res = await browserListAvailable(options, cmd);
         logger.debug(`Call to browserAvailable succeeded: ${JSON.stringify(res, null, 2)}`);
     } catch (err) {
-        logger.error(`BROWSER MAIN 10: ${err}`);
-        if (err.message) {
-            logger.error(`BROWSER MAIN 10 (message): ${err.message}`);
-        }
-        if (err.stack) {
-            logger.error(`BROWSER MAIN 10 (stack): ${err.stack}`);
-        }
+        // browserListAvailable has already explained the failure - a connectivity problem gets
+        // actionable advice, anything else gets its message. Repeating it here three times over,
+        // stack trace included, is what made an offline run unreadable (issue #785). The stack
+        // stays available at debug level.
+        logger.error('Could not list available browsers.');
+        logger.debug(err?.stack ?? String(err));
     }
 };
 

--- a/src/lib/util/reported-error.js
+++ b/src/lib/util/reported-error.js
@@ -1,0 +1,50 @@
+/**
+ * Marker for errors whose cause has already been explained to the user.
+ *
+ * Butler Sheet Icons layers several `catch` blocks over the same failure: a module that knows why
+ * something failed, then the command handler that invoked it. Without a way to tell that the
+ * cause has already been reported, each layer logs its own version and the operator ends up with
+ * the same failure described three or four times, usually with a stack trace attached. That is
+ * what made an offline `browser list-available` run unreadable in issue #785.
+ *
+ * The pattern is: whichever layer can actually explain the failure logs a useful message and
+ * calls `markReported(err)`. Outer layers call `alreadyReported(err)` and stay quiet when it is
+ * true, letting the error propagate without re-describing it.
+ */
+
+/**
+ * Symbol used to tag an error as already explained.
+ *
+ * A Symbol rather than a plain property so the marker never appears in `JSON.stringify` output,
+ * in `Object.keys`, or anywhere else that enumerates an error's own properties.
+ */
+const FAILURE_REPORTED = Symbol('butler-sheet-icons.failureReported');
+
+/**
+ * Records that a failure has been explained to the user, so outer handlers do not repeat it.
+ *
+ * Values that cannot carry a property (strings, numbers, `null`) are ignored rather than throwing,
+ * since a `catch` block cannot assume it was handed an `Error`.
+ *
+ * @param {Error|unknown} err - The error to mark.
+ *
+ * @returns {Error|unknown} The same value, for convenient use in `throw markReported(err)`.
+ */
+export function markReported(err) {
+    if (err && typeof err === 'object' && Object.isExtensible(err)) {
+        err[FAILURE_REPORTED] = true;
+    }
+
+    return err;
+}
+
+/**
+ * Reports whether a more specific handler has already explained this failure.
+ *
+ * @param {Error|unknown} err - The error to test.
+ *
+ * @returns {boolean} `true` when the failure has already been logged for the user.
+ */
+export function alreadyReported(err) {
+    return Boolean(err && typeof err === 'object' && err[FAILURE_REPORTED]);
+}


### PR DESCRIPTION
Closes #785.

## The root cause was not where the report pointed

#785 reported `browser list-available` failing offline with:

```
error: Error checking for available browsers: TypeError: Cannot read properties of undefined (reading 'status')
error: BROWSER MAIN 10 (stack): TypeError: ...
    at ./build/build.cjs:172381:26
    at async Axios.request
```

That error did not originate in the browser code. `src/lib/cloud/cloud-repo-request.js` installs an axios response interceptor whose error handler read `e.response.status` **unguarded**:

```js
(e) => Promise.reject({ status: e.response.status, ... })
```

`e.response` is absent whenever a request never reaches a server — offline, DNS failure, connection refused. So every such failure became `TypeError: Cannot read properties of undefined (reading 'status')`, thrown from inside axios. That matches the reported message exactly, and explains the `at async Axios.request` frame.

**The interceptor is registered on the *shared* axios instance**, and the CLI imports every command module. So a Qlik Cloud module was corrupting the error of every failed HTTP request in the process — which is why a browser-version lookup was the thing that broke.

## What changed

**1. The interceptor (`3d42bed`)** — guards the response access, and passes `code` and the response **status** through so callers can still tell "offline" from "the server said no". Deliberately only the status, never the response object: it carries `config.headers.Authorization`, and nine call sites log errors with `JSON.stringify(err)`.

Two more defects of the same class in that file:
- Pagination accepted `links.next` **or** `links.Next`, then read `links.next.href` unconditionally — a response using only the capitalised form threw.
- `response.data.data` was read unguarded three lines after the module's own logging guards `if (response.data)`.

**2. Error reporting (`0f0ca16`, `1bbf8a0`)** — the failure is now explained once, with advice, and stacks move to debug:

```
error: Could not reach versionhistory.googleapis.com to look up available browser versions.
error: Butler Sheet Icons needs internet access for this command. If this machine is offline
       or behind a proxy, use "butler-sheet-icons browser list-installed" ...
```

Detection keys off the **absence of an HTTP response**, not `err.code` — the reported symptom was a code-less TypeError, so a code-based check would have missed the very case in the report. An HTTP failure reports differently, quoting the status.

A shared `src/lib/util/reported-error.js` lets a module that can explain a failure mark it, so outer handlers stay quiet. Without that, `browser install --browser-version latest` still dumped a stack via the same code path. Also guards `err.message.includes(...)` in `browserInstall`, which turned a non-Error throw into a second TypeError inside the handler.

**3. `467e2c3`** — `if (path.toLowerCase().indexOf('extensions'))` used `indexOf` as a boolean. `-1` (absent) is truthy and `0` (at the start) is falsy, so the check was inverted at both edges. Dormant today (nothing passes `multipart/form-data`), but `contentType` is a public parameter of the module's default export.

**4. Docs (`3a9a816`)** — staged page on which browser commands need internet access, per the convention in AGENTS.md.

## Tests

**247 passing across 25 suites.** Two modules gained their first tests:

| Module | Before | After |
|---|---|---|
| `cloud-repo-request.js` | **0%** | 90.2% |
| `browser-list-available.js` | 56.7% | ~64% |

Every new test was checked against the pre-fix code rather than assumed useful — 3 of 4 interceptor tests fail without the guard, 2 of 3 multipart tests fail against the inverted check, and 6 of 8 offline tests fail without the error handling.

Three tests drive real errors through the **live interceptor** and assert the result against what `browser-list-available` expects, pinning a contract that mocked tests on either side cannot see.

Each of the six commits is independently lint-clean and green.

## Worth knowing before merging

- `gitnexus_impact` reports **HIGH risk** on `cloud-repo-request.js` — 6 execution flows touch it, since the interceptor is on the shared axios instance.
- **Nothing here has run against a real Qlik Cloud tenant.** Everything is unit-level with axios mocked, and a shared interceptor is exactly where mocks can agree with each other while disagreeing with reality. The `ci.yaml` integration suites cover this path if credentials are available.
- The same `err.stack`-at-error-level pattern remains in eight other command files. The shared helper makes fixing them straightforward, but that is deliberately left out of scope here.
