### PR TITLE
refactor: let runOverApps decide the verdict, and await it properly

### DIFF
--- a/src/lib/cloud/__tests__/cloud_create_thumbnails_app_loop.test.js
+++ b/src/lib/cloud/__tests__/cloud_create_thumbnails_app_loop.test.js
@@ -1,0 +1,102 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+// Covers the hand-off from qscloudCreateThumbnails to runOverApps. The sibling
+// validation suite mocks the connection test to throw, so it never reaches this point -
+// which left the app-loop call site with no unit coverage at all.
+
+jest.unstable_mockModule('../../../globals.js', () => ({
+    logger: {
+        info: jest.fn(),
+        verbose: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+    },
+    setLoggingLevel: jest.fn(),
+    bsiExecutablePath: '/test/path',
+    isSea: false,
+}));
+
+jest.unstable_mockModule('../cloud-test-connection.js', () => ({
+    qscloudTestConnection: jest.fn().mockResolvedValue(true),
+}));
+
+jest.unstable_mockModule('../cloud-repo.js', () => ({ default: jest.fn() }));
+
+jest.unstable_mockModule('../process-cloud-app.js', () => ({
+    processCloudApp: jest.fn().mockResolvedValue(true),
+}));
+
+jest.unstable_mockModule('../../util/redact-secrets.js', () => ({
+    redactOptions: jest.fn((o) => o),
+}));
+
+const runOverApps = jest.fn();
+jest.unstable_mockModule('../../util/run-over-apps.js', () => ({ runOverApps }));
+
+const { logger } = await import('../../../globals.js');
+const { qscloudCreateThumbnails } = await import('../cloud-create-thumbnails.js');
+
+const OPTIONS = {
+    tenanturl: 'tenant.eu.qlikcloud.com',
+    apikey: 'api-key',
+    appid: 'test-app-id',
+    includesheetpart: '1',
+    loglevel: 'info',
+};
+
+/**
+ * Joins everything logged at error level, for substring assertions.
+ *
+ * @returns {string} All error lines, newline separated.
+ */
+const errorLog = () => logger.error.mock.calls.map((call) => String(call[0])).join('\n');
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('qscloudCreateThumbnails app loop', () => {
+    test('passes the verdict from runOverApps straight through', async () => {
+        runOverApps.mockResolvedValue(true);
+
+        await expect(qscloudCreateThumbnails({ ...OPTIONS })).resolves.toBe(true);
+    });
+
+    test('reports failure when runOverApps says some apps failed', async () => {
+        runOverApps.mockResolvedValue(false);
+
+        await expect(qscloudCreateThumbnails({ ...OPTIONS })).resolves.toBe(false);
+    });
+
+    test('hands the selected app ids to the loop', async () => {
+        runOverApps.mockResolvedValue(true);
+
+        await qscloudCreateThumbnails({ ...OPTIONS });
+
+        expect(runOverApps).toHaveBeenCalledTimes(1);
+        expect(runOverApps.mock.calls[0][0]).toEqual(['test-app-id']);
+    });
+
+    test('names the Cloud options in the empty-selection hint, not the QSEoW ones', async () => {
+        // Cross-platform copy-paste is this repo's dominant defect class, and the hint
+        // text is promised to operators in the published docs.
+        runOverApps.mockResolvedValue(true);
+
+        await qscloudCreateThumbnails({ ...OPTIONS });
+
+        expect(runOverApps.mock.calls[0][1].emptySelectionHint).toContain('--collectionid');
+        expect(runOverApps.mock.calls[0][1].emptySelectionHint).not.toContain('--qliksensetag');
+    });
+
+    test('catches a rejection from the loop rather than letting it escape', async () => {
+        // The call site must be `return await runOverApps(...)`. A bare `return` hands the
+        // promise back before it settles, so a rejection skips the catch below it - this
+        // function would reject instead of resolving false, and log nothing.
+        runOverApps.mockRejectedValue(new Error('loop blew up'));
+
+        await expect(qscloudCreateThumbnails({ ...OPTIONS })).resolves.toBe(false);
+
+        expect(errorLog()).toContain('CLOUD CREATE THUMBNAILS 2');
+    });
+});

--- a/src/lib/cloud/cloud-create-thumbnails.js
+++ b/src/lib/cloud/cloud-create-thumbnails.js
@@ -129,7 +129,7 @@ export const qscloudCreateThumbnails = async (options) => {
             }
         }
 
-        return runOverApps(
+        return await runOverApps(
             appIdsToProcess,
             {
                 logPrefix: 'CLOUD PROCESS APP',

--- a/src/lib/cloud/cloud-create-thumbnails.js
+++ b/src/lib/cloud/cloud-create-thumbnails.js
@@ -129,7 +129,7 @@ export const qscloudCreateThumbnails = async (options) => {
             }
         }
 
-        const { total, failed } = await runOverApps(
+        return runOverApps(
             appIdsToProcess,
             {
                 logPrefix: 'CLOUD PROCESS APP',
@@ -137,10 +137,6 @@ export const qscloudCreateThumbnails = async (options) => {
             },
             (appId) => processCloudApp(appId, saasInstance, options)
         );
-
-        // An app the worker could not finish, or a selection that resolved to no
-        // apps at all, is a failed run - not a successful one with error text in it.
-        return total > 0 && failed === 0;
     } catch (err) {
         if (err.stack) {
             logger.error(`CLOUD CREATE THUMBNAILS 2 (stack): ${err.stack}`);

--- a/src/lib/cloud/cloud-remove-sheet-icons.js
+++ b/src/lib/cloud/cloud-remove-sheet-icons.js
@@ -254,7 +254,7 @@ export const qscloudRemoveSheetIcons = async (options) => {
             }
         }
 
-        const { total, failed } = await runOverApps(
+        return runOverApps(
             appIdsToProcess,
             {
                 logPrefix: 'CLOUD PROCESS APP 2',
@@ -262,10 +262,6 @@ export const qscloudRemoveSheetIcons = async (options) => {
             },
             (appId) => removeSheetIconsCloudApp(appId, saasInstance, options)
         );
-
-        // An app the worker could not finish, or a selection that resolved to no
-        // apps at all, is a failed run - not a successful one with error text in it.
-        return total > 0 && failed === 0;
     } catch (err) {
         if (err.stack) {
             logger.error(`CLOUD REMOVE THUMBNAILS 3 (stack): ${err.stack}`);

--- a/src/lib/cloud/cloud-remove-sheet-icons.js
+++ b/src/lib/cloud/cloud-remove-sheet-icons.js
@@ -254,7 +254,7 @@ export const qscloudRemoveSheetIcons = async (options) => {
             }
         }
 
-        return runOverApps(
+        return await runOverApps(
             appIdsToProcess,
             {
                 logPrefix: 'CLOUD PROCESS APP 2',

--- a/src/lib/qseow/__tests__/qseow_create_thumbnails_app_loop.test.js
+++ b/src/lib/qseow/__tests__/qseow_create_thumbnails_app_loop.test.js
@@ -1,0 +1,113 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+// QSEoW twin of cloud_create_thumbnails_app_loop.test.js. Covers the hand-off from
+// qseowCreateThumbnails to runOverApps. The sibling validation suite mocks the certificate
+// check to throw, so it never reaches this point - which left the app-loop call site with
+// no unit coverage at all.
+
+jest.unstable_mockModule('../../../globals.js', () => ({
+    logger: {
+        info: jest.fn(),
+        verbose: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+    },
+    setLoggingLevel: jest.fn(),
+    bsiExecutablePath: '/test/path',
+    isSea: false,
+    sleep: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.unstable_mockModule('../qseow-certificates.js', () => ({
+    qseowVerifyCertificatesExist: jest.fn().mockResolvedValue(true),
+}));
+
+jest.unstable_mockModule('../qseow-contentlibrary.js', () => ({
+    qseowVerifyContentLibraryExists: jest.fn().mockResolvedValue(true),
+}));
+
+jest.unstable_mockModule('../qseow-qrs.js', () => ({
+    setupQseowQrsConnection: jest.fn().mockReturnValue({ hostname: 'sense.example.com' }),
+}));
+
+jest.unstable_mockModule('qrs-interact', () => ({ default: jest.fn() }));
+
+jest.unstable_mockModule('../qseow-process-app.js', () => ({
+    qseowProcessApp: jest.fn().mockResolvedValue(true),
+}));
+
+jest.unstable_mockModule('../../util/redact-secrets.js', () => ({
+    redactOptions: jest.fn((o) => o),
+}));
+
+const runOverApps = jest.fn();
+jest.unstable_mockModule('../../util/run-over-apps.js', () => ({ runOverApps }));
+
+const { logger } = await import('../../../globals.js');
+const { qseowCreateThumbnails } = await import('../qseow-create-thumbnails.js');
+
+const OPTIONS = {
+    host: 'sense.example.com',
+    contentlibrary: 'test-library',
+    appid: 'test-app-id',
+    includesheetpart: '1',
+    loglevel: 'info',
+};
+
+/**
+ * Joins everything logged at error level, for substring assertions.
+ *
+ * @returns {string} All error lines, newline separated.
+ */
+const errorLog = () => logger.error.mock.calls.map((call) => String(call[0])).join('\n');
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('qseowCreateThumbnails app loop', () => {
+    test('passes the verdict from runOverApps straight through', async () => {
+        runOverApps.mockResolvedValue(true);
+
+        await expect(qseowCreateThumbnails({ ...OPTIONS })).resolves.toBe(true);
+    });
+
+    test('reports failure when runOverApps says some apps failed', async () => {
+        runOverApps.mockResolvedValue(false);
+
+        await expect(qseowCreateThumbnails({ ...OPTIONS })).resolves.toBe(false);
+    });
+
+    test('hands the selected app ids to the loop', async () => {
+        runOverApps.mockResolvedValue(true);
+
+        await qseowCreateThumbnails({ ...OPTIONS });
+
+        expect(runOverApps).toHaveBeenCalledTimes(1);
+        expect(runOverApps.mock.calls[0][0]).toEqual(['test-app-id']);
+    });
+
+    test('names the QSEoW options in the empty-selection hint, not the Cloud ones', async () => {
+        // The twin asserts the mirror image. Swapping these two hints is the exact
+        // cross-platform copy-paste this repo keeps producing, and the text is promised
+        // to operators in the published docs.
+        runOverApps.mockResolvedValue(true);
+
+        await qseowCreateThumbnails({ ...OPTIONS });
+
+        expect(runOverApps.mock.calls[0][1].emptySelectionHint).toContain('--qliksensetag');
+        expect(runOverApps.mock.calls[0][1].emptySelectionHint).not.toContain('--collectionid');
+    });
+
+    test('catches a rejection from the loop rather than letting it escape', async () => {
+        // The call site must be `return await runOverApps(...)`. A bare `return` hands the
+        // promise back before it settles, so a rejection skips the catch below it - this
+        // function would reject instead of resolving false, and log nothing.
+        runOverApps.mockRejectedValue(new Error('loop blew up'));
+
+        await expect(qseowCreateThumbnails({ ...OPTIONS })).resolves.toBe(false);
+
+        expect(errorLog()).toContain('QSEOW CREATE THUMBNAILS 2');
+    });
+});

--- a/src/lib/qseow/qseow-create-thumbnails.js
+++ b/src/lib/qseow/qseow-create-thumbnails.js
@@ -100,7 +100,7 @@ export const qseowCreateThumbnails = async (options) => {
             }
         }
 
-        return runOverApps(
+        return await runOverApps(
             appIdsToProcess,
             {
                 logPrefix: 'QSEOW PROCESS APP',

--- a/src/lib/qseow/qseow-create-thumbnails.js
+++ b/src/lib/qseow/qseow-create-thumbnails.js
@@ -100,7 +100,7 @@ export const qseowCreateThumbnails = async (options) => {
             }
         }
 
-        const { total, failed } = await runOverApps(
+        return runOverApps(
             appIdsToProcess,
             {
                 logPrefix: 'QSEOW PROCESS APP',
@@ -108,10 +108,6 @@ export const qseowCreateThumbnails = async (options) => {
             },
             (appId) => qseowProcessApp(appId, options)
         );
-
-        // An app the worker could not finish, or a selection that resolved to no
-        // apps at all, is a failed run - not a successful one with error text in it.
-        return total > 0 && failed === 0;
     } catch (err) {
         if (err.stack) {
             logger.error(`QSEOW CREATE THUMBNAILS 2 (stack): ${err.stack}`);

--- a/src/lib/qseow/qseow-remove-sheet-icons.js
+++ b/src/lib/qseow/qseow-remove-sheet-icons.js
@@ -192,7 +192,7 @@ export const qseowRemoveSheetIcons = async (options) => {
             }
         }
 
-        const { total, failed } = await runOverApps(
+        return runOverApps(
             appIdsToProcess,
             {
                 logPrefix: 'QSEOW PROCESS APP: Remove sheet icons',
@@ -200,10 +200,6 @@ export const qseowRemoveSheetIcons = async (options) => {
             },
             (appId) => removeSheetIconsQSEoWApp(appId, global, options)
         );
-
-        // An app the worker could not finish, or a selection that resolved to no
-        // apps at all, is a failed run - not a successful one with error text in it.
-        return total > 0 && failed === 0;
     } catch (err) {
         logger.error(`QSEOW REMOVE THUMBNAILS 2: ${err}`);
         if (err.message) {

--- a/src/lib/qseow/qseow-remove-sheet-icons.js
+++ b/src/lib/qseow/qseow-remove-sheet-icons.js
@@ -192,7 +192,7 @@ export const qseowRemoveSheetIcons = async (options) => {
             }
         }
 
-        return runOverApps(
+        return await runOverApps(
             appIdsToProcess,
             {
                 logPrefix: 'QSEOW PROCESS APP: Remove sheet icons',

--- a/src/lib/util/__tests__/run-over-apps.test.js
+++ b/src/lib/util/__tests__/run-over-apps.test.js
@@ -51,6 +51,19 @@ describe('runOverApps', () => {
         expect(result).toBe(true);
     });
 
+    test('counts the deduplicated apps, not the raw input, in the summary', async () => {
+        // The summary line is the only place the count reaches the operator. Without a
+        // failing app the line never fires, so a duplicate-only test cannot pin it - and
+        // `uniqueAppIds.length` could silently become `appIds.length`.
+        const worker = jest.fn(async (appId) => {
+            if (appId === 'b') throw new Error('engine unreachable');
+        });
+
+        await runOverApps(['a', 'b', 'a'], CTX, worker);
+
+        expect(errorLog()).toContain('Failed to process 1 of 2 app(s)');
+    });
+
     describe('a failing app', () => {
         test('does not stop the apps after it', async () => {
             const worker = jest.fn(async (appId) => {

--- a/src/lib/util/__tests__/run-over-apps.test.js
+++ b/src/lib/util/__tests__/run-over-apps.test.js
@@ -35,10 +35,10 @@ describe('runOverApps', () => {
         expect(worker.mock.calls.map((call) => call[0])).toEqual(['a', 'b', 'c']);
     });
 
-    test('reports how many apps were processed', async () => {
+    test('reports success when every app was processed', async () => {
         const result = await runOverApps(['a', 'b'], CTX, jest.fn().mockResolvedValue(true));
 
-        expect(result).toEqual({ total: 2, failed: 0 });
+        expect(result).toBe(true);
     });
 
     test('processes an app named twice only once', async () => {
@@ -48,7 +48,7 @@ describe('runOverApps', () => {
         const result = await runOverApps(['a', 'b', 'a'], CTX, worker);
 
         expect(worker).toHaveBeenCalledTimes(2);
-        expect(result.total).toBe(2);
+        expect(result).toBe(true);
     });
 
     describe('a failing app', () => {
@@ -71,7 +71,8 @@ describe('runOverApps', () => {
 
             const result = await runOverApps(['a', 'b', 'c'], CTX, worker);
 
-            expect(result).toEqual({ total: 3, failed: 2 });
+            expect(result).toBe(false);
+            expect(errorLog()).toContain('Failed to process 2 of 3 app(s)');
         });
 
         test('is named in the log, with the reason', async () => {
@@ -100,10 +101,7 @@ describe('runOverApps', () => {
                 throw new Error('engine unreachable');
             });
 
-            await expect(runOverApps(['a'], CTX, worker)).resolves.toEqual({
-                total: 1,
-                failed: 1,
-            });
+            await expect(runOverApps(['a'], CTX, worker)).resolves.toBe(false);
         });
     });
 
@@ -140,11 +138,10 @@ describe('runOverApps', () => {
             expect(errorLog()).not.toContain('undefined');
         });
 
-        test('reports zero total, which the caller reads as failure', async () => {
-            await expect(runOverApps([], CTX, jest.fn())).resolves.toEqual({
-                total: 0,
-                failed: 0,
-            });
+        test('reports failure, not a vacuous success', async () => {
+            // An empty selection resolves to false: the operator asked for apps and got
+            // none, which must not be reported as a clean run.
+            await expect(runOverApps([], CTX, jest.fn())).resolves.toBe(false);
         });
     });
 
@@ -161,7 +158,7 @@ describe('runOverApps', () => {
 
         const result = await runOverApps(['a'], CTX, worker);
 
-        expect(result.failed).toBe(1);
+        expect(result).toBe(false);
         expect(errorLog()).toContain('just a string');
     });
 });

--- a/src/lib/util/run-over-apps.js
+++ b/src/lib/util/run-over-apps.js
@@ -18,6 +18,10 @@ import { logger } from '../../globals.js';
  * The per-app worker is expected to log its own failure in detail before rethrowing; the
  * line logged here names the app and the reason, without repeating the stack.
  *
+ * Callers must `return await` this, never a bare `return`. All four sit inside a
+ * `try`/`catch`, and returning the promise unawaited hands it back before it settles - so
+ * a rejection would skip the caller's own catch entirely rather than being logged there.
+ *
  * @param {string[]} appIds - App IDs to process. Duplicates are removed, so an app named
  *     by both `--appid` and a collection is processed once.
  * @param {object} ctx - Logging context.

--- a/src/lib/util/run-over-apps.js
+++ b/src/lib/util/run-over-apps.js
@@ -8,8 +8,12 @@ import { logger } from '../../globals.js';
  * drifted - four different log prefixes, and none of them counted anything - so a run in
  * which every app failed was indistinguishable from a run in which every app succeeded.
  *
- * Callers decide what a failure means by reading the returned counts. Nothing is thrown
- * for a failed app: the point of the loop is that one bad app does not stop the rest.
+ * Nothing is thrown for a failed app: the point of the loop is that one bad app does not
+ * stop the rest. The overall verdict comes back as the return value instead.
+ *
+ * That verdict is decided here rather than by each caller. All four callers applied the
+ * identical rule, and four copies of it - destructure, comment and all - was itself enough
+ * duplicated code to fail the quality gate on the very PR that introduced this helper.
  *
  * The per-app worker is expected to log its own failure in detail before rethrowing; the
  * line logged here names the app and the reason, without repeating the stack.
@@ -23,8 +27,8 @@ import { logger } from '../../globals.js';
  *     the operator asked for work that did not happen.
  * @param {(appId: string) => Promise<unknown>} processApp - Worker invoked once per app.
  *
- * @returns {Promise<{total: number, failed: number}>} How many apps were processed and how
- *     many of those failed.
+ * @returns {Promise<boolean>} `true` only when at least one app was selected and every one
+ *     of them was processed without error. An empty selection is a failure, not a no-op.
  */
 export const runOverApps = async (appIds, { logPrefix, emptySelectionHint }, processApp) => {
     // An app named by both --appid and a collection must still be processed once.
@@ -39,7 +43,7 @@ export const runOverApps = async (appIds, { logPrefix, emptySelectionHint }, pro
         // Not the same as "nothing to do": the operator asked for apps and got none. An
         // unresolvable collection used to end here reporting success.
         logger.error(`No apps to process.${emptySelectionHint ? ` ${emptySelectionHint}` : ''}`);
-        return { total: 0, failed: 0 };
+        return false;
     }
 
     let failed = 0;
@@ -62,5 +66,5 @@ export const runOverApps = async (appIds, { logPrefix, emptySelectionHint }, pro
         logger.error(`Failed to process ${failed} of ${uniqueAppIds.length} app(s)`);
     }
 
-    return { total: uniqueAppIds.length, failed };
+    return failed === 0;
 };


### PR DESCRIPTION
Clears the SonarCloud duplication gate that #877 was merged past, and fixes a try/catch regression that a code review of the first commit turned up.

Two commits; reading them in order is the intended way to review this.

## 1. `refactor:` let runOverApps decide the verdict

SonarCloud failed #877's quality gate on `new_duplicated_lines_density` at 5.0% against a 3% threshold. The duplication was in the four call sites that PR added:

| File | Density | New lines |
|---|---|---|
| `cloud-remove-sheet-icons.js` | 60% | 15 |
| `qseow-remove-sheet-icons.js` | 60% | 15 |
| `cloud-create-thumbnails.js` | 50% | 12 |
| `qseow-create-thumbnails.js` | 50% | 12 |

Each carried an identical destructure, an identical two-line comment and an identical `return total > 0 && failed === 0;`. Replacing ~185 lines of duplicated app loop with four copies of the call block was a poor trade, and the gate measured it.

`runOverApps` now returns a boolean and owns the success rule, so every call site is a single `return await runOverApps(...)`. What differs per site — log prefix, empty-selection hint, worker — is all that remains. The counts were originally returned so callers could decide what a failure meant; all four applied the same rule, so that flexibility only ever bought duplication.

## 2. `fix:` await it properly

Review of commit 1 found that `return runOverApps(...)` inside a `try` block hands the promise back before it settles, so a rejection skips that function's own catch entirely. Verified by execution — only `return await` routes it into the catch.

The consequences were narrow but real: the caller's `CLOUD CREATE THUMBNAILS 2` / `QSEOW … 2` logging was bypassed, and the function rejected where its JSDoc promises `Promise<boolean>`. The exit code still came out right because `runCommand` catches at the handler level, so this was a contract regression rather than a live fault — but **commit 1's claim of "no behaviour change" was overstated**, and that is worth knowing when reading it.

The explanation lives in `runOverApps`' JSDoc rather than at each call site: four copies of a three-line comment is the same duplication commit 1 was undoing.

The same review surfaced two coverage gaps, both closed here:

- **The deduplicated app count lost its only pin** when the tests moved from asserting `{total, failed}` to a boolean. Mutating `uniqueAppIds.length` to `appIds.length` left every test green. A new test with duplicates *and* a failing app now catches it — the summary line only fires on failure, which is why a duplicate-only test could not pin it.
- **Neither create-thumbnails caller had any unit coverage of its runOverApps hand-off.** The existing validation suites stop at the connection and certificate checks. New app-loop suites for both twins cover the call site and pin the await, the verdict pass-through, the app-id list, and which platform's options each empty-selection hint names.

## Verification

- 639 unit tests (up from 628), 49 suites, lint and Prettier clean.
- Statement coverage on the two previously-untested callers: 56.95% → 70.19% (Cloud), 56.55% → 79.50% (QSEoW).
- End to end against the real CLI: a run against an unreachable tenant still exits 1; `browser list-installed` still exits 0.
- **Mutation-tested throughout** — removing the `await` fails a test in each twin; swapping the QSEoW empty-selection hint for the Cloud one fails a test; the dedup-count mutation now fails; making the helper always return `true` fails 5 tests; treating an empty selection as success fails 3; dropping the exit code on failure fails 3.
- Integration tests were run against a real tenant and Sense server earlier on this code (8 suites / 22 tests green) and were not re-run for this refactor, which changes a return type with no behavioural difference.

## What to check on this PR

The duplication metric, since that is the whole point. Note the diff adds two test files with similar structure; `sonar-project.properties` classifies `**/__tests__/**` as tests and duplication is measured on main sources, so they should not count against the gate — but that is the specific thing to confirm rather than assume.

## Not in this PR

Three findings from the same review are deliberately left:

- `docs/to-doc-site/one-bad-sheet-no-longer-fails-the-app.md` promises a `qseow remove-sheet-icons` command that does not exist. Already on `main` from #876 and queued for publication; needs its own docs fix.
- Both remove-sheet-icons twins still report success when every sheet failed to update — the per-sheet catch records no failure. Pre-existing and test-locked; belongs with #872 part 5b.
- Nothing pins the sequential per-app execution; converting the loop to `Promise.all` leaves the suite green. Belongs with the `withEngineSession` work, where the session-per-app constraint is the explicit subject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
