### PR TITLE
chore: add a manual macOS signing and notarization canary

### DIFF
--- a/.github/workflows/macos-signing-canary.yaml
+++ b/.github/workflows/macos-signing-canary.yaml
@@ -1,0 +1,95 @@
+name: macos-signing-canary
+
+# Manually-run smoke test for the macOS release path.
+#
+# release-macos-arm64 in ci.yaml only runs when release-please actually cuts a release, so the
+# signing and notarization path is otherwise exercised for the first time during a live release.
+# This job runs the very same script on the very same runner image, but stops short of publishing:
+# nothing is uploaded to a release and no tag is touched.
+#
+# Run it after changing scripts/release-macos.sh, after changing the runner image in
+# release-macos-arm64, or periodically to catch GitHub retiring the pinned macOS image before a
+# release does.
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  sign-and-notarize:
+    # MUST stay in sync with release-macos-arm64 in ci.yaml - proving that image is the point.
+    runs-on: macos-15
+    permissions:
+      contents: read
+    env:
+      DIST_FILE_NAME: butler-sheet-icons
+      # scripts/release-macos.sh names the archive "${RELEASE_VERSION}-macos-arm64.zip".
+      RELEASE_VERSION: canary-${{ github.run_id }}
+      MACOS_CERTIFICATE: ${{ secrets.PROD_MACOS_CERTIFICATE_BASE64_CODESIGN }}
+      MACOS_CERTIFICATE_PWD: ${{ secrets.PROD_MACOS_CERTIFICATE_CODESIGN_PWD }}
+      MACOS_CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_CODESIGN_NAME }}
+      MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
+      PROD_MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_APPLE_ID }}
+      PROD_MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_TEAM_ID }}
+      PROD_MACOS_NOTARIZATION_PWD: ${{ secrets.PROD_MACOS_NOTARIZATION_PWD }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+
+      # The release script snapshots the user keychain list and expands it unguarded under
+      # `set -u`. An empty list is the one input that breaks it, so record what this host reports
+      # before the script runs - it turns a confusing mid-script exit into an obvious cause.
+      - name: Report host details
+        run: |
+          sw_vers
+          echo "arch          : $(uname -m)"
+          echo "bash          : ${BASH_VERSION:-unknown} at $(command -v bash)"
+          echo "node          : $(node --version) at $(command -v node)"
+          echo "--- security list-keychains -d user ---"
+          security list-keychains -d user
+
+      - name: Install dependencies
+        run: npm ci --include=dev --include=prod
+
+      - name: Build, sign and notarize
+        run: bash ./scripts/release-macos.sh
+
+      # codesign -dv writes to stderr, hence the redirect. Assert the two properties that actually
+      # matter and that a wrong signing identity would silently get wrong: the Developer ID
+      # authority, and the hardened runtime that notarization requires.
+      - name: Verify the signature
+        run: |
+          set -euo pipefail
+          codesign -dv --verbose=4 "./${DIST_FILE_NAME}" 2> codesign-info.txt
+          cat codesign-info.txt
+
+          if ! grep -q 'Authority=Developer ID Application' codesign-info.txt; then
+            echo "::error::binary is not signed with a Developer ID Application certificate"
+            exit 1
+          fi
+
+          if ! grep -q 'flags=.*runtime' codesign-info.txt; then
+            echo "::error::hardened runtime is not enabled - notarization would be rejected"
+            exit 1
+          fi
+
+          # --deep is for bundles; this is a bare Mach-O executable.
+          codesign --verify --strict --verbose=2 "./${DIST_FILE_NAME}"
+
+          echo "Signature OK. Check the notarization status printed by notarytool in the"
+          echo "'Build, sign and notarize' step above - it must read 'status: Accepted'."
+
+      - name: Upload the signed archive for inspection
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: macos-signing-canary-${{ github.run_id }}
+          path: ./*-macos-arm64.zip
+          retention-days: 3


### PR DESCRIPTION
## Why

`release-macos-arm64` in `ci.yaml` only runs when release-please actually cuts a release. That means the codesign + notarization path is exercised for the first time **during a live release** — with the tag already created and other platforms' artifacts possibly already uploaded.

That is about to matter more: a follow-up change moves that job off the self-hosted Mac onto a hosted `macos-15` runner. This canary exists so that migration can be proven before it is merged, rather than discovered during a release.

## What it does

A `workflow_dispatch`-only job on `macos-15` that runs `scripts/release-macos.sh` unmodified with `RELEASE_VERSION=canary-<run_id>`, then asserts the result. It **publishes nothing** — no tag, no release asset. The signed zip goes to a 3-day workflow artifact.

Assertions are limited to what actually changes when the host changes:

- `Authority=Developer ID Application` in the `codesign -dv` output
- `flags=...runtime` — hardened runtime, which notarization requires
- `codesign --verify --strict`

It deliberately does **not** use `spctl -a -t install`. This is a bare Mach-O executable, not a bundle, and the script never staples a ticket (bare binaries can't be stapled), so `spctl` would report rejection on a perfectly good build. The notarytool status stays visible in the step log instead.

## The keychain detail

The job prints `bash --version` and `security list-keychains -d user` before running the script.

`scripts/release-macos.sh:54` expands `"${ORIGINAL_KEYCHAINS[@]}"` unguarded under `set -u`, while the identical expansion in its `cleanup()` at line 33 *is* guarded by a length check. An empty keychain list is the one input that breaks it, and under bash 3.2 — the system bash on macOS — expanding an empty array with `set -u` is a fatal "unbound variable".

`scripts/insider-build-mac.sh` carries a byte-identical keychain block with the same asymmetry at its own lines 38 and 64. Reading the list into the array was deliberately made 3.2-compatible (`mapfile` was replaced with a `while IFS= read` loop in 9d1b457, "enhance keychain handling ... for CI stability"), so someone has already been bitten by a bash-version difference here — but the unguarded expansion was left in place in both scripts.

Which `bash` actually resolves on each host is the open question, and printing the version plus the keychain list up front settles it on the first run instead of turning into a confusing mid-script exit.

## Secrets

All seven signing/notarization secrets match `release-macos-arm64` exactly. `secrets.PAT` is deliberately omitted — `ci.yaml` passes it as `GITHUB_TOKEN`, but the script never reads it.

## Verification

- YAML parses; `workflow_dispatch` is the sole trigger; `runs-on: macos-15` matches the job it is proving
- `zizmor` reports no findings on this file

It has to land on `main` before `workflow_dispatch` will offer it — that is the only reason this is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)