### PR TITLE
docs: record the GitNexus hook fixes that could not be committed

### DIFF
--- a/docs/README.gitnexus.md
+++ b/docs/README.gitnexus.md
@@ -69,6 +69,16 @@ That second one is worth knowing about: those files still tell agents to run a b
 
 Until that is fixed upstream, the authoritative instruction is the one in this file and in the managed block: re-index through the npm scripts.
 
+## The Claude Code hook is a separate case, and *has* been corrected
+
+The paragraph above applies to the generated skill files only. The Claude Code hook is not generated and is not reverted, so the same bad advice there was fixable — and has been fixed.
+
+The hook lives at `~/.claude/hooks/gitnexus/gitnexus-hook.cjs`, wired up in `~/.claude/settings.json`. It began as a copy of `hooks/claude/gitnexus-hook.cjs` from the GitNexus package, but is now a hand-maintained fork: it adds `hook-lock.cjs` and `hook-db-lock-probe.cjs` — two files that do not exist in the package at all — to keep the hook off the database while the MCP server owns it. Nothing regenerates it; `gitnexus:refresh` does not touch it.
+
+On a stale index after a `git commit`, `merge`, `rebase`, `cherry-pick` or `pull`, it used to tell the agent to run a bare `npx gitnexus analyze` — the one command this file forbids, recommended to the agent by the tooling itself. It now recommends `npm run gitnexus:index` whenever the repository's `package.json` exposes a `gitnexus:index` script, and falls back to the generic command everywhere else. Detection is by that script's presence rather than by repository name, so butler-sos is covered by the same logic with nothing to keep in sync.
+
+**This fix is machine-local.** The hook sits outside the repository, so a fresh clone on another machine gets a stock hook and the old advice with it. Re-apply it there, or set `GITNEXUS_HOOK_CLI_PATH` and copy the fork across.
+
 ## Version pinning
 
 The version is pinned deliberately. An unpinned `npx gitnexus` executes whatever the registry serves at that moment — a new major, or a compromised release — with no repository change and no review. That matters more once re-indexing runs from a git hook (issue #829).

--- a/docs/README.gitnexus.md
+++ b/docs/README.gitnexus.md
@@ -77,6 +77,8 @@ The hook lives at `~/.claude/hooks/gitnexus/gitnexus-hook.cjs`, wired up in `~/.
 
 On a stale index after a `git commit`, `merge`, `rebase`, `cherry-pick` or `pull`, it used to tell the agent to run a bare `npx gitnexus analyze` — the one command this file forbids, recommended to the agent by the tooling itself. It now recommends `npm run gitnexus:index` whenever the repository's `package.json` exposes a `gitnexus:index` script, and falls back to the generic command everywhere else. Detection is by that script's presence rather than by repository name, so butler-sos is covered by the same logic with nothing to keep in sync.
 
+It is also worktree-aware. A linked worktree under `.claude/worktrees/` never carries its own `.gitnexus/`, so the hook resolves the index to the canonical checkout — and therefore reads `HEAD` from that checkout too, not from the worktree. Comparing a worktree branch's `HEAD` against an index built from the canonical checkout marked the index stale on every commit made on a branch, and re-indexing would not have cleared it, because the index describes the canonical checkout either way. The warning now fires when the index is genuinely behind what it indexes, and names the canonical directory so the suggested command is runnable as written.
+
 **This fix is machine-local.** The hook sits outside the repository, so a fresh clone on another machine gets a stock hook and the old advice with it. Re-apply it there, or set `GITNEXUS_HOOK_CLI_PATH` and copy the fork across.
 
 ## Version pinning


### PR DESCRIPTION
## Why

`docs/README.gitnexus.md` said the bare-`analyze` advice "cannot be corrected here", because a `refresh` restores the original text. That holds for the generated `.claude/skills/gitnexus/*/SKILL.md` files — but not for the Claude Code hook, and the file did not distinguish between them, so the hook read as unfixable too.

It was not. The hook at `~/.claude/hooks/gitnexus/gitnexus-hook.cjs` is a hand-maintained fork of the copy shipped in the GitNexus package: it adds `hook-lock.cjs` and `hook-db-lock-probe.cjs`, neither of which the package contains, and nothing regenerates it.

Three defects were fixed in that hook. Since it lives outside the repository it cannot be committed, so these two commits record what changed and why.

## What the hook now does

- **Recommends `npm run gitnexus:index`** instead of a bare `npx gitnexus analyze` — the one command this repo forbids, previously recommended to agents by the tooling itself on every stale index. Detection is by the presence of a `gitnexus:index` script in `package.json`, not by repository name, so butler-sos is covered by the same logic with nothing to keep in sync. Repos without the wrapper keep the generic command unchanged.
- **Reads `HEAD` from the checkout that owns the index.** A linked worktree under `.claude/worktrees/` carries no `.gitnexus/`, so the index resolves to the canonical checkout — but `HEAD` was still read from the worktree. Those diverge the moment anything is committed on a branch, so every commit made in a worktree reported "stale", and re-indexing could not clear it. The warning now names the canonical directory too, so the suggested command is runnable as written.
- **Dropped a dead success-guard.** It tested `input.tool_output.exit_code`, but the PostToolUse payload field is `tool_response`, and for Bash it carries only `stdout`, `stderr` and `interrupted` — there is no `exit_code`. Wrong field name and absent property, so it never suppressed anything and a *failed* `git commit` nagged identically to a successful one. Now tests `interrupted`.

## Verification

The hook was driven directly with synthetic PostToolUse payloads across every branch — wrapper path, both fallback paths, `embeddings: 0` vs non-zero, `interrupted`, and non-git commands. Worktree behaviour was checked against a real git repo with a real linked worktree nested the same way `.claude/worktrees/` is, covering all four combinations of canonical/worktree × current/stale index.

Confirmed live afterwards: `npm run gitnexus:index` moved the index `5b7f89b` → `fdce835`, preserved all 729 embeddings, and left the managed block and generated-skills table in `CLAUDE.md`/`AGENTS.md` untouched — which is the behaviour `--skip-agents-md` exists to guarantee.

## Note

The hook fix is machine-local. A fresh clone elsewhere gets a stock hook and the old advice with it; the new doc section says so.

Docs only — no runtime code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)