### PR TITLE
chore: clear the two remaining zizmor warnings in code scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    # Mirrors `min-release-age=7` in .npmrc. Without it Dependabot proposes bumps that npm then
+    # refuses to resolve, so the PR sits until the version ages out anyway - see the fast-uri
+    # 3.1.5 bump opened one day after that version was published.
+    cooldown:
+      default-days: 7
 
   # Workflow action pins. Without this the SHAs never move on their own, which is how they
   # drifted 1-3 majors behind and ended up on the deprecated Node.js 20 runtime.

--- a/.github/workflows/insiders-build.yaml
+++ b/.github/workflows/insiders-build.yaml
@@ -79,7 +79,7 @@ jobs:
         if: |
           github.repository_owner == 'ptarmiganlabs' &&
           matrix.target == 'linux'
-        uses: snyk/actions/node@9adf32b1121593767fc3c057af55b55db032dc04 # master
+        uses: snyk/actions/node@9adf32b1121593767fc3c057af55b55db032dc04 # v1.0.0
         continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
Clears the two `warning`-severity zizmor findings in code scanning. Both are config/comment corrections — no workflow behaviour changes.

## `insiders-build.yaml` — `ref-version-mismatch`

The `snyk/actions/node` pin carried `# master`, but master has since moved to `12140f4059e2` while the workflow stays on `9adf32b1`, so the comment no longer described the pinned commit.

That SHA is exactly tag **v1.0.0** (verified against the snyk/actions API), so the comment now names it. **The pin itself is unchanged**, so the action resolves to the same code as before.

## `dependabot.yml` — `dependabot-cooldown`

The `github-actions` ecosystem already had a 7-day cooldown; `npm` did not. Without it Dependabot proposes bumps that npm then refuses to resolve under `min-release-age=7` in `.npmrc`, so the PR sits until the version ages out anyway — #816 bumps fast-uri to 3.1.5, opened one day after that version was published.

Note this may cause Dependabot to close #816 until 3.1.5 clears the 7-day window on Aug 10. The fix is not lost, only deferred.

## Verification

Ran zizmor 1.29.0 locally — the same version CI runs — stashing the edits to get a real before/after:

- **Before:** `dependabot-cooldown` + `ref-version-mismatch` both present
- **After:** both gone, 0 findings on these two files
- **Full repo sweep:** 24 findings, exactly the expected 20 `template-injection` + 4 `superfluous-actions` — nothing new introduced

zizmor auditing `dependabot.yml` successfully is itself proof the YAML parses.

## Scope

No JS changed, so no tests or impact analysis apply. Neither change is user-observable, so no doc-site page is needed.

After this and #816, code scanning drops to 24 open — all `note`-severity zizmor style findings, with no High or Critical remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)