### PR TITLE
refactor: move the non-Windows build jobs to GitHub-hosted runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -339,12 +339,10 @@ jobs:
     permissions:
       contents: read
       actions: write
-    runs-on:
-      - self-hosted
-      - macos
-      - arm64
-      - mac-build2
-      - sp53
+    # Builds a linux/arm64 image, so it needs an arm64 host but not the local Qlik Sense
+    # environment. A hosted arm64 runner builds natively, rather than going through Docker
+    # Desktop on the self-hosted Mac.
+    runs-on: ubuntu-24.04-arm
     env:
       IMAGE_NAME: butler-sheet-icons:ci-arm64
       IMAGE_TAR: butler-sheet-icons-ci-arm64.tar
@@ -409,12 +407,8 @@ jobs:
     permissions:
       contents: read
       actions: write
-    runs-on:
-      - self-hosted
-      - x64
-      - sp53
-      - linux
-      - pve101
+    # Image build only - no Qlik Sense access needed, so this does not have to be on-premise.
+    runs-on: ubuntu-latest
     env:
       IMAGE_NAME: butler-sheet-icons:ci-amd64
       IMAGE_TAR: butler-sheet-icons-ci-amd64.tar
@@ -759,6 +753,10 @@ jobs:
     needs:
       - docker-test-on-macos-arm64
       - docker-test-on-ubuntu-amd64
+    # release-please targets main, so it must not run for a workflow_dispatch fired from a
+    # feature branch. Skipping it here also skips every release-* job, since they gate on its
+    # releases_created output - which is what makes the pipeline safe to dry-run from a branch.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -867,11 +865,10 @@ jobs:
 
   release-macos-arm64:
     needs: release-please
-    runs-on:
-      - self-hosted
-      - arm64
-      - macos
-      - sp53
+    # scripts/release-macos.sh builds its own ephemeral keychain from MACOS_CERTIFICATE and
+    # notarizes via xcrun notarytool, so signing needs no on-premise state. Pinned rather than
+    # macos-latest because the artifact must be arm64.
+    runs-on: macos-15
     # timeout-minutes: 15
     permissions:
       contents: write

--- a/scripts/insider-build-mac.sh
+++ b/scripts/insider-build-mac.sh
@@ -61,7 +61,11 @@ printf '%s' "$MACOS_CERTIFICATE" | base64 --decode > certificate.p12
 # with a UI dialog asking for the certificate password, which we can't
 # use in a headless CI environment
 security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
-security list-keychains -d user -s build.keychain "${ORIGINAL_KEYCHAINS[@]}"
+# GitHub's macOS runners execute this under /bin/bash 3.2, where expanding an empty array under
+# `set -u` is a fatal "unbound variable" - so the ${arr[@]+...} guard is what keeps this working
+# if `security list-keychains` ever comes back empty. cleanup() already guards the same
+# expansion; this line was the one that did not.
+security list-keychains -d user -s build.keychain ${ORIGINAL_KEYCHAINS[@]+"${ORIGINAL_KEYCHAINS[@]}"}
 security default-keychain -d user -s build.keychain
 security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
 security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign -A

--- a/scripts/release-macos.sh
+++ b/scripts/release-macos.sh
@@ -51,7 +51,11 @@ printf '%s' "$MACOS_CERTIFICATE" | base64 --decode > certificate.p12
 # with a UI dialog asking for the certificate password, which we can't
 # use in a headless CI environment
 security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
-security list-keychains -d user -s build.keychain "${ORIGINAL_KEYCHAINS[@]}"
+# GitHub's macOS runners execute this under /bin/bash 3.2, where expanding an empty array under
+# `set -u` is a fatal "unbound variable" - so the ${arr[@]+...} guard is what keeps this working
+# if `security list-keychains` ever comes back empty. cleanup() already guards the same
+# expansion; this line was the one that did not.
+security list-keychains -d user -s build.keychain ${ORIGINAL_KEYCHAINS[@]+"${ORIGINAL_KEYCHAINS[@]}"}
 security default-keychain -d user -s build.keychain
 security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
 security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign


### PR DESCRIPTION
## Why

`ci.yaml` runs almost entirely on self-hosted hardware, in a strictly serial chain. On the last green run that was ~10 min (macOS) + ~29 min (Windows) of serialized private-runner time before anything else could start. Most of that hardware dependency isn't required: **only the steps that talk to the local Qlik Sense server need to be on-premise.**

This is the first, low-risk half of that cleanup — runner swaps only, no topology changes.

**Cost: zero.** The repo is public, and standard GitHub-hosted runners are free and unlimited on public repos. Every label used here is a standard one; no `-large`/`-xlarge` anywhere.

## What moves

| Job | Was | Now |
|---|---|---|
| `docker-build-arm64` | self-hosted macOS | `ubuntu-24.04-arm` |
| `docker-build-on-ubuntu-amd64` | self-hosted Linux | `ubuntu-latest` |
| `release-macos-arm64` | self-hosted macOS | `macos-15` |

`ubuntu-24.04-arm` is already proven in `docker-image-build.yaml`. It also makes the arm64 image a *native* build rather than going through Docker Desktop on the Mac.

`release-macos-arm64` could move because `scripts/release-macos.sh` was already cloud-ready — it decodes the p12 from `MACOS_CERTIFICATE`, builds an ephemeral keychain, and notarizes via `xcrun notarytool`, all from secrets. Pinned to `macos-15` rather than `macos-latest` because the artifact must be arm64.

**Windows stays self-hosted throughout.** Its integration tests reach a local Qlik Sense environment that isn't accessible from the internet, and `release-win64` signs against a certificate thumbprint in that machine's store — the private key isn't in a secret, so it can't move regardless.

## Also here

**`release-please` is now gated on `refs/heads/main`.** It had no event guard, so a `workflow_dispatch` from a feature branch would have run it against `target-branch: main`. Skipping it also skips every `release-*` job, which is what makes the pipeline safe to dry-run from a branch.

**The keychain array expansion is guarded** (separate `fix:` commit, `scripts/release-macos.sh` + `scripts/insider-build-mac.sh`). Both snapshot the user keychain list into an array then expanded it unguarded, while their own `cleanup()` guards the identical expansion. GitHub's macOS runners execute these under `/bin/bash 3.2.57`, where expanding an empty array with `set -u` is a fatal "unbound variable" — it would abort mid-signing, after `build.keychain` is created but before the cert is imported.

## Verification

The macOS move is **evidence-backed, not assumed**. `macos-signing-canary` (#852) run [31085801652](https://github.com/ptarmiganlabs/butler-sheet-icons/actions/runs/31085801652) passed on `macos-15` in 82 seconds:

```
status: Accepted                                        ← xcrun notarytool
CodeDirectory ... flags=0x10000(runtime)                ← hardened runtime
Authority=***  →  Developer ID Certification Authority  →  Apple Root CA
./butler-sheet-icons: valid on disk
./butler-sheet-icons: satisfies its Designated Requirement
```

Host: macOS 15.7.7 / arm64, Node v24.18.0 arm64 — so the `-macos-arm64.zip` name is honest.

That run is also what confirmed the keychain fix is needed: it reported `bash 3.2.57(1)-release at /bin/bash`. The guard was then verified against that same bash version locally — the old line exits 1 on an empty array; the guarded form expands to nothing and still sets `build.keychain`, and a populated array survives intact including paths containing spaces. Both scripts pass `bash -n` under 3.2.

Also: `ci.yaml` parses, `zizmor` unchanged at 0 low/medium/high (186 → 183 findings, the three removed being suppressed ones on the deleted self-hosted label lines).

## Not in scope

The `needs:` chain is untouched, so both build jobs still queue behind the self-hosted test chain — this PR frees hardware capacity but not wall-clock time. Splitting the Qlik-touching jobs by resource and adding separate QSEoW / QS Cloud concurrency singletons is the follow-up, and it's a materially riskier change to a release pipeline than swapping runner labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)