### PR TITLE
fix: stop the cacheDir test assuming a forward-slash separator

### DIFF
--- a/src/lib/browser/__tests__/browser_install.test.js
+++ b/src/lib/browser/__tests__/browser_install.test.js
@@ -1,4 +1,6 @@
 import { jest, test, expect, describe, beforeEach } from '@jest/globals';
+import path from 'node:path';
+import { homedir } from 'node:os';
 
 jest.unstable_mockModule('@puppeteer/browsers', () => ({
     install: jest.fn(),
@@ -156,7 +158,9 @@ describe('browserInstall — retry logic', () => {
         expect(uninstall).toHaveBeenCalledWith({
             browser: 'chrome',
             buildId: '123.0.0.0',
-            cacheDir: expect.stringContaining('.cache/puppeteer'),
+            // Built with path.join, so the separator is platform-specific - a literal
+            // '.cache/puppeteer' never matches on Windows. Assert the whole path instead.
+            cacheDir: path.join(homedir(), '.cache', 'puppeteer'),
         });
     });
 


### PR DESCRIPTION
## Why

`main` is red on Windows. The `insiders-build` Windows leg has failed on this since #847, whose own insiders run was cancelled — so the test had never actually run on Windows before today.

This is the **second** bug of exactly this shape in as many PRs. #853 fixed a test that assumed a non-Windows *host*; this one assumes a non-Windows *path separator*.

## What was wrong

[browser-install.js:64](src/lib/browser/browser-install.js#L64) builds the cache path with `path.join`:

```js
const browserPath = path.join(homedir(), '.cache/puppeteer');
```

On Windows that normalises to `C:\Users\<user>\.cache\puppeteer` — backslashes. But the test asserted a literal forward-slash substring:

```js
cacheDir: expect.stringContaining('.cache/puppeteer'),
```

which can never match there. The source is correct; the expectation was wrong.

```
Expected: StringContaining ".cache/puppeteer"
Received: "C:\\Users\\goran\\.cache\\puppeteer"
```

## The fix

Assert the whole path, built the same way the source builds it:

```js
cacheDir: path.join(homedir(), '.cache', 'puppeteer'),
```

Platform-agnostic, and **stronger** than the original — it pins the exact `cacheDir` rather than accepting any string containing those characters. The source's `uninstall()` call passes exactly these three keys, so the exact-match assertion is the right shape.

## Verification

- `npm run lint` clean; `npm run test:unit` — 25 suites, 251 tests, all passing
- Cross-platform equivalence proved directly with `path.win32`, comparing the exact expressions from source and test:

```
win32  EQUAL "C:\\Users\\goran\\.cache\\puppeteer"
posix  EQUAL "/Users/goran/.cache/puppeteer"
```

and the old expectation confirmed to **not** match under win32, which is the failure being fixed.

Worth noting what I could *not* do: unlike #853, this one can't be reproduced locally by swapping `path` to win32 semantics inside jest — jest itself depends on `path`, so the swap breaks the runner before any test executes. The equivalence proof above is the substitute.

It's the only such assumption in the suite — `grep -rn "\.cache/puppeteer" src --include="*.test.js"` returns one hit.

## Follow-up

A pre-merge Windows unit-test workflow is coming next. Both this bug and #853's would have been caught before merge by it; today unit tests run on PRs only via `sonarcloud.yaml`, on `ubuntu-latest`, and `insiders-build` is the sole Windows run — after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)