### PR TITLE
fix: fail Windows CI loudly when the native module resolver cannot load

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,6 +119,21 @@ jobs:
         shell: powershell
         run: npm ci --include=dev --include=prod
 
+      # jest-resolve@30 resolves config paths with unrs-resolver, a Rust/napi-rs native addon,
+      # and its findNodeModule() swallows every error the resolver throws. A .node binding that
+      # cannot be loaded therefore surfaces as "Module <path> in the testRunner option was not
+      # found" - naming a JavaScript file that is present, intact, and resolvable by Node itself.
+      # That misdirection cost a full investigation on PVE-WINSRV19-2, where the binding was on
+      # disk but vcruntime140_1.dll was missing from the host. Fail here instead, naming the
+      # runner and the real cause. Costs about a second.
+      #
+      # unrs-resolver's own message blames an npm optional-dependency bug, which is usually
+      # wrong: check whether the .node file exists before believing it.
+      - name: Verify native module resolver
+        shell: powershell
+        run: |
+          node -e "try { require('unrs-resolver') } catch (e) { console.error('Native module resolver (unrs-resolver) failed to load on runner ' + process.env.RUNNER_NAME + '.'); console.error('This is a runner fault, not a repo fault. Most often the Microsoft VC++ 2015-2022 x64 redistributable is missing (vcruntime140_1.dll), or AV is blocking the .node binary.'); console.error(require('util').inspect(e, {depth: 6})); process.exit(1) }"
+
       - name: Run browser tests
         shell: powershell
         run: npm run test:integration:browser
@@ -219,6 +234,21 @@ jobs:
       - name: Install dependencies
         shell: powershell
         run: npm ci --include=dev --include=prod
+
+      # jest-resolve@30 resolves config paths with unrs-resolver, a Rust/napi-rs native addon,
+      # and its findNodeModule() swallows every error the resolver throws. A .node binding that
+      # cannot be loaded therefore surfaces as "Module <path> in the testRunner option was not
+      # found" - naming a JavaScript file that is present, intact, and resolvable by Node itself.
+      # That misdirection cost a full investigation on PVE-WINSRV19-2, where the binding was on
+      # disk but vcruntime140_1.dll was missing from the host. Fail here instead, naming the
+      # runner and the real cause. Costs about a second.
+      #
+      # unrs-resolver's own message blames an npm optional-dependency bug, which is usually
+      # wrong: check whether the .node file exists before believing it.
+      - name: Verify native module resolver
+        shell: powershell
+        run: |
+          node -e "try { require('unrs-resolver') } catch (e) { console.error('Native module resolver (unrs-resolver) failed to load on runner ' + process.env.RUNNER_NAME + '.'); console.error('This is a runner fault, not a repo fault. Most often the Microsoft VC++ 2015-2022 x64 redistributable is missing (vcruntime140_1.dll), or AV is blocking the .node binary.'); console.error(require('util').inspect(e, {depth: 6})); process.exit(1) }"
 
       - name: Run QS cloud tests
         shell: powershell
@@ -354,6 +384,21 @@ jobs:
       - name: Install dependencies
         shell: powershell
         run: npm ci --include=dev --include=prod
+
+      # jest-resolve@30 resolves config paths with unrs-resolver, a Rust/napi-rs native addon,
+      # and its findNodeModule() swallows every error the resolver throws. A .node binding that
+      # cannot be loaded therefore surfaces as "Module <path> in the testRunner option was not
+      # found" - naming a JavaScript file that is present, intact, and resolvable by Node itself.
+      # That misdirection cost a full investigation on PVE-WINSRV19-2, where the binding was on
+      # disk but vcruntime140_1.dll was missing from the host. Fail here instead, naming the
+      # runner and the real cause. Costs about a second.
+      #
+      # unrs-resolver's own message blames an npm optional-dependency bug, which is usually
+      # wrong: check whether the .node file exists before believing it.
+      - name: Verify native module resolver
+        shell: powershell
+        run: |
+          node -e "try { require('unrs-resolver') } catch (e) { console.error('Native module resolver (unrs-resolver) failed to load on runner ' + process.env.RUNNER_NAME + '.'); console.error('This is a runner fault, not a repo fault. Most often the Microsoft VC++ 2015-2022 x64 redistributable is missing (vcruntime140_1.dll), or AV is blocking the .node binary.'); console.error(require('util').inspect(e, {depth: 6})); process.exit(1) }"
 
       # Writes the client certificate into RUNNER_TEMP from secrets, the same way the macOS job
       # does. It previously took BSI_CERT_FILE/BSI_CERT_KEY_FILE from secrets holding *paths* to


### PR DESCRIPTION
## What

Adds a `Verify native module resolver` step to the three Windows jobs in `ci.yaml`
(`test-browser-win`, `test-qscloud-win`, `test-qseow-win`), between `Install dependencies`
and the test step. ~1 second per job.

## Why

Every Jest run on the self-hosted runner `PVE-WINSRV19-2` failed at config load with:

```
Module D:\...\node_modules\jest-circus\build\runner.js in the testRunner option was not found.
```

naming a file that was present, intact, and resolvable by Node's own resolver in the same job
seconds earlier. That contradiction cost a full investigation before the cause was found.

There is no contradiction — **Jest 30 does not use Node's resolver here.** `jest-config`
resolves the default `testRunner` twice:

1. `jest-config/build/index.js:1679` — `require.resolve('jest-circus/runner')`, Node's CJS
   resolver, **succeeds**. This is where the absolute path in the error text comes from.
2. `jest-config/build/index.js:1757` → `utils.resolve()` → `Resolver.findNodeModule()` →
   `jest-resolve/build/index.js:177`, which delegates to **`unrs-resolver`**, a Rust/napi-rs
   native addon.

`jest-resolve`'s `findNodeModule` catches *every* error the resolver throws and returns `null`
(`index.js:625-632`), so a `.node` binding that cannot be loaded is reported as a missing
JavaScript file.

The actual fault on that host: `vcruntime140_1.dll` was absent. napi-rs prebuilds link the MSVC
runtime dynamically, while `node.exe` links it statically — so Node ran fine and the addon did
not. The machine carried the 2015-era runtime (`vcruntime140.dll`, `msvcp140.dll`,
`concrt140.dll` all present) but not the VC++ 2015–2022 redistributable. The `.node` binding on
disk was byte-identical to the working runner's (1,886,720 bytes), so npm was never involved —
despite `unrs-resolver`'s own message blaming an npm optional-dependency bug.

This guard turns that misdirection into a message naming the runner and the likely host cause.

It also addresses a secondary problem: a broken runner failed at config load in under a minute,
freeing itself to claim the next Windows job while a healthy runner was still mid-suite. Two
consecutive runs put *every* Windows job on the broken machine.

## Verification

Tested in both directions on both Windows runners, via a temporary workflow since removed:

| | `plabs-pve-101` | `PVE-WINSRV19-2` |
|---|---|---|
| guard, before host fix | pass | **red**, with the actionable message |
| guard, after host fix | pass | **pass** |
| browser suite | 5/5 suites, 19/19 tests | 5/5 suites, 19/19 tests, 245 s |
| `vcruntime140_1.dll` | True | True (after fix) |

Pooled `sp53` scheduling confirmed to spread across both machines.

The host itself was fixed out of band — VC++ 2015–2022 x64 redistributable installed, plus Git
for Windows, which also stopped `actions/checkout` silently falling back to a REST-API zip
download on that machine.

`zizmor` on `ci.yaml`: 148 findings before, 148 after — no new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)