### PR TITLE
fix: three sheet-icon correctness bugs (#872 part 1)

### DIFF
--- a/docs/to-doc-site/exclude-and-blur-sheet-number-fix.md
+++ b/docs/to-doc-site/exclude-and-blur-sheet-number-fix.md
@@ -1,0 +1,97 @@
+# Fixed: `--exclude-sheet-number` and `--blur-sheet-number` affected the wrong sheets
+
+**Applies to:** `qseow create-sheet-thumbnails` and `qscloud create-sheet-thumbnails`
+
+**Options affected:** `--exclude-sheet-number`, `--blur-sheet-number` (and their environment variables)
+
+::: warning Requires BSI 3.12.0 or later
+In earlier versions these two options selected the wrong sheets. See "Who was affected" below — if you use either option, your existing thumbnails may need regenerating after upgrading.
+:::
+
+## Summary
+
+Butler Sheet Icons was reading these two options incorrectly. Two things went wrong at once:
+
+1. **Only the last number you listed was kept.** `--exclude-sheet-number 1 2 12` behaved as though you had written `--exclude-sheet-number 12`. Sheets 1 and 2 were processed anyway.
+2. **Numbers were matched as text fragments rather than as whole sheet numbers.** Because of this, `--exclude-sheet-number 12` also excluded sheet 1 and sheet 2 — any sheet whose number appears as a fragment of the number you asked for.
+
+Both options now behave as documented. Every number you list is kept, and each is matched as a whole sheet number.
+
+## Who was affected
+
+You were affected if you used `--exclude-sheet-number` or `--blur-sheet-number` (or the matching environment variables) with **either**:
+
+- more than one number, **or**
+- a single number of two or more digits.
+
+A single one-digit number — for example `--exclude-sheet-number 3` — was handled correctly, because there is no other sheet number hiding inside "3".
+
+The more digits in the number, the more sheets were wrongly affected. `--exclude-sheet-number 123` also excluded sheets 1, 2, 3, 12 and 23.
+
+## What this looked like in practice
+
+Say an app has 15 sheets, and you ran:
+
+```
+butler-sheet-icons qseow create-sheet-thumbnails ... --exclude-sheet-number 12
+```
+
+**Before this fix:** sheets 1, 2 and 12 were all skipped. Sheets 1 and 2 kept whatever icons they already had, and the run finished without an error.
+
+**After this fix:** only sheet 12 is skipped. Sheets 1 and 2 get new thumbnails as expected.
+
+The same applies to `--blur-sheet-number`: sheets you never asked to blur were being blurred.
+
+## How to confirm which sheets were affected
+
+Butler Sheet Icons has always listed each skipped sheet in its log at the default log level, so an existing log from an earlier run tells you exactly what happened. Look for lines beginning:
+
+```
+Excluded sheet: 1: 'Sales overview', ...
+```
+
+Any sheet number in that list that you did not ask to exclude was wrongly skipped. For blurring, the equivalent line begins:
+
+```
+Using blurred thumbnail for sheet 1: ...
+```
+
+There was no error or warning to draw attention to it — the run reported success — so this is worth checking deliberately rather than expecting to have noticed it at the time.
+
+## What you should do
+
+**Re-run your thumbnail generation.** Sheets that were wrongly excluded still have their old icons, and sheets that were wrongly blurred still have blurred icons. Neither corrects itself until Butler Sheet Icons runs again.
+
+**Re-check your options first.** If you had previously worked around this behaviour — for example by listing sheet numbers one run at a time, or by choosing sheet numbers that avoided the overlap — those workarounds are no longer needed and may now produce the wrong result. Options such as `--exclude-sheet-title` or `--exclude-sheet-status` are unaffected and always worked correctly.
+
+## Using the options
+
+Both options take one or more whole numbers, separated by spaces, where **1 is the first sheet in the app**:
+
+```
+--exclude-sheet-number 1 2 12
+--blur-sheet-number 4 7
+```
+
+A value that is not a non-negative whole number is rejected before Butler Sheet Icons connects to Qlik Sense:
+
+```
+error: option '--exclude-sheet-number <number...>' argument 'abc' is invalid. Exclude sheet number must be a non-negative integer.
+```
+
+### Environment variables
+
+The same options can be set through environment variables:
+
+| Command | Option | Environment variable |
+|---|---|---|
+| `qseow create-sheet-thumbnails` | `--exclude-sheet-number` | `BSI_QSEOW_CST_EXCLUDE_SHEET_NUMBER` |
+| `qseow create-sheet-thumbnails` | `--blur-sheet-number` | `BSI_QSEOW_CST_BLUR_SHEET_NUMBER` |
+| `qscloud create-sheet-thumbnails` | `--exclude-sheet-number` | `BSI_QSCLOUD_CST_EXCLUDE_SHEET_NUMBER` |
+| `qscloud create-sheet-thumbnails` | `--blur-sheet-number` | `BSI_QSCLOUD_CST_BLUR_SHEET_NUMBER` |
+
+An environment variable holds **one** sheet number. This has always been the case and is unchanged by this fix — to exclude or blur several sheets, use the command-line option instead.
+
+## Other options are not affected
+
+The remaining sheet-selection options — `--exclude-sheet-status`, `--exclude-sheet-tag`, `--exclude-sheet-title`, `--blur-sheet-status`, `--blur-sheet-title` — were never affected by this problem and need no action. Every option that accepts multiple values was checked; these two were the only ones with the fault.

--- a/docs/to-doc-site/failed-uploads-no-longer-break-sheet-icons.md
+++ b/docs/to-doc-site/failed-uploads-no-longer-break-sheet-icons.md
@@ -1,0 +1,47 @@
+# Fixed: a failed image upload no longer replaces working sheet icons with broken ones
+
+**Applies to:** `qseow create-sheet-thumbnails` and `qscloud create-sheet-thumbnails`
+
+::: warning Requires BSI 3.12.0 or later
+In earlier versions, an app whose thumbnail images failed to upload had its sheet icons replaced with broken images, and the run gave no sign that anything had gone wrong.
+:::
+
+## Summary
+
+Butler Sheet Icons generates thumbnail images, uploads them to Qlik Sense, and then updates each sheet to point at its uploaded image. If the upload step failed — an image rejected as too large, a content library that could not be written to, a dropped connection partway through — Butler Sheet Icons carried on to the last step anyway.
+
+The result was the worst possible outcome: **every sheet was repointed at an image that was not there.** Sheets that previously had perfectly good icons were left showing broken ones, and the run reported no error.
+
+Butler Sheet Icons now stops after a failed upload and leaves the app's sheets alone, so they keep the icons they already had.
+
+## What you will see now
+
+If any image fails to upload, the app is left untouched and the log records why. On Qlik Sense Cloud:
+
+```
+CLOUD APP (stack): CloudError: Failed to upload 2 of 5 thumbnail image(s) to Qlik Sense Cloud app abc-123
+```
+
+On Qlik Sense Enterprise on Windows:
+
+```
+QSEOW: qseowProcessApp (stack): QseowError: Failed to upload 2 of 5 thumbnail image(s) to content library BSI thumbnails
+```
+
+The individual upload failures are logged too, immediately above, prefixed `CLOUD UPLOAD 1` or `QSEOW UPLOAD 1`. Those lines name the underlying reason — that is where to look for the actual cause.
+
+Butler Sheet Icons still attempts every image before stopping, so one failure does not hide the others. The count in the message tells you how widespread the problem is.
+
+## What to do about it
+
+1. **Your sheets are safe.** Nothing was changed in the app, so its existing icons are intact. There is no cleanup to do.
+2. **Read the `UPLOAD 1` lines** to find out why the upload was refused. Common causes are an image larger than the tenant or server accepts, a content library name that does not exist or cannot be written to by the account Butler Sheet Icons is using, and network interruptions.
+3. **Fix the cause and re-run.** The command is safe to run again.
+
+## Recovering apps affected before the upgrade
+
+If earlier runs left apps showing broken sheet icons, re-running `create-sheet-thumbnails` against those apps repairs them, provided the upload problem itself has been resolved. If you would rather clear the icons than regenerate them, `qscloud remove-sheet-icons` removes them on Qlik Sense Cloud.
+
+## A note on exit codes
+
+Butler Sheet Icons still exits with code 0 in this situation. If you run it from a scheduled job or pipeline, **checking the exit code will not tell you that an app failed** — check the log for the lines above instead. Making the exit code reflect failures is a separate change that has not shipped yet.

--- a/docs/to-doc-site/one-bad-sheet-no-longer-fails-the-app.md
+++ b/docs/to-doc-site/one-bad-sheet-no-longer-fails-the-app.md
@@ -1,0 +1,54 @@
+# Fixed: a single sheet with missing layout data no longer fails the whole app
+
+**Applies to:** all commands that read an app's sheets — `create-sheet-thumbnails` and `remove-sheet-icons`, on both Qlik Sense Enterprise on Windows and Qlik Sense Cloud
+
+::: warning Requires BSI 3.12.0 or later
+In earlier versions, one sheet with missing layout data stopped Butler Sheet Icons from processing the app at all.
+:::
+
+## Summary
+
+Butler Sheet Icons sorts an app's sheets into their display order before doing anything with them, so that sheet 1 is the first sheet in the app. If the Qlik Sense engine returned a sheet without its layout data — the part that carries the sheet's position in the app and its show condition — that sorting step failed. Because sorting happens before any per-sheet handling, **the whole app was abandoned before a single thumbnail was created or removed.** Every other sheet in the app was left untouched.
+
+Such sheets are now sorted to the end of the list and processed normally, so the app completes.
+
+## How to tell if this affected you
+
+The run failed for the whole app, and the log contained an error ending in:
+
+```
+TypeError: Cannot read properties of undefined (reading 'rank')
+```
+
+Search your logs for `reading 'rank'` — that phrase is the same in every case. The text in front of it varies by platform and by the stage the run had reached:
+
+| Platform | Stage | Log line begins |
+|---|---|---|
+| Qlik Sense Cloud | Creating thumbnails | `CLOUD APP (stack):` |
+| Qlik Sense Cloud | Applying thumbnails to sheets | `CLOUD UPDATE SHEETS (stack):` |
+| Qlik Sense Cloud | Removing sheet icons | `CLOUD REMOVE SHEET ICONS 1 (stack):` |
+| Enterprise on Windows | Creating thumbnails | `QSEOW: qseowProcessApp (stack):` |
+| Enterprise on Windows | Applying thumbnails to sheets | `QSEOW UPDATE SHEETS (stack):` |
+| Enterprise on Windows | Removing sheet icons | `QSEOW: removeSheetIconsQSEoWApp (stack):` |
+
+A closely related failure, `reading 'showCondition'`, is fixed by the same change and is worth searching for too. It struck slightly later in the run — after thumbnails had been generated but before they were uploaded, so the work was still discarded.
+
+If you saw either error, re-run the command; the affected apps should now complete.
+
+## What causes a sheet to be missing its layout data
+
+This is uncommon, and it comes from Qlik Sense rather than from Butler Sheet Icons. It has been seen with sheets that are partially created or partially deleted, and with sheets whose owner no longer exists.
+
+Butler Sheet Icons now treats such a sheet as an ordinary sheet: it appears at the end of the sheet list and gets a thumbnail like any other. It is named in the log as it is processed, so you can still find it in Qlik Sense if you want to repair or delete it.
+
+## A note on sheet numbering
+
+Sheet numbers — used by `--exclude-sheet-number` and `--blur-sheet-number`, where 1 is the first sheet in the app — come from this sort order. Because sheets with missing layout data are now placed at the end of the list, **sheet numbering can differ from before in an app that contains one.**
+
+In practice there is nothing to migrate, because those apps were failing outright before. But if you use `--exclude-sheet-number` or `--blur-sheet-number` on an app that used to hit this error, check the sheet numbers in the log of the first successful run before relying on them.
+
+Apps whose sheets all have complete layout data are numbered exactly as before.
+
+## What is not covered
+
+This change deals with sheets missing their **layout data**. A sheet missing its **title and description** (a different part of the sheet record) can still interrupt a run. That case is less common and is being addressed separately.

--- a/src/lib/cloud/__tests__/cloud_remove_sheet_icons.test.js
+++ b/src/lib/cloud/__tests__/cloud_remove_sheet_icons.test.js
@@ -198,6 +198,23 @@ describe('qscloudRemoveSheetIcons', () => {
             ]);
         });
 
+        test('still processes the well-formed sheets when one sheet has no qData', async () => {
+            // Sorting runs before the per-sheet try/catch blocks, so an unguarded read of
+            // sheet.qData.rank in the comparator aborted the whole app before a single
+            // icon was touched. The rank-less sheet now sorts last.
+            const broken = makeSheet('broken', 1);
+            delete broken.item.qData;
+            const { app } = wireEnigma([makeSheet('sheet-b', 2), broken, makeSheet('sheet-a', 1)]);
+
+            await qscloudRemoveSheetIcons({ ...BASE_OPTIONS });
+
+            expect(app.getObject.mock.calls.map((call) => call[0])).toEqual([
+                'sheet-a',
+                'sheet-b',
+                'broken',
+            ]);
+        });
+
         test('closes the engine session when done', async () => {
             const { session } = wireEnigma([makeSheet('sheet-1', 1)]);
 

--- a/src/lib/cloud/__tests__/cloud_updatesheets.test.js
+++ b/src/lib/cloud/__tests__/cloud_updatesheets.test.js
@@ -173,6 +173,35 @@ describe('qscloudUpdateSheetThumbnails', () => {
         ]);
     });
 
+    test('still processes the well-formed sheets when one sheet has no qData', async () => {
+        // Sorting runs before any per-sheet handling, so an unguarded read of
+        // sheet.qData.rank in the comparator discarded every update for the app.
+        // The rank-less sheet now sorts last.
+        const broken = makeSheet({ qId: 'broken', rank: 1 });
+        delete broken.item.qData;
+        const { app } = wireEnigma([
+            makeSheet({ qId: 'sheet-b', rank: 2 }),
+            broken,
+            makeSheet({ qId: 'sheet-a', rank: 1 }),
+        ]);
+
+        await qscloudUpdateSheetThumbnails(
+            [
+                { sheetPos: 1, fileNameShort: 'thumbnail-1.png' },
+                { sheetPos: 2, fileNameShort: 'thumbnail-2.png' },
+                { sheetPos: 3, fileNameShort: 'thumbnail-3.png' },
+            ],
+            APP_ID,
+            BASE_OPTIONS
+        );
+
+        expect(app.getObject.mock.calls.map((call) => call[0])).toEqual([
+            'sheet-a',
+            'sheet-b',
+            'broken',
+        ]);
+    });
+
     test('skips a sheet that has no created file', async () => {
         const sheets = [
             makeSheet({ qId: 'sheet-a', rank: 1 }),

--- a/src/lib/cloud/__tests__/cloud_upload.test.js
+++ b/src/lib/cloud/__tests__/cloud_upload.test.js
@@ -1,6 +1,8 @@
 import { jest, describe, test, expect, beforeEach } from '@jest/globals';
 import path from 'path';
 
+import { CloudError } from '../../util/errors.js';
+
 const statSync = jest.fn();
 // Bytes derived from the path, so an upload that reads the wrong file is detectable.
 // A constant buffer here would let the blurred upload silently ship the unblurred image.
@@ -196,46 +198,87 @@ describe('qscloudUploadToApp', () => {
     });
 
     describe('error handling', () => {
+        // A resolved promise from this function is the caller's signal that every image is
+        // in place, and the caller then points the app's sheets at those images. Anything
+        // that did not upload has to surface as a rejection, or sheets that had working
+        // icons end up showing broken ones while the run reports success.
+
         test('a failed upload does not stop the remaining files', async () => {
             withFiles(['thumbnail-1.png', 'thumbnail-2.png']);
             Put.mockRejectedValueOnce(new Error('413 Payload Too Large'));
 
-            await qscloudUploadToApp(
-                [{ fileNameShort: 'thumbnail-1.png' }, { fileNameShort: 'thumbnail-2.png' }],
-                APP_ID,
-                BASE_OPTIONS
-            );
+            await expect(
+                qscloudUploadToApp(
+                    [{ fileNameShort: 'thumbnail-1.png' }, { fileNameShort: 'thumbnail-2.png' }],
+                    APP_ID,
+                    BASE_OPTIONS
+                )
+            ).rejects.toThrow(CloudError);
 
             expect(Put).toHaveBeenCalledTimes(2);
+        });
+
+        test('rejects when a single file failed to upload', async () => {
+            withFiles(['thumbnail-1.png', 'thumbnail-2.png']);
+            Put.mockRejectedValueOnce(new Error('413 Payload Too Large'));
+
+            await expect(
+                qscloudUploadToApp(
+                    [{ fileNameShort: 'thumbnail-1.png' }, { fileNameShort: 'thumbnail-2.png' }],
+                    APP_ID,
+                    BASE_OPTIONS
+                )
+            ).rejects.toThrow('Failed to upload 1 of 2 thumbnail image(s)');
         });
 
         test('logs a failed upload rather than swallowing it silently', async () => {
             withFiles(['thumbnail-1.png']);
             Put.mockRejectedValue(new Error('413 Payload Too Large'));
 
-            await qscloudUploadToApp([{ fileNameShort: 'thumbnail-1.png' }], APP_ID, BASE_OPTIONS);
+            await expect(
+                qscloudUploadToApp([{ fileNameShort: 'thumbnail-1.png' }], APP_ID, BASE_OPTIONS)
+            ).rejects.toThrow(CloudError);
 
             expect(logger.error).toHaveBeenCalled();
         });
 
-        test('does not reject when a file cannot be stat-ed', async () => {
+        test('rejects when a file cannot be stat-ed', async () => {
             statSync.mockImplementation(() => {
                 throw new Error('ENOENT: no such file or directory');
             });
 
             await expect(
                 qscloudUploadToApp([{ fileNameShort: 'thumbnail-1.png' }], APP_ID, BASE_OPTIONS)
-            ).resolves.toBeUndefined();
+            ).rejects.toThrow(CloudError);
 
             expect(logger.error).toHaveBeenCalled();
         });
 
-        test('does not reject when the file list is not iterable', async () => {
+        test('names the app whose upload failed', async () => {
+            withFiles(['thumbnail-1.png']);
+            Put.mockRejectedValue(new Error('413 Payload Too Large'));
+
             await expect(
-                qscloudUploadToApp(undefined, APP_ID, BASE_OPTIONS)
-            ).resolves.toBeUndefined();
+                qscloudUploadToApp([{ fileNameShort: 'thumbnail-1.png' }], APP_ID, BASE_OPTIONS)
+            ).rejects.toThrow(APP_ID);
+        });
+
+        test('rejects when the file list is not iterable', async () => {
+            await expect(qscloudUploadToApp(undefined, APP_ID, BASE_OPTIONS)).rejects.toThrow(
+                CloudError
+            );
 
             expect(logger.error).toHaveBeenCalled();
+        });
+
+        test('keeps the underlying failure as the cause when setup itself fails', async () => {
+            // Only the setup path wraps a single underlying error. A per-file failure is
+            // reported as a count, so there is no one cause to attach.
+            await expect(qscloudUploadToApp(undefined, APP_ID, BASE_OPTIONS)).rejects.toMatchObject(
+                {
+                    cause: expect.any(TypeError),
+                }
+            );
         });
     });
 

--- a/src/lib/cloud/__tests__/process_cloud_app.test.js
+++ b/src/lib/cloud/__tests__/process_cloud_app.test.js
@@ -92,6 +92,7 @@ let browserInstall;
 let detectAvailableBrowser;
 let takeSheetScreenshot;
 let qscloudUploadToApp;
+let qscloudUpdateSheetThumbnails;
 
 beforeAll(async () => {
     await Promise.all([
@@ -117,6 +118,7 @@ beforeAll(async () => {
     ({ detectAvailableBrowser } = await import('../../browser/browser-detect.js'));
     ({ takeSheetScreenshot } = await import('../sheet-screenshot.js'));
     ({ qscloudUploadToApp } = await import('../cloud-upload.js'));
+    ({ qscloudUpdateSheetThumbnails } = await import('../cloud-updatesheets.js'));
     ({ processCloudApp } = await import('../process-cloud-app.js'));
 });
 
@@ -404,6 +406,7 @@ describe('process-cloud-app.js — a sheet with no metadata does not abort the a
         });
         takeSheetScreenshot.mockResolvedValue(true);
         qscloudUploadToApp.mockResolvedValue(true);
+        qscloudUpdateSheetThumbnails.mockResolvedValue(true);
 
         const mockApp = {
             createSessionObject: jest.fn().mockResolvedValue({
@@ -480,5 +483,107 @@ describe('process-cloud-app.js — a sheet with no metadata does not abort the a
 
         const logged = logger.error.mock.calls.map((call) => String(call[0])).join('\n');
         expect(logged).not.toContain("reading 'showCondition'");
+    });
+});
+
+describe('process-cloud-app.js — a failed upload must not update the sheets', () => {
+    /**
+     * Wires just enough of the stack to reach the upload step with one sheet.
+     *
+     * @returns {object} The mock SaaS instance to pass to `processCloudApp`.
+     */
+    function setupToUploadStep() {
+        jest.clearAllMocks();
+
+        detectAvailableBrowser.mockResolvedValue({
+            executablePath: '/test/browser',
+            source: 'system',
+            browser: 'chrome',
+            buildId: 'system-installed',
+        });
+        takeSheetScreenshot.mockResolvedValue(true);
+        qscloudUpdateSheetThumbnails.mockResolvedValue(true);
+
+        const mockApp = {
+            createSessionObject: jest.fn().mockResolvedValue({
+                getLayout: jest.fn().mockResolvedValue({
+                    qAppObjectList: {
+                        qItems: [
+                            {
+                                qInfo: { qId: 'sheet-a' },
+                                qMeta: {
+                                    title: 'Sheet A',
+                                    description: '',
+                                    approved: false,
+                                    published: false,
+                                },
+                                qData: { rank: 1, showCondition: null },
+                            },
+                        ],
+                    },
+                }),
+            }),
+            evaluateEx: jest.fn().mockResolvedValue({ qIsNumeric: false, qNumber: 1 }),
+        };
+        enigma.create.mockResolvedValue({
+            open: jest.fn().mockResolvedValue({
+                engineVersion: jest.fn().mockResolvedValue({ qComponentVersion: '1.0.0' }),
+                openDoc: jest.fn().mockResolvedValue(mockApp),
+            }),
+            close: jest.fn().mockResolvedValue(true),
+            on: jest.fn(),
+        });
+
+        puppeteer.launch.mockResolvedValue({
+            newPage: jest.fn().mockResolvedValue({
+                setViewport: jest.fn().mockResolvedValue(true),
+                setDefaultTimeout: jest.fn().mockResolvedValue(true),
+                goto: jest.fn().mockResolvedValue(true),
+                waitForNavigation: jest.fn().mockResolvedValue(true),
+                screenshot: jest.fn().mockResolvedValue(true),
+                click: jest.fn().mockResolvedValue(true),
+                keyboard: { type: jest.fn().mockResolvedValue(true) },
+            }),
+            close: jest.fn().mockResolvedValue(true),
+        });
+
+        const saasInstance = { Get: jest.fn() };
+        saasInstance.Get.mockImplementation((p) => {
+            if (p.includes('media/list')) return Promise.resolve([]);
+            return Promise.resolve({
+                attributes: { name: 'Test App', published: false, publishTime: null },
+            });
+        });
+        return saasInstance;
+    }
+
+    test('does not point sheets at images that failed to upload', async () => {
+        // The upload used to swallow every failure and return normally, so the caller
+        // went straight on to repoint every sheet at files that were never uploaded.
+        // Sheets that had working icons ended up showing broken ones.
+        const saasInstance = setupToUploadStep();
+        qscloudUploadToApp.mockRejectedValue(new Error('Failed to upload 1 of 1 image(s)'));
+
+        await processCloudApp('test-app-id', saasInstance, {
+            tenanturl: 'test-tenant.eu.qlikcloud.com',
+            apikey: 'test-api-key',
+            imagedir: './img',
+            logonuserid: 'test-user',
+            logonpwd: 'password',
+            appid: 'test-app-id',
+            includesheetpart: '1',
+            schemaversion: '12.612.0',
+            browser: 'chrome',
+            browserVersion: 'latest',
+            headless: true,
+            pagewait: 0,
+            loglevel: 'info',
+            excludeSheetStatus: [],
+            excludeSheetNumber: [],
+            excludeSheetTitle: [],
+        });
+
+        expect(qscloudUploadToApp).toHaveBeenCalledTimes(1);
+        expect(qscloudUpdateSheetThumbnails).not.toHaveBeenCalled();
     });
 });

--- a/src/lib/cloud/__tests__/process_cloud_app.test.js
+++ b/src/lib/cloud/__tests__/process_cloud_app.test.js
@@ -90,6 +90,8 @@ let enigma;
 let logger;
 let browserInstall;
 let detectAvailableBrowser;
+let takeSheetScreenshot;
+let qscloudUploadToApp;
 
 beforeAll(async () => {
     await Promise.all([
@@ -113,6 +115,8 @@ beforeAll(async () => {
     ({ logger } = await import('../../../globals.js'));
     ({ browserInstall } = await import('../../browser/browser-install.js'));
     ({ detectAvailableBrowser } = await import('../../browser/browser-detect.js'));
+    ({ takeSheetScreenshot } = await import('../sheet-screenshot.js'));
+    ({ qscloudUploadToApp } = await import('../cloud-upload.js'));
     ({ processCloudApp } = await import('../process-cloud-app.js'));
 });
 
@@ -341,5 +345,140 @@ describe('process-cloud-app.js — puppeteer launch and click options', () => {
             'Failed to install a browser for Qlik Sense Cloud app test-app-id'
         );
         expect(puppeteer.launch).not.toHaveBeenCalled();
+    });
+});
+
+describe('process-cloud-app.js — a sheet with no metadata does not abort the app', () => {
+    const options = {
+        tenanturl: 'test-tenant.eu.qlikcloud.com',
+        apikey: 'test-api-key',
+        imagedir: './img',
+        logonuserid: 'test-user',
+        logonpwd: 'password',
+        appid: 'test-app-id',
+        includesheetpart: '1',
+        schemaversion: '12.612.0',
+        browser: 'chrome',
+        browserVersion: 'latest',
+        headless: true,
+        pagewait: 0,
+        loglevel: 'info',
+        excludeSheetStatus: [],
+        excludeSheetNumber: [],
+        excludeSheetTitle: [],
+    };
+
+    /**
+     * Builds a well-formed sheet as the engine's `SheetList` returns it.
+     *
+     * @param {string} id - Engine object id for the sheet.
+     * @param {number} rank - Sheet rank.
+     *
+     * @returns {object} A sheet object with complete metadata.
+     */
+    const goodSheet = (id, rank) => ({
+        qInfo: { qId: id },
+        qMeta: { title: id, description: '', approved: false, published: false },
+        qData: { rank, showCondition: null },
+    });
+
+    /**
+     * Wires the full mock stack, with a caller-supplied sheet list.
+     *
+     * The whole stack is re-established here rather than shared with the describe block
+     * above, because that block's last test leaves `detectAvailableBrowser` and
+     * `browserInstall` in a failure state and this file does not reset between tests.
+     *
+     * @param {Array<object>} qItems - Sheets to return from the SheetList session object.
+     *
+     * @returns {object} The mock SaaS instance to pass to `processCloudApp`.
+     */
+    function setup(qItems) {
+        jest.clearAllMocks();
+
+        detectAvailableBrowser.mockResolvedValue({
+            executablePath: '/test/browser',
+            source: 'system',
+            browser: 'chrome',
+            buildId: 'system-installed',
+        });
+        takeSheetScreenshot.mockResolvedValue(true);
+        qscloudUploadToApp.mockResolvedValue(true);
+
+        const mockApp = {
+            createSessionObject: jest.fn().mockResolvedValue({
+                getLayout: jest.fn().mockResolvedValue({ qAppObjectList: { qItems } }),
+            }),
+            evaluateEx: jest.fn().mockResolvedValue({ qIsNumeric: false, qNumber: 1 }),
+        };
+        enigma.create.mockResolvedValue({
+            open: jest.fn().mockResolvedValue({
+                engineVersion: jest.fn().mockResolvedValue({ qComponentVersion: '1.0.0' }),
+                openDoc: jest.fn().mockResolvedValue(mockApp),
+            }),
+            close: jest.fn().mockResolvedValue(true),
+            on: jest.fn(),
+        });
+
+        const page = {
+            setViewport: jest.fn().mockResolvedValue(true),
+            setDefaultTimeout: jest.fn().mockResolvedValue(true),
+            goto: jest.fn().mockResolvedValue(true),
+            waitForNavigation: jest.fn().mockResolvedValue(true),
+            screenshot: jest.fn().mockResolvedValue(true),
+            click: jest.fn().mockResolvedValue(true),
+            keyboard: { type: jest.fn().mockResolvedValue(true) },
+        };
+        puppeteer.launch.mockResolvedValue({
+            newPage: jest.fn().mockResolvedValue(page),
+            close: jest.fn().mockResolvedValue(true),
+        });
+
+        const saasInstance = { Get: jest.fn() };
+        saasInstance.Get.mockImplementation((path) => {
+            if (path.includes('media/list')) return Promise.resolve([]);
+            return Promise.resolve({
+                attributes: { name: 'Test App', published: false, publishTime: null },
+            });
+        });
+        return saasInstance;
+    }
+
+    test('sorts the rank-less sheet last instead of throwing from the comparator', async () => {
+        // Sorting happens before any per-sheet handling, so an unguarded read of
+        // sheet.qData.rank inside the comparator aborted the app before a single
+        // screenshot was taken.
+        const saasInstance = setup([
+            goodSheet('sheet-b', 2),
+            { qInfo: { qId: 'broken' }, qMeta: { title: 'Broken' } },
+            goodSheet('sheet-a', 1),
+        ]);
+
+        await processCloudApp('test-app-id', saasInstance, options);
+
+        // The rank-less sheet sorts last but is still a real sheet, with an id and a
+        // title, so it is processed like any other once the comparator stops throwing.
+        const screenshotted = takeSheetScreenshot.mock.calls.map((call) => call[4].qInfo.qId);
+        expect(screenshotted).toEqual(['sheet-a', 'sheet-b', 'broken']);
+
+        const logged = logger.error.mock.calls.map((call) => String(call[0])).join('\n');
+        expect(logged).not.toContain("reading 'rank'");
+    });
+
+    test('finishes the app, uploading the thumbnails it managed to create', async () => {
+        // Getting past the sort is not enough on its own: the show-condition read a few
+        // lines further down was unguarded too, so the app still died before the upload
+        // and every screenshot taken was discarded.
+        const saasInstance = setup([
+            goodSheet('sheet-a', 1),
+            { qInfo: { qId: 'broken' }, qMeta: { title: 'Broken' } },
+        ]);
+
+        await processCloudApp('test-app-id', saasInstance, options);
+
+        expect(qscloudUploadToApp).toHaveBeenCalledTimes(1);
+
+        const logged = logger.error.mock.calls.map((call) => String(call[0])).join('\n');
+        expect(logged).not.toContain("reading 'showCondition'");
     });
 });

--- a/src/lib/cloud/cloud-create-thumbnails.js
+++ b/src/lib/cloud/cloud-create-thumbnails.js
@@ -22,7 +22,7 @@ import { processCloudApp } from './process-cloud-app.js';
  * @param {string} options.browserVersion - Version of browser to use for rendering thumbnails.
  * @param {string} options.blurSheetStatus - Which sheet statuses should be blurred.
  * @param {string} options.blurSheetTag - Which sheet tags should be blurred.
- * @param {string} options.blurSheetNumber - Number of sheets to blur.
+ * @param {Array<string>} options.blurSheetNumber - Sheet numbers (1=first sheet) to blur.
  * @param {string} options.blurFactor - Blur factor.
  *
  * @returns {Promise<boolean>} Resolves to `true` if thumbnails were created successfully, `false` otherwise.

--- a/src/lib/cloud/cloud-remove-sheet-icons.js
+++ b/src/lib/cloud/cloud-remove-sheet-icons.js
@@ -5,6 +5,7 @@ import { logger, setLoggingLevel, bsiExecutablePath, isSea } from '../../globals
 import { redactOptions } from '../util/redact-secrets.js';
 import QlikSaas from './cloud-repo.js';
 import { qscloudTestConnection } from './cloud-test-connection.js';
+import { sortSheetsByRank } from '../util/sheet-list.js';
 
 /**
  * Removes all sheet icons from a Qlik Sense Cloud app.
@@ -99,11 +100,7 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
             logger.info(`Number of sheets in app: ${sheetListObj.qAppObjectList.qItems.length}`);
 
             // Sort sheets
-            sheetListObj.qAppObjectList.qItems.sort((sheet1, sheet2) => {
-                if (sheet1.qData.rank < sheet2.qData.rank) return -1;
-                if (sheet1.qData.rank > sheet2.qData.rank) return 1;
-                return 0;
-            });
+            sortSheetsByRank(sheetListObj.qAppObjectList.qItems);
 
             let iSheetNum = 1;
 

--- a/src/lib/cloud/cloud-updatesheets.js
+++ b/src/lib/cloud/cloud-updatesheets.js
@@ -3,6 +3,7 @@ import enigma from 'enigma.js';
 import { setupEnigmaConnection } from './cloud-enigma.js';
 import { logger } from '../../globals.js';
 import { CloudError } from '../util/errors.js';
+import { sortSheetsByRank } from '../util/sheet-list.js';
 
 /**
  * Updates sheet thumbnails in a Qlik Sense Cloud app.
@@ -69,11 +70,7 @@ export const qscloudUpdateSheetThumbnails = async (createdFiles, appId, options)
             logger.info(`Number of sheets: ${sheetListObj.qAppObjectList.qItems.length}`);
 
             // Sort sheets
-            sheetListObj.qAppObjectList.qItems.sort((sheet1, sheet2) => {
-                if (sheet1.qData.rank < sheet2.qData.rank) return -1;
-                if (sheet1.qData.rank > sheet2.qData.rank) return 1;
-                return 0;
-            });
+            sortSheetsByRank(sheetListObj.qAppObjectList.qItems);
 
             let iSheetNum = 1;
 

--- a/src/lib/cloud/cloud-upload.js
+++ b/src/lib/cloud/cloud-upload.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { logger, setLoggingLevel } from '../../globals.js';
+import { CloudError } from '../util/errors.js';
 import QlikSaas from './cloud-repo.js';
 
 /**
@@ -21,9 +22,15 @@ import QlikSaas from './cloud-repo.js';
  *     - `apikey` (string): API key for authentication.
  *     - `imagedir` (string): Directory path for storing image thumbnails.
  *
- * @returns {Promise<void>} Resolves when the files have been successfully uploaded to the Qlik Sense Cloud app.
+ * @returns {Promise<void>} Resolves only when every qualifying file was uploaded.
+ *
+ * @throws {CloudError} When any file failed to upload, or the upload could not be set up
+ *     at all. The caller must not go on to point sheets at images that are not there.
  */
 export const qscloudUploadToApp = async (filesToUpload, appId, options) => {
+    let uploadedCount = 0;
+    let failedCount = 0;
+
     try {
         // Set log level
         if (options.loglevel === undefined || options.logLevel) {
@@ -51,24 +58,26 @@ export const qscloudUploadToApp = async (filesToUpload, appId, options) => {
         filesToUpload.forEach((file) => logger.debug(JSON.stringify(file)));
 
         for (const file of filesToUpload) {
-            logger.info(`Uploading file: ${file.fileNameShort}`);
+            // Each file is isolated so one bad image does not skip the ones after it.
+            // Failures are counted rather than ignored - see the throw below the loop.
+            try {
+                logger.info(`Uploading file: ${file.fileNameShort}`);
 
-            // Get complete path for file
-            const fileFullPath = path.join(iconFolderAbsolute, file.fileNameShort);
-            logger.debug(`fileFullPath: ${fileFullPath}`);
+                // Get complete path for file
+                const fileFullPath = path.join(iconFolderAbsolute, file.fileNameShort);
+                logger.debug(`fileFullPath: ${fileFullPath}`);
 
-            const fileStat = fs.statSync(fileFullPath);
-            logger.silly(`fileStat: ${JSON.stringify(fileStat, null, 2)}`);
+                const fileStat = fs.statSync(fileFullPath);
+                logger.silly(`fileStat: ${JSON.stringify(fileStat, null, 2)}`);
 
-            if (
-                fileStat.isFile() &&
-                file.fileNameShort.substring(0, 10) === 'thumbnail-' &&
-                path.extname(file.fileNameShort) === '.png'
-            ) {
-                const apiUrl = `apps/${appId}/media/files/thumbnails/${file.fileNameShort}`;
-                logger.debug(`Thumbnail image upload URL: ${apiUrl}`);
+                if (
+                    fileStat.isFile() &&
+                    file.fileNameShort.substring(0, 10) === 'thumbnail-' &&
+                    path.extname(file.fileNameShort) === '.png'
+                ) {
+                    const apiUrl = `apps/${appId}/media/files/thumbnails/${file.fileNameShort}`;
+                    logger.debug(`Thumbnail image upload URL: ${apiUrl}`);
 
-                try {
                     const fileData = fs.readFileSync(fileFullPath);
 
                     const result = await saasInstance.Put({
@@ -100,26 +109,43 @@ export const qscloudUploadToApp = async (filesToUpload, appId, options) => {
                         );
                         logger.verbose(`Blurred image upload done.`);
                     }
-                } catch (err) {
-                    logger.error(`CLOUD UPLOAD 1: ${JSON.stringify(err, null, 2)}`);
-                    if (err.message) {
-                        logger.error(`CLOUD UPLOAD 1 (stack): ${err.message}`);
-                    }
-                    if (err.stack) {
-                        logger.error(`CLOUD UPLOAD 1 (stack): ${err.stack}`);
-                    }
+
+                    uploadedCount += 1;
+                } else if (fileStat.isDirectory()) {
+                    logger.verbose(`${fileFullPath} is a directory, skipping.`);
                 }
-            } else if (fileStat.isDirectory()) {
-                logger.verbose(`${fileFullPath} is a directory, skipping.`);
+            } catch (err) {
+                failedCount += 1;
+                logger.error(`CLOUD UPLOAD 1: ${JSON.stringify(err, null, 2)}`);
+                if (err.message) {
+                    logger.error(`CLOUD UPLOAD 1 (message): ${err.message}`);
+                }
+                if (err.stack) {
+                    logger.error(`CLOUD UPLOAD 1 (stack): ${err.stack}`);
+                }
             }
         }
     } catch (err) {
         if (err.stack) {
             logger.error(`CLOUD UPLOAD 2 (stack): ${err.stack}`);
         } else if (err.message) {
-            logger.error(`CLOUD UPLOAD 2 (stack): ${err.message}`);
+            logger.error(`CLOUD UPLOAD 2 (message): ${err.message}`);
         } else {
             logger.error(`CLOUD UPLOAD 2: ${JSON.stringify(err, null, 2)}`);
         }
+
+        // Rethrow: returning normally here told the caller every image was in place, and
+        // it went on to point every sheet at files that had never been uploaded.
+        throw new CloudError(`Failed to upload sheet thumbnails to Qlik Sense Cloud app ${appId}`, {
+            cause: err,
+        });
+    }
+
+    // Individual failures were logged above but must still fail the app. Sheets that had
+    // working icons keep them, rather than being pointed at images that are not there.
+    if (failedCount > 0) {
+        throw new CloudError(
+            `Failed to upload ${failedCount} of ${failedCount + uploadedCount} thumbnail image(s) to Qlik Sense Cloud app ${appId}`
+        );
     }
 };

--- a/src/lib/cloud/process-cloud-app.js
+++ b/src/lib/cloud/process-cloud-app.js
@@ -8,6 +8,7 @@ import { deleteCloudAppThumbnail } from './cloud-delete-thumbnails.js';
 import { takeSheetScreenshot } from './sheet-screenshot.js';
 import { CloudError } from '../util/errors.js';
 import { launchBrowserForApp } from '../browser/browser-launch.js';
+import { sortSheetsByRank } from '../util/sheet-list.js';
 
 // Selector paths to elements on login page
 const selectorLoginPageUserName = '[id="\u0031-email"]';
@@ -201,11 +202,7 @@ export const processCloudApp = async (appId, saasInstance, options) => {
             // Take screenshot of app overview page
             await page.screenshot({ path: `${imgDir}/cloud/${appId}/overview-1.png` });
             // Sort sheets
-            sheetListObj.qAppObjectList.qItems.sort((sheet1, sheet2) => {
-                if (sheet1.qData.rank < sheet2.qData.rank) return -1;
-                if (sheet1.qData.rank > sheet2.qData.rank) return 1;
-                return 0;
-            });
+            sortSheetsByRank(sheetListObj.qAppObjectList.qItems);
 
             // Loop over all sheets in app
             for (const sheet of sheetListObj.qAppObjectList.qItems) {
@@ -291,7 +288,7 @@ export const processCloudApp = async (appId, saasInstance, options) => {
                 };
                 const showConditionEval = await app.evaluateEx(showConditionCall);
                 const sheetIsHidden =
-                    sheet.qData.showCondition &&
+                    sheet?.qData?.showCondition &&
                     (sheet.qData.showCondition.toLowerCase() === 'false' ||
                         (showConditionEval?.qIsNumeric === true &&
                             showConditionEval?.qNumber === 0))

--- a/src/lib/commands/__tests__/commands.test.js
+++ b/src/lib/commands/__tests__/commands.test.js
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, jest, beforeAll } from '@jest/globals';
-import { InvalidArgumentError } from 'commander';
+import { Command, InvalidArgumentError } from 'commander';
 
 const loggerMock = {
     info: jest.fn(),
@@ -80,6 +80,7 @@ let browserUninstall;
 let browserUninstallAll;
 let browserListAvailable;
 let parsePositiveInteger;
+let collectPositiveIntegers;
 let buildQseowCommand;
 let handleQseowCreateSheetThumbnails;
 let handleCloudCreateSheetThumbnails;
@@ -115,7 +116,7 @@ beforeAll(async () => {
     ({ browserUninstall, browserUninstallAll } =
         await import('../../browser/browser-uninstall.js'));
     ({ browserListAvailable } = await import('../../browser/browser-list-available.js'));
-    ({ parsePositiveInteger } = await import('../helpers.js'));
+    ({ parsePositiveInteger, collectPositiveIntegers } = await import('../helpers.js'));
     ({ buildQseowCommand, handleQseowCreateSheetThumbnails } = await import('../qseow/index.js'));
     ({ handleCloudCreateSheetThumbnails } = await import('../qscloud/create-sheet-thumbnails.js'));
     ({ handleCloudListCollections } = await import('../qscloud/list-collections.js'));
@@ -149,6 +150,98 @@ describe('parsePositiveInteger', () => {
     test('enforces configured boundaries', () => {
         expect(() => parsePositiveInteger('1', { min: 2 })).toThrow(InvalidArgumentError);
         expect(() => parsePositiveInteger('10', { max: 5 })).toThrow(InvalidArgumentError);
+    });
+});
+
+describe('collectPositiveIntegers', () => {
+    test('accumulates onto the previous value instead of replacing it', () => {
+        const parser = collectPositiveIntegers();
+        expect(parser('1')).toEqual(['1']);
+        expect(parser('2', ['1'])).toEqual(['1', '2']);
+        expect(parser('12', ['1', '2'])).toEqual(['1', '2', '12']);
+    });
+
+    test('does not mutate the accumulator it is given', () => {
+        const previous = ['1'];
+        collectPositiveIntegers()('2', previous);
+        expect(previous).toEqual(['1']);
+    });
+
+    test('validates each value with the configured message', () => {
+        const parser = collectPositiveIntegers({ errorMessage: 'nope' });
+        expect(() => parser('abc')).toThrow(InvalidArgumentError);
+        expect(() => parser('abc')).toThrow('nope');
+    });
+});
+
+/**
+ * Drives a single real `Option` instance, taken from a real command builder, through
+ * Commander. A bare parent `Command` is used so no action handler fires - the point is
+ * to observe exactly what Commander stores for that option, with the option's real
+ * variadic declaration and real `argParser` in place.
+ *
+ * @param {import('commander').Command} command - Command owning the option.
+ * @param {string} flag - Long flag to exercise, e.g. `'--exclude-sheet-number'`.
+ * @param {string[]} argv - Argument words to parse, excluding the flag itself.
+ *
+ * @returns {object} The parsed options object.
+ */
+const parseOptionInIsolation = (command, flag, argv) => {
+    const option = command.options.find((opt) => opt.long === flag);
+    if (!option) {
+        throw new Error(`Option ${flag} not found on command ${command.name()}`);
+    }
+    const parent = new Command();
+    parent.exitOverride();
+    parent.addOption(option);
+    parent.parse(['node', 'test', flag, ...argv]);
+    return parent.opts();
+};
+
+describe('variadic sheet-number options collect into arrays', () => {
+    // A variadic option that also has an argParser takes Commander's parser branch, not
+    // its array-collecting branch. A parser ignoring the accumulator leaves the option a
+    // bare string - and the consumers all use `.includes()`, which on a string means
+    // substring matching. `--exclude-sheet-number 12` then also excludes sheets 1 and 2.
+    const cases = [
+        ['qseow', () => buildQseowCommand(), 'excludeSheetNumber', '--exclude-sheet-number'],
+        ['qseow', () => buildQseowCommand(), 'blurSheetNumber', '--blur-sheet-number'],
+        ['qscloud', () => buildQscloudCommand(), 'excludeSheetNumber', '--exclude-sheet-number'],
+        ['qscloud', () => buildQscloudCommand(), 'blurSheetNumber', '--blur-sheet-number'],
+    ];
+
+    describe.each(cases)('%s %s', (platform, build, optionKey, flag) => {
+        /**
+         * Resolves the `create-sheet-thumbnails` subcommand for the platform under test.
+         *
+         * @returns {import('commander').Command} The subcommand carrying the sheet-number options.
+         */
+        const subcommand = () =>
+            build().commands.find((cmd) => cmd.name() === 'create-sheet-thumbnails');
+
+        test('keeps every value when several are supplied', () => {
+            const opts = parseOptionInIsolation(subcommand(), flag, ['1', '2', '12']);
+            expect(opts[optionKey]).toEqual(['1', '2', '12']);
+        });
+
+        test('yields a one-element array for a single value', () => {
+            const opts = parseOptionInIsolation(subcommand(), flag, ['12']);
+            expect(opts[optionKey]).toEqual(['12']);
+        });
+
+        test('does not substring-match other sheet numbers', () => {
+            const opts = parseOptionInIsolation(subcommand(), flag, ['12']);
+            // The regression this guards: as the string '12' both of these were true.
+            expect(opts[optionKey].includes('1')).toBe(false);
+            expect(opts[optionKey].includes('2')).toBe(false);
+            expect(opts[optionKey].includes('12')).toBe(true);
+        });
+
+        test('still rejects a non-integer value', () => {
+            expect(() => parseOptionInIsolation(subcommand(), flag, ['abc'])).toThrow(
+                /must be a non-negative integer/i
+            );
+        });
     });
 });
 

--- a/src/lib/commands/helpers.js
+++ b/src/lib/commands/helpers.js
@@ -44,4 +44,40 @@ const parsePositiveInteger = (value, { min = 0, max, errorMessage, returnNumber 
     return returnNumber ? parsed : stringValue;
 };
 
-export { parsePositiveInteger };
+/**
+ * Builds a Commander `argParser` for a **variadic** integer option (`<number...>`).
+ *
+ * Commander has two ways of producing an array-valued option, and they are mutually
+ * exclusive. Declaring the option variadic makes Commander collect the values itself -
+ * but only for options with no `argParser`. The moment an `argParser` is attached,
+ * Commander switches to calling that parser once per value, passing the accumulated
+ * result so far as the second argument, and stores whatever the parser returns. A
+ * parser that ignores that second argument therefore throws away everything collected
+ * before it, and the option ends up holding a bare string instead of an array.
+ *
+ * That is not a harmless type difference: every consumer of these options asks
+ * `.includes(iSheetNum.toString())`, and `String.prototype.includes` is substring
+ * matching. `--exclude-sheet-number 12` left as the string `'12'` matches sheet 1 and
+ * sheet 2 as well as sheet 12.
+ *
+ * This helper closes over the validation options and accumulates, so a variadic option
+ * keeps its array while still validating each value.
+ *
+ * Values are kept as **strings**, matching `parsePositiveInteger`'s default, because
+ * consumers compare them against `iSheetNum.toString()`.
+ *
+ * @param {object} [parseOptions] - Validation options forwarded to `parsePositiveInteger`.
+ *
+ * @returns {(value: string, previous?: string[]) => string[]} Parser suitable for `Option.argParser()`.
+ *
+ * @throws {InvalidArgumentError} When any single value is not a non-negative integer.
+ *
+ * @example
+ * new Option('--exclude-sheet-number <number...>', '...')
+ *     .argParser(collectPositiveIntegers({ errorMessage: 'Must be a non-negative integer.' }))
+ */
+const collectPositiveIntegers =
+    (parseOptions = {}) =>
+    (value, previous = []) => [...previous, parsePositiveInteger(value, parseOptions)];
+
+export { parsePositiveInteger, collectPositiveIntegers };

--- a/src/lib/commands/qscloud/create-sheet-thumbnails.js
+++ b/src/lib/commands/qscloud/create-sheet-thumbnails.js
@@ -1,7 +1,7 @@
 import { Command, Option } from 'commander';
 import { logger, appVersion } from '../../../globals.js';
 import { qscloudCreateThumbnails } from '../../cloud/cloud-create-thumbnails.js';
-import { parsePositiveInteger } from '../helpers.js';
+import { parsePositiveInteger, collectPositiveIntegers } from '../helpers.js';
 
 /**
  * Commander action for generating Qlik Sense Cloud sheet thumbnails via the worker module.
@@ -185,8 +185,8 @@ const buildCloudCreateSheetThumbnailsCommand = () => {
                 '--exclude-sheet-number <number...>',
                 'Sheet numbers (1=first sheet in an app) that will be excluded from sheet icon update.'
             )
-                .argParser((value) =>
-                    parsePositiveInteger(value, {
+                .argParser(
+                    collectPositiveIntegers({
                         errorMessage: 'Exclude sheet number must be a non-negative integer.',
                     })
                 )
@@ -218,8 +218,8 @@ const buildCloudCreateSheetThumbnailsCommand = () => {
                 '--blur-sheet-number <number...>',
                 'Sheet numbers (1=first sheet in an app) that will be blurred in the sheet icon update.'
             )
-                .argParser((value) =>
-                    parsePositiveInteger(value, {
+                .argParser(
+                    collectPositiveIntegers({
                         errorMessage: 'Blur sheet number must be a non-negative integer.',
                     })
                 )

--- a/src/lib/commands/qseow/index.js
+++ b/src/lib/commands/qseow/index.js
@@ -1,7 +1,7 @@
 import { Command, Option } from 'commander';
 import { logger, appVersion } from '../../../globals.js';
 import { qseowCreateThumbnails } from '../../qseow/qseow-create-thumbnails.js';
-import { parsePositiveInteger } from '../helpers.js';
+import { parsePositiveInteger, collectPositiveIntegers } from '../helpers.js';
 
 /**
  * Commander action that triggers QSEoW thumbnail creation with normalized options and error logging.
@@ -272,8 +272,8 @@ const buildQseowCommand = () => {
                 '--exclude-sheet-number <number...>',
                 'Sheet numbers (1=first sheet in an app) that will be excluded from sheet icon update.'
             )
-                .argParser((value) =>
-                    parsePositiveInteger(value, {
+                .argParser(
+                    collectPositiveIntegers({
                         errorMessage: 'Exclude sheet number must be a non-negative integer.',
                     })
                 )
@@ -305,8 +305,8 @@ const buildQseowCommand = () => {
                 '--blur-sheet-number <number...>',
                 'Sheet numbers (1=first sheet in an app) that will be blurred in the sheet icon update.'
             )
-                .argParser((value) =>
-                    parsePositiveInteger(value, {
+                .argParser(
+                    collectPositiveIntegers({
                         errorMessage: 'Blur sheet number must be a non-negative integer.',
                     })
                 )

--- a/src/lib/qseow/__tests__/determine_sheet_exclude_status.test.js
+++ b/src/lib/qseow/__tests__/determine_sheet_exclude_status.test.js
@@ -167,6 +167,19 @@ describe('determineSheetExcludeStatus', () => {
     });
 
     describe('hidden sheets', () => {
+        test('does not throw for a sheet the engine returned without qData', async () => {
+            // The line above this read already used `sheet?.qData?.showCondition`, but the
+            // hidden check itself did not - so a sheet with no qData threw
+            // `TypeError: Cannot read properties of undefined (reading 'showCondition')`
+            // and took the whole app down with it.
+            const sheet = { qInfo: { qId: 'broken' }, qMeta: { title: 'Broken' } };
+
+            await expect(run({ sheet })).resolves.toEqual({
+                excludeSheet: false,
+                sheetIsHidden: false,
+            });
+        });
+
         test('treats a literal "false" showCondition as hidden', async () => {
             const sheet = createSheet({ showCondition: 'false' });
 

--- a/src/lib/qseow/__tests__/qseow_process_app.test.js
+++ b/src/lib/qseow/__tests__/qseow_process_app.test.js
@@ -99,6 +99,8 @@ let logger;
 let browserInstall;
 let detectAvailableBrowser;
 let determineSheetExcludeStatus;
+let qseowUploadToContentLibrary;
+let qseowUpdateSheetThumbnails;
 
 beforeAll(async () => {
     await Promise.all([
@@ -125,6 +127,8 @@ beforeAll(async () => {
     ({ browserInstall } = await import('../../browser/browser-install.js'));
     ({ detectAvailableBrowser } = await import('../../browser/browser-detect.js'));
     ({ determineSheetExcludeStatus } = await import('../determine-sheet-exclude-status.js'));
+    ({ qseowUploadToContentLibrary } = await import('../qseow-upload.js'));
+    ({ qseowUpdateSheetThumbnails } = await import('../qseow-updatesheets.js'));
     ({ qseowProcessApp } = await import('../qseow-process-app.js'));
 });
 
@@ -423,6 +427,8 @@ describe('qseow-process-app.js — a sheet with no metadata does not abort the a
             excludeSheet: false,
             sheetIsHidden: false,
         });
+        qseowUploadToContentLibrary.mockResolvedValue(true);
+        qseowUpdateSheetThumbnails.mockResolvedValue(true);
 
         const mockGet = jest.fn().mockImplementation((path) => {
             if (path.includes('app?filter=id eq')) {
@@ -485,5 +491,20 @@ describe('qseow-process-app.js — a sheet with no metadata does not abort the a
 
         const logged = logger.error.mock.calls.map((call) => String(call[0])).join('\n');
         expect(logged).not.toContain("reading 'rank'");
+    });
+
+    test('does not point sheets at images that failed to upload', async () => {
+        // The upload used to swallow every failure and return normally, so the caller
+        // went straight on to repoint every sheet at files that were never uploaded.
+        // Sheets that had working icons ended up showing broken ones.
+        setup([sheetItem('sheet-a', 1)]);
+        qseowUploadToContentLibrary.mockRejectedValue(
+            new Error('Failed to upload 1 of 1 thumbnail image(s)')
+        );
+
+        await qseowProcessApp('test-app-id', options);
+
+        expect(qseowUploadToContentLibrary).toHaveBeenCalledTimes(1);
+        expect(qseowUpdateSheetThumbnails).not.toHaveBeenCalled();
     });
 });

--- a/src/lib/qseow/__tests__/qseow_process_app.test.js
+++ b/src/lib/qseow/__tests__/qseow_process_app.test.js
@@ -98,6 +98,7 @@ let qrsInteract;
 let logger;
 let browserInstall;
 let detectAvailableBrowser;
+let determineSheetExcludeStatus;
 
 beforeAll(async () => {
     await Promise.all([
@@ -123,6 +124,7 @@ beforeAll(async () => {
     ({ logger } = await import('../../../globals.js'));
     ({ browserInstall } = await import('../../browser/browser-install.js'));
     ({ detectAvailableBrowser } = await import('../../browser/browser-detect.js'));
+    ({ determineSheetExcludeStatus } = await import('../determine-sheet-exclude-status.js'));
     ({ qseowProcessApp } = await import('../qseow-process-app.js'));
 });
 
@@ -360,5 +362,128 @@ describe('qseow-process-app.js — puppeteer launch and click options', () => {
         const logged = logger.error.mock.calls.map((call) => String(call[0])).join('\n');
         expect(logged).toContain('Failed to install a browser for QSEoW app test-app-id');
         expect(puppeteer.launch).not.toHaveBeenCalled();
+    });
+});
+
+describe('qseow-process-app.js — a sheet with no metadata does not abort the app', () => {
+    const options = {
+        senseVersion: '2023-Nov',
+        imagedir: './img',
+        host: 'test-server.example.com',
+        logonuserdir: 'INTERNAL',
+        logonuserid: 'sa_api',
+        logonpwd: 'password',
+        excludeSheetNumber: [],
+        excludeSheetTitle: [],
+        excludeSheetStatus: [],
+        includesheetpart: '1',
+        pagewait: 0,
+        secure: true,
+        prefix: '',
+        headless: true,
+        blurFactor: 5,
+        loglevel: 'info',
+    };
+
+    /**
+     * Builds a well-formed sheet list item.
+     *
+     * @param {string} qId - Engine object id.
+     * @param {number} rank - Sheet rank.
+     *
+     * @returns {object} A sheet list item.
+     */
+    const sheetItem = (qId, rank) => ({
+        qInfo: { qId },
+        qMeta: { title: qId, description: '', approved: false, published: false },
+        qData: { rank, showCondition: null },
+    });
+
+    /**
+     * Wires the full mock stack over a caller-supplied sheet list.
+     *
+     * Everything is re-established here rather than shared with the describe block above,
+     * because that block's last test leaves `detectAvailableBrowser` and `browserInstall`
+     * in a failure state and this file does not reset between tests.
+     *
+     * @param {Array<object>} qItems - Sheets the SheetList session object should report.
+     *
+     * @returns {void}
+     */
+    function setup(qItems) {
+        jest.clearAllMocks();
+
+        detectAvailableBrowser.mockResolvedValue({
+            executablePath: '/test/browser',
+            source: 'system',
+            browser: 'chrome',
+            buildId: 'system-installed',
+        });
+        determineSheetExcludeStatus.mockResolvedValue({
+            excludeSheet: false,
+            sheetIsHidden: false,
+        });
+
+        const mockGet = jest.fn().mockImplementation((path) => {
+            if (path.includes('app?filter=id eq')) {
+                return Promise.resolve({
+                    body: [{ id: 'test-app-id', name: 'Test App', published: true }],
+                });
+            }
+            return Promise.resolve({ body: [] });
+        });
+        qrsInteract.mockImplementation(() => ({ Get: mockGet }));
+
+        const mockApp = {
+            createSessionObject: jest.fn().mockResolvedValue({
+                getLayout: jest.fn().mockResolvedValue({ qAppObjectList: { qItems } }),
+            }),
+            getObject: jest.fn().mockResolvedValue({ screenshot: jest.fn() }),
+            evaluateEx: jest.fn().mockResolvedValue({ qIsNumeric: false, qNumber: 1 }),
+        };
+        enigma.create.mockResolvedValue({
+            open: jest.fn().mockResolvedValue({
+                engineVersion: jest.fn().mockResolvedValue({ qComponentVersion: '1.0.0' }),
+                openDoc: jest.fn().mockResolvedValue(mockApp),
+            }),
+            close: jest.fn().mockResolvedValue(true),
+            on: jest.fn(),
+        });
+
+        const page = {
+            setViewport: jest.fn().mockResolvedValue(true),
+            setDefaultTimeout: jest.fn().mockResolvedValue(true),
+            goto: jest.fn().mockResolvedValue(true),
+            waitForNavigation: jest.fn().mockResolvedValue(true),
+            screenshot: jest.fn().mockResolvedValue(true),
+            click: jest.fn().mockResolvedValue(true),
+            keyboard: { type: jest.fn().mockResolvedValue(true) },
+            waitForSelector: jest.fn().mockResolvedValue(true),
+            $: jest.fn().mockResolvedValue({ screenshot: jest.fn().mockResolvedValue(true) }),
+            $$: jest.fn().mockResolvedValue([{ click: jest.fn().mockResolvedValue(true) }]),
+        };
+        puppeteer.launch.mockResolvedValue({
+            newPage: jest.fn().mockResolvedValue(page),
+            close: jest.fn().mockResolvedValue(true),
+        });
+    }
+
+    test('still examines the well-formed sheets when one sheet has no qData', async () => {
+        // Sorting runs before the per-sheet handling, so an unguarded read of
+        // sheet.qData.rank in the comparator aborted the whole app before a single
+        // sheet was looked at. The rank-less sheet now sorts last.
+        setup([
+            sheetItem('sheet-b', 2),
+            { qInfo: { qId: 'broken' }, qMeta: { title: 'Broken', description: '' } },
+            sheetItem('sheet-a', 1),
+        ]);
+
+        await qseowProcessApp('test-app-id', options);
+
+        const examined = determineSheetExcludeStatus.mock.calls.map((call) => call[1].qInfo.qId);
+        expect(examined).toEqual(['sheet-a', 'sheet-b', 'broken']);
+
+        const logged = logger.error.mock.calls.map((call) => String(call[0])).join('\n');
+        expect(logged).not.toContain("reading 'rank'");
     });
 });

--- a/src/lib/qseow/__tests__/qseow_remove_sheet_icons.test.js
+++ b/src/lib/qseow/__tests__/qseow_remove_sheet_icons.test.js
@@ -199,6 +199,23 @@ describe('qseowRemoveSheetIcons', () => {
             ]);
         });
 
+        test('still processes the well-formed sheets when one sheet has no qData', async () => {
+            // Sorting runs before the per-sheet try/catch blocks, so an unguarded read of
+            // sheet.qData.rank in the comparator aborted the whole app before a single
+            // icon was touched. The rank-less sheet now sorts last.
+            const broken = makeSheet('broken', 1);
+            delete broken.item.qData;
+            const { app } = wireEnigma([makeSheet('sheet-b', 2), broken, makeSheet('sheet-a', 1)]);
+
+            await qseowRemoveSheetIcons(BASE_OPTIONS);
+
+            expect(app.getObject.mock.calls.map((call) => call[0])).toEqual([
+                'sheet-a',
+                'sheet-b',
+                'broken',
+            ]);
+        });
+
         test('closes the engine session when done', async () => {
             const { session } = wireEnigma([makeSheet('sheet-1', 1)]);
 

--- a/src/lib/qseow/__tests__/qseow_updatesheets.test.js
+++ b/src/lib/qseow/__tests__/qseow_updatesheets.test.js
@@ -182,3 +182,79 @@ describe('qseowUpdateSheetThumbnails — --blur-sheet-tag handling (issue #840)'
         expect(verbose).not.toContain('via tags');
     });
 });
+
+describe('qseowUpdateSheetThumbnails — sheets with missing metadata', () => {
+    /**
+     * Wires the enigma mock chain over a caller-supplied list of sheet list items.
+     *
+     * @param {Array<object>} qItems - Sheet list items to return from the SheetList object.
+     *
+     * @returns {object} The mock app, so tests can inspect `getObject` call order.
+     */
+    function wireEnigmaWithSheets(qItems) {
+        const app = {
+            createSessionObject: jest.fn().mockResolvedValue({
+                getLayout: jest.fn().mockResolvedValue({ qAppObjectList: { qItems } }),
+            }),
+            getObject: jest.fn().mockImplementation(async () => ({
+                getProperties: jest
+                    .fn()
+                    .mockResolvedValue({ thumbnail: { qStaticContentUrlDef: { qUrl: '' } } }),
+                setProperties: jest.fn().mockResolvedValue({ ok: true }),
+            })),
+            doSave: jest.fn().mockResolvedValue(true),
+        };
+
+        enigma.create.mockResolvedValue({
+            open: jest.fn().mockResolvedValue({
+                engineVersion: jest.fn().mockResolvedValue({ qComponentVersion: '12.0.0' }),
+                openDoc: jest.fn().mockResolvedValue(app),
+            }),
+            close: jest.fn().mockResolvedValue(true),
+            on: jest.fn(),
+        });
+
+        return app;
+    }
+
+    /**
+     * Builds a well-formed sheet list item.
+     *
+     * @param {string} qId - Engine object id.
+     * @param {number} rank - Sheet rank.
+     *
+     * @returns {object} A sheet list item.
+     */
+    const sheetItem = (qId, rank) => ({
+        qInfo: { qId },
+        qMeta: { title: qId, description: '' },
+        qData: { rank },
+    });
+
+    test('still processes the well-formed sheets when one sheet has no qData', async () => {
+        // Sorting runs before any per-sheet handling, so an unguarded read of
+        // sheet.qData.rank in the comparator discarded every update for the app.
+        // The rank-less sheet now sorts last.
+        const app = wireEnigmaWithSheets([
+            sheetItem('sheet-b', 2),
+            { qInfo: { qId: 'broken' }, qMeta: { title: 'Broken', description: '' } },
+            sheetItem('sheet-a', 1),
+        ]);
+
+        await qseowUpdateSheetThumbnails(
+            [
+                { sheetPos: 1, fileNameShort: 'thumbnail-1.png' },
+                { sheetPos: 2, fileNameShort: 'thumbnail-2.png' },
+                { sheetPos: 3, fileNameShort: 'thumbnail-3.png' },
+            ],
+            'test-app-id',
+            BASE_OPTIONS
+        );
+
+        expect(app.getObject.mock.calls.map((call) => call[0])).toEqual([
+            'sheet-a',
+            'sheet-b',
+            'broken',
+        ]);
+    });
+});

--- a/src/lib/qseow/__tests__/qseow_upload.test.js
+++ b/src/lib/qseow/__tests__/qseow_upload.test.js
@@ -1,6 +1,8 @@
 import { jest, describe, test, expect, beforeEach } from '@jest/globals';
 import path from 'path';
 
+import { QseowError } from '../../util/errors.js';
+
 const statSync = jest.fn();
 const readFileSync = jest.fn().mockReturnValue(Buffer.from('png-bytes'));
 
@@ -227,37 +229,63 @@ describe('qseowUploadToContentLibrary', () => {
     });
 
     describe('error handling', () => {
+        // A resolved promise from this function is the caller's signal that every image is
+        // in place, and the caller then points the app's sheets at those images. Anything
+        // that did not upload has to surface as a rejection, or sheets that had working
+        // icons end up showing broken ones while the run reports success.
+
         test('a failed upload does not stop the remaining files', async () => {
             withFiles(['thumbnail-1.png', 'thumbnail-2.png', 'thumbnail-3.png']);
             Post.mockRejectedValueOnce(new Error('QRS rejected the upload'));
 
-            await qseowUploadToContentLibrary(
-                [
-                    { fileNameShort: 'thumbnail-1.png' },
-                    { fileNameShort: 'thumbnail-2.png' },
-                    { fileNameShort: 'thumbnail-3.png' },
-                ],
-                APP_ID,
-                BASE_OPTIONS
-            );
+            await expect(
+                qseowUploadToContentLibrary(
+                    [
+                        { fileNameShort: 'thumbnail-1.png' },
+                        { fileNameShort: 'thumbnail-2.png' },
+                        { fileNameShort: 'thumbnail-3.png' },
+                    ],
+                    APP_ID,
+                    BASE_OPTIONS
+                )
+            ).rejects.toThrow(QseowError);
 
             expect(Post).toHaveBeenCalledTimes(3);
+        });
+
+        test('rejects when a single file failed to upload', async () => {
+            withFiles(['thumbnail-1.png', 'thumbnail-2.png', 'thumbnail-3.png']);
+            Post.mockRejectedValueOnce(new Error('QRS rejected the upload'));
+
+            await expect(
+                qseowUploadToContentLibrary(
+                    [
+                        { fileNameShort: 'thumbnail-1.png' },
+                        { fileNameShort: 'thumbnail-2.png' },
+                        { fileNameShort: 'thumbnail-3.png' },
+                    ],
+                    APP_ID,
+                    BASE_OPTIONS
+                )
+            ).rejects.toThrow('Failed to upload 1 of 3 thumbnail image(s)');
         });
 
         test('logs a failed upload rather than swallowing it silently', async () => {
             withFiles(['thumbnail-1.png']);
             Post.mockRejectedValue(new Error('QRS rejected the upload'));
 
-            await qseowUploadToContentLibrary(
-                [{ fileNameShort: 'thumbnail-1.png' }],
-                APP_ID,
-                BASE_OPTIONS
-            );
+            await expect(
+                qseowUploadToContentLibrary(
+                    [{ fileNameShort: 'thumbnail-1.png' }],
+                    APP_ID,
+                    BASE_OPTIONS
+                )
+            ).rejects.toThrow(QseowError);
 
             expect(logger.error).toHaveBeenCalled();
         });
 
-        test('does not reject when a file cannot be stat-ed', async () => {
+        test('rejects when a file cannot be stat-ed', async () => {
             statSync.mockImplementation(() => {
                 throw new Error('ENOENT: no such file or directory');
             });
@@ -268,17 +296,38 @@ describe('qseowUploadToContentLibrary', () => {
                     APP_ID,
                     BASE_OPTIONS
                 )
-            ).resolves.toBeUndefined();
+            ).rejects.toThrow(QseowError);
 
             expect(logger.error).toHaveBeenCalled();
         });
 
-        test('does not reject when the file list is not iterable', async () => {
+        test('names the content library whose upload failed', async () => {
+            withFiles(['thumbnail-1.png']);
+            Post.mockRejectedValue(new Error('QRS rejected the upload'));
+
+            await expect(
+                qseowUploadToContentLibrary(
+                    [{ fileNameShort: 'thumbnail-1.png' }],
+                    APP_ID,
+                    BASE_OPTIONS
+                )
+            ).rejects.toThrow(BASE_OPTIONS.contentlibrary);
+        });
+
+        test('rejects when the file list is not iterable', async () => {
             await expect(
                 qseowUploadToContentLibrary(undefined, APP_ID, BASE_OPTIONS)
-            ).resolves.toBeUndefined();
+            ).rejects.toThrow(QseowError);
 
             expect(logger.error).toHaveBeenCalled();
+        });
+
+        test('keeps the underlying failure as the cause when setup itself fails', async () => {
+            // Only the setup path wraps a single underlying error. A per-file failure is
+            // reported as a count, so there is no one cause to attach.
+            await expect(
+                qseowUploadToContentLibrary(undefined, APP_ID, BASE_OPTIONS)
+            ).rejects.toMatchObject({ cause: expect.any(TypeError) });
         });
     });
 

--- a/src/lib/qseow/determine-sheet-exclude-status.js
+++ b/src/lib/qseow/determine-sheet-exclude-status.js
@@ -73,7 +73,7 @@ export const determineSheetExcludeStatus = async (
 
     const showConditionEval = await app.evaluateEx(showConditionCall);
     const sheetIsHidden =
-        sheet.qData.showCondition &&
+        sheet?.qData?.showCondition &&
         (sheet.qData.showCondition.toLowerCase() === 'false' ||
             (showConditionEval?.qIsNumeric === true && showConditionEval?.qNumber === 0))
             ? true

--- a/src/lib/qseow/qseow-process-app.js
+++ b/src/lib/qseow/qseow-process-app.js
@@ -11,6 +11,7 @@ import { setupQseowQrsConnection } from './qseow-qrs.js';
 import { determineSheetExcludeStatus } from './determine-sheet-exclude-status.js';
 import { QseowError } from '../util/errors.js';
 import { launchBrowserForApp } from '../browser/browser-launch.js';
+import { sortSheetsByRank } from '../util/sheet-list.js';
 
 const selectorLoginPageUserName = '#username-input';
 const selectorLoginPageUserPwd = '#password-input';
@@ -333,11 +334,7 @@ export const qseowProcessApp = async (appId, options) => {
             await page.screenshot({ path: `${imgDir}/qseow/${appId}/overview-1.png` });
 
             // Sort sheets
-            sheetListObj.qAppObjectList.qItems.sort((sheet1, sheet2) => {
-                if (sheet1.qData.rank < sheet2.qData.rank) return -1;
-                if (sheet1.qData.rank > sheet2.qData.rank) return 1;
-                return 0;
-            });
+            sortSheetsByRank(sheetListObj.qAppObjectList.qItems);
 
             // Loop over all sheets in app, processing each one unless excluded
             for (const sheet of sheetListObj.qAppObjectList.qItems) {

--- a/src/lib/qseow/qseow-remove-sheet-icons.js
+++ b/src/lib/qseow/qseow-remove-sheet-icons.js
@@ -6,6 +6,7 @@ import { logger, setLoggingLevel, bsiExecutablePath, isSea } from '../../globals
 import { redactOptions } from '../util/redact-secrets.js';
 import { qseowVerifyCertificatesExist } from './qseow-certificates.js';
 import { setupQseowQrsConnection } from './qseow-qrs.js';
+import { sortSheetsByRank } from '../util/sheet-list.js';
 
 /**
  * Removes all sheet icons from a Qlik Sense Enterprise on Windows (QSEoW) application.
@@ -71,11 +72,7 @@ const removeSheetIconsQSEoWApp = async (appId, g, options) => {
             logger.info(`Number of sheets in app: ${sheetListObj.qAppObjectList.qItems.length}`);
 
             // Sort sheets
-            sheetListObj.qAppObjectList.qItems.sort((sheet1, sheet2) => {
-                if (sheet1.qData.rank < sheet2.qData.rank) return -1;
-                if (sheet1.qData.rank > sheet2.qData.rank) return 1;
-                return 0;
-            });
+            sortSheetsByRank(sheetListObj.qAppObjectList.qItems);
 
             let iSheetNum = 1;
 

--- a/src/lib/qseow/qseow-updatesheets.js
+++ b/src/lib/qseow/qseow-updatesheets.js
@@ -3,6 +3,7 @@ import enigma from 'enigma.js';
 import { setupEnigmaConnection } from './qseow-enigma.js';
 import { logger } from '../../globals.js';
 import { QseowError } from '../util/errors.js';
+import { sortSheetsByRank } from '../util/sheet-list.js';
 
 /**
  * Updates sheet thumbnails in a Qlik Sense Enterprise on Windows (QSEoW) app.
@@ -76,11 +77,7 @@ export const qseowUpdateSheetThumbnails = async (
             logger.info(`Number of sheets: ${sheetListObj.qAppObjectList.qItems.length}`);
 
             // Sort sheets
-            sheetListObj.qAppObjectList.qItems.sort((sheet1, sheet2) => {
-                if (sheet1.qData.rank < sheet2.qData.rank) return -1;
-                if (sheet1.qData.rank > sheet2.qData.rank) return 1;
-                return 0;
-            });
+            sortSheetsByRank(sheetListObj.qAppObjectList.qItems);
 
             let iSheetNum = 1;
 

--- a/src/lib/qseow/qseow-upload.js
+++ b/src/lib/qseow/qseow-upload.js
@@ -3,6 +3,7 @@ import path from 'path';
 import qrsInteract from 'qrs-interact';
 
 import { logger, setLoggingLevel } from '../../globals.js';
+import { QseowError } from '../util/errors.js';
 import { setupQseowQrsConnection } from './qseow-qrs.js';
 
 /**
@@ -23,9 +24,16 @@ import { setupQseowQrsConnection } from './qseow-qrs.js';
  *         located. Must contain a subdirectory named `qseow` with a subdirectory
  *         named after the app ID, which contains the files to be uploaded.
  *
- * @returns {Promise<boolean>} Resolves to `true` if the files were uploaded successfully, `false` otherwise.
+ * @returns {Promise<void>} Resolves only when every qualifying file was uploaded. This
+ *     previously claimed to resolve to a boolean; it never returned one.
+ *
+ * @throws {QseowError} When any file failed to upload, or the upload could not be set up
+ *     at all. The caller must not go on to point sheets at images that are not there.
  */
 export const qseowUploadToContentLibrary = async (filesToUpload, appId, options) => {
+    let uploadedCount = 0;
+    let failedCount = 0;
+
     try {
         // Set log level
         if (options.loglevel === undefined || options.logLevel) {
@@ -55,43 +63,48 @@ export const qseowUploadToContentLibrary = async (filesToUpload, appId, options)
         filesToUpload.forEach((file) => logger.debug(JSON.stringify(file)));
 
         for (const file of filesToUpload) {
-            logger.verbose(`Uploading file: ${JSON.stringify(file)}`);
+            // Each file is isolated so one bad image does not skip the ones after it.
+            // Failures are counted rather than ignored - see the throw below the loop.
+            try {
+                logger.verbose(`Uploading file: ${JSON.stringify(file)}`);
 
-            // Get complete path for file
-            const fileFullPath = path.join(iconFolderAbsolute, file.fileNameShort);
-            logger.debug(`fileFullPath: ${fileFullPath}`);
+                // Get complete path for file
+                const fileFullPath = path.join(iconFolderAbsolute, file.fileNameShort);
+                logger.debug(`fileFullPath: ${fileFullPath}`);
 
-            const fileStat = fs.statSync(fileFullPath);
-            logger.silly(`fileStat: ${JSON.stringify(fileStat, null, 2)}`);
+                const fileStat = fs.statSync(fileFullPath);
+                logger.silly(`fileStat: ${JSON.stringify(fileStat, null, 2)}`);
 
-            if (
-                fileStat.isFile() &&
-                file.fileNameShort.substring(0, 10) === 'thumbnail-' &&
-                path.extname(file.fileNameShort) === '.png'
-            ) {
-                const apiUrl = `/contentlibrary/${encodeURIComponent(
-                    contentlibrary
-                )}/uploadfile?externalpath=${file.fileNameShort}&overwrite=true`;
+                if (
+                    fileStat.isFile() &&
+                    file.fileNameShort.substring(0, 10) === 'thumbnail-' &&
+                    path.extname(file.fileNameShort) === '.png'
+                ) {
+                    const apiUrl = `/contentlibrary/${encodeURIComponent(
+                        contentlibrary
+                    )}/uploadfile?externalpath=${file.fileNameShort}&overwrite=true`;
 
-                logger.debug(`Thumbnail imague upload URL: ${apiUrl}`);
+                    logger.debug(`Thumbnail imague upload URL: ${apiUrl}`);
 
-                try {
                     const fileData = fs.readFileSync(fileFullPath);
 
                     const result = await qrsInteractInstance.Post(apiUrl, fileData, 'image/png');
                     logger.debug(`QSEoW image upload result=${JSON.stringify(result)}`);
                     logger.verbose(`QSEoW image upload done: ${JSON.stringify(file)}`);
-                } catch (err) {
-                    if (err.stack) {
-                        logger.error(`QSEOW UPLOAD 1 (stack): ${err.stack}`);
-                    } else if (err.message) {
-                        logger.error(`QSEOW UPLOAD 1 (message): ${err.message}`);
-                    } else {
-                        logger.error(`QSEOW UPLOAD 1: ${JSON.stringify(err, null, 2)}`);
-                    }
+
+                    uploadedCount += 1;
+                } else if (fileStat.isDirectory()) {
+                    logger.verbose(`${fileFullPath} is a directory, skipping.`);
                 }
-            } else if (fileStat.isDirectory()) {
-                logger.verbose(`${fileFullPath} is a directory, skipping.`);
+            } catch (err) {
+                failedCount += 1;
+                if (err.stack) {
+                    logger.error(`QSEOW UPLOAD 1 (stack): ${err.stack}`);
+                } else if (err.message) {
+                    logger.error(`QSEOW UPLOAD 1 (message): ${err.message}`);
+                } else {
+                    logger.error(`QSEOW UPLOAD 1: ${JSON.stringify(err, null, 2)}`);
+                }
             }
         }
     } catch (err) {
@@ -102,5 +115,20 @@ export const qseowUploadToContentLibrary = async (filesToUpload, appId, options)
         } else {
             logger.error(`QSEOW UPLOAD 2: ${JSON.stringify(err, null, 2)}`);
         }
+
+        // Rethrow: returning normally here told the caller every image was in place, and
+        // it went on to point every sheet at files that had never been uploaded.
+        throw new QseowError(
+            `Failed to upload sheet thumbnails to content library ${options.contentlibrary}`,
+            { cause: err }
+        );
+    }
+
+    // Individual failures were logged above but must still fail the app. Sheets that had
+    // working icons keep them, rather than being pointed at images that are not there.
+    if (failedCount > 0) {
+        throw new QseowError(
+            `Failed to upload ${failedCount} of ${failedCount + uploadedCount} thumbnail image(s) to content library ${options.contentlibrary}`
+        );
     }
 };

--- a/src/lib/util/__tests__/sheet-list.test.js
+++ b/src/lib/util/__tests__/sheet-list.test.js
@@ -1,0 +1,96 @@
+import { describe, test, expect } from '@jest/globals';
+
+import { sortSheetsByRank } from '../sheet-list.js';
+
+/**
+ * Builds a sheet shaped like an entry in the engine's `qAppObjectList.qItems`.
+ *
+ * @param {string} id - Value for `qInfo.qId`, used to identify the sheet in assertions.
+ * @param {number|undefined} rank - Value for `qData.rank`. Pass `undefined` for a sheet
+ *     that has `qData` but no rank in it.
+ *
+ * @returns {object} A sheet object.
+ */
+const sheet = (id, rank) => ({ qInfo: { qId: id }, qMeta: { title: id }, qData: { rank } });
+
+/**
+ * Builds a sheet with no `qData` at all - what the engine returns for a sheet whose
+ * metadata could not be read. This is the shape that used to crash the sort.
+ *
+ * @param {string} id - Value for `qInfo.qId`.
+ *
+ * @returns {object} A sheet object without `qData`.
+ */
+const sheetWithoutQData = (id) => ({ qInfo: { qId: id }, qMeta: { title: id } });
+
+/**
+ * Extracts the sheet ids from a sorted list, for order assertions.
+ *
+ * @param {Array<object>} sheets - Sheets to read ids from.
+ *
+ * @returns {string[]} The ids, in list order.
+ */
+const ids = (sheets) => sheets.map((s) => s.qInfo.qId);
+
+describe('sortSheetsByRank', () => {
+    test('orders sheets by ascending rank', () => {
+        const sheets = [sheet('c', 3), sheet('a', 1), sheet('b', 2)];
+        expect(ids(sortSheetsByRank(sheets))).toEqual(['a', 'b', 'c']);
+    });
+
+    test('sorts in place and returns the same array', () => {
+        const sheets = [sheet('b', 2), sheet('a', 1)];
+        const returned = sortSheetsByRank(sheets);
+        expect(returned).toBe(sheets);
+        expect(ids(sheets)).toEqual(['a', 'b']);
+    });
+
+    test('does not throw on a sheet with no qData', () => {
+        // The regression this guards: sorting runs before the per-sheet try/catch
+        // blocks, so this TypeError used to abort the entire app.
+        const sheets = [sheet('a', 1), sheetWithoutQData('broken'), sheet('b', 2)];
+        expect(() => sortSheetsByRank(sheets)).not.toThrow();
+    });
+
+    test('places a sheet with no qData after every ranked sheet', () => {
+        const sheets = [sheet('b', 2), sheetWithoutQData('broken'), sheet('a', 1)];
+        expect(ids(sortSheetsByRank(sheets))).toEqual(['a', 'b', 'broken']);
+    });
+
+    test('places a sheet whose rank is undefined after every ranked sheet', () => {
+        const sheets = [sheet('noRank', undefined), sheet('b', 2), sheet('a', 1)];
+        expect(ids(sortSheetsByRank(sheets))).toEqual(['a', 'b', 'noRank']);
+    });
+
+    test('treats a null rank as missing', () => {
+        const sheets = [sheet('nullRank', null), sheet('a', 1)];
+        expect(ids(sortSheetsByRank(sheets))).toEqual(['a', 'nullRank']);
+    });
+
+    test('keeps rank 0 ahead of ranked sheets rather than treating it as missing', () => {
+        const sheets = [sheet('b', 1), sheet('zero', 0)];
+        expect(ids(sortSheetsByRank(sheets))).toEqual(['zero', 'b']);
+    });
+
+    test('keeps the original relative order of sheets sharing a rank', () => {
+        const sheets = [sheet('first', 1), sheet('second', 1), sheet('third', 1)];
+        expect(ids(sortSheetsByRank(sheets))).toEqual(['first', 'second', 'third']);
+    });
+
+    test('keeps the original relative order of several rank-less sheets', () => {
+        const sheets = [sheetWithoutQData('x'), sheet('a', 1), sheetWithoutQData('y')];
+        expect(ids(sortSheetsByRank(sheets))).toEqual(['a', 'x', 'y']);
+    });
+
+    test('handles an empty list and a single-sheet list', () => {
+        expect(sortSheetsByRank([])).toEqual([]);
+        expect(ids(sortSheetsByRank([sheetWithoutQData('only')]))).toEqual(['only']);
+    });
+
+    test('does not perturb the order of well-formed sheets around a rank-less one', () => {
+        // The old comparator reported "equal" for any pair involving a missing rank,
+        // which is not transitive - the good sheets could come out in any order.
+        const sheets = [sheet('c', 3), sheetWithoutQData('broken'), sheet('a', 1), sheet('b', 2)];
+        expect(ids(sortSheetsByRank(sheets))).toEqual(['a', 'b', 'c', 'broken']);
+    });
+});

--- a/src/lib/util/sheet-list.js
+++ b/src/lib/util/sheet-list.js
@@ -1,0 +1,51 @@
+/**
+ * Helpers for working with the sheet list returned by the Qlik engine's `SheetList`
+ * session object, shared by the Qlik Sense Cloud and QSEoW code paths.
+ */
+
+/**
+ * Sorts a list of app sheets by their engine rank, in place.
+ *
+ * Sheet order matters beyond presentation: it assigns each sheet its 1-based sheet
+ * number, which names the thumbnail file and decides what `--exclude-sheet-number` and
+ * `--blur-sheet-number` select.
+ *
+ * Two things are handled here that the six hand-written copies of this comparator did
+ * not:
+ *
+ * 1. **Missing metadata no longer aborts the app.** Reading `sheet.qData.rank`
+ *    unguarded throws `TypeError: Cannot read properties of undefined (reading 'rank')`
+ *    on a sheet the engine returned without `qData`. Because sorting happens before the
+ *    per-sheet try/catch blocks, a single such sheet took down the whole app before one
+ *    icon had been touched.
+ * 2. **The ordering is now total.** The previous comparator reported "equal" for any
+ *    pair involving an absent rank, which is not transitive - so one rank-less sheet
+ *    could perturb the relative order of the well-formed sheets around it, and with it
+ *    their sheet numbers. Sheets without a usable rank are now placed after all sheets
+ *    that have one, leaving the numbering of the well-formed sheets predictable.
+ *
+ * Ranks are compared with `<` / `>` on their raw values rather than being coerced, which
+ * keeps the ordering of valid data identical to before. Equal ranks keep their original
+ * relative order, as `Array.prototype.sort` is stable.
+ *
+ * @param {Array<object>} sheets - Sheets from `qAppObjectList.qItems`. Sorted in place.
+ *
+ * @returns {Array<object>} The same array, sorted, so the call can be chained.
+ */
+export const sortSheetsByRank = (sheets) =>
+    sheets.sort((sheet1, sheet2) => {
+        const rank1 = sheet1?.qData?.rank;
+        const rank2 = sheet2?.qData?.rank;
+        const hasRank1 = rank1 !== undefined && rank1 !== null;
+        const hasRank2 = rank2 !== undefined && rank2 !== null;
+
+        // Sheets with no usable rank sort after every sheet that has one, keeping their
+        // own relative order.
+        if (!hasRank1 && !hasRank2) return 0;
+        if (!hasRank1) return 1;
+        if (!hasRank2) return -1;
+
+        if (rank1 < rank2) return -1;
+        if (rank1 > rank2) return 1;
+        return 0;
+    });


### PR DESCRIPTION
Part 1 of #872 — the three live bugs, each independent of the refactor work in that issue.

Each is a separate commit; reading them in order is the intended way to review this.

## 1. `--exclude-sheet-number` / `--blur-sheet-number` selected the wrong sheets

Highest user impact of anything in #872. These options are declared variadic (`<number...>`) **and** given an `.argParser()`. Commander takes the parser branch rather than its array-collecting branch, and `parsePositiveInteger` ignores the accumulator Commander passes as the second argument — so the option ended up a bare string. Every consumer then does `.includes(iSheetNum.toString())`, and `String.prototype.includes` is substring matching:

```
--exclude-sheet-number 1 2 12  ->  "12"   (only the last value survived)
--exclude-sheet-number 12      ->  excluded sheets 1, 2 AND 12
```

Fixed with `collectPositiveIntegers()` in `commands/helpers.js`. Four declarations were affected; every other variadic option was audited and none pairs a variadic declaration with an argParser.

## 2. One metadata-less sheet aborted the whole app

The rank comparator read `sheet1.qData.rank` unguarded in 12 places across six modules, inside `sort()` — which runs *before* the per-sheet try/catch blocks. A sheet the engine returned without `qData` threw `TypeError: Cannot read properties of undefined (reading 'rank')` and the app was abandoned before a single icon was touched.

Replaced all 12 sites with one `sortSheetsByRank()` in `util/sheet-list.js`. It also makes the ordering total — the old comparator reported "equal" for any pair involving an absent rank, which is not transitive, so one bad sheet could perturb the numbering of the good ones.

Getting past the sort was not enough on its own: both twins read `sheet.qData.showCondition` unguarded on the line *after* a guarded `sheet?.qData?.showCondition`, so the app still died later, after screenshots were taken but before upload. Both guarded here.

## 3. Upload failures were swallowed, so a broken upload reported success

Both upload modules swallowed at two levels and always resolved. The caller took that as "every image is in place" and repointed every sheet at files that had never been uploaded. Sheets with previously working icons were left showing broken ones, with no error.

Failures are now counted, every image is still attempted, and a non-zero count throws — so the caller skips the sheet update and the app keeps the icons it already had.

## Verification

- 602 unit tests (up from 556 on `main`), lint and Prettier clean.
- **Every fix is mutation-tested**: each of the six sort call sites, both halves of the upload fix on both twins, and the option parser were reverted individually to confirm a test fails. #872 specifically warns that the earlier attempt at this work had guards with no test holding them.
- The option fix was verified by driving the real `Option` instances out of the real command builders through Commander, not a replica.
- **Integration tests have not been run** — they need real Qlik servers and certificates.

## Note for reviewers

**Eight existing tests are inverted here** (four per upload twin: `does not reject when a file cannot be stat-ed`, `does not reject when the file list is not iterable`, and two more). They asserted the swallowing behaviour — they encoded the bug. Those are the changes most worth a second opinion.

Three `docs/to-doc-site/` pages are included. Every quoted log string in them was captured by running the code, not written from expectation.

## Not in this PR

The exit-code work from #872 Part 3 is held back as a follow-up, because it carries a `BREAKING CHANGE:` footer and a major version bump. Until it lands, a failed app still exits 0 — the upload doc page says so explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
