### PR TITLE
fix: clear partial install directory before retrying browser install

### DIFF
--- a/src/lib/browser/__tests__/browser_install.test.js
+++ b/src/lib/browser/__tests__/browser_install.test.js
@@ -5,8 +5,9 @@ jest.unstable_mockModule('@puppeteer/browsers', () => ({
     resolveBuildId: jest.fn(),
     detectBrowserPlatform: jest.fn(),
     canDownload: jest.fn(),
+    uninstall: jest.fn(),
 }));
-const { install, resolveBuildId, detectBrowserPlatform, canDownload } =
+const { install, resolveBuildId, detectBrowserPlatform, canDownload, uninstall } =
     await import('@puppeteer/browsers');
 
 jest.unstable_mockModule('../../../globals.js', () => ({
@@ -137,5 +138,92 @@ describe('browserInstall — retry logic', () => {
 
         expect(install).toHaveBeenCalledTimes(3);
         expect(logger.warn).toHaveBeenCalledTimes(2);
+    });
+
+    test('clears the partial install directory before retrying', async () => {
+        const installed = { browser: 'chrome', buildId: '123.0.0.0', executablePath: '/p/chrome' };
+        install
+            .mockImplementationOnce(() => {
+                throw new Error(
+                    'All providers failed: DefaultProvider: Extraction failed: bad zip'
+                );
+            })
+            .mockResolvedValueOnce(installed);
+
+        await browserInstall({ browser: 'chrome', browserVersion: '123.0.0.0', loglevel: 'error' });
+
+        expect(uninstall).toHaveBeenCalledTimes(1);
+        expect(uninstall).toHaveBeenCalledWith({
+            browser: 'chrome',
+            buildId: '123.0.0.0',
+            cacheDir: expect.stringContaining('.cache/puppeteer'),
+        });
+    });
+
+    // The regression this guards against: `install()` treats an existing install directory as an
+    // already-installed browser, so it skips the download and fails validation instead. A retry
+    // that does not first clear the partial directory left by a failed extraction can therefore
+    // never recover, and the misleading validation error replaces the real extraction failure as
+    // the error the caller finally sees. The directory is modelled here the way
+    // `@puppeteer/browsers` treats it - the mocks in the test above always succeed on retry
+    // regardless of cache state, which is why they did not catch this.
+    test('recovers from an extraction failure that left a partial install directory', async () => {
+        const installed = { browser: 'chrome', buildId: '123.0.0.0', executablePath: '/p/chrome' };
+        let partialDirExists = false;
+
+        install
+            .mockImplementationOnce(() => {
+                // Download succeeds, extraction fails part-way through.
+                partialDirExists = true;
+                throw new Error(
+                    'All providers failed: DefaultProvider: Extraction failed: bad zip'
+                );
+            })
+            .mockImplementationOnce(() => {
+                if (partialDirExists) {
+                    throw new Error(
+                        'All providers failed for chrome 123.0.0.0:\n  - DefaultProvider: The browser folder exists but the executable is missing'
+                    );
+                }
+                return installed;
+            });
+        uninstall.mockImplementationOnce(() => {
+            partialDirExists = false;
+        });
+
+        const result = await browserInstall({
+            browser: 'chrome',
+            browserVersion: '123.0.0.0',
+            loglevel: 'error',
+        });
+
+        expect(result).toBe(installed);
+        expect(install).toHaveBeenCalledTimes(2);
+    });
+
+    test('a failing cleanup does not mask the install error', async () => {
+        const lastError = new Error(
+            'All providers failed: DefaultProvider: Extraction failed: bad zip'
+        );
+        install
+            .mockImplementationOnce(() => {
+                throw new Error('attempt 1');
+            })
+            .mockImplementationOnce(() => {
+                throw new Error('attempt 2');
+            })
+            .mockImplementationOnce(() => {
+                throw lastError;
+            });
+        uninstall
+            .mockRejectedValueOnce(new Error('ENOENT: no such file or directory'))
+            .mockRejectedValueOnce(new Error('ENOENT: no such file or directory'));
+
+        await expect(
+            browserInstall({ browser: 'chrome', browserVersion: '123.0.0.0', loglevel: 'error' })
+        ).rejects.toBe(lastError);
+
+        // Cleanup runs before each retry, never after the final attempt.
+        expect(uninstall).toHaveBeenCalledTimes(2);
     });
 });

--- a/src/lib/browser/__tests__/browser_install_offline.test.js
+++ b/src/lib/browser/__tests__/browser_install_offline.test.js
@@ -12,6 +12,7 @@ jest.unstable_mockModule('@puppeteer/browsers', () => ({
     canDownload: jest.fn().mockResolvedValue(true),
     install: jest.fn(),
     resolveBuildId: jest.fn(),
+    uninstall: jest.fn(),
 }));
 
 jest.unstable_mockModule('../../../globals.js', () => ({

--- a/src/lib/browser/browser-install.js
+++ b/src/lib/browser/browser-install.js
@@ -1,4 +1,10 @@
-import { install, resolveBuildId, detectBrowserPlatform, canDownload } from '@puppeteer/browsers';
+import {
+    install,
+    resolveBuildId,
+    detectBrowserPlatform,
+    canDownload,
+    uninstall,
+} from '@puppeteer/browsers';
 import path from 'path';
 import { homedir } from 'os';
 import cliProgress from 'cli-progress';
@@ -127,11 +133,17 @@ export const browserInstall = async (options, _command) => {
             unpack: true,
         };
 
-        // `@puppeteer/browsers` v3+ uses the OS `unzip` binary for extraction
-        // (macOS ships a 2009 build that occasionally fails on the Chrome for
-        // Testing archives with "End-of-central-directory signature not found").
-        // Wrap the install in a small retry loop to ride out the transient
-        // failures that were not present with v2's JS-based `extract-zip`.
+        // `@puppeteer/browsers` v3+ uses the OS `unzip` binary for extraction, which reports a
+        // damaged archive as "End-of-central-directory signature not found". Retry to ride out
+        // the transient failures that were not present with v2's JS-based `extract-zip`.
+        //
+        // Note the archive is usually damaged rather than mis-read: `downloadFile` streams
+        // straight to a deterministic path under the cache dir with no temp file or atomic
+        // rename, `install()` reuses any archive already sitting at that path, and its `finally`
+        // unlinks it. Two Butler Sheet Icons processes sharing the cache therefore race on one
+        // file - and `browserUninstallAll` empties the whole cache directory, so it can delete an
+        // archive another process is still downloading. Retrying does not make concurrent runs
+        // safe; only giving them separate cache directories would.
         const MAX_INSTALL_ATTEMPTS = 3;
         const RETRY_DELAY_MS = 2000;
         let browser;
@@ -150,6 +162,28 @@ export const browserInstall = async (options, _command) => {
                     logger.warn(
                         `Install attempt ${attempt}/${MAX_INSTALL_ATTEMPTS} failed: ${err.message}. Retrying in ${RETRY_DELAY_MS / 1000}s...`
                     );
+
+                    // A failed extraction leaves a partially unpacked install directory behind, and
+                    // `install()` treats an existing install directory as an already-installed
+                    // browser: it skips the download entirely, then fails validation with "The
+                    // browser folder exists but the executable is missing". Without this cleanup
+                    // every retry hit that instead of retrying the download, so the loop could
+                    // never recover - and the misleading validation error replaced the real
+                    // extraction failure as the error the caller finally saw.
+                    try {
+                        await uninstall({
+                            browser: options.browser,
+                            buildId,
+                            cacheDir: browserPath,
+                        });
+                    } catch (cleanupErr) {
+                        // Nothing to clean up is the common case - the attempt may have failed
+                        // before anything was written. Never let cleanup mask the install error.
+                        logger.debug(
+                            `Could not clear partial install directory: ${cleanupErr?.message ?? cleanupErr}`
+                        );
+                    }
+
                     await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
                     progressBar.start(100, 0);
                 }


### PR DESCRIPTION
## Problem

A browser install that fails during extraction leaves a partially unpacked install directory behind. `@puppeteer/browsers` treats an existing install directory as an already-installed browser — it skips the download entirely, then fails validation:

```
All providers failed for chrome 151.0.7922.76:
  - DefaultProvider: The browser folder (…/chrome/mac_arm-151.0.7922.76) exists but
    the executable (…/Google Chrome for Testing) is missing
```

Because the retry loop in `browserInstall` never cleared that directory, attempts 2 and 3 hit the validation error instead of retrying the download. The loop could never recover, and the misleading validation error replaced the real extraction failure as the error the caller finally saw — so the actual cause was discarded exactly when it was needed.

## Change

Remove the partial install directory before each retry, so the next attempt starts from nothing. A failing cleanup is logged at debug and never masks the install error.

The rationale comment above the retry loop is also corrected. It blamed the 2009 `unzip` binary macOS ships, but that binary reports the damage accurately — the archive really is damaged. `downloadFile` streams straight to a deterministic path with no temp file or atomic rename, `install()` reuses any archive already sitting there, and `browserUninstallAll` empties the whole cache directory. Two Butler Sheet Icons processes sharing `~/.cache/puppeteer` therefore race on a single file. Retrying does not make concurrent runs safe; only separate cache directories would. That is left as follow-up work — see below.

## Testing

Three regression tests added. All three were confirmed to fail without the fix, including one reproducing the reported error text:

- cleanup is invoked with the right build id and cache dir before retrying
- recovery from an extraction failure that left a partial install directory
- a failing cleanup does not mask the install error

The pre-existing test `retries on extraction failure and eventually succeeds` mocked `install()` to succeed on retry regardless of cache state, which is why this went unnoticed. The new tests model the install directory the way `@puppeteer/browsers` treats it.

Verified with:

- full unit suite — 250 tests, 25 suites, green
- `browser_install_uninstall.integration.test.js` — green, with real downloads of Chrome 151 and 114 through full install/uninstall cycles
- `npm run lint` clean at `--max-warnings 0`, Prettier clean

`uninstall` was added to the `@puppeteer/browsers` mock in two test files, which the new named import requires.

## Follow-up (not in this PR)

`~/.cache/puppeteer` is hardcoded in five modules, so concurrent Butler Sheet Icons runs will keep corrupting each other's downloads. Making the cache directory configurable would fix that properly and would help CI parallelism, but it is user-facing and needs its own doc-site page. Worth doing only if parallel integration runs are actually wanted.

## Docs

No doc-site page. The user-visible effect is that a flaky install now recovers and the error text on genuine failure becomes accurate; nothing an administrator needs to do differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)