### PR TITLE
chore: run lint and unit tests on Windows before merge

### DIFF
--- a/.github/workflows/pr-unit-tests.yaml
+++ b/.github/workflows/pr-unit-tests.yaml
@@ -1,0 +1,59 @@
+name: pr-unit-tests
+
+# Lint and unit tests on every platform the project ships binaries for, before merge.
+#
+# Until this existed, unit tests ran on pull requests only via sonarcloud.yaml, on ubuntu-latest.
+# insiders-build is the only workflow that runs them on Windows and it fires *after* merge, so a
+# Windows-only test bug could not be caught until it was already on main. That happened twice in
+# quick succession - #839 assumed a non-Windows host, #847 assumed a forward-slash path separator -
+# and each cost a red main plus a wasted insiders cycle.
+#
+# GitHub-hosted runners only, so pull requests from forks never reach the self-hosted machines.
+# This workflow reads no secrets at all, which is what makes it safe to run for any contributor:
+# a job-level secret would be in the environment of the test run, and the test run executes code
+# from the pull request.
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: pr-unit-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit-tests:
+    name: lint + unit tests (${{ matrix.os }})
+    strategy:
+      # Report both platforms rather than cancelling the sibling on first failure - a Windows
+      # failure should not hide a Linux one, and vice versa.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Safe to run on Windows: .gitattributes pins `* text eol=lf`, so the checkout has Unix
+      # line endings on every platform and prettier's default endOfLine: lf matches.
+      - name: Run lint
+        run: npm run lint
+
+      - name: Run unit tests
+        run: npm run test:unit


### PR DESCRIPTION
## Why

Unit tests run on pull requests only via `sonarcloud.yaml`, on `ubuntu-latest`. `insiders-build` is the only workflow that runs them on Windows — and it fires **after** merge. So a Windows-only test bug cannot be caught until it is already on `main`.

That has now happened twice in quick succession:

| PR | Assumption | Cost |
|---|---|---|
| #839 | test assumed a non-Windows *host* | 3 red insiders runs, fixed in #853 |
| #847 | test assumed a forward-slash *path separator* | red main, fixed in #855 |

Both are the same shape, and both were invisible until after merge.

## What this adds

A matrix over `ubuntu-latest` and `windows-latest` on `pull_request`, running `npm run lint` and `npm run test:unit`.

- **GitHub-hosted only** — fork pull requests never reach the self-hosted machines.
- **Reads no secrets at all.** That's deliberate, and it's what makes it safe to run for any contributor: a job-level secret sits in the environment of every step including the test run, and the test run executes code from the pull request. `sonarcloud.yaml` already documents this hazard; this workflow sidesteps it by needing nothing.
- **`fail-fast: false`** so a Windows failure doesn't hide a Linux one.
- Free on a public repo; both are standard runners.

It duplicates sonarcloud's ubuntu unit-test run by design. Relying on a *coverage* workflow to also be the Linux test gate is the kind of implicit coupling that let this gap exist — and sonarcloud uses `cancel-in-progress: true`, so on rapid pushes that run can vanish silently.

Linting on Windows is safe: `.gitattributes` pins `* text eol=lf`, so checkouts have Unix line endings on every platform and prettier's default `endOfLine: lf` matches. I checked that before including it.

## Expect the Windows leg to fail on this PR

This branch is based on `main`, which still contains the `cacheDir` bug that #855 fixes. **The Windows job failing here is the proof that the gate works** — it's the natural experiment for "would this have caught #847?", and the answer should be yes.

Merge #855 first, then this branch rebases green. If the Windows leg had passed against a known-broken `main`, the gate would be worthless.

## Verification

- YAML parses; triggers, matrix, `fail-fast: false` and step list confirmed by parsing the file
- `zizmor` — **no findings at all**
- Confirmed no `secrets.` reference anywhere in the file

## Deliberately not done

No `pull_request` trigger on `ci.yaml`. That workflow is the release pipeline — it would drag `release-please` and the live-Qlik integration jobs onto every PR, and queue them on the self-hosted runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)