### PR TITLE
chore: move GitHub Actions off the deprecated Node.js 20 runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,19 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+
+  # Workflow action pins. Without this the SHAs never move on their own, which is how they
+  # drifted 1-3 majors behind and ended up on the deprecated Node.js 20 runtime.
+  # Grouped so this arrives as one PR a week rather than one per action.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Same 7-day supply-chain quarantine that .npmrc applies to npm packages: a freshly
+    # published action release is the most likely to be a compromised one, so let it age first.
+    cooldown:
+      default-days: 7
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
       # The npm bundled with Node 24 is 11.x, and 11.x resolves this lockfile differently between
@@ -62,7 +62,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
       # See the note on the other jobs: pins npm so the install is identical on every runner.
@@ -101,7 +101,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: ''
@@ -147,7 +147,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
       # The npm bundled with Node 24 is 11.x, and 11.x resolves this lockfile differently between
@@ -202,7 +202,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: ''
@@ -260,7 +260,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
       # The npm bundled with Node 24 is 11.x, and 11.x resolves this lockfile differently between
@@ -337,7 +337,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: ''
@@ -464,7 +464,7 @@ jobs:
         run: docker save "$IMAGE_NAME" -o "$IMAGE_TAR"
 
       - name: Upload Docker image artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: butler-sheet-icons-ci-arm64-image
           path: ${{ env.IMAGE_TAR }}
@@ -516,7 +516,7 @@ jobs:
         run: docker save "$IMAGE_NAME" -o "$IMAGE_TAR"
 
       - name: Upload Docker image artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: butler-sheet-icons-ci-amd64-image
           path: ${{ env.IMAGE_TAR }}
@@ -548,7 +548,7 @@ jobs:
       BSI_CLOUD_APP_ID: ${{ secrets.BSI_CLOUD_APP_ID }}
     steps:
       - name: Download Docker image artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: butler-sheet-icons-ci-arm64-image
 
@@ -600,7 +600,7 @@ jobs:
       BSI_CLOUD_APP_ID: ${{ secrets.BSI_CLOUD_APP_ID }}
     steps:
       - name: Download Docker image artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: butler-sheet-icons-ci-amd64-image
 
@@ -660,7 +660,7 @@ jobs:
       BSI_INCLUDE_SHEET_PART: ${{ secrets.BSI_INCLUDE_SHEET_PART }}
     steps:
       - name: Download Docker image artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: butler-sheet-icons-ci-arm64-image
 
@@ -752,7 +752,7 @@ jobs:
       BSI_INCLUDE_SHEET_PART: ${{ secrets.BSI_INCLUDE_SHEET_PART }}
     steps:
       - name: Download Docker image artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: butler-sheet-icons-ci-amd64-image
 
@@ -842,7 +842,7 @@ jobs:
       - name: Show github.ref
         run: echo "$GITHUB_REF"
 
-      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         if: |
           github.repository_owner == 'ptarmiganlabs'
@@ -897,7 +897,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: ''
@@ -927,7 +927,7 @@ jobs:
           $RUNNER_TEMP/sbom-tool generate -b ./build/sbom -bc . -pn ${DIST_FILE_NAME} -pv ${{ needs.release-please.outputs.release_version }} -ps "Ptarmigan Labs" -nsb https://sbom.ptarmiganlabs.com -V verbose
 
       - name: Upload SBOM to Release
-        uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b # v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           allowUpdates: true
           omitBodyDuringUpdate: true
@@ -938,7 +938,7 @@ jobs:
           token: ${{ github.token }}
 
       - name: Upload SBOM as Workflow Artifact (backup)
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom-${{ needs.release-please.outputs.release_version }}
           path: ./build/sbom/
@@ -972,12 +972,12 @@ jobs:
           echo "upload_url : ${{ needs.release-please.outputs.release_upload_url }}"
 
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
       # The npm bundled with Node 24 is 11.x, and 11.x resolves this lockfile differently between
@@ -1003,7 +1003,7 @@ jobs:
         run: bash ./scripts/release-macos.sh
 
       - name: Upload to existing release
-        uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b # v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           allowUpdates: true
           omitBodyDuringUpdate: true
@@ -1044,12 +1044,12 @@ jobs:
           Write-Output 'upload_url      : ${{ needs.release-please.outputs.release_upload_url }}'
 
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
       # See the note on the other jobs: pins npm so the install is identical on every runner.
@@ -1073,7 +1073,7 @@ jobs:
         run: ./scripts/release-win.ps1
 
       - name: Upload to existing release
-        uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b # v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           allowUpdates: true
           omitBodyDuringUpdate: true
@@ -1107,12 +1107,12 @@ jobs:
           echo "upload_url : ${{ needs.release-please.outputs.release_upload_url }}"
 
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
       # The npm bundled with Node 24 is 11.x, and 11.x resolves this lockfile differently between
@@ -1146,7 +1146,7 @@ jobs:
           ls -la
 
       - name: Upload to existing release
-        uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b # v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           allowUpdates: true
           omitBodyDuringUpdate: true

--- a/.github/workflows/docker-image-build.yaml
+++ b/.github/workflows/docker-image-build.yaml
@@ -55,12 +55,12 @@ jobs:
         run: docker system df || true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       # https://github.com/marketplace/actions/docker-login
       # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context
       - name: Login to Docker Hub
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -100,7 +100,7 @@ jobs:
         run: echo "$RUNNER_CONTEXT"
       - name: Extract Docker metadata (amd64)
         id: meta
-        uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # v5
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ github.repository }}
           flavor: |
@@ -123,7 +123,7 @@ jobs:
 
       - name: Build and push (amd64)
         id: docker_build
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: src/Dockerfile
@@ -200,10 +200,10 @@ jobs:
           docker version
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Login to Docker Hub
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -243,7 +243,7 @@ jobs:
         run: echo "$RUNNER_CONTEXT"
       - name: Extract Docker metadata (arm64)
         id: meta
-        uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # v5
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ github.repository }}
           flavor: |
@@ -266,7 +266,7 @@ jobs:
 
       - name: Build and push (arm64)
         id: docker_build
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: src/Dockerfile
@@ -348,17 +348,17 @@ jobs:
           echo "Version validation successful: $VERSION"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Login to Docker Hub
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract Docker metadata (multi-arch)
         id: meta
-        uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # v5
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ github.repository }}
           tags: |

--- a/.github/workflows/insiders-build.yaml
+++ b/.github/workflows/insiders-build.yaml
@@ -47,7 +47,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: ''
@@ -91,7 +91,7 @@ jobs:
         if: |
           github.repository_owner == 'ptarmiganlabs' &&
           matrix.target == 'linux'
-        uses: github/codeql-action/upload-sarif@c3d42c5d08633d8b33635fbd94b000a0e2585b3c # v3
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:
           sarif_file: snyk.sarif
 
@@ -146,13 +146,13 @@ jobs:
 
       - name: Upload SBOM artifact
         if: matrix.target == 'linux'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom-insiders-${{ github.sha }}
           path: ./build/sbom/
 
       - name: Upload insider build artifacts to GitHub
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.artifact_insider }}
           path: ${{ matrix.artifact_insider }}

--- a/.github/workflows/macos-signing-canary.yaml
+++ b/.github/workflows/macos-signing-canary.yaml
@@ -40,7 +40,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
       # The npm bundled with Node 24 is 11.x, and 11.x resolves this lockfile differently between
@@ -99,7 +99,7 @@ jobs:
           echo "'Build, sign and notarize' step above - it must read 'status: Accepted'."
 
       - name: Upload the signed archive for inspection
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: macos-signing-canary-${{ github.run_id }}
           path: ./*-macos-arm64.zip

--- a/.github/workflows/pr-unit-tests.yaml
+++ b/.github/workflows/pr-unit-tests.yaml
@@ -42,7 +42,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/.github/workflows/remove-old-artifacts.yaml
+++ b/.github/workflows/remove-old-artifacts.yaml
@@ -2,22 +2,70 @@ name: Remove old artifacts
 
 on:
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'List what would be deleted without deleting anything'
+        type: boolean
+        default: false
   schedule:
     # Every Sunday at 1am
     - cron: '0 1 * * 0'
+
+permissions: {}
 
 jobs:
   remove-old-artifacts:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      actions: write
+      actions: write # delete artifacts
+      contents: read # list tags, so tagged runs can be skipped
 
     steps:
-      - name: Remove old artifacts
-        uses: c-hive/gha-remove-artifacts@44fc7acaf1b3d0987da0e8d4707a989d80e9554b # v1
-        with:
-          age: '3 days' # '<number> <unit>', e.g. 5 days, 2 years, 90 seconds, parsed by Moment.js
-          # Optional inputs
-          skip-tags: true
-          # skip-recent: 5
+      # This replaces c-hive/gha-remove-artifacts, which was abandoned in 2024 and never moved off
+      # the Node.js 20 action runtime. Same behaviour as before: delete artifacts older than 3 days,
+      # but keep anything produced by a run on a tag.
+      - name: Remove artifacts older than 3 days
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          # Empty on the scheduled run, which is what we want - only a manual dispatch can ask for
+          # a dry run.
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          cutoff=$(date -u -d '3 days ago' +%s)
+          echo "Deleting unexpired artifacts created before $(date -u -d @"$cutoff" '+%Y-%m-%d %H:%M:%SZ')"
+
+          gh api --paginate "repos/$REPO/tags" --jq '.[].name' > /tmp/tags.txt
+
+          kept=0
+          removed=0
+
+          while IFS=$'\t' read -r id created name branch; do
+            if [ "$(date -u -d "$created" +%s)" -ge "$cutoff" ]; then
+              kept=$((kept + 1))
+              continue
+            fi
+            if [ -n "$branch" ] && grep -qxF "$branch" /tmp/tags.txt; then
+              echo "skip (tag $branch): $name"
+              kept=$((kept + 1))
+              continue
+            fi
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "would delete: $name (created $created)"
+            else
+              echo "delete: $name (created $created)"
+              gh api -X DELETE "repos/$REPO/actions/artifacts/$id"
+            fi
+            removed=$((removed + 1))
+          done < <(gh api --paginate "repos/$REPO/actions/artifacts" \
+            --jq '.artifacts[] | select(.expired == false)
+                  | [.id, .created_at, .name, (.workflow_run.head_branch // "")] | @tsv')
+
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "kept $kept, would have removed $removed"
+          else
+            echo "kept $kept, removed $removed"
+          fi

--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -58,7 +58,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/.github/workflows/virus-scan.yaml
+++ b/.github/workflows/virus-scan.yaml
@@ -11,7 +11,7 @@ jobs:
       contents: write
     steps:
       - name: VirusTotal Scan
-        uses: crazy-max/ghaction-virustotal@d34968c958ae283fe976efed637081b9f9dcf74f # v4
+        uses: crazy-max/ghaction-virustotal@936d8c5c00afe97d3d9a1af26d017cfdf26800a2 # v5.0.0
         with:
           vt_api_key: ${{ secrets.VIRUSTOTAL_API_KEY }}
           request_rate: 4


### PR DESCRIPTION
## Why

CI was warning:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/setup-node@49933ea…`

`setup-node` was only the one that ran first. **12 actions across 47 pinned references** were still on the node20 action runtime, which fails outright once GitHub withdraws the compatibility shim.

The root cause is that `.github/dependabot.yml` only watched the `npm` ecosystem, so action pins never moved on their own and drifted 1–3 majors behind.

## What changed

**1. Dependabot now tracks `github-actions`** — grouped into one weekly PR, with a 7-day `cooldown` matching the `min-release-age=7` policy `.npmrc` already applies to npm packages.

**2. All node20 pins bumped:**

| Action | → | Refs |
|---|---|---|
| `setup-node` v4 | **v7.0.0** | 15 |
| `upload-artifact` v4 | **v7.0.1** | 6 |
| `download-artifact` v4 | **v8.0.1** | 4 |
| `ncipollo/release-action` v1 | **v1.21.0** | 4 |
| `checkout` v4.3.1 | **v6.0.2** | 3 |
| `docker/setup-buildx` · `login` · `metadata` · `build-push` | **v4.2.0 · v4.6.0 · v6.2.0 · v7.3.0** | 11 |
| `release-please-action` v4 | **v5.0.0** | 1 |
| `codeql-action/upload-sarif` v3 | **v4.35.1** | 1 |
| `ghaction-virustotal` v4 | **v5.0.0** | 1 |

Two internal inconsistencies collapse as a side effect: three `checkout` refs on v4.3.1 join the other 19 on v6.0.2, and one `upload-sarif` on v3 joins the rest on v4.35.1. Version comments now carry the full version so future drift is visible at a glance.

**3. `c-hive/gha-remove-artifacts` replaced with a `gh` CLI step.** Abandoned since April 2024 and still node20 even at v1.4.0 — unlike the others, there was nothing to upgrade to. Same behaviour (3 days, skip tagged runs), plus a `dry_run` dispatch input.

## Breaking changes, checked against actual usage here

- **setup-node v7** — v5's auto-caching triggers only on a `packageManager` field in `package.json`, which this repo doesn't have; v6 narrowed it to npm anyway. `cache: ''` and `node-version-file` inputs unaffected.
- **download-artifact v8** — the v5 path change applies only to downloads *by ID*; every usage here downloads *by name*. v8 does now **error on digest mismatch** rather than warn — the one genuinely new failure mode.
- **upload-artifact v7** — new `archive` input is opt-in.
- **release-please v5** — node24 upgrade is its only breaking change.
- **docker/\*** — v7 `build-push` drops two env vars, neither used; v4 `setup-buildx` drops deprecated inputs and every call site passes none; v6 `metadata` changes `#` handling in list inputs, and no tag value contains `#`.
- **ncipollo** stays within v1.

## Self-hosted runners

Node24 actions need Actions Runner ≥ 2.327.1. All three self-hosted runners (`plabs-mac-build2`, `plabs-pve-101`, `sp53-c0fb46ff135b`) already emit the *"forced to run on Node.js 24"* annotation, which only happens on a runner shipping node24. **No runner work needed.**

## Verification

- **No node20 remains** — `runs.using` re-read from `action.yml` at every new SHA. Only `snyk/actions/node` is non-node24, and it's a Docker action.
- **Cleanup script tested against live repo data in a Linux container** (CI's GNU `date`; macOS can't run it). Live data kept all 117 artifacts, so a fixture forced the untested paths: old-on-main **deleted**, old-on-a-real-tag **skipped**, empty-branch and spaces-in-name **handled**.
- **zizmor: 22 medium findings → 2.** The one finding this change introduced (missing Dependabot cooldown) is fixed; the 2 remaining are pre-existing.
- All 10 workflows + `dependabot.yml` parse as valid YAML.

### Two `run:` details that matter

- `contents: read` had to be **added** to the cleanup job — it previously only had `actions: write`, which cannot list tags, and without the tag list every tagged artifact would be deleted.
- The age and tag tests use explicit `if/then/continue`, not `[ ] && continue` — under `set -e` a false `&&` list returns non-zero and would abort the step.

## What this PR cannot verify

The four `ncipollo` refs, release-please's actual release path, and `docker-image-build.yaml` / `virus-scan.yaml` only execute on a real release. Their breaking changes were checked above; the next release runs them for the first time. Leaving them on node20 is worse — the shim's removal breaks them with no warning.

## Unrelated pre-existing failure

`main` is currently red at `test-qscloud-win` → step *"Run QS cloud tests"* ([run 31148836253](https://github.com/ptarmiganlabs/butler-sheet-icons/actions/runs/31148836253)). Every action step in that job succeeds; it's the Qlik Cloud integration test. Predates this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)