### PR TITLE
docs: stop claiming a qseow remove-sheet-icons command exists

### DIFF
--- a/docs/to-doc-site/one-bad-sheet-no-longer-fails-the-app.md
+++ b/docs/to-doc-site/one-bad-sheet-no-longer-fails-the-app.md
@@ -1,6 +1,6 @@
 # Fixed: a single sheet with missing layout data no longer fails the whole app
 
-**Applies to:** all commands that read an app's sheets — `create-sheet-thumbnails` and `remove-sheet-icons`, on both Qlik Sense Enterprise on Windows and Qlik Sense Cloud
+**Applies to:** `create-sheet-thumbnails` on both Qlik Sense Enterprise on Windows and Qlik Sense Cloud, and `remove-sheet-icons` on Qlik Sense Cloud
 
 ::: warning Requires BSI 3.12.0 or later
 In earlier versions, one sheet with missing layout data stopped Butler Sheet Icons from processing the app at all.
@@ -29,7 +29,8 @@ Search your logs for `reading 'rank'` — that phrase is the same in every case.
 | Qlik Sense Cloud | Removing sheet icons | `CLOUD REMOVE SHEET ICONS 1 (stack):` |
 | Enterprise on Windows | Creating thumbnails | `QSEOW: qseowProcessApp (stack):` |
 | Enterprise on Windows | Applying thumbnails to sheets | `QSEOW UPDATE SHEETS (stack):` |
-| Enterprise on Windows | Removing sheet icons | `QSEOW: removeSheetIconsQSEoWApp (stack):` |
+
+There is no `remove-sheet-icons` command for Qlik Sense Enterprise on Windows — it exists only for Qlik Sense Cloud.
 
 A closely related failure, `reading 'showCondition'`, is fixed by the same change and is worth searching for too. It struck slightly later in the run — after thumbnails had been generated but before they were uploaded, so the work was still discarded.
 


### PR DESCRIPTION
Corrects a factual error in a staged doc page merged in #876, before it reaches the public site.

The page claimed the fix applies to `remove-sheet-icons` on **both** platforms, and its log-prefix table carried a row for QSEoW "Removing sheet icons". Neither is reachable — `buildQseowCommand()` registers only `create-sheet-thumbnails`, so `butler-sheet-icons qseow remove-sheet-icons` answers `error: unknown command`. Only `qscloud` registers it.

An administrator searching their logs for `QSEOW: removeSheetIconsQSEoWApp` would never find it, and one trying the command would hit an error while believing the docs covered their platform.

- Header scoped to what exists: `create-sheet-thumbnails` on both platforms, `remove-sheet-icons` on Cloud.
- Unreachable table row dropped, with an explicit line saying the command is Cloud-only so the absence does not read as an omission.
- Every remaining log prefix on the page re-verified against current source.

Found by the code review on #880. Documentation only.

Note for later: the module `qseow-remove-sheet-icons.js` does exist and is maintained — it received fixes in #876 — but nothing registers it as a CLI command. Whether to register or remove it is a separate question from what the docs should claim today.