### PR TITLE
fix: stop the browser-arg test asserting the host platform

### DIFF
--- a/src/lib/browser/__tests__/browser_launch.test.js
+++ b/src/lib/browser/__tests__/browser_launch.test.js
@@ -76,15 +76,20 @@ describe('buildBrowserArgs', () => {
         expect(args).toEqual(expect.arrayContaining(['--no-sandbox', '--disable-gpu']));
     });
 
-    test('adds --single-process outside Windows and Docker', async () => {
-        // The unit test hosts (macOS locally, Ubuntu in CI) are both non-Windows.
-        expect(await buildBrowserArgs()).toContain('--single-process');
+    test('adds --single-process on non-Windows hosts outside Docker', async () => {
+        expect(await buildBrowserArgs({ platform: 'linux' })).toContain('--single-process');
+    });
+
+    test('omits --single-process on Windows, where it broke QS Cloud (issue #742)', async () => {
+        expect(await buildBrowserArgs({ platform: 'win32' })).not.toContain('--single-process');
     });
 
     test('omits --single-process in Docker, where it crashes Chromium', async () => {
         fs.existsSync.mockImplementation((p) => p === '/.dockerenv');
 
-        expect(await buildBrowserArgs()).not.toContain('--single-process');
+        // A non-Windows platform, so the Docker check is what omits the flag rather than the
+        // Windows check short-circuiting ahead of it.
+        expect(await buildBrowserArgs({ platform: 'linux' })).not.toContain('--single-process');
     });
 });
 

--- a/src/lib/browser/browser-launch.js
+++ b/src/lib/browser/browser-launch.js
@@ -55,16 +55,21 @@ const detectDocker = async () => {
 };
 
 /**
- * Builds the Chromium argument list for the current platform.
+ * Builds the Chromium argument list for the given platform.
+ *
+ * @param {object} [options] - Overrides for values normally read from the running process.
+ * @param {string} [options.platform] - Node platform identifier, e.g. `win32` or `linux`.
+ * Defaults to `process.platform`; tests pass it explicitly so every branch is exercised
+ * regardless of which host runs the suite.
  *
  * @returns {Promise<string[]>} Browser arguments, including `--single-process` where safe.
  */
-export const buildBrowserArgs = async () => {
+export const buildBrowserArgs = async ({ platform = process.platform } = {}) => {
     const browserArgs = [...BASE_BROWSER_ARGS];
 
     const isDocker = await detectDocker();
 
-    if (process.platform !== 'win32' && !isDocker) {
+    if (platform !== 'win32' && !isDocker) {
         browserArgs.push('--single-process');
         logger.debug('Added --single-process flag for non-Windows native environment');
     } else if (isDocker) {


### PR DESCRIPTION
## Why

The Windows leg of `insiders-build` has failed on **every run since #839** — three consecutive runs on `main`, while macOS and Linux pass. No Windows insider binary has been produced since #837.

All three failed on the same single test, and the production code was correct the whole time.

## What was wrong

`buildBrowserArgs()` deliberately omits `--single-process` on Windows — that's the fix for #742, and the JSDoc on `detectDocker` says in as many words not to reintroduce it. But the test added in `31e48cc` asserted the flag was *always* present:

```js
test('adds --single-process outside Windows and Docker', async () => {
    // The unit test hosts (macOS locally, Ubuntu in CI) are both non-Windows.
    expect(await buildBrowserArgs()).toContain('--single-process');
});
```

That assumption holds for the PR checks — unit tests run on PRs only via `sonarcloud.yaml`, on `ubuntu-latest`. `insiders-build` is the only workflow that runs them on Windows, and it fires *after* merge. So the bug could not be caught before landing.

## The fix

`buildBrowserArgs` now takes the platform as an injectable parameter defaulting to `process.platform`. The only call site, `launchBrowserForApp`, calls it with no arguments, so runtime behaviour is byte-identical on every platform.

The tests now drive each branch explicitly:

- the failing test passes `{ platform: 'linux' }`
- a **new** test covers the Windows branch, which had no test at all despite the "do not reintroduce" warning
- the Docker test passes `{ platform: 'linux' }` — it was passing on Windows only because the platform check short-circuited ahead of it, so it never reached the Docker branch it claims to test

## Verification

Reproduced the CI failure locally first by forcing `process.platform` to `win32` via a `--setupFiles` stub — same test, same received array as the CI log. After the fix that command passes 10/10.

- `npm run lint` — clean (zero-warning gate)
- `npm run test:unit` — 25 suites, 251 tests, all passing
- `browser-launch.js` branch coverage 80% → 88%; uncovered lines `53-54,68-69` → `53-54`, so both platform branches are now covered
- `gitnexus impact` on `buildBrowserArgs` — LOW risk, no external callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)