### PR TITLE
feat!: make the exit code reflect whether the run succeeded (#872 part 3)

### DIFF
--- a/docs/to-doc-site/exit-code-now-reflects-failures.md
+++ b/docs/to-doc-site/exit-code-now-reflects-failures.md
@@ -1,0 +1,72 @@
+# Butler Sheet Icons now exits with a non-zero code when something fails
+
+**Applies to:** every Butler Sheet Icons command
+
+::: danger Action may be required — requires BSI 3.12.0 or later
+If you run Butler Sheet Icons from a scheduled task, CI pipeline, or shell script, **this change can turn a job that always reported success into one that reports failure.** That is the intended behaviour, but read this page before upgrading so the change does not surprise you.
+:::
+
+## What changed
+
+Until now, Butler Sheet Icons always exited with code 0 — the code that means "success" — no matter what happened. A run in which every single app failed to process finished with exactly the same exit code as a run in which everything worked. The only way to tell them apart was to read the log.
+
+That made it impossible to build reliable automation around it. A scheduled job that checked the exit code was, in effect, checking nothing.
+
+Butler Sheet Icons now exits with:
+
+| Exit code | Meaning |
+|---|---|
+| `0` | The command completed and everything it was asked to do succeeded. |
+| `1` | The command failed, or completed with one or more apps it could not process. |
+
+## What now counts as a failure
+
+- **Any app that could not be processed.** Other apps in the same run are still attempted — one bad app does not stop the rest — but the run as a whole reports failure at the end.
+- **A connection that could not be established** to the Qlik Sense server or Qlik Sense Cloud tenant.
+- **A selection that matched no apps at all** — for example a `--collectionid` that exists but contains no apps, or a `--qliksensetag` that no app carries. Previously this finished silently and reported success.
+- **A Qlik Sense Cloud connection test that returns a response with no user in it.** This used to print `Connection to tenant … successful.` followed by four lines reading `undefined`, and the run then failed later for reasons that looked unrelated.
+
+## New messages in the log
+
+When apps fail, the run ends with a count:
+
+```
+CLOUD PROCESS APP: Failed to process app b: engine unreachable
+Failed to process 1 of 3 app(s)
+```
+
+When the options matched no apps:
+
+```
+No apps to process. Check the --appid and --collectionid options.
+```
+
+On Qlik Sense Enterprise on Windows the hint names `--appid` and `--qliksensetag` instead.
+
+When a Qlik Sense Cloud connection test cannot be read:
+
+```
+Connection test to tenant mytenant.eu.qlikcloud.com returned a response with no user in it. Check that --tenanturl points at a Qlik Sense Cloud tenant and that --apikey is a valid, unexpired API key for it.
+```
+
+## What to do before upgrading
+
+**If you run Butler Sheet Icons interactively, there is nothing to do.** The change only affects the exit code, which you do not normally see.
+
+**If you run it from automation, check what your job does with a non-zero exit code.** Most schedulers treat it as a failed job and may send an alert, stop a pipeline, or skip later steps.
+
+1. Run your existing command by hand once after upgrading and check the exit code. On Linux and macOS:
+
+   ```bash
+   butler-sheet-icons qscloud create-sheet-thumbnails ... ; echo "exit code: $?"
+   ```
+
+   On Windows PowerShell, use `$LASTEXITCODE` instead of `$?`.
+
+2. **If it returns 1, that is a real problem that was already happening** — it was simply invisible before. Read the log for the lines above and fix the underlying cause.
+
+3. If you need the job to keep going for now while you investigate, most schedulers let you ignore the exit code of a step. Treat that as temporary: the exit code is telling you that sheet icons are not being updated the way you asked.
+
+## What is still not covered
+
+A sheet that could not be updated **within** an otherwise successful app does not by itself make the run report failure. Those failures are logged, but the exit code stays 0 if every app was otherwise processed. Per-sheet failure reporting is a separate change that has not shipped yet.

--- a/docs/to-doc-site/failed-uploads-no-longer-break-sheet-icons.md
+++ b/docs/to-doc-site/failed-uploads-no-longer-break-sheet-icons.md
@@ -44,4 +44,4 @@ If earlier runs left apps showing broken sheet icons, re-running `create-sheet-t
 
 ## A note on exit codes
 
-Butler Sheet Icons still exits with code 0 in this situation. If you run it from a scheduled job or pipeline, **checking the exit code will not tell you that an app failed** — check the log for the lines above instead. Making the exit code reflect failures is a separate change that has not shipped yet.
+An app that fails this way now makes Butler Sheet Icons exit with code 1, so a scheduled job or pipeline sees the failure rather than passing silently. See *Butler Sheet Icons now exits with a non-zero code when something fails* for what that means for existing automation.

--- a/src/lib/cloud/__tests__/cloud_remove_sheet_icons.test.js
+++ b/src/lib/cloud/__tests__/cloud_remove_sheet_icons.test.js
@@ -359,6 +359,67 @@ describe('qscloudRemoveSheetIcons', () => {
             expect(enigmaCreate).toHaveBeenCalledTimes(2);
         });
 
+        test('reports failure when the collection resolves to no apps at all', async () => {
+            // An unresolvable collection is not the same as "nothing to do". This used to
+            // return true, so a --collectionid typo looked like a clean run.
+            Get.mockImplementation(async (path) => {
+                if (path === 'collections') return [{ id: 'collection-1' }];
+                if (path === 'collections/collection-1/items') return [];
+                return [];
+            });
+
+            await expect(
+                qscloudRemoveSheetIcons({
+                    ...BASE_OPTIONS,
+                    appid: '',
+                    collectionid: 'collection-1',
+                })
+            ).resolves.toBe(false);
+
+            const errors = logger.error.mock.calls.map((call) => String(call[0])).join('\n');
+            expect(errors).toContain('No apps to process');
+        });
+
+        test('a collection with only non-app items counts as no apps', async () => {
+            Get.mockImplementation(async (path) => {
+                if (path === 'collections') return [{ id: 'collection-1' }];
+                if (path === 'collections/collection-1/items') {
+                    return [{ resourceType: 'dataset', id: 'ds-1' }];
+                }
+                return [];
+            });
+
+            await expect(
+                qscloudRemoveSheetIcons({
+                    ...BASE_OPTIONS,
+                    appid: '',
+                    collectionid: 'collection-1',
+                })
+            ).resolves.toBe(false);
+        });
+
+        test('an explicitly named --appid still runs when the collection is empty', async () => {
+            // An earlier attempt at the empty check threw from inside the collection
+            // resolver, which discarded an --appid that had already been queued.
+            wireEnigma([makeSheet('sheet-1', 1)]);
+            Get.mockImplementation(async (path) => {
+                if (path === 'collections') return [{ id: 'collection-1' }];
+                if (path === 'collections/collection-1/items') return [];
+                if (path.endsWith('/media/list')) return [];
+                return [];
+            });
+
+            await expect(
+                qscloudRemoveSheetIcons({
+                    ...BASE_OPTIONS,
+                    appid: 'test-app-id',
+                    collectionid: 'collection-1',
+                })
+            ).resolves.toBe(true);
+
+            expect(enigmaCreate).toHaveBeenCalledTimes(1);
+        });
+
         test('returns false when the collection does not exist', async () => {
             Get.mockImplementation(async (path) => {
                 if (path === 'collections') return [{ id: 'a-different-collection' }];
@@ -415,21 +476,27 @@ describe('qscloudRemoveSheetIcons', () => {
                 return [];
             });
 
+            // The other app is still attempted - but the run as a whole is a failure now,
+            // not a success with error text buried in the log.
             await expect(
                 qscloudRemoveSheetIcons({
                     ...BASE_OPTIONS,
                     appid: '',
                     collectionid: 'collection-1',
                 })
-            ).resolves.toBe(true);
+            ).resolves.toBe(false);
 
             expect(enigmaCreate).toHaveBeenCalledTimes(2);
+
+            const errors = logger.error.mock.calls.map((call) => String(call[0])).join('\n');
+            expect(errors).toContain('Failed to process 1 of 2 app(s)');
         });
 
-        test('logs an engine failure instead of rejecting', async () => {
+        test('reports failure instead of rejecting when the engine is unreachable', async () => {
             enigmaCreate.mockRejectedValue(new Error('engine unreachable'));
 
-            await expect(qscloudRemoveSheetIcons({ ...BASE_OPTIONS })).resolves.toBe(true);
+            // Reports false rather than throwing: the caller sets the exit code from it.
+            await expect(qscloudRemoveSheetIcons({ ...BASE_OPTIONS })).resolves.toBe(false);
 
             expect(logger.error).toHaveBeenCalled();
         });

--- a/src/lib/cloud/__tests__/cloud_test_connection.test.js
+++ b/src/lib/cloud/__tests__/cloud_test_connection.test.js
@@ -67,12 +67,35 @@ describe('qscloudTestConnection', () => {
         expect(info).toContain('tenant.eu.qlikcloud.com');
     });
 
-    test('tolerates a response missing the user fields', async () => {
-        await expect(qscloudTestConnection(OPTIONS, saasReturning({}))).resolves.toBe(true);
+    test('rejects a response with no user in it', async () => {
+        // This used to resolve true, and the operator saw "Connection to tenant ...
+        // successful." followed by four lines of `undefined`.
+        await expect(qscloudTestConnection(OPTIONS, saasReturning({}))).rejects.toThrow(
+            /no user in it/
+        );
     });
 
-    test('tolerates a response of undefined', async () => {
-        await expect(qscloudTestConnection(OPTIONS, saasReturning(undefined))).resolves.toBe(true);
+    test('rejects a response of undefined', async () => {
+        await expect(qscloudTestConnection(OPTIONS, saasReturning(undefined))).rejects.toThrow(
+            /no user in it/
+        );
+    });
+
+    test('does not claim the connection was successful when it could not be read', async () => {
+        await expect(qscloudTestConnection(OPTIONS, saasReturning({}))).rejects.toThrow();
+
+        const info = logger.info.mock.calls.map((call) => String(call[0])).join('\n');
+        expect(info).not.toContain('successful');
+        expect(info).not.toContain('undefined');
+    });
+
+    test('tells the operator which options to check, not to check an id they never gave', async () => {
+        // Routing this through a generic object reader produced "Check the id is correct"
+        // for users/me, where the operator supplied no id at all.
+        await expect(qscloudTestConnection(OPTIONS, saasReturning({}))).rejects.toThrow(
+            /--tenanturl/
+        );
+        await expect(qscloudTestConnection(OPTIONS, saasReturning({}))).rejects.toThrow(/--apikey/);
     });
 
     test('rejects when the API call fails', async () => {

--- a/src/lib/cloud/__tests__/process_cloud_app.test.js
+++ b/src/lib/cloud/__tests__/process_cloud_app.test.js
@@ -338,9 +338,12 @@ describe('process-cloud-app.js — puppeteer launch and click options', () => {
         detectAvailableBrowser.mockResolvedValue(null);
         browserInstall.mockRejectedValue(new Error('network unreachable'));
 
-        // processCloudApp catches and logs rather than rethrowing, so callers can continue to
-        // the next app. Assert it resolves; `rejects.toThrow` would fail here.
-        await processCloudApp('test-app-id', defaultSaasInstance, defaultOptions);
+        // processCloudApp logs in detail and then rethrows, so the app loop above it can
+        // count this app as failed. Isolation between apps is the loop's job, not this
+        // function's - it used to swallow here, and the run reported success.
+        await expect(
+            processCloudApp('test-app-id', defaultSaasInstance, defaultOptions)
+        ).rejects.toThrow();
 
         const logged = logger.error.mock.calls.map((call) => String(call[0])).join('\n');
         expect(logged).toContain(
@@ -564,24 +567,26 @@ describe('process-cloud-app.js — a failed upload must not update the sheets', 
         const saasInstance = setupToUploadStep();
         qscloudUploadToApp.mockRejectedValue(new Error('Failed to upload 1 of 1 image(s)'));
 
-        await processCloudApp('test-app-id', saasInstance, {
-            tenanturl: 'test-tenant.eu.qlikcloud.com',
-            apikey: 'test-api-key',
-            imagedir: './img',
-            logonuserid: 'test-user',
-            logonpwd: 'password',
-            appid: 'test-app-id',
-            includesheetpart: '1',
-            schemaversion: '12.612.0',
-            browser: 'chrome',
-            browserVersion: 'latest',
-            headless: true,
-            pagewait: 0,
-            loglevel: 'info',
-            excludeSheetStatus: [],
-            excludeSheetNumber: [],
-            excludeSheetTitle: [],
-        });
+        await expect(
+            processCloudApp('test-app-id', saasInstance, {
+                tenanturl: 'test-tenant.eu.qlikcloud.com',
+                apikey: 'test-api-key',
+                imagedir: './img',
+                logonuserid: 'test-user',
+                logonpwd: 'password',
+                appid: 'test-app-id',
+                includesheetpart: '1',
+                schemaversion: '12.612.0',
+                browser: 'chrome',
+                browserVersion: 'latest',
+                headless: true,
+                pagewait: 0,
+                loglevel: 'info',
+                excludeSheetStatus: [],
+                excludeSheetNumber: [],
+                excludeSheetTitle: [],
+            })
+        ).rejects.toThrow('Failed to upload 1 of 1 image(s)');
 
         expect(qscloudUploadToApp).toHaveBeenCalledTimes(1);
         expect(qscloudUpdateSheetThumbnails).not.toHaveBeenCalled();

--- a/src/lib/cloud/cloud-create-thumbnails.js
+++ b/src/lib/cloud/cloud-create-thumbnails.js
@@ -3,6 +3,7 @@ import { redactOptions } from '../util/redact-secrets.js';
 import QlikSaas from './cloud-repo.js';
 import { qscloudTestConnection } from './cloud-test-connection.js';
 import { processCloudApp } from './process-cloud-app.js';
+import { runOverApps } from '../util/run-over-apps.js';
 
 /**
  * Create thumbnails for Qlik Sense Cloud (QSC).
@@ -128,36 +129,18 @@ export const qscloudCreateThumbnails = async (options) => {
             }
         }
 
-        // Remove duplicates (if any) from list of app IDs that will be processed
-        const uniqueAppIds = [...new Set(appIdsToProcess)];
+        const { total, failed } = await runOverApps(
+            appIdsToProcess,
+            {
+                logPrefix: 'CLOUD PROCESS APP',
+                emptySelectionHint: 'Check the --appid and --collectionid options.',
+            },
+            (appId) => processCloudApp(appId, saasInstance, options)
+        );
 
-        // Debug output of apps that will be processed
-        logger.debug('Will process these app IDs:');
-        uniqueAppIds.forEach((appId) => {
-            logger.debug(appId);
-        });
-
-        // Process all apps
-        for (const appId of uniqueAppIds) {
-            try {
-                logger.info(`--------------------------------------------------`);
-                logger.info(`About to process app ${appId}`);
-
-                await processCloudApp(appId, saasInstance, options);
-
-                logger.verbose(`Done processing app ${appId}`);
-            } catch (err) {
-                if (err.stack) {
-                    logger.error(`CLOUD PROCESS APP (stack): ${err.stack}`);
-                } else if (err.message) {
-                    logger.error(`CLOUD PROCESS APP (message): ${err.message}`);
-                } else {
-                    logger.error(`CLOUD PROCESS APP: ${err}`);
-                }
-            }
-        }
-
-        return true;
+        // An app the worker could not finish, or a selection that resolved to no
+        // apps at all, is a failed run - not a successful one with error text in it.
+        return total > 0 && failed === 0;
     } catch (err) {
         if (err.stack) {
             logger.error(`CLOUD CREATE THUMBNAILS 2 (stack): ${err.stack}`);

--- a/src/lib/cloud/cloud-remove-sheet-icons.js
+++ b/src/lib/cloud/cloud-remove-sheet-icons.js
@@ -5,6 +5,7 @@ import { logger, setLoggingLevel, bsiExecutablePath, isSea } from '../../globals
 import { redactOptions } from '../util/redact-secrets.js';
 import QlikSaas from './cloud-repo.js';
 import { qscloudTestConnection } from './cloud-test-connection.js';
+import { runOverApps } from '../util/run-over-apps.js';
 import { sortSheetsByRank } from '../util/sheet-list.js';
 
 /**
@@ -149,6 +150,9 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
         } else {
             logger.error(`CLOUD REMOVE SHEET ICONS 1: ${err}`);
         }
+        // Rethrow so the app loop can count this app as failed. Logging and returning
+        // normally made a run in which every app failed look exactly like a clean run.
+        throw err;
     }
 };
 
@@ -250,37 +254,18 @@ export const qscloudRemoveSheetIcons = async (options) => {
             }
         }
 
-        // Remove duplicates (if any) from list of app IDs that will be processed
-        const uniqueAppIds = [...new Set(appIdsToProcess)];
+        const { total, failed } = await runOverApps(
+            appIdsToProcess,
+            {
+                logPrefix: 'CLOUD PROCESS APP 2',
+                emptySelectionHint: 'Check the --appid and --collectionid options.',
+            },
+            (appId) => removeSheetIconsCloudApp(appId, saasInstance, options)
+        );
 
-        // Debug output of apps that will be processed
-        logger.debug('Will process these app IDs:');
-        uniqueAppIds.forEach((appId) => {
-            logger.debug(appId);
-        });
-
-        // Process all apps
-
-        for (const appId of uniqueAppIds) {
-            try {
-                logger.info(`--------------------------------------------------`);
-                logger.info(`About to process app ${appId}`);
-
-                await removeSheetIconsCloudApp(appId, saasInstance, options);
-
-                logger.verbose(`Done processing app ${appId}`);
-            } catch (err) {
-                logger.error(`CLOUD PROCESS APP 2: ${err}`);
-                if (err.message) {
-                    logger.error(`CLOUD PROCESS APP 2 (message): ${err.message}`);
-                }
-                if (err.stack) {
-                    logger.error(`CLOUD PROCESS APP 2 (stack): ${err.stack}`);
-                }
-            }
-        }
-
-        return true;
+        // An app the worker could not finish, or a selection that resolved to no
+        // apps at all, is a failed run - not a successful one with error text in it.
+        return total > 0 && failed === 0;
     } catch (err) {
         if (err.stack) {
             logger.error(`CLOUD REMOVE THUMBNAILS 3 (stack): ${err.stack}`);

--- a/src/lib/cloud/cloud-test-connection.js
+++ b/src/lib/cloud/cloud-test-connection.js
@@ -1,4 +1,5 @@
 import { logger } from '../../globals.js';
+import { CloudError } from '../util/errors.js';
 
 /**
  * A Qlik SaaS HTTP client, returned by the default export of `cloud-repo.js`.
@@ -22,23 +23,42 @@ import { logger } from '../../globals.js';
  * @param {string} options.loglevel - Log level for the operation.
  * @param {QlikSaasInstance} saasInstance - Instance of QlikSaas class.
  *
- * @returns {Promise<boolean>} Resolves to `true` if connection is successful, `false` otherwise.
+ * @returns {Promise<true>} Resolves to `true` when the API returned a user. There is no
+ *     resolved-`false` path: an unusable connection rejects.
  *
- * @throws {Error} Throws an error if there is an issue during the connection test.
+ * @throws {CloudError} When the API answered but the response carries no user.
+ * @throws {Error} Whatever the SaaS client threw when the call itself failed.
  */
 export const qscloudTestConnection = async (options, saasInstance) => {
     // Test connection to QS Cloud by getting info about the user associated with the API key
+    let res;
     try {
         logger.info(`Testing connection to Qlik Sense Cloud...`);
-        const res = await saasInstance.Get('users/me');
-        logger.info(`Connection to tenant ${options.tenanturl} successful.`);
-        logger.info(`    Tenant ID : ${res?.tenantId}`);
-        logger.info(`    User name : ${res?.name}`);
-        logger.info(`    User email: ${res?.email}`);
-        logger.info(`    User ID   : ${res?.id}`);
-        logger.debug(`Full user info: ${JSON.stringify(res, null, 2)}`);
+        res = await saasInstance.Get('users/me');
     } catch (err) {
         return Promise.reject(err);
     }
+
+    // A response the API accepted but that carries no user is not a working connection.
+    // Reporting it as one produced `Connection to tenant ... successful.` followed by four
+    // lines of `undefined`, and the run then failed later for reasons that looked unrelated.
+    // The guidance below is written for this specific call - a generic "check the id is
+    // correct" would be nonsense here, as the operator supplied no id.
+    if (!res || typeof res !== 'object' || res.id === undefined) {
+        return Promise.reject(
+            new CloudError(
+                `Connection test to tenant ${options.tenanturl} returned a response with no user in it. ` +
+                    `Check that --tenanturl points at a Qlik Sense Cloud tenant and that --apikey is a valid, unexpired API key for it.`
+            )
+        );
+    }
+
+    logger.info(`Connection to tenant ${options.tenanturl} successful.`);
+    logger.info(`    Tenant ID : ${res.tenantId}`);
+    logger.info(`    User name : ${res.name}`);
+    logger.info(`    User email: ${res.email}`);
+    logger.info(`    User ID   : ${res.id}`);
+    logger.debug(`Full user info: ${JSON.stringify(res, null, 2)}`);
+
     return true;
 };

--- a/src/lib/cloud/process-cloud-app.js
+++ b/src/lib/cloud/process-cloud-app.js
@@ -381,5 +381,8 @@ export const processCloudApp = async (appId, saasInstance, options) => {
         } else {
             logger.error(`CLOUD APP: ${err.stack}`);
         }
+        // Rethrow so the app loop can count this app as failed. Logging and returning
+        // normally made a run in which every app failed look exactly like a clean run.
+        throw err;
     }
 };

--- a/src/lib/commands/__tests__/commands.test.js
+++ b/src/lib/commands/__tests__/commands.test.js
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, jest, beforeAll } from '@jest/globals';
+import { describe, test, expect, beforeEach, afterEach, jest, beforeAll } from '@jest/globals';
 import { Command, InvalidArgumentError } from 'commander';
 
 const loggerMock = {
@@ -445,7 +445,9 @@ describe('browser commands', () => {
     });
 
     test('install handles null options gracefully', async () => {
-        await expect(handleBrowserInstall(null)).resolves.toBeUndefined();
+        // Reports failure rather than throwing. It used to resolve undefined, which the
+        // caller could not distinguish from success.
+        await expect(handleBrowserInstall(null)).resolves.toBe(false);
         expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('BROWSER MAIN 9'));
     });
 
@@ -462,5 +464,73 @@ describe('browser commands', () => {
         await handleBrowserInstall(options, command);
 
         expect(browserInstall).toHaveBeenCalledWith(options, command);
+    });
+});
+
+describe('exit code reflects whether the command succeeded', () => {
+    // process.exitCode is global to the worker, and a stray 1 left behind here would make
+    // Jest itself report failure. Every test restores it.
+    let originalExitCode;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        originalExitCode = process.exitCode;
+        process.exitCode = undefined;
+    });
+
+    afterEach(() => {
+        process.exitCode = originalExitCode;
+    });
+
+    test('leaves the exit code alone when the command succeeds', async () => {
+        qscloudCreateThumbnails.mockResolvedValue(true);
+
+        await handleCloudCreateSheetThumbnails({ browser: 'chrome' }, {});
+
+        expect(process.exitCode).toBeUndefined();
+    });
+
+    test('sets exit code 1 when the command reports failure', async () => {
+        // The whole point of the change: a run in which nothing worked used to exit 0, so
+        // no scheduler or CI job could tell it apart from a clean run.
+        qscloudCreateThumbnails.mockResolvedValue(false);
+
+        await handleCloudCreateSheetThumbnails({ browser: 'chrome' }, {});
+
+        expect(process.exitCode).toBe(1);
+    });
+
+    test('sets exit code 1 when the command throws', async () => {
+        qscloudCreateThumbnails.mockRejectedValue(new Error('tenant unreachable'));
+
+        await handleCloudCreateSheetThumbnails({ browser: 'chrome' }, {});
+
+        expect(process.exitCode).toBe(1);
+    });
+
+    test('does not let a command failure escape as an unhandled rejection', async () => {
+        // Throwing on out of the handler would reach the process-level unhandledRejection
+        // handler, which writes a crash dump - the wrong response to an unreachable server.
+        qscloudCreateThumbnails.mockRejectedValue(new Error('tenant unreachable'));
+
+        await expect(handleCloudCreateSheetThumbnails({ browser: 'chrome' }, {})).resolves.toBe(
+            false
+        );
+    });
+
+    test('applies to the QSEoW command too', async () => {
+        qseowCreateThumbnails.mockResolvedValue(false);
+
+        await handleQseowCreateSheetThumbnails({ browser: 'chrome' }, {});
+
+        expect(process.exitCode).toBe(1);
+    });
+
+    test('applies to the cloud remove-sheet-icons command too', async () => {
+        qscloudRemoveSheetIcons.mockResolvedValue(false);
+
+        await handleCloudRemoveSheetIcons({}, {});
+
+        expect(process.exitCode).toBe(1);
     });
 });

--- a/src/lib/commands/browser/install.js
+++ b/src/lib/commands/browser/install.js
@@ -1,6 +1,7 @@
 import { Command, Option } from 'commander';
 import { logger, appVersion } from '../../../globals.js';
 import { browserInstall } from '../../browser/browser-install.js';
+import { runCommand } from '../run-command.js';
 
 /**
  * Commander action that normalizes requested browser defaults and installs the browser.
@@ -13,7 +14,7 @@ import { browserInstall } from '../../browser/browser-install.js';
 const handleBrowserInstall = async (options = {}, cmd) => {
     logger.info(`App version: ${appVersion}`);
 
-    try {
+    return runCommand('BROWSER MAIN 9', () => {
         // Normalize browser version defaults
         if (!options.browserVersion || options.browserVersion === '') {
             if (options.browser === 'chrome') {
@@ -24,17 +25,8 @@ const handleBrowserInstall = async (options = {}, cmd) => {
         }
 
         // Install the browser
-        const res = await browserInstall(options, cmd);
-        logger.debug(`Call to browserInstall succeeded: ${JSON.stringify(res)}`);
-    } catch (err) {
-        logger.error(`BROWSER MAIN 9: ${err}`);
-        if (err.message) {
-            logger.error(`BROWSER MAIN 9 (message): ${err.message}`);
-        }
-        if (err.stack) {
-            logger.error(`BROWSER MAIN 9 (stack): ${err.stack}`);
-        }
-    }
+        return browserInstall(options, cmd);
+    });
 };
 
 /**

--- a/src/lib/commands/browser/list-available.js
+++ b/src/lib/commands/browser/list-available.js
@@ -1,6 +1,7 @@
 import { Command, Option } from 'commander';
 import { logger, appVersion } from '../../../globals.js';
 import { browserListAvailable } from '../../browser/browser-list-available.js';
+import { runCommand } from '../run-command.js';
 
 /**
  * Commander action that queries which browsers are available for download.
@@ -13,17 +14,18 @@ import { browserListAvailable } from '../../browser/browser-list-available.js';
 const handleBrowserListAvailable = async (options = {}, cmd) => {
     logger.info(`App version: ${appVersion}`);
 
-    try {
-        const res = await browserListAvailable(options, cmd);
-        logger.debug(`Call to browserAvailable succeeded: ${JSON.stringify(res, null, 2)}`);
-    } catch (err) {
-        // browserListAvailable has already explained the failure - a connectivity problem gets
-        // actionable advice, anything else gets its message. Repeating it here three times over,
-        // stack trace included, is what made an offline run unreadable (issue #785). The stack
-        // stays available at debug level.
-        logger.error('Could not list available browsers.');
-        logger.debug(err?.stack ?? String(err));
-    }
+    return runCommand(
+        'BROWSER MAIN 10',
+        () => browserListAvailable(options, cmd),
+        (err) => {
+            // browserListAvailable has already explained the failure - a connectivity problem
+            // gets actionable advice, anything else gets its message. Repeating it here three
+            // times over, stack trace included, is what made an offline run unreadable
+            // (issue #785). The stack stays available at debug level.
+            logger.error('Could not list available browsers.');
+            logger.debug(err?.stack ?? String(err));
+        }
+    );
 };
 
 /**

--- a/src/lib/commands/browser/list-installed.js
+++ b/src/lib/commands/browser/list-installed.js
@@ -1,6 +1,7 @@
 import { Command, Option } from 'commander';
 import { logger, appVersion } from '../../../globals.js';
 import { browserInstalled } from '../../browser/browser-installed.js';
+import { runCommand } from '../run-command.js';
 
 /**
  * Commander action that lists browsers already downloaded into the Butler cache.
@@ -14,18 +15,7 @@ const handleBrowserListInstalled = async (options = {}, cmd) => {
     logger.info(`App version: ${appVersion}`);
 
     logger.verbose(`appid=${options.appid}`);
-    try {
-        const res = await browserInstalled(options, cmd);
-        logger.debug(`Call to browserInstalled succeeded: ${res}`);
-    } catch (err) {
-        logger.error(`BROWSER MAIN 6: ${err}`);
-        if (err.message) {
-            logger.error(`BROWSER MAIN 6 (message): ${err.message}`);
-        }
-        if (err.stack) {
-            logger.error(`BROWSER MAIN 6 (stack): ${err.stack}`);
-        }
-    }
+    return runCommand('BROWSER MAIN 6', () => browserInstalled(options, cmd));
 };
 
 /**

--- a/src/lib/commands/browser/uninstall-all.js
+++ b/src/lib/commands/browser/uninstall-all.js
@@ -1,6 +1,7 @@
 import { Command, Option } from 'commander';
 import { logger, appVersion } from '../../../globals.js';
 import { browserUninstallAll } from '../../browser/browser-uninstall.js';
+import { runCommand } from '../run-command.js';
 
 /**
  * Commander action that removes every cached browser managed by Butler Sheet Icons.
@@ -13,18 +14,7 @@ import { browserUninstallAll } from '../../browser/browser-uninstall.js';
 const handleBrowserUninstallAll = async (options = {}, cmd) => {
     logger.info(`App version: ${appVersion}`);
 
-    try {
-        const res = await browserUninstallAll(options, cmd);
-        logger.debug(`Call to browserUninstallAll succeeded: ${res}`);
-    } catch (err) {
-        logger.error(`BROWSER MAIN 8: ${err}`);
-        if (err.message) {
-            logger.error(`BROWSER MAIN 8 (message): ${err.message}`);
-        }
-        if (err.stack) {
-            logger.error(`BROWSER MAIN 8 (stack): ${err.stack}`);
-        }
-    }
+    return runCommand('BROWSER MAIN 8', () => browserUninstallAll(options, cmd));
 };
 
 /**

--- a/src/lib/commands/browser/uninstall.js
+++ b/src/lib/commands/browser/uninstall.js
@@ -1,6 +1,7 @@
 import { Command, Option } from 'commander';
 import { logger, appVersion } from '../../../globals.js';
 import { browserUninstall } from '../../browser/browser-uninstall.js';
+import { runCommand } from '../run-command.js';
 
 /**
  * Commander action that uninstalls a single browser build from the local cache.
@@ -13,18 +14,7 @@ import { browserUninstall } from '../../browser/browser-uninstall.js';
 const handleBrowserUninstall = async (options = {}, cmd) => {
     logger.info(`App version: ${appVersion}`);
 
-    try {
-        const res = await browserUninstall(options, cmd);
-        logger.debug(`Call to browserUninstall succeeded: ${res}`);
-    } catch (err) {
-        logger.error(`BROWSER MAIN 7: ${err}`);
-        if (err.message) {
-            logger.error(`BROWSER MAIN 7 (message): ${err.message}`);
-        }
-        if (err.stack) {
-            logger.error(`BROWSER MAIN 7 (stack): ${err.stack}`);
-        }
-    }
+    return runCommand('BROWSER MAIN 7', () => browserUninstall(options, cmd));
 };
 
 /**

--- a/src/lib/commands/qscloud/create-sheet-thumbnails.js
+++ b/src/lib/commands/qscloud/create-sheet-thumbnails.js
@@ -2,6 +2,7 @@ import { Command, Option } from 'commander';
 import { logger, appVersion } from '../../../globals.js';
 import { qscloudCreateThumbnails } from '../../cloud/cloud-create-thumbnails.js';
 import { parsePositiveInteger, collectPositiveIntegers } from '../helpers.js';
+import { runCommand } from '../run-command.js';
 
 /**
  * Commander action for generating Qlik Sense Cloud sheet thumbnails via the worker module.
@@ -15,7 +16,7 @@ const handleCloudCreateSheetThumbnails = async (options = {}, cmd) => {
     logger.info(`App version: ${appVersion}`);
 
     logger.verbose(`appid=${options.appid}`);
-    try {
+    return runCommand('CLOUD MAIN 3', () => {
         const resolvedOptions = { ...options };
         if (!resolvedOptions.browserVersion || resolvedOptions.browserVersion === '') {
             if (resolvedOptions.browser === 'chrome') {
@@ -25,17 +26,8 @@ const handleCloudCreateSheetThumbnails = async (options = {}, cmd) => {
             }
         }
 
-        const res = await qscloudCreateThumbnails(resolvedOptions, cmd);
-        logger.debug(`Call to qscloudCreateThumbnails succeeded: ${res}`);
-    } catch (err) {
-        logger.error(`CLOUD MAIN 3: ${err}`);
-        if (err.message) {
-            logger.error(`CLOUD MAIN 3 (message): ${err.message}`);
-        }
-        if (err.stack) {
-            logger.error(`CLOUD MAIN 3 (stack): ${err.stack}`);
-        }
-    }
+        return qscloudCreateThumbnails(resolvedOptions, cmd);
+    });
 };
 
 /**

--- a/src/lib/commands/qscloud/list-collections.js
+++ b/src/lib/commands/qscloud/list-collections.js
@@ -1,6 +1,7 @@
 import { Command, Option } from 'commander';
 import { logger, appVersion } from '../../../globals.js';
 import { qscloudListCollections } from '../../cloud/cloud-collections.js';
+import { runCommand } from '../run-command.js';
 
 /**
  * Commander action that lists available Qlik Sense Cloud collections through the worker module.
@@ -14,18 +15,7 @@ const handleCloudListCollections = async (options = {}, cmd) => {
     logger.info(`App version: ${appVersion}`);
 
     logger.verbose(`collection=${options.collection}`);
-    try {
-        const res = await qscloudListCollections(options, cmd);
-        logger.debug(`Call to qscloudListCollections succeeded: ${res}`);
-    } catch (err) {
-        logger.error(`CLOUD MAIN 4: ${err}`);
-        if (err.message) {
-            logger.error(`CLOUD MAIN 4 (message): ${err.message}`);
-        }
-        if (err.stack) {
-            logger.error(`CLOUD MAIN 4 (stack): ${err.stack}`);
-        }
-    }
+    return runCommand('CLOUD MAIN 4', () => qscloudListCollections(options, cmd));
 };
 
 /**

--- a/src/lib/commands/qscloud/remove-sheet-icons.js
+++ b/src/lib/commands/qscloud/remove-sheet-icons.js
@@ -1,6 +1,7 @@
 import { Command, Option } from 'commander';
 import { logger, appVersion } from '../../../globals.js';
 import { qscloudRemoveSheetIcons } from '../../cloud/cloud-remove-sheet-icons.js';
+import { runCommand } from '../run-command.js';
 
 /**
  * Commander action that removes sheet icons from specified Qlik Sense Cloud apps.
@@ -13,18 +14,7 @@ import { qscloudRemoveSheetIcons } from '../../cloud/cloud-remove-sheet-icons.js
 const handleCloudRemoveSheetIcons = async (options = {}, cmd) => {
     logger.info(`App version: ${appVersion}`);
 
-    try {
-        const res = await qscloudRemoveSheetIcons(options, cmd);
-        logger.debug(`Call to qscloudRemoveSheetIcons succeeded: ${res}`);
-    } catch (err) {
-        logger.error(`CLOUD MAIN 5: ${err}`);
-        if (err.message) {
-            logger.error(`CLOUD MAIN 5 (message): ${err.message}`);
-        }
-        if (err.stack) {
-            logger.error(`CLOUD MAIN 5 (stack): ${err.stack}`);
-        }
-    }
+    return runCommand('CLOUD MAIN 5', () => qscloudRemoveSheetIcons(options, cmd));
 };
 
 /**

--- a/src/lib/commands/qseow/index.js
+++ b/src/lib/commands/qseow/index.js
@@ -2,6 +2,7 @@ import { Command, Option } from 'commander';
 import { logger, appVersion } from '../../../globals.js';
 import { qseowCreateThumbnails } from '../../qseow/qseow-create-thumbnails.js';
 import { parsePositiveInteger, collectPositiveIntegers } from '../helpers.js';
+import { runCommand } from '../run-command.js';
 
 /**
  * Commander action that triggers QSEoW thumbnail creation with normalized options and error logging.
@@ -16,7 +17,7 @@ const handleQseowCreateSheetThumbnails = async (options = {}, command) => {
 
     logger.verbose(`appid=${options.appid}`);
     logger.verbose(`itemid=${options.itemid}`);
-    try {
+    return runCommand('QSEOW MAIN 1', () => {
         const resolvedOptions = { ...options };
         if (!resolvedOptions.browserVersion || resolvedOptions.browserVersion === '') {
             if (resolvedOptions.browser === 'chrome') {
@@ -26,17 +27,8 @@ const handleQseowCreateSheetThumbnails = async (options = {}, command) => {
             }
         }
 
-        const res = await qseowCreateThumbnails(resolvedOptions, command);
-        logger.debug(`Call to qseowCreateThumbnails succeeded: ${res}`);
-    } catch (err) {
-        logger.error(`QSEOW MAIN 1: ${err}`);
-        if (err.message) {
-            logger.error(`QSEOW MAIN 1 (message): ${err.message}`);
-        }
-        if (err.stack) {
-            logger.error(`QSEOW MAIN 1 (stack): ${err.stack}`);
-        }
-    }
+        return qseowCreateThumbnails(resolvedOptions, command);
+    });
 };
 
 /**

--- a/src/lib/commands/run-command.js
+++ b/src/lib/commands/run-command.js
@@ -1,0 +1,56 @@
+import { logger } from '../../globals.js';
+
+/**
+ * Runs a command implementation on behalf of a Commander action handler, and makes its
+ * outcome visible in the process exit code.
+ *
+ * Every command in Butler Sheet Icons returns a boolean saying whether it succeeded, and
+ * before this existed every handler threw that boolean away. `process.exitCode` was set
+ * nowhere in the codebase, so a run in which every app failed exited 0 - indistinguishable
+ * from a clean run to any scheduler, CI job or shell script.
+ *
+ * A thrown error is treated the same as `false`: logged, exit code 1, no rethrow. Letting
+ * it escape would reach the `unhandledRejection` handler in `butler-sheet-icons.js`, which
+ * writes a crash dump - the wrong response to an operational failure such as an
+ * unreachable server.
+ *
+ * @param {string} logPrefix - Prefix for error lines, e.g. `'CLOUD MAIN 3'`. Kept
+ *     per-handler so existing log output stays greppable.
+ * @param {() => Promise<boolean>} run - The command implementation to invoke.
+ * @param {(err: unknown) => void} [onError] - Replaces the default error logging. Used by
+ *     handlers whose command already explained the failure, where repeating it made the
+ *     output unreadable (issue #785).
+ *
+ * @returns {Promise<boolean>} What the command returned, or `false` if it threw.
+ */
+export const runCommand = async (logPrefix, run, onError) => {
+    try {
+        const result = await run();
+
+        if (result === false) {
+            process.exitCode = 1;
+            logger.verbose(`${logPrefix}: command reported failure, exit code set to 1`);
+            return false;
+        }
+
+        logger.debug(`${logPrefix}: command completed successfully`);
+        return result;
+    } catch (err) {
+        process.exitCode = 1;
+
+        if (onError) {
+            onError(err);
+            return false;
+        }
+
+        logger.error(`${logPrefix}: ${err}`);
+        if (err?.message) {
+            logger.error(`${logPrefix} (message): ${err.message}`);
+        }
+        if (err?.stack) {
+            logger.error(`${logPrefix} (stack): ${err.stack}`);
+        }
+
+        return false;
+    }
+};

--- a/src/lib/qseow/__tests__/qseow_process_app.test.js
+++ b/src/lib/qseow/__tests__/qseow_process_app.test.js
@@ -359,9 +359,10 @@ describe('qseow-process-app.js — puppeteer launch and click options', () => {
         detectAvailableBrowser.mockResolvedValue(null);
         browserInstall.mockRejectedValue(new Error('network unreachable'));
 
-        // qseowProcessApp catches and logs rather than rethrowing, so callers can continue
-        // to the next app. Assert it resolves; `rejects.toThrow` would fail here.
-        await qseowProcessApp('test-app-id', defaultOptions);
+        // qseowProcessApp logs in detail and then rethrows, so the app loop above it can
+        // count this app as failed. Isolation between apps is the loop's job, not this
+        // function's - it used to swallow here, and the run reported success.
+        await expect(qseowProcessApp('test-app-id', defaultOptions)).rejects.toThrow();
 
         const logged = logger.error.mock.calls.map((call) => String(call[0])).join('\n');
         expect(logged).toContain('Failed to install a browser for QSEoW app test-app-id');
@@ -502,7 +503,7 @@ describe('qseow-process-app.js — a sheet with no metadata does not abort the a
             new Error('Failed to upload 1 of 1 thumbnail image(s)')
         );
 
-        await qseowProcessApp('test-app-id', options);
+        await expect(qseowProcessApp('test-app-id', options)).rejects.toThrow();
 
         expect(qseowUploadToContentLibrary).toHaveBeenCalledTimes(1);
         expect(qseowUpdateSheetThumbnails).not.toHaveBeenCalled();

--- a/src/lib/qseow/__tests__/qseow_remove_sheet_icons.test.js
+++ b/src/lib/qseow/__tests__/qseow_remove_sheet_icons.test.js
@@ -331,17 +331,23 @@ describe('qseowRemoveSheetIcons', () => {
             enigmaCreate.mockRejectedValueOnce(new Error('engine unreachable'));
             Get.mockResolvedValue({ body: [{ id: 'app-a' }, { id: 'app-b' }] });
 
+            // The other app is still attempted - but the run as a whole is a failure now,
+            // not a success with error text buried in the log.
             await expect(
                 qseowRemoveSheetIcons({ ...BASE_OPTIONS, appid: '', qliksensetag: 'BSI' })
-            ).resolves.toBe(true);
+            ).resolves.toBe(false);
 
             expect(enigmaCreate).toHaveBeenCalledTimes(2);
+
+            const errors = logger.error.mock.calls.map((call) => String(call[0])).join('\n');
+            expect(errors).toContain('Failed to process 1 of 2 app(s)');
         });
 
-        test('logs an engine failure instead of rejecting', async () => {
+        test('reports failure instead of rejecting when the engine is unreachable', async () => {
             enigmaCreate.mockRejectedValue(new Error('engine unreachable'));
 
-            await expect(qseowRemoveSheetIcons(BASE_OPTIONS)).resolves.toBe(true);
+            // Reports false rather than throwing: the caller sets the exit code from it.
+            await expect(qseowRemoveSheetIcons(BASE_OPTIONS)).resolves.toBe(false);
 
             expect(logger.error).toHaveBeenCalled();
         });

--- a/src/lib/qseow/qseow-create-thumbnails.js
+++ b/src/lib/qseow/qseow-create-thumbnails.js
@@ -6,6 +6,7 @@ import { qseowVerifyContentLibraryExists } from './qseow-contentlibrary.js';
 import { qseowVerifyCertificatesExist } from './qseow-certificates.js';
 import { setupQseowQrsConnection } from './qseow-qrs.js';
 import { qseowProcessApp } from './qseow-process-app.js';
+import { runOverApps } from '../util/run-over-apps.js';
 
 /**
  * Create thumbnails for Qlik Sense Enterprise on Windows (QSEoW).
@@ -99,37 +100,18 @@ export const qseowCreateThumbnails = async (options) => {
             }
         }
 
-        // Remove duplicates (if any) from list of app IDs that will be processed
-        const uniqueAppIds = [...new Set(appIdsToProcess)];
+        const { total, failed } = await runOverApps(
+            appIdsToProcess,
+            {
+                logPrefix: 'QSEOW PROCESS APP',
+                emptySelectionHint: 'Check the --appid and --qliksensetag options.',
+            },
+            (appId) => qseowProcessApp(appId, options)
+        );
 
-        // Debug output of apps that will be processed
-        logger.debug('Will process these app IDs:');
-        uniqueAppIds.forEach((appId) => {
-            logger.debug(appId);
-        });
-
-        // Process all apps
-
-        for (const appId of uniqueAppIds) {
-            try {
-                logger.info(`--------------------------------------------------`);
-                logger.info(`About to process app ${appId}`);
-
-                await qseowProcessApp(appId, options);
-
-                logger.verbose(`Done processing app ${appId}`);
-            } catch (err) {
-                if (err.stack) {
-                    logger.error(`QSEOW PROCESS APP (stack): ${err.stack}`);
-                } else if (err.message) {
-                    logger.error(`QSEOW PROCESS APP (message): ${err.message}`);
-                } else {
-                    logger.error(`QSEOW PROCESS APP: ${err}`);
-                }
-            }
-        }
-
-        return true;
+        // An app the worker could not finish, or a selection that resolved to no
+        // apps at all, is a failed run - not a successful one with error text in it.
+        return total > 0 && failed === 0;
     } catch (err) {
         if (err.stack) {
             logger.error(`QSEOW CREATE THUMBNAILS 2 (stack): ${err.stack}`);

--- a/src/lib/qseow/qseow-process-app.js
+++ b/src/lib/qseow/qseow-process-app.js
@@ -564,5 +564,8 @@ export const qseowProcessApp = async (appId, options) => {
         } else {
             logger.error(`QSEOW: qseowProcessApp: ${err}`);
         }
+        // Rethrow so the app loop can count this app as failed. Logging and returning
+        // normally made a run in which every app failed look exactly like a clean run.
+        throw err;
     }
 };

--- a/src/lib/qseow/qseow-remove-sheet-icons.js
+++ b/src/lib/qseow/qseow-remove-sheet-icons.js
@@ -7,6 +7,7 @@ import { redactOptions } from '../util/redact-secrets.js';
 import { qseowVerifyCertificatesExist } from './qseow-certificates.js';
 import { setupQseowQrsConnection } from './qseow-qrs.js';
 import { sortSheetsByRank } from '../util/sheet-list.js';
+import { runOverApps } from '../util/run-over-apps.js';
 
 /**
  * Removes all sheet icons from a Qlik Sense Enterprise on Windows (QSEoW) application.
@@ -121,6 +122,9 @@ const removeSheetIconsQSEoWApp = async (appId, g, options) => {
         } else {
             logger.error(`QSEOW: removeSheetIconsQSEoWApp: ${err}`);
         }
+        // Rethrow so the app loop can count this app as failed. Logging and returning
+        // normally made a run in which every app failed look exactly like a clean run.
+        throw err;
     }
 };
 
@@ -188,37 +192,18 @@ export const qseowRemoveSheetIcons = async (options) => {
             }
         }
 
-        // Remove duplicates (if any) from list of app IDs that will be processed
-        const uniqueAppIds = [...new Set(appIdsToProcess)];
+        const { total, failed } = await runOverApps(
+            appIdsToProcess,
+            {
+                logPrefix: 'QSEOW PROCESS APP: Remove sheet icons',
+                emptySelectionHint: 'Check the --appid and --qliksensetag options.',
+            },
+            (appId) => removeSheetIconsQSEoWApp(appId, global, options)
+        );
 
-        // Debug output of apps that will be processed
-        logger.debug('Will process these app IDs:');
-        uniqueAppIds.forEach((appId) => {
-            logger.debug(appId);
-        });
-
-        // Process all apps
-
-        for (const appId of uniqueAppIds) {
-            try {
-                logger.info(`--------------------------------------------------`);
-                logger.info(`About to process app ${appId}`);
-
-                await removeSheetIconsQSEoWApp(appId, global, options);
-
-                logger.verbose(`Done processing app ${appId}`);
-            } catch (err) {
-                logger.error(`QSEOW PROCESS APP: Remove sheet icons: ${err}`);
-                if (err.message) {
-                    logger.error(`QSEOW PROCESS APP: Remove sheet icons (message): ${err.message}`);
-                }
-                if (err.stack) {
-                    logger.error(`QSEOW PROCESS APP: Remove sheet icons (stack): ${err.stack}`);
-                }
-            }
-        }
-
-        return true;
+        // An app the worker could not finish, or a selection that resolved to no
+        // apps at all, is a failed run - not a successful one with error text in it.
+        return total > 0 && failed === 0;
     } catch (err) {
         logger.error(`QSEOW REMOVE THUMBNAILS 2: ${err}`);
         if (err.message) {

--- a/src/lib/util/__tests__/run-over-apps.test.js
+++ b/src/lib/util/__tests__/run-over-apps.test.js
@@ -1,0 +1,167 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+jest.unstable_mockModule('../../../globals.js', () => ({
+    logger: {
+        info: jest.fn(),
+        error: jest.fn(),
+        verbose: jest.fn(),
+        debug: jest.fn(),
+        warn: jest.fn(),
+    },
+}));
+
+const { logger } = await import('../../../globals.js');
+const { runOverApps } = await import('../run-over-apps.js');
+
+const CTX = { logPrefix: 'TEST PREFIX' };
+
+/**
+ * Joins everything logged at error level, for substring assertions.
+ *
+ * @returns {string} All error lines, newline separated.
+ */
+const errorLog = () => logger.error.mock.calls.map((call) => String(call[0])).join('\n');
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('runOverApps', () => {
+    test('runs the worker once per app', async () => {
+        const worker = jest.fn().mockResolvedValue(true);
+
+        await runOverApps(['a', 'b', 'c'], CTX, worker);
+
+        expect(worker.mock.calls.map((call) => call[0])).toEqual(['a', 'b', 'c']);
+    });
+
+    test('reports how many apps were processed', async () => {
+        const result = await runOverApps(['a', 'b'], CTX, jest.fn().mockResolvedValue(true));
+
+        expect(result).toEqual({ total: 2, failed: 0 });
+    });
+
+    test('processes an app named twice only once', async () => {
+        // An app can be named by both --appid and a collection.
+        const worker = jest.fn().mockResolvedValue(true);
+
+        const result = await runOverApps(['a', 'b', 'a'], CTX, worker);
+
+        expect(worker).toHaveBeenCalledTimes(2);
+        expect(result.total).toBe(2);
+    });
+
+    describe('a failing app', () => {
+        test('does not stop the apps after it', async () => {
+            const worker = jest.fn(async (appId) => {
+                if (appId === 'a') throw new Error('engine unreachable');
+            });
+
+            await runOverApps(['a', 'b', 'c'], CTX, worker);
+
+            expect(worker).toHaveBeenCalledTimes(3);
+        });
+
+        test('is counted rather than ignored', async () => {
+            // Nothing counted these before, so a run in which every app failed was
+            // indistinguishable from a clean one.
+            const worker = jest.fn(async (appId) => {
+                if (appId !== 'b') throw new Error('engine unreachable');
+            });
+
+            const result = await runOverApps(['a', 'b', 'c'], CTX, worker);
+
+            expect(result).toEqual({ total: 3, failed: 2 });
+        });
+
+        test('is named in the log, with the reason', async () => {
+            const worker = jest.fn(async () => {
+                throw new Error('engine unreachable');
+            });
+
+            await runOverApps(['app-a'], CTX, worker);
+
+            expect(errorLog()).toContain('TEST PREFIX: Failed to process app app-a');
+            expect(errorLog()).toContain('engine unreachable');
+        });
+
+        test('produces a summary naming the counts', async () => {
+            const worker = jest.fn(async (appId) => {
+                if (appId === 'b') throw new Error('engine unreachable');
+            });
+
+            await runOverApps(['a', 'b', 'c'], CTX, worker);
+
+            expect(errorLog()).toContain('Failed to process 1 of 3 app(s)');
+        });
+
+        test('does not reject, so the caller decides what a failure means', async () => {
+            const worker = jest.fn(async () => {
+                throw new Error('engine unreachable');
+            });
+
+            await expect(runOverApps(['a'], CTX, worker)).resolves.toEqual({
+                total: 1,
+                failed: 1,
+            });
+        });
+    });
+
+    describe('no apps at all', () => {
+        test('never calls the worker', async () => {
+            const worker = jest.fn();
+
+            await runOverApps([], CTX, worker);
+
+            expect(worker).not.toHaveBeenCalled();
+        });
+
+        test('is reported as an error, not as a clean run', async () => {
+            // An unresolvable collection is not the same as "nothing to do".
+            await runOverApps([], CTX, jest.fn());
+
+            expect(errorLog()).toContain('No apps to process');
+        });
+
+        test('includes the caller-supplied hint about which options to check', async () => {
+            await runOverApps(
+                [],
+                { ...CTX, emptySelectionHint: 'Check the --appid and --collectionid options.' },
+                jest.fn()
+            );
+
+            expect(errorLog()).toContain('Check the --appid and --collectionid options.');
+        });
+
+        test('omits the hint cleanly when the caller supplied none', async () => {
+            await runOverApps([], CTX, jest.fn());
+
+            expect(errorLog()).toContain('No apps to process.');
+            expect(errorLog()).not.toContain('undefined');
+        });
+
+        test('reports zero total, which the caller reads as failure', async () => {
+            await expect(runOverApps([], CTX, jest.fn())).resolves.toEqual({
+                total: 0,
+                failed: 0,
+            });
+        });
+    });
+
+    test('logs no failure summary when every app succeeded', async () => {
+        await runOverApps(['a', 'b'], CTX, jest.fn().mockResolvedValue(true));
+
+        expect(errorLog()).not.toContain('Failed to process');
+    });
+
+    test('survives a worker that throws a non-Error', async () => {
+        const worker = jest.fn(async () => {
+            throw 'just a string';
+        });
+
+        const result = await runOverApps(['a'], CTX, worker);
+
+        expect(result.failed).toBe(1);
+        expect(errorLog()).toContain('just a string');
+    });
+});

--- a/src/lib/util/run-over-apps.js
+++ b/src/lib/util/run-over-apps.js
@@ -1,0 +1,66 @@
+import { logger } from '../../globals.js';
+
+/**
+ * Runs a per-app worker over a list of app IDs, isolating each app from the others and
+ * keeping count of the ones that failed.
+ *
+ * This replaces four hand-written copies of the same loop. The copies had already
+ * drifted - four different log prefixes, and none of them counted anything - so a run in
+ * which every app failed was indistinguishable from a run in which every app succeeded.
+ *
+ * Callers decide what a failure means by reading the returned counts. Nothing is thrown
+ * for a failed app: the point of the loop is that one bad app does not stop the rest.
+ *
+ * The per-app worker is expected to log its own failure in detail before rethrowing; the
+ * line logged here names the app and the reason, without repeating the stack.
+ *
+ * @param {string[]} appIds - App IDs to process. Duplicates are removed, so an app named
+ *     by both `--appid` and a collection is processed once.
+ * @param {object} ctx - Logging context.
+ * @param {string} ctx.logPrefix - Prefix for the per-app failure lines, e.g. `'CLOUD PROCESS APP'`.
+ * @param {string} [ctx.emptySelectionHint] - Extra guidance logged when the list is empty,
+ *     e.g. which options to check. An empty list is reported as an error, because it means
+ *     the operator asked for work that did not happen.
+ * @param {(appId: string) => Promise<unknown>} processApp - Worker invoked once per app.
+ *
+ * @returns {Promise<{total: number, failed: number}>} How many apps were processed and how
+ *     many of those failed.
+ */
+export const runOverApps = async (appIds, { logPrefix, emptySelectionHint }, processApp) => {
+    // An app named by both --appid and a collection must still be processed once.
+    const uniqueAppIds = [...new Set(appIds)];
+
+    logger.debug('Will process these app IDs:');
+    uniqueAppIds.forEach((appId) => {
+        logger.debug(appId);
+    });
+
+    if (uniqueAppIds.length === 0) {
+        // Not the same as "nothing to do": the operator asked for apps and got none. An
+        // unresolvable collection used to end here reporting success.
+        logger.error(`No apps to process.${emptySelectionHint ? ` ${emptySelectionHint}` : ''}`);
+        return { total: 0, failed: 0 };
+    }
+
+    let failed = 0;
+
+    for (const appId of uniqueAppIds) {
+        try {
+            logger.info(`--------------------------------------------------`);
+            logger.info(`About to process app ${appId}`);
+
+            await processApp(appId);
+
+            logger.verbose(`Done processing app ${appId}`);
+        } catch (err) {
+            failed += 1;
+            logger.error(`${logPrefix}: Failed to process app ${appId}: ${err?.message ?? err}`);
+        }
+    }
+
+    if (failed > 0) {
+        logger.error(`Failed to process ${failed} of ${uniqueAppIds.length} app(s)`);
+    }
+
+    return { total: uniqueAppIds.length, failed };
+};


### PR DESCRIPTION
Part 3 of #872, "failures that currently report success". Follows #876.

## The problem

Every per-app worker caught its own failures and returned normally, so the app loops never saw them; the loops counted nothing; the commands always returned `true`; and every action handler discarded that boolean. `process.exitCode` was set **nowhere** in `src/`.

A run in which every app failed exited 0 — identical, to any scheduler or CI job, to a clean run. Automation built around this tool was checking nothing.

## The chain, now connected

- **`util/run-over-apps.js`** replaces four copies of the app loop. Owns dedupe, per-app isolation, failure accounting, and the `Failed to process N of M app(s)` summary. The four copies had drifted into four different log prefixes, now supplied by the caller from one place.
- **The four per-app workers rethrow** after logging, so the loop can count them.
- **Commands return `total > 0 && failed === 0`.**
- **`commands/run-command.js`** wraps all nine action handlers and sets `process.exitCode = 1`. It deliberately does *not* rethrow — an escaping rejection would reach the `unhandledRejection` handler and write a crash dump, the wrong response to an unreachable server.
- **A selection resolving to no apps is a failure.** The check sits where the combined list is known, so an explicitly-named `--appid` alongside an empty collection still runs; an earlier attempt threw from inside the collection resolver and discarded it.
- **`qscloudTestConnection` rejects a body with no user** instead of logging `Connection to tenant ... successful.` followed by four lines of `undefined`.

## Breaking change

Butler Sheet Icons now exits 1 when a command fails or completes with apps it could not process. **Scheduled jobs and pipelines that previously always saw exit 0 may start reporting failure.** That is the intent, but it needs announcing — `docs/to-doc-site/exit-code-now-reflects-failures.md` is written for administrators and flagged action-required.

This carries a `BREAKING CHANGE:` footer, so release-please will compute a major bump.

## Verification

- 628 unit tests, lint and Prettier clean.
- **End to end against the real CLI**: a run against an unreachable tenant exits 1 on this branch and 0 on `main`; `browser list-installed` and `--help` still exit 0.
- **Mutation-tested at each link**: dropping the exit code on the false branch fails 3 tests, on the throw branch 1; making a command always return `true` fails 4; making a worker swallow again fails 2.
- **Integration tests have not been run** — they need real Qlik servers and certificates. Given this changes what a failed run reports, exercising it against a real environment before release is worth doing.

## Note for reviewers

**Nine existing tests are inverted here.** Four asserted `resolves.toBe(true)` when apps failed, two that the connection test tolerates an unreadable body, two that the per-app workers resolve rather than reject, one that a handler resolves `undefined`. Each encoded the "failures report success" behaviour this PR removes. Those are the changes most worth a second opinion.

The four divergent app-loop log prefixes are kept as-is and merely passed in from one place, so this PR does not mix a message change into an exit-code change. Unifying them belongs with the remaining message work in #872.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
