### PR TITLE
fix: count per-sheet failures instead of reporting the app as clean (#872 part 5b)

### DIFF
--- a/docs/to-doc-site/exit-code-now-reflects-failures.md
+++ b/docs/to-doc-site/exit-code-now-reflects-failures.md
@@ -24,6 +24,7 @@ Butler Sheet Icons now exits with:
 - **Any app that could not be processed.** Other apps in the same run are still attempted — one bad app does not stop the rest — but the run as a whole reports failure at the end.
 - **A connection that could not be established** to the Qlik Sense server or Qlik Sense Cloud tenant.
 - **A selection that matched no apps at all** — for example a `--collectionid` that exists but contains no apps, or a `--qliksensetag` that no app carries. Previously this finished silently and reported success.
+- **Any sheet within an app that could not be updated, or whose icon could not be removed.** The other sheets are still attempted; the app is reported as failed at the end.
 - **A Qlik Sense Cloud connection test that returns a response with no user in it.** This used to print `Connection to tenant … successful.` followed by four lines reading `undefined`, and the run then failed later for reasons that looked unrelated.
 
 ## New messages in the log
@@ -67,6 +68,17 @@ Connection test to tenant mytenant.eu.qlikcloud.com returned a response with no 
 
 3. If you need the job to keep going for now while you investigate, most schedulers let you ignore the exit code of a step. Treat that as temporary: the exit code is telling you that sheet icons are not being updated the way you asked.
 
-## What is still not covered
+## Individual sheets count too
 
-A sheet that could not be updated **within** an otherwise successful app does not by itself make the run report failure. Those failures are logged, but the exit code stays 0 if every app was otherwise processed. Per-sheet failure reporting is a separate change that has not shipped yet.
+A sheet that could not be updated within an app now fails that app, and therefore the run.
+
+Butler Sheet Icons still tries every other sheet first — one read-only sheet does not stop the ones after it — and the engine session is always released. Only at the end is the app reported as failed:
+
+```
+CLOUD UPDATE SHEETS: Failed to update sheet 1 ('Sales overview', ID abc-123) in app 97089caf: Sheet is read-only
+Failed to update 1 of 2 sheet(s) in app 97089caf
+```
+
+The count is of sheets Butler Sheet Icons **tried** to update. Sheets deliberately left alone — because you excluded them, or because no thumbnail was generated for them — are not counted in either figure. So "1 of 2" means two sheets were attempted and one of them failed, regardless of how many sheets the app has in total.
+
+The per-sheet line names the sheet by title and ID, which is what you need to find it in Qlik Sense. The number is the sheet's position in the app, counting from 1.

--- a/src/lib/cloud/__tests__/cloud_remove_sheet_icons.test.js
+++ b/src/lib/cloud/__tests__/cloud_remove_sheet_icons.test.js
@@ -501,14 +501,32 @@ describe('qscloudRemoveSheetIcons', () => {
             expect(logger.error).toHaveBeenCalled();
         });
 
-        test('logs a per-sheet failure instead of rejecting', async () => {
+        test('reports failure when a sheet could not be updated, without rejecting', async () => {
+            // Isolation is not the same as success. This used to resolve true, so an app in
+            // which no icon at all was removed looked identical to a clean run and the
+            // process exited 0.
             const sheet = makeSheet('sheet-1', 1);
             sheet.obj.setProperties.mockRejectedValue(new Error('sheet is read-only'));
             wireEnigma([sheet]);
 
-            await expect(qscloudRemoveSheetIcons({ ...BASE_OPTIONS })).resolves.toBe(true);
+            await expect(qscloudRemoveSheetIcons({ ...BASE_OPTIONS })).resolves.toBe(false);
 
             expect(logger.error).toHaveBeenCalled();
+        });
+
+        test('says how many sheets failed', async () => {
+            const sheets = [
+                makeSheet('sheet-1', 1),
+                makeSheet('sheet-2', 2),
+                makeSheet('sheet-3', 3),
+            ];
+            sheets[0].obj.setProperties.mockRejectedValue(new Error('sheet is read-only'));
+            wireEnigma(sheets);
+
+            await qscloudRemoveSheetIcons({ ...BASE_OPTIONS });
+
+            const errors = logger.error.mock.calls.map((call) => String(call[0])).join('\n');
+            expect(errors).toContain('Failed to remove icons for 1 of 3 sheet(s)');
         });
 
         test('a failing sheet does not stop the sheets after it', async () => {

--- a/src/lib/cloud/__tests__/cloud_updatesheets.test.js
+++ b/src/lib/cloud/__tests__/cloud_updatesheets.test.js
@@ -346,6 +346,59 @@ describe('qscloudUpdateSheetThumbnails', () => {
         });
     });
 
+    describe('a sheet that cannot be updated', () => {
+        const THREE_FILES = [
+            { sheetPos: 1, fileNameShort: 'thumbnail-1.png' },
+            { sheetPos: 2, fileNameShort: 'thumbnail-2.png' },
+            { sheetPos: 3, fileNameShort: 'thumbnail-3.png' },
+        ];
+
+        test('does not stop the sheets after it', async () => {
+            // There was no per-sheet isolation here at all: one read-only sheet discarded
+            // every update that came after it.
+            const sheets = [
+                makeSheet({ qId: 'sheet-a', rank: 1 }),
+                makeSheet({ qId: 'sheet-b', rank: 2 }),
+                makeSheet({ qId: 'sheet-c', rank: 3 }),
+            ];
+            sheets[0].obj.setProperties.mockRejectedValue(new Error('sheet is read-only'));
+            wireEnigma(sheets);
+
+            await expect(
+                qscloudUpdateSheetThumbnails(THREE_FILES, APP_ID, BASE_OPTIONS)
+            ).rejects.toThrow(CloudError);
+
+            expect(sheets[1].obj.setProperties).toHaveBeenCalledTimes(1);
+            expect(sheets[2].obj.setProperties).toHaveBeenCalledTimes(1);
+        });
+
+        test('still closes the engine session', async () => {
+            const sheets = [makeSheet({ qId: 'sheet-a', rank: 1 })];
+            sheets[0].obj.setProperties.mockRejectedValue(new Error('sheet is read-only'));
+            const { session } = wireEnigma(sheets);
+
+            await expect(
+                qscloudUpdateSheetThumbnails(THREE_FILES, APP_ID, BASE_OPTIONS)
+            ).rejects.toThrow();
+
+            expect(session.close).toHaveBeenCalledTimes(1);
+        });
+
+        test('fails the app, naming how many sheets could not be updated', async () => {
+            const sheets = [
+                makeSheet({ qId: 'sheet-a', rank: 1 }),
+                makeSheet({ qId: 'sheet-b', rank: 2 }),
+                makeSheet({ qId: 'sheet-c', rank: 3 }),
+            ];
+            sheets[0].obj.setProperties.mockRejectedValue(new Error('sheet is read-only'));
+            wireEnigma(sheets);
+
+            await expect(
+                qscloudUpdateSheetThumbnails(THREE_FILES, APP_ID, BASE_OPTIONS)
+            ).rejects.toThrow('Failed to update 1 of 3 sheet(s)');
+        });
+    });
+
     describe('error handling', () => {
         test('rejects with CloudError when the engine session cannot be created', async () => {
             enigmaCreate.mockRejectedValue(new Error('engine unreachable'));

--- a/src/lib/cloud/__tests__/cloud_updatesheets.test.js
+++ b/src/lib/cloud/__tests__/cloud_updatesheets.test.js
@@ -384,6 +384,26 @@ describe('qscloudUpdateSheetThumbnails', () => {
             expect(session.close).toHaveBeenCalledTimes(1);
         });
 
+        test('counts only the sheets it tried to update, not the ones it skipped', async () => {
+            // Only sheet 1 has a thumbnail; 2 and 3 are deliberately left alone. Reporting
+            // "1 of 3" would read as mostly-fine when in fact nothing was updated.
+            const sheets = [
+                makeSheet({ qId: 'sheet-a', rank: 1 }),
+                makeSheet({ qId: 'sheet-b', rank: 2 }),
+                makeSheet({ qId: 'sheet-c', rank: 3 }),
+            ];
+            sheets[0].obj.setProperties.mockRejectedValue(new Error('sheet is read-only'));
+            wireEnigma(sheets);
+
+            await expect(
+                qscloudUpdateSheetThumbnails(
+                    [{ sheetPos: 1, fileNameShort: 'thumbnail-1.png' }],
+                    APP_ID,
+                    BASE_OPTIONS
+                )
+            ).rejects.toThrow('Failed to update 1 of 1 sheet(s)');
+        });
+
         test('fails the app, naming how many sheets could not be updated', async () => {
             const sheets = [
                 makeSheet({ qId: 'sheet-a', rank: 1 }),

--- a/src/lib/cloud/cloud-remove-sheet-icons.js
+++ b/src/lib/cloud/cloud-remove-sheet-icons.js
@@ -19,9 +19,16 @@ import { runOverSheets, sortSheetsByRank } from '../util/sheet-list.js';
  * @param {string} options.apikey - API key for the Qlik Sense Cloud tenant.
  * @param {string} options.loglevel - The level of logging to output. Valid values are 'error', 'warn', 'info', 'verbose', 'debug', 'silly'.
  *
- * @returns {Promise<void>} Resolves once all sheet icons in the app have been removed (or the app has no sheets).
+ * @returns {Promise<void>} Resolves once every sheet's icon has been removed, or the app has
+ *     no sheets.
+ *
+ * @throws {CloudError} When any sheet's icon could not be removed. Other sheets are still
+ *     attempted first and the engine session is always released.
+ * @throws {Error} Whatever the engine or media API threw, if the session itself was lost.
  */
 const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
+    let sheetRun;
+
     try {
         // Does the app have a thumbnail folder in its media library?
         const mediaList = await saasInstance.Get(`apps/${appId}/media/list`);
@@ -94,8 +101,6 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
             },
         };
 
-        let sheetRun;
-
         const genericListObj = await app.createSessionObject(appSheetsCall);
         const sheetListObj = await genericListObj.getLayout();
 
@@ -141,8 +146,6 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
             `Closed session after updating sheet thumbnail images in QS Cloud app ${appId} on host ${options.host}`
         );
 
-        sheetRun?.assertAllProcessed();
-
         logger.info(`Done processing app ${appId}`);
     } catch (err) {
         if (err.stack) {
@@ -156,6 +159,8 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
         // normally made a run in which every app failed look exactly like a clean run.
         throw err;
     }
+
+    sheetRun?.assertAllProcessed();
 };
 
 /**

--- a/src/lib/cloud/cloud-remove-sheet-icons.js
+++ b/src/lib/cloud/cloud-remove-sheet-icons.js
@@ -7,7 +7,7 @@ import QlikSaas from './cloud-repo.js';
 import { qscloudTestConnection } from './cloud-test-connection.js';
 import { runOverApps } from '../util/run-over-apps.js';
 import { CloudError } from '../util/errors.js';
-import { assertAllSheetsProcessed, sortSheetsByRank } from '../util/sheet-list.js';
+import { runOverSheets, sortSheetsByRank } from '../util/sheet-list.js';
 
 /**
  * Removes all sheet icons from a Qlik Sense Cloud app.
@@ -94,8 +94,7 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
             },
         };
 
-        let failedSheets = 0;
-        let totalSheets = 0;
+        let sheetRun;
 
         const genericListObj = await app.createSessionObject(appSheetsCall);
         const sheetListObj = await genericListObj.getLayout();
@@ -103,17 +102,19 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
         if (sheetListObj.qAppObjectList.qItems.length > 0) {
             // sheetListObj.qAppObjectList.qItems[] now contains array of app sheets.
             logger.info(`Number of sheets in app: ${sheetListObj.qAppObjectList.qItems.length}`);
-            totalSheets = sheetListObj.qAppObjectList.qItems.length;
 
             // Sort sheets
             sortSheetsByRank(sheetListObj.qAppObjectList.qItems);
 
-            let iSheetNum = 1;
-
-            for (const sheet of sheetListObj.qAppObjectList.qItems) {
-                // One unwritable sheet must not abandon the sheets after it, or skip the
-                // session close below.
-                try {
+            sheetRun = await runOverSheets(
+                sheetListObj.qAppObjectList.qItems,
+                {
+                    logPrefix: 'CLOUD REMOVE SHEET ICONS',
+                    appId,
+                    action: 'remove icons for',
+                    ErrorClass: CloudError,
+                },
+                async (sheet, iSheetNum) => {
                     logger.info(
                         `Removing icon for sheet ${iSheetNum}: Name '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
                     );
@@ -128,15 +129,8 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
                     const res = await sheetObj.setProperties(sheetProperties);
                     logger.debug(`Set thumbnail result: ${JSON.stringify(res, null, 2)}`);
                     await app.doSave();
-                } catch (err) {
-                    failedSheets += 1;
-                    logger.error(
-                        `CLOUD: Failed to remove icon for sheet ${iSheetNum} ('${sheet.qMeta.title}', ID ${sheet.qInfo.qId}) in app ${appId}: ${err.message ?? err}`
-                    );
                 }
-
-                iSheetNum += 1;
-            }
+            );
         }
 
         // Closed outside the sheet-count guard: an app with no sheets still holds an open
@@ -147,11 +141,7 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
             `Closed session after updating sheet thumbnail images in QS Cloud app ${appId} on host ${options.host}`
         );
 
-        assertAllSheetsProcessed(failedSheets, totalSheets, {
-            appId,
-            action: 'remove icons for',
-            ErrorClass: CloudError,
-        });
+        sheetRun?.assertAllProcessed();
 
         logger.info(`Done processing app ${appId}`);
     } catch (err) {

--- a/src/lib/cloud/cloud-remove-sheet-icons.js
+++ b/src/lib/cloud/cloud-remove-sheet-icons.js
@@ -6,7 +6,8 @@ import { redactOptions } from '../util/redact-secrets.js';
 import QlikSaas from './cloud-repo.js';
 import { qscloudTestConnection } from './cloud-test-connection.js';
 import { runOverApps } from '../util/run-over-apps.js';
-import { sortSheetsByRank } from '../util/sheet-list.js';
+import { CloudError } from '../util/errors.js';
+import { assertAllSheetsProcessed, sortSheetsByRank } from '../util/sheet-list.js';
 
 /**
  * Removes all sheet icons from a Qlik Sense Cloud app.
@@ -93,12 +94,16 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
             },
         };
 
+        let failedSheets = 0;
+        let totalSheets = 0;
+
         const genericListObj = await app.createSessionObject(appSheetsCall);
         const sheetListObj = await genericListObj.getLayout();
 
         if (sheetListObj.qAppObjectList.qItems.length > 0) {
             // sheetListObj.qAppObjectList.qItems[] now contains array of app sheets.
             logger.info(`Number of sheets in app: ${sheetListObj.qAppObjectList.qItems.length}`);
+            totalSheets = sheetListObj.qAppObjectList.qItems.length;
 
             // Sort sheets
             sortSheetsByRank(sheetListObj.qAppObjectList.qItems);
@@ -124,6 +129,7 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
                     logger.debug(`Set thumbnail result: ${JSON.stringify(res, null, 2)}`);
                     await app.doSave();
                 } catch (err) {
+                    failedSheets += 1;
                     logger.error(
                         `CLOUD: Failed to remove icon for sheet ${iSheetNum} ('${sheet.qMeta.title}', ID ${sheet.qInfo.qId}) in app ${appId}: ${err.message ?? err}`
                     );
@@ -140,6 +146,12 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
         logger.verbose(
             `Closed session after updating sheet thumbnail images in QS Cloud app ${appId} on host ${options.host}`
         );
+
+        assertAllSheetsProcessed(failedSheets, totalSheets, {
+            appId,
+            action: 'remove icons for',
+            ErrorClass: CloudError,
+        });
 
         logger.info(`Done processing app ${appId}`);
     } catch (err) {

--- a/src/lib/cloud/cloud-updatesheets.js
+++ b/src/lib/cloud/cloud-updatesheets.js
@@ -3,7 +3,7 @@ import enigma from 'enigma.js';
 import { setupEnigmaConnection } from './cloud-enigma.js';
 import { logger } from '../../globals.js';
 import { CloudError } from '../util/errors.js';
-import { runOverSheets, sortSheetsByRank } from '../util/sheet-list.js';
+import { runOverSheets, SHEET_SKIPPED, sortSheetsByRank } from '../util/sheet-list.js';
 
 /**
  * Updates sheet thumbnails in a Qlik Sense Cloud app.
@@ -87,9 +87,14 @@ export const qscloudUpdateSheetThumbnails = async (createdFiles, appId, options)
                         (element) => element.sheetPos === iSheetNum
                     );
                     if (!createdFile) {
+                        // Guarded: this line is inside the counted region, so an unguarded
+                        // dereference here would fail the app over a sheet nobody was
+                        // going to touch.
                         logger.info(
-                            `Skipping update of sheet ${iSheetNum}: Name '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
+                            `Skipping update of sheet ${iSheetNum}: Name '${sheet?.qMeta?.title}', ID ${sheet?.qInfo?.qId}, description '${sheet?.qMeta?.description}'`
                         );
+
+                        return SHEET_SKIPPED;
                     } else {
                         // Should blurred sheet thumbnail be used?
                         // Options are

--- a/src/lib/cloud/cloud-updatesheets.js
+++ b/src/lib/cloud/cloud-updatesheets.js
@@ -21,7 +21,13 @@ import { runOverSheets, SHEET_SKIPPED, sortSheetsByRank } from '../util/sheet-li
  * @param {Array<string>} [options.blurSheetNumber] - Array of sheet numbers to be blurred.
  * @param {Array<string>} [options.blurSheetTitle] - Array of sheet titles to be blurred.
  *
- * @returns {Promise<void>} Resolves when the sheet thumbnails have been successfully updated in the Qlik Sense Cloud app.
+ * @returns {Promise<void>} Resolves when every sheet that had a generated thumbnail was
+ *     updated.
+ *
+ * @throws {CloudError} When any sheet could not be updated, or when thumbnails were created
+ *     but no sheet matched one. Other sheets are still attempted first and the engine
+ *     session is always released.
+ * @throws {Error} Whatever the engine threw, if the session itself was lost.
  */
 export const qscloudUpdateSheetThumbnails = async (createdFiles, appId, options) => {
     let sheetRun;
@@ -80,6 +86,7 @@ export const qscloudUpdateSheetThumbnails = async (createdFiles, appId, options)
                     logPrefix: 'CLOUD UPDATE SHEETS',
                     appId,
                     action: 'update',
+                    requireAttempt: createdFiles.length > 0,
                     ErrorClass: CloudError,
                 },
                 async (sheet, iSheetNum) => {

--- a/src/lib/cloud/cloud-updatesheets.js
+++ b/src/lib/cloud/cloud-updatesheets.js
@@ -3,7 +3,7 @@ import enigma from 'enigma.js';
 import { setupEnigmaConnection } from './cloud-enigma.js';
 import { logger } from '../../globals.js';
 import { CloudError } from '../util/errors.js';
-import { assertAllSheetsProcessed, sortSheetsByRank } from '../util/sheet-list.js';
+import { runOverSheets, sortSheetsByRank } from '../util/sheet-list.js';
 
 /**
  * Updates sheet thumbnails in a Qlik Sense Cloud app.
@@ -24,8 +24,7 @@ import { assertAllSheetsProcessed, sortSheetsByRank } from '../util/sheet-list.j
  * @returns {Promise<void>} Resolves when the sheet thumbnails have been successfully updated in the Qlik Sense Cloud app.
  */
 export const qscloudUpdateSheetThumbnails = async (createdFiles, appId, options) => {
-    let failedSheets = 0;
-    let totalSheets = 0;
+    let sheetRun;
 
     try {
         logger.verbose(`Starting update of sheet icons for app ${appId}`);
@@ -71,18 +70,19 @@ export const qscloudUpdateSheetThumbnails = async (createdFiles, appId, options)
         if (sheetListObj.qAppObjectList.qItems.length > 0) {
             // dimObj.qAppObjectList.qItems[] now contains array of app sheets.
             logger.info(`Number of sheets: ${sheetListObj.qAppObjectList.qItems.length}`);
-            totalSheets = sheetListObj.qAppObjectList.qItems.length;
 
             // Sort sheets
             sortSheetsByRank(sheetListObj.qAppObjectList.qItems);
 
-            let iSheetNum = 1;
-
-            for (const sheet of sheetListObj.qAppObjectList.qItems) {
-                // One unwritable sheet must not discard the updates already made, nor skip
-                // the session close below. Failures are counted, not ignored - see the
-                // assertion after the loop.
-                try {
+            sheetRun = await runOverSheets(
+                sheetListObj.qAppObjectList.qItems,
+                {
+                    logPrefix: 'CLOUD UPDATE SHEETS',
+                    appId,
+                    action: 'update',
+                    ErrorClass: CloudError,
+                },
+                async (sheet, iSheetNum) => {
                     const createdFile = createdFiles.find(
                         (element) => element.sheetPos === iSheetNum
                     );
@@ -191,14 +191,8 @@ export const qscloudUpdateSheetThumbnails = async (createdFiles, appId, options)
                         logger.debug(`Set thumbnail result: ${JSON.stringify(res, null, 2)}`);
                         await app.doSave();
                     }
-                } catch (err) {
-                    failedSheets += 1;
-                    logger.error(
-                        `CLOUD UPDATE SHEETS: Failed to update sheet ${iSheetNum} in app ${appId}: ${err?.message ?? err}`
-                    );
                 }
-                iSheetNum += 1;
-            }
+            );
         }
 
         // enigma.js always resolves close() truthy; a real failure rejects into the catch below.
@@ -218,9 +212,5 @@ export const qscloudUpdateSheetThumbnails = async (createdFiles, appId, options)
         throw new CloudError(`Failed to update sheet thumbnails in app ${appId}`, { cause: err });
     }
 
-    assertAllSheetsProcessed(failedSheets, totalSheets, {
-        appId,
-        action: 'update',
-        ErrorClass: CloudError,
-    });
+    sheetRun?.assertAllProcessed();
 };

--- a/src/lib/cloud/cloud-updatesheets.js
+++ b/src/lib/cloud/cloud-updatesheets.js
@@ -3,7 +3,7 @@ import enigma from 'enigma.js';
 import { setupEnigmaConnection } from './cloud-enigma.js';
 import { logger } from '../../globals.js';
 import { CloudError } from '../util/errors.js';
-import { sortSheetsByRank } from '../util/sheet-list.js';
+import { assertAllSheetsProcessed, sortSheetsByRank } from '../util/sheet-list.js';
 
 /**
  * Updates sheet thumbnails in a Qlik Sense Cloud app.
@@ -24,6 +24,9 @@ import { sortSheetsByRank } from '../util/sheet-list.js';
  * @returns {Promise<void>} Resolves when the sheet thumbnails have been successfully updated in the Qlik Sense Cloud app.
  */
 export const qscloudUpdateSheetThumbnails = async (createdFiles, appId, options) => {
+    let failedSheets = 0;
+    let totalSheets = 0;
+
     try {
         logger.verbose(`Starting update of sheet icons for app ${appId}`);
 
@@ -68,6 +71,7 @@ export const qscloudUpdateSheetThumbnails = async (createdFiles, appId, options)
         if (sheetListObj.qAppObjectList.qItems.length > 0) {
             // dimObj.qAppObjectList.qItems[] now contains array of app sheets.
             logger.info(`Number of sheets: ${sheetListObj.qAppObjectList.qItems.length}`);
+            totalSheets = sheetListObj.qAppObjectList.qItems.length;
 
             // Sort sheets
             sortSheetsByRank(sheetListObj.qAppObjectList.qItems);
@@ -75,108 +79,123 @@ export const qscloudUpdateSheetThumbnails = async (createdFiles, appId, options)
             let iSheetNum = 1;
 
             for (const sheet of sheetListObj.qAppObjectList.qItems) {
-                const createdFile = createdFiles.find((element) => element.sheetPos === iSheetNum);
-                if (!createdFile) {
-                    logger.info(
-                        `Skipping update of sheet ${iSheetNum}: Name '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
+                // One unwritable sheet must not discard the updates already made, nor skip
+                // the session close below. Failures are counted, not ignored - see the
+                // assertion after the loop.
+                try {
+                    const createdFile = createdFiles.find(
+                        (element) => element.sheetPos === iSheetNum
                     );
-                } else {
-                    // Should blurred sheet thumbnail be used?
-                    // Options are
-                    // --blur-sheet-number <number...>
-                    // --blur-sheet-title <title...>
-                    // --blur-sheet-status <status...>
-
-                    let blurSheet = false;
-
-                    // Get published status of sheet
-                    let sheetPublished;
-                    if (sheet.qMeta?.published === undefined || sheet.qMeta.published === false) {
-                        sheetPublished = false;
-                    } else {
-                        sheetPublished = true;
-                    }
-
-                    // Get approved status of sheet
-                    let sheetApproved;
-                    if (sheet.qMeta?.approved === undefined || sheet.qMeta.approved === false) {
-                        sheetApproved = false;
-                    } else {
-                        sheetApproved = true;
-                    }
-
-                    // Should this sheet be blurred based on its published status?
-                    // Public sheets
-                    if (
-                        sheetApproved === true &&
-                        sheetPublished === true &&
-                        options.blurSheetStatus &&
-                        options.blurSheetStatus.includes('public')
-                    ) {
-                        blurSheet = true;
-                        logger.verbose(
-                            `Blurred sheet thumbnail (status public): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
+                    if (!createdFile) {
+                        logger.info(
+                            `Skipping update of sheet ${iSheetNum}: Name '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
                         );
-                    }
+                    } else {
+                        // Should blurred sheet thumbnail be used?
+                        // Options are
+                        // --blur-sheet-number <number...>
+                        // --blur-sheet-title <title...>
+                        // --blur-sheet-status <status...>
 
-                    // Published sheets
-                    if (
-                        sheetApproved === false &&
-                        sheetPublished === true &&
-                        options.blurSheetStatus &&
-                        options.blurSheetStatus.includes('published')
-                    ) {
-                        blurSheet = true;
-                        logger.verbose(
-                            `Blurred sheet thumbnail (status published): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
-                        );
-                    }
+                        let blurSheet = false;
 
-                    // Should this sheet be blurred based on its position/sheet number?
-                    if (options.blurSheetNumber && blurSheet === false) {
-                        // Does the sheet number match any of the numbers in options.blurSheetNumber array?
-                        // Take into account that iSheetNum is an integer, so we need to convert it to a string
-                        if (options.blurSheetNumber.includes(iSheetNum.toString())) {
+                        // Get published status of sheet
+                        let sheetPublished;
+                        if (
+                            sheet.qMeta?.published === undefined ||
+                            sheet.qMeta.published === false
+                        ) {
+                            sheetPublished = false;
+                        } else {
+                            sheetPublished = true;
+                        }
+
+                        // Get approved status of sheet
+                        let sheetApproved;
+                        if (sheet.qMeta?.approved === undefined || sheet.qMeta.approved === false) {
+                            sheetApproved = false;
+                        } else {
+                            sheetApproved = true;
+                        }
+
+                        // Should this sheet be blurred based on its published status?
+                        // Public sheets
+                        if (
+                            sheetApproved === true &&
+                            sheetPublished === true &&
+                            options.blurSheetStatus &&
+                            options.blurSheetStatus.includes('public')
+                        ) {
                             blurSheet = true;
                             logger.verbose(
-                                `Blurred sheet thumbnail (via sheet number): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
+                                `Blurred sheet thumbnail (status public): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
                             );
                         }
-                    }
 
-                    // Should this sheet be blurred based on its title?
-                    if (options.blurSheetTitle && blurSheet === false) {
-                        // Does the sheet title match any of the titles options.blurSheetTitle array?
-                        if (options.blurSheetTitle.includes(sheet.qMeta.title)) {
+                        // Published sheets
+                        if (
+                            sheetApproved === false &&
+                            sheetPublished === true &&
+                            options.blurSheetStatus &&
+                            options.blurSheetStatus.includes('published')
+                        ) {
                             blurSheet = true;
                             logger.verbose(
-                                `Blurred sheet thumbnail (via sheet title): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
+                                `Blurred sheet thumbnail (status published): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
                             );
                         }
+
+                        // Should this sheet be blurred based on its position/sheet number?
+                        if (options.blurSheetNumber && blurSheet === false) {
+                            // Does the sheet number match any of the numbers in options.blurSheetNumber array?
+                            // Take into account that iSheetNum is an integer, so we need to convert it to a string
+                            if (options.blurSheetNumber.includes(iSheetNum.toString())) {
+                                blurSheet = true;
+                                logger.verbose(
+                                    `Blurred sheet thumbnail (via sheet number): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
+                                );
+                            }
+                        }
+
+                        // Should this sheet be blurred based on its title?
+                        if (options.blurSheetTitle && blurSheet === false) {
+                            // Does the sheet title match any of the titles options.blurSheetTitle array?
+                            if (options.blurSheetTitle.includes(sheet.qMeta.title)) {
+                                blurSheet = true;
+                                logger.verbose(
+                                    `Blurred sheet thumbnail (via sheet title): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
+                                );
+                            }
+                        }
+
+                        // Get properties of current sheet
+                        const sheetObj = await app.getObject(sheet.qInfo.qId);
+                        const sheetProperties = await sheetObj.getProperties();
+
+                        if (blurSheet === true && createdFile.fileNameShortBlurred) {
+                            logger.info(
+                                `Using blurred thumbnail for sheet ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
+                            );
+
+                            sheetProperties.thumbnail.qStaticContentUrlDef.qUrl = `/api/v1/apps/${appId}/media/files/thumbnails/${createdFile.fileNameShortBlurred}`;
+                        } else {
+                            logger.info(
+                                `Using regular thumbnail for sheet ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
+                            );
+
+                            sheetProperties.thumbnail.qStaticContentUrlDef.qUrl = `/api/v1/apps/${appId}/media/files/thumbnails/${createdFile.fileNameShort}`;
+                        }
+
+                        // Set & save new sheet thumbnail
+                        const res = await sheetObj.setProperties(sheetProperties);
+                        logger.debug(`Set thumbnail result: ${JSON.stringify(res, null, 2)}`);
+                        await app.doSave();
                     }
-
-                    // Get properties of current sheet
-                    const sheetObj = await app.getObject(sheet.qInfo.qId);
-                    const sheetProperties = await sheetObj.getProperties();
-
-                    if (blurSheet === true && createdFile.fileNameShortBlurred) {
-                        logger.info(
-                            `Using blurred thumbnail for sheet ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
-                        );
-
-                        sheetProperties.thumbnail.qStaticContentUrlDef.qUrl = `/api/v1/apps/${appId}/media/files/thumbnails/${createdFile.fileNameShortBlurred}`;
-                    } else {
-                        logger.info(
-                            `Using regular thumbnail for sheet ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
-                        );
-
-                        sheetProperties.thumbnail.qStaticContentUrlDef.qUrl = `/api/v1/apps/${appId}/media/files/thumbnails/${createdFile.fileNameShort}`;
-                    }
-
-                    // Set & save new sheet thumbnail
-                    const res = await sheetObj.setProperties(sheetProperties);
-                    logger.debug(`Set thumbnail result: ${JSON.stringify(res, null, 2)}`);
-                    await app.doSave();
+                } catch (err) {
+                    failedSheets += 1;
+                    logger.error(
+                        `CLOUD UPDATE SHEETS: Failed to update sheet ${iSheetNum} in app ${appId}: ${err?.message ?? err}`
+                    );
                 }
                 iSheetNum += 1;
             }
@@ -198,4 +217,10 @@ export const qscloudUpdateSheetThumbnails = async (createdFiles, appId, options)
 
         throw new CloudError(`Failed to update sheet thumbnails in app ${appId}`, { cause: err });
     }
+
+    assertAllSheetsProcessed(failedSheets, totalSheets, {
+        appId,
+        action: 'update',
+        ErrorClass: CloudError,
+    });
 };

--- a/src/lib/qseow/__tests__/qseow_remove_sheet_icons.test.js
+++ b/src/lib/qseow/__tests__/qseow_remove_sheet_icons.test.js
@@ -352,14 +352,32 @@ describe('qseowRemoveSheetIcons', () => {
             expect(logger.error).toHaveBeenCalled();
         });
 
-        test('logs a per-sheet failure instead of rejecting', async () => {
+        test('reports failure when a sheet could not be updated, without rejecting', async () => {
+            // Isolation is not the same as success. This used to resolve true, so an app in
+            // which no icon at all was removed looked identical to a clean run and the
+            // process exited 0.
             const sheet = makeSheet('sheet-1', 1);
             sheet.obj.setProperties.mockRejectedValue(new Error('sheet is read-only'));
             wireEnigma([sheet]);
 
-            await expect(qseowRemoveSheetIcons(BASE_OPTIONS)).resolves.toBe(true);
+            await expect(qseowRemoveSheetIcons(BASE_OPTIONS)).resolves.toBe(false);
 
             expect(logger.error).toHaveBeenCalled();
+        });
+
+        test('says how many sheets failed', async () => {
+            const sheets = [
+                makeSheet('sheet-1', 1),
+                makeSheet('sheet-2', 2),
+                makeSheet('sheet-3', 3),
+            ];
+            sheets[0].obj.setProperties.mockRejectedValue(new Error('sheet is read-only'));
+            wireEnigma(sheets);
+
+            await qseowRemoveSheetIcons(BASE_OPTIONS);
+
+            const errors = logger.error.mock.calls.map((call) => String(call[0])).join('\n');
+            expect(errors).toContain('Failed to remove icons for 1 of 3 sheet(s)');
         });
 
         test('a failing sheet does not stop the sheets after it', async () => {

--- a/src/lib/qseow/__tests__/qseow_updatesheets.test.js
+++ b/src/lib/qseow/__tests__/qseow_updatesheets.test.js
@@ -21,6 +21,7 @@ jest.unstable_mockModule('../../../globals.js', () => ({
 const { logger } = await import('../../../globals.js');
 
 const { qseowUpdateSheetThumbnails } = await import('../qseow-updatesheets.js');
+const { QseowError } = await import('../../util/errors.js');
 
 const BLUR_TAG_WARNING = '--blur-sheet-tag is not yet implemented';
 
@@ -256,5 +257,112 @@ describe('qseowUpdateSheetThumbnails — sheets with missing metadata', () => {
             'sheet-b',
             'broken',
         ]);
+    });
+});
+
+describe('qseowUpdateSheetThumbnails — a sheet that cannot be updated', () => {
+    const THREE_FILES = [
+        { sheetPos: 1, fileNameShort: 'thumbnail-1.png' },
+        { sheetPos: 2, fileNameShort: 'thumbnail-2.png' },
+        { sheetPos: 3, fileNameShort: 'thumbnail-3.png' },
+    ];
+
+    /**
+     * Wires the enigma chain with three sheets, failing `setProperties` on the first.
+     *
+     * @returns {{app: object, session: object}} The mock app and session.
+     */
+    function wireThreeSheetsFirstUnwritable() {
+        const objects = ['sheet-a', 'sheet-b', 'sheet-c'].map((qId) => ({
+            qId,
+            getProperties: jest
+                .fn()
+                .mockResolvedValue({ thumbnail: { qStaticContentUrlDef: { qUrl: '' } } }),
+            setProperties:
+                qId === 'sheet-a'
+                    ? jest.fn().mockRejectedValue(new Error('sheet is read-only'))
+                    : jest.fn().mockResolvedValue({ ok: true }),
+        }));
+
+        const app = {
+            createSessionObject: jest.fn().mockResolvedValue({
+                getLayout: jest.fn().mockResolvedValue({
+                    qAppObjectList: {
+                        qItems: objects.map((o, i) => ({
+                            qInfo: { qId: o.qId },
+                            qMeta: { title: o.qId, description: '' },
+                            qData: { rank: i + 1 },
+                        })),
+                    },
+                }),
+            }),
+            getObject: jest.fn(async (qId) => objects.find((o) => o.qId === qId)),
+            doSave: jest.fn().mockResolvedValue(true),
+        };
+
+        const session = {
+            open: jest.fn().mockResolvedValue({
+                engineVersion: jest.fn().mockResolvedValue({ qComponentVersion: '12.0.0' }),
+                openDoc: jest.fn().mockResolvedValue(app),
+            }),
+            close: jest.fn().mockResolvedValue(true),
+            on: jest.fn(),
+        };
+        enigma.create.mockResolvedValue(session);
+
+        return { app, session, objects };
+    }
+
+    test('does not stop the sheets after it', async () => {
+        const { objects } = wireThreeSheetsFirstUnwritable();
+
+        await expect(
+            qseowUpdateSheetThumbnails(THREE_FILES, 'test-app-id', { ...BASE_OPTIONS })
+        ).rejects.toThrow();
+
+        expect(objects[1].setProperties).toHaveBeenCalledTimes(1);
+        expect(objects[2].setProperties).toHaveBeenCalledTimes(1);
+    });
+
+    test('still closes the engine session', async () => {
+        const { session } = wireThreeSheetsFirstUnwritable();
+
+        await expect(
+            qseowUpdateSheetThumbnails(THREE_FILES, 'test-app-id', { ...BASE_OPTIONS })
+        ).rejects.toThrow();
+
+        expect(session.close).toHaveBeenCalledTimes(1);
+    });
+
+    test('fails the app, naming how many sheets could not be updated', async () => {
+        wireThreeSheetsFirstUnwritable();
+
+        await expect(
+            qseowUpdateSheetThumbnails(THREE_FILES, 'test-app-id', { ...BASE_OPTIONS })
+        ).rejects.toThrow('Failed to update 1 of 3 sheet(s)');
+    });
+
+    test('counts only the sheets it tried to update, not the ones it skipped', async () => {
+        // Only sheet 1 has a thumbnail; 2 and 3 are deliberately left alone. Reporting
+        // "1 of 3" would read as mostly-fine when in fact nothing was updated.
+        wireThreeSheetsFirstUnwritable();
+
+        await expect(
+            qseowUpdateSheetThumbnails(
+                [{ sheetPos: 1, fileNameShort: 'thumbnail-1.png' }],
+                'test-app-id',
+                {
+                    ...BASE_OPTIONS,
+                }
+            )
+        ).rejects.toThrow('Failed to update 1 of 1 sheet(s)');
+    });
+
+    test('reports failure with the QSEoW error type', async () => {
+        wireThreeSheetsFirstUnwritable();
+
+        await expect(
+            qseowUpdateSheetThumbnails(THREE_FILES, 'test-app-id', { ...BASE_OPTIONS })
+        ).rejects.toThrow(QseowError);
     });
 });

--- a/src/lib/qseow/determine-sheet-exclude-status.js
+++ b/src/lib/qseow/determine-sheet-exclude-status.js
@@ -1,3 +1,5 @@
+import { isSheetTagged } from '../util/sheet-list.js';
+
 /**
  * Determines whether a sheet should be excluded from updates based on various criteria.
  *
@@ -92,9 +94,7 @@ export const determineSheetExcludeStatus = async (
     if (options.excludeSheetTag && excludeSheet === false) {
         // Does the sheet id match any of the ids in tagSheetAppMetadata array?
         // Set excludeSheet to true/false based on the result
-        excludeSheet = tagSheetAppMetadata.some(
-            (element) => element.engineObjectId === sheet.qInfo.qId
-        );
+        excludeSheet = isSheetTagged(tagSheetAppMetadata, sheet);
         // Only claim an exclusion that actually happened: this line used to be logged
         // whether or not the tag matched.
         if (excludeSheet === true) {

--- a/src/lib/qseow/qseow-remove-sheet-icons.js
+++ b/src/lib/qseow/qseow-remove-sheet-icons.js
@@ -21,9 +21,16 @@ import { runOverApps } from '../util/run-over-apps.js';
  * @param {string} options.qrsport - Qlik Sense Repository Service (QRS) port of the Qlik server.
  * @param {string} options.senseVersion - The version of Qlik Sense being used.
  *
- * @returns {Promise<void>} Resolves once all sheet icons in the app have been cleared.
+ * @returns {Promise<void>} Resolves once every sheet's icon has been cleared, or the app has
+ *     no sheets.
+ *
+ * @throws {QseowError} When any sheet's icon could not be cleared. Other sheets are still
+ *     attempted first and the engine session is always released.
+ * @throws {Error} Whatever the engine threw, if the session itself was lost.
  */
 const removeSheetIconsQSEoWApp = async (appId, g, options) => {
+    let sheetRun;
+
     try {
         // Configure Enigma.js
         const configEnigma = setupEnigmaConnection(appId, options);
@@ -65,8 +72,6 @@ const removeSheetIconsQSEoWApp = async (appId, g, options) => {
                 },
             },
         };
-
-        let sheetRun;
 
         const genericListObj = await app.createSessionObject(appSheetsCall);
         const sheetListObj = await genericListObj.getLayout();
@@ -113,8 +118,6 @@ const removeSheetIconsQSEoWApp = async (appId, g, options) => {
             `Closed session after generating sheet thumbnail images for all sheets in QSEoW app ${appId} on host ${options.host}`
         );
 
-        sheetRun?.assertAllProcessed();
-
         logger.info(`Done processing app ${appId}`);
     } catch (err) {
         if (err.stack) {
@@ -128,6 +131,8 @@ const removeSheetIconsQSEoWApp = async (appId, g, options) => {
         // normally made a run in which every app failed look exactly like a clean run.
         throw err;
     }
+
+    sheetRun?.assertAllProcessed();
 };
 
 /**

--- a/src/lib/qseow/qseow-remove-sheet-icons.js
+++ b/src/lib/qseow/qseow-remove-sheet-icons.js
@@ -7,7 +7,7 @@ import { redactOptions } from '../util/redact-secrets.js';
 import { qseowVerifyCertificatesExist } from './qseow-certificates.js';
 import { setupQseowQrsConnection } from './qseow-qrs.js';
 import { QseowError } from '../util/errors.js';
-import { assertAllSheetsProcessed, sortSheetsByRank } from '../util/sheet-list.js';
+import { runOverSheets, sortSheetsByRank } from '../util/sheet-list.js';
 import { runOverApps } from '../util/run-over-apps.js';
 
 /**
@@ -66,8 +66,7 @@ const removeSheetIconsQSEoWApp = async (appId, g, options) => {
             },
         };
 
-        let failedSheets = 0;
-        let totalSheets = 0;
+        let sheetRun;
 
         const genericListObj = await app.createSessionObject(appSheetsCall);
         const sheetListObj = await genericListObj.getLayout();
@@ -75,17 +74,19 @@ const removeSheetIconsQSEoWApp = async (appId, g, options) => {
         if (sheetListObj.qAppObjectList.qItems.length > 0) {
             // sheetListObj.qAppObjectList.qItems[] now contains array of app sheets.
             logger.info(`Number of sheets in app: ${sheetListObj.qAppObjectList.qItems.length}`);
-            totalSheets = sheetListObj.qAppObjectList.qItems.length;
 
             // Sort sheets
             sortSheetsByRank(sheetListObj.qAppObjectList.qItems);
 
-            let iSheetNum = 1;
-
-            for (const sheet of sheetListObj.qAppObjectList.qItems) {
-                // One unwritable sheet must not abandon the sheets after it, or skip the
-                // session close below.
-                try {
+            sheetRun = await runOverSheets(
+                sheetListObj.qAppObjectList.qItems,
+                {
+                    logPrefix: 'QSEOW REMOVE SHEET ICONS',
+                    appId,
+                    action: 'remove icons for',
+                    ErrorClass: QseowError,
+                },
+                async (sheet, iSheetNum) => {
                     logger.info(
                         `Removing icon for sheet: ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
                     );
@@ -100,15 +101,8 @@ const removeSheetIconsQSEoWApp = async (appId, g, options) => {
                     const res = await sheetObj.setProperties(sheetProperties);
                     logger.debug(`Set thumbnail result: ${JSON.stringify(res, null, 2)}`);
                     await app.doSave();
-                } catch (err) {
-                    failedSheets += 1;
-                    logger.error(
-                        `QSEOW: Failed to remove icon for sheet ${iSheetNum} ('${sheet.qMeta.title}', ID ${sheet.qInfo.qId}) in app ${appId}: ${err.message ?? err}`
-                    );
                 }
-
-                iSheetNum += 1;
-            }
+            );
         }
 
         // Closed outside the sheet-count guard: an app with no sheets still holds an open
@@ -119,11 +113,7 @@ const removeSheetIconsQSEoWApp = async (appId, g, options) => {
             `Closed session after generating sheet thumbnail images for all sheets in QSEoW app ${appId} on host ${options.host}`
         );
 
-        assertAllSheetsProcessed(failedSheets, totalSheets, {
-            appId,
-            action: 'remove icons for',
-            ErrorClass: QseowError,
-        });
+        sheetRun?.assertAllProcessed();
 
         logger.info(`Done processing app ${appId}`);
     } catch (err) {

--- a/src/lib/qseow/qseow-remove-sheet-icons.js
+++ b/src/lib/qseow/qseow-remove-sheet-icons.js
@@ -6,7 +6,8 @@ import { logger, setLoggingLevel, bsiExecutablePath, isSea } from '../../globals
 import { redactOptions } from '../util/redact-secrets.js';
 import { qseowVerifyCertificatesExist } from './qseow-certificates.js';
 import { setupQseowQrsConnection } from './qseow-qrs.js';
-import { sortSheetsByRank } from '../util/sheet-list.js';
+import { QseowError } from '../util/errors.js';
+import { assertAllSheetsProcessed, sortSheetsByRank } from '../util/sheet-list.js';
 import { runOverApps } from '../util/run-over-apps.js';
 
 /**
@@ -65,12 +66,16 @@ const removeSheetIconsQSEoWApp = async (appId, g, options) => {
             },
         };
 
+        let failedSheets = 0;
+        let totalSheets = 0;
+
         const genericListObj = await app.createSessionObject(appSheetsCall);
         const sheetListObj = await genericListObj.getLayout();
 
         if (sheetListObj.qAppObjectList.qItems.length > 0) {
             // sheetListObj.qAppObjectList.qItems[] now contains array of app sheets.
             logger.info(`Number of sheets in app: ${sheetListObj.qAppObjectList.qItems.length}`);
+            totalSheets = sheetListObj.qAppObjectList.qItems.length;
 
             // Sort sheets
             sortSheetsByRank(sheetListObj.qAppObjectList.qItems);
@@ -96,6 +101,7 @@ const removeSheetIconsQSEoWApp = async (appId, g, options) => {
                     logger.debug(`Set thumbnail result: ${JSON.stringify(res, null, 2)}`);
                     await app.doSave();
                 } catch (err) {
+                    failedSheets += 1;
                     logger.error(
                         `QSEOW: Failed to remove icon for sheet ${iSheetNum} ('${sheet.qMeta.title}', ID ${sheet.qInfo.qId}) in app ${appId}: ${err.message ?? err}`
                     );
@@ -112,6 +118,12 @@ const removeSheetIconsQSEoWApp = async (appId, g, options) => {
         logger.verbose(
             `Closed session after generating sheet thumbnail images for all sheets in QSEoW app ${appId} on host ${options.host}`
         );
+
+        assertAllSheetsProcessed(failedSheets, totalSheets, {
+            appId,
+            action: 'remove icons for',
+            ErrorClass: QseowError,
+        });
 
         logger.info(`Done processing app ${appId}`);
     } catch (err) {

--- a/src/lib/qseow/qseow-updatesheets.js
+++ b/src/lib/qseow/qseow-updatesheets.js
@@ -3,7 +3,7 @@ import enigma from 'enigma.js';
 import { setupEnigmaConnection } from './qseow-enigma.js';
 import { logger } from '../../globals.js';
 import { QseowError } from '../util/errors.js';
-import { assertAllSheetsProcessed, isSheetTagged, sortSheetsByRank } from '../util/sheet-list.js';
+import { isSheetTagged, runOverSheets, sortSheetsByRank } from '../util/sheet-list.js';
 
 /**
  * Updates sheet thumbnails in a Qlik Sense Enterprise on Windows (QSEoW) app.
@@ -24,8 +24,7 @@ export const qseowUpdateSheetThumbnails = async (
     options,
     tagSheetAppMetadata = []
 ) => {
-    let failedSheets = 0;
-    let totalSheets = 0;
+    let sheetRun;
 
     try {
         logger.verbose(`Starting update of sheet icons for app ${appId}`);
@@ -78,18 +77,19 @@ export const qseowUpdateSheetThumbnails = async (
         if (sheetListObj.qAppObjectList.qItems.length > 0) {
             // dimObj.qAppObjectList.qItems[] now contains array of app sheets.
             logger.info(`Number of sheets: ${sheetListObj.qAppObjectList.qItems.length}`);
-            totalSheets = sheetListObj.qAppObjectList.qItems.length;
 
             // Sort sheets
             sortSheetsByRank(sheetListObj.qAppObjectList.qItems);
 
-            let iSheetNum = 1;
-
-            for (const sheet of sheetListObj.qAppObjectList.qItems) {
-                // One unwritable sheet must not discard the updates already made, nor skip
-                // the session close below. Failures are counted, not ignored - see the
-                // assertion after the loop.
-                try {
+            sheetRun = await runOverSheets(
+                sheetListObj.qAppObjectList.qItems,
+                {
+                    logPrefix: 'QSEOW UPDATE SHEETS',
+                    appId,
+                    action: 'update',
+                    ErrorClass: QseowError,
+                },
+                async (sheet, iSheetNum) => {
                     // Is this sheet among those that should be updated?
 
                     if (
@@ -197,15 +197,8 @@ export const qseowUpdateSheetThumbnails = async (
                         logger.debug(`Set thumbnail result: ${JSON.stringify(res, null, 2)}`);
                         await app.doSave();
                     }
-                } catch (err) {
-                    failedSheets += 1;
-                    logger.error(
-                        `QSEOW UPDATE SHEETS: Failed to update sheet ${iSheetNum} in app ${appId}: ${err?.message ?? err}`
-                    );
                 }
-
-                iSheetNum += 1;
-            }
+            );
         }
 
         // enigma.js always resolves close() truthy; a real failure rejects into the catch below.
@@ -225,9 +218,5 @@ export const qseowUpdateSheetThumbnails = async (
         throw new QseowError(`Failed to update sheet thumbnails in app ${appId}`, { cause: err });
     }
 
-    assertAllSheetsProcessed(failedSheets, totalSheets, {
-        appId,
-        action: 'update',
-        ErrorClass: QseowError,
-    });
+    sheetRun?.assertAllProcessed();
 };

--- a/src/lib/qseow/qseow-updatesheets.js
+++ b/src/lib/qseow/qseow-updatesheets.js
@@ -3,7 +3,12 @@ import enigma from 'enigma.js';
 import { setupEnigmaConnection } from './qseow-enigma.js';
 import { logger } from '../../globals.js';
 import { QseowError } from '../util/errors.js';
-import { isSheetTagged, runOverSheets, sortSheetsByRank } from '../util/sheet-list.js';
+import {
+    isSheetTagged,
+    runOverSheets,
+    SHEET_SKIPPED,
+    sortSheetsByRank,
+} from '../util/sheet-list.js';
 
 /**
  * Updates sheet thumbnails in a Qlik Sense Enterprise on Windows (QSEoW) app.
@@ -95,10 +100,14 @@ export const qseowUpdateSheetThumbnails = async (
                     if (
                         createdFiles.find((element) => element.sheetPos === iSheetNum) === undefined
                     ) {
-                        // No thumbnail for this sheet, skip
+                        // No thumbnail for this sheet, skip. Guarded: this line is inside
+                        // the counted region, so an unguarded dereference here would fail
+                        // the app over a sheet nobody was going to touch.
                         logger.info(
-                            `Skipping update of sheet sheet ${iSheetNum}: Name '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
+                            `Skipping update of sheet sheet ${iSheetNum}: Name '${sheet?.qMeta?.title}', ID ${sheet?.qInfo?.qId}, description '${sheet?.qMeta?.description}'`
                         );
+
+                        return SHEET_SKIPPED;
                     } else {
                         // Should blurred sheet thumbnail be used?
                         // Options are

--- a/src/lib/qseow/qseow-updatesheets.js
+++ b/src/lib/qseow/qseow-updatesheets.js
@@ -3,7 +3,7 @@ import enigma from 'enigma.js';
 import { setupEnigmaConnection } from './qseow-enigma.js';
 import { logger } from '../../globals.js';
 import { QseowError } from '../util/errors.js';
-import { sortSheetsByRank } from '../util/sheet-list.js';
+import { assertAllSheetsProcessed, isSheetTagged, sortSheetsByRank } from '../util/sheet-list.js';
 
 /**
  * Updates sheet thumbnails in a Qlik Sense Enterprise on Windows (QSEoW) app.
@@ -24,6 +24,9 @@ export const qseowUpdateSheetThumbnails = async (
     options,
     tagSheetAppMetadata = []
 ) => {
+    let failedSheets = 0;
+    let totalSheets = 0;
+
     try {
         logger.verbose(`Starting update of sheet icons for app ${appId}`);
 
@@ -75,6 +78,7 @@ export const qseowUpdateSheetThumbnails = async (
         if (sheetListObj.qAppObjectList.qItems.length > 0) {
             // dimObj.qAppObjectList.qItems[] now contains array of app sheets.
             logger.info(`Number of sheets: ${sheetListObj.qAppObjectList.qItems.length}`);
+            totalSheets = sheetListObj.qAppObjectList.qItems.length;
 
             // Sort sheets
             sortSheetsByRank(sheetListObj.qAppObjectList.qItems);
@@ -82,112 +86,122 @@ export const qseowUpdateSheetThumbnails = async (
             let iSheetNum = 1;
 
             for (const sheet of sheetListObj.qAppObjectList.qItems) {
-                // Is this sheet among those that should be updated?
+                // One unwritable sheet must not discard the updates already made, nor skip
+                // the session close below. Failures are counted, not ignored - see the
+                // assertion after the loop.
+                try {
+                    // Is this sheet among those that should be updated?
 
-                if (createdFiles.find((element) => element.sheetPos === iSheetNum) === undefined) {
-                    // No thumbnail for this sheet, skip
-                    logger.info(
-                        `Skipping update of sheet sheet ${iSheetNum}: Name '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
-                    );
-                } else {
-                    // Should blurred sheet thumbnail be used?
-                    // Options are
-                    // --blur-sheet-tag <value>
-                    // --blur-sheet-number <number...>
-                    // --blur-sheet-title <title...>
-                    // --blur-sheet-status <status...>
-
-                    let blurSheet = false;
-
-                    // Should this sheet be blurred based on its published status?
-                    // Public sheets
                     if (
-                        sheet.qMeta.approved === true &&
-                        sheet.qMeta.published === true &&
-                        options.blurSheetStatus &&
-                        options.blurSheetStatus.includes('public')
+                        createdFiles.find((element) => element.sheetPos === iSheetNum) === undefined
                     ) {
-                        blurSheet = true;
-                        logger.verbose(
-                            `Blurred sheet thumbnail (status public): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
-                        );
-                    }
-
-                    // Published sheets
-                    if (
-                        sheet.qMeta.approved === false &&
-                        sheet.qMeta.published === true &&
-                        options.blurSheetStatus &&
-                        options.blurSheetStatus.includes('published')
-                    ) {
-                        blurSheet = true;
-                        logger.verbose(
-                            `Blurred sheet thumbnail (status published): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
-                        );
-                    }
-
-                    // Should this sheet be blurred based on tags?
-                    // tagSheetAppMetadata is an array of sheet objects, each exposing engineObjectId.
-                    // It arrives empty unless the caller looked the tag up, which nothing does yet -
-                    // see issue #840. Until then the rule matches nothing rather than throwing.
-                    if (options.blurSheetTag && blurSheet === false) {
-                        blurSheet = tagSheetAppMetadata.some(
-                            (element) => element.engineObjectId === sheet.qInfo.qId
-                        );
-                        if (blurSheet) {
-                            logger.verbose(
-                                `Blurred sheet thumbnail (via tags): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
-                            );
-                        }
-                    }
-
-                    // Should this sheet be blurred based on its position/sheet number?
-                    if (options.blurSheetNumber && blurSheet === false) {
-                        // Does the sheet number match any of the numbers in options.blurSheetNumber array?
-                        // Take into account that iSheetNum is an integer, so we need to convert it to a string
-                        if (options.blurSheetNumber.includes(iSheetNum.toString())) {
-                            blurSheet = true;
-                            logger.verbose(
-                                `Blurred sheet thumbnail (via sheet number): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
-                            );
-                        }
-                    }
-
-                    // Should this sheet be blurred based on its title?
-                    if (options.blurSheetTitle && blurSheet === false) {
-                        // Does the sheet title match any of the titles options.blurSheetTitle array?
-                        if (options.blurSheetTitle.includes(sheet.qMeta.title)) {
-                            blurSheet = true;
-                            logger.verbose(
-                                `Blurred sheet thumbnail (via sheet title): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
-                            );
-                        }
-                    }
-
-                    // Get properties of current sheet
-                    const sheetObj = await app.getObject(sheet.qInfo.qId);
-                    const sheetProperties = await sheetObj.getProperties();
-
-                    if (blurSheet === true) {
+                        // No thumbnail for this sheet, skip
                         logger.info(
-                            `Using blurred thumbnail for sheet ${iSheetNum}: Name '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
+                            `Skipping update of sheet sheet ${iSheetNum}: Name '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
                         );
-
-                        // Set new sheet thumbnail
-                        sheetProperties.thumbnail.qStaticContentUrlDef.qUrl = `/content/${options.contentlibrary}/thumbnail-${appId}-${iSheetNum}-blurred.png`;
                     } else {
-                        logger.info(
-                            `Using regular thumbnail for sheet ${iSheetNum}: Name '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
-                        );
+                        // Should blurred sheet thumbnail be used?
+                        // Options are
+                        // --blur-sheet-tag <value>
+                        // --blur-sheet-number <number...>
+                        // --blur-sheet-title <title...>
+                        // --blur-sheet-status <status...>
 
-                        // Set new sheet thumbnail
-                        sheetProperties.thumbnail.qStaticContentUrlDef.qUrl = `/content/${options.contentlibrary}/thumbnail-${appId}-${iSheetNum}.png`;
+                        let blurSheet = false;
+
+                        // Should this sheet be blurred based on its published status?
+                        // Public sheets
+                        if (
+                            sheet.qMeta.approved === true &&
+                            sheet.qMeta.published === true &&
+                            options.blurSheetStatus &&
+                            options.blurSheetStatus.includes('public')
+                        ) {
+                            blurSheet = true;
+                            logger.verbose(
+                                `Blurred sheet thumbnail (status public): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
+                            );
+                        }
+
+                        // Published sheets
+                        if (
+                            sheet.qMeta.approved === false &&
+                            sheet.qMeta.published === true &&
+                            options.blurSheetStatus &&
+                            options.blurSheetStatus.includes('published')
+                        ) {
+                            blurSheet = true;
+                            logger.verbose(
+                                `Blurred sheet thumbnail (status published): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
+                            );
+                        }
+
+                        // Should this sheet be blurred based on tags?
+                        // tagSheetAppMetadata is an array of sheet objects, each exposing engineObjectId.
+                        // It arrives empty unless the caller looked the tag up, which nothing does yet -
+                        // see issue #840. Until then the rule matches nothing rather than throwing.
+                        if (options.blurSheetTag && blurSheet === false) {
+                            blurSheet = isSheetTagged(tagSheetAppMetadata, sheet);
+                            if (blurSheet) {
+                                logger.verbose(
+                                    `Blurred sheet thumbnail (via tags): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
+                                );
+                            }
+                        }
+
+                        // Should this sheet be blurred based on its position/sheet number?
+                        if (options.blurSheetNumber && blurSheet === false) {
+                            // Does the sheet number match any of the numbers in options.blurSheetNumber array?
+                            // Take into account that iSheetNum is an integer, so we need to convert it to a string
+                            if (options.blurSheetNumber.includes(iSheetNum.toString())) {
+                                blurSheet = true;
+                                logger.verbose(
+                                    `Blurred sheet thumbnail (via sheet number): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
+                                );
+                            }
+                        }
+
+                        // Should this sheet be blurred based on its title?
+                        if (options.blurSheetTitle && blurSheet === false) {
+                            // Does the sheet title match any of the titles options.blurSheetTitle array?
+                            if (options.blurSheetTitle.includes(sheet.qMeta.title)) {
+                                blurSheet = true;
+                                logger.verbose(
+                                    `Blurred sheet thumbnail (via sheet title): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
+                                );
+                            }
+                        }
+
+                        // Get properties of current sheet
+                        const sheetObj = await app.getObject(sheet.qInfo.qId);
+                        const sheetProperties = await sheetObj.getProperties();
+
+                        if (blurSheet === true) {
+                            logger.info(
+                                `Using blurred thumbnail for sheet ${iSheetNum}: Name '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
+                            );
+
+                            // Set new sheet thumbnail
+                            sheetProperties.thumbnail.qStaticContentUrlDef.qUrl = `/content/${options.contentlibrary}/thumbnail-${appId}-${iSheetNum}-blurred.png`;
+                        } else {
+                            logger.info(
+                                `Using regular thumbnail for sheet ${iSheetNum}: Name '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
+                            );
+
+                            // Set new sheet thumbnail
+                            sheetProperties.thumbnail.qStaticContentUrlDef.qUrl = `/content/${options.contentlibrary}/thumbnail-${appId}-${iSheetNum}.png`;
+                        }
+
+                        // Set & save new sheet thumbnail
+                        const res = await sheetObj.setProperties(sheetProperties);
+                        logger.debug(`Set thumbnail result: ${JSON.stringify(res, null, 2)}`);
+                        await app.doSave();
                     }
-
-                    // Set & save new sheet thumbnail
-                    const res = await sheetObj.setProperties(sheetProperties);
-                    logger.debug(`Set thumbnail result: ${JSON.stringify(res, null, 2)}`);
-                    await app.doSave();
+                } catch (err) {
+                    failedSheets += 1;
+                    logger.error(
+                        `QSEOW UPDATE SHEETS: Failed to update sheet ${iSheetNum} in app ${appId}: ${err?.message ?? err}`
+                    );
                 }
 
                 iSheetNum += 1;
@@ -210,4 +224,10 @@ export const qseowUpdateSheetThumbnails = async (
 
         throw new QseowError(`Failed to update sheet thumbnails in app ${appId}`, { cause: err });
     }
+
+    assertAllSheetsProcessed(failedSheets, totalSheets, {
+        appId,
+        action: 'update',
+        ErrorClass: QseowError,
+    });
 };

--- a/src/lib/qseow/qseow-updatesheets.js
+++ b/src/lib/qseow/qseow-updatesheets.js
@@ -21,7 +21,13 @@ import {
  * tag named by `--blur-sheet-tag`, each entry exposing `engineObjectId`. Defaults to empty so the
  * tag rule simply matches nothing when the caller has not looked it up.
  *
- * @returns {Promise<void>} Resolves when the sheet thumbnails have been updated in the QSEoW app.
+ * @returns {Promise<void>} Resolves when every sheet that had a generated thumbnail was
+ *     updated.
+ *
+ * @throws {QseowError} When any sheet could not be updated, or when thumbnails were created
+ *     but no sheet matched one. Other sheets are still attempted first and the engine
+ *     session is always released.
+ * @throws {Error} Whatever the engine threw, if the session itself was lost.
  */
 export const qseowUpdateSheetThumbnails = async (
     createdFiles,
@@ -92,6 +98,7 @@ export const qseowUpdateSheetThumbnails = async (
                     logPrefix: 'QSEOW UPDATE SHEETS',
                     appId,
                     action: 'update',
+                    requireAttempt: createdFiles.length > 0,
                     ErrorClass: QseowError,
                 },
                 async (sheet, iSheetNum) => {

--- a/src/lib/util/__tests__/sheet-list.test.js
+++ b/src/lib/util/__tests__/sheet-list.test.js
@@ -1,6 +1,29 @@
-import { describe, test, expect } from '@jest/globals';
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
 
-import { isSheetTagged, sortSheetsByRank } from '../sheet-list.js';
+jest.unstable_mockModule('../../../globals.js', () => ({
+    logger: {
+        info: jest.fn(),
+        error: jest.fn(),
+        verbose: jest.fn(),
+        debug: jest.fn(),
+        warn: jest.fn(),
+    },
+}));
+
+const { logger } = await import('../../../globals.js');
+const { isSheetTagged, runOverSheets, SHEET_SKIPPED, sortSheetsByRank } =
+    await import('../sheet-list.js');
+
+/**
+ * Joins everything logged at error level, for substring assertions.
+ *
+ * @returns {string} All error lines, newline separated.
+ */
+const errorLog = () => logger.error.mock.calls.map((call) => String(call[0])).join('\n');
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
 
 /**
  * Builds a sheet shaped like an entry in the engine's `qAppObjectList.qItems`.
@@ -126,5 +149,130 @@ describe('isSheetTagged', () => {
     test('treats a missing or empty tag list as no match', () => {
         expect(isSheetTagged(undefined, { qInfo: { qId: 'sheet-a' } })).toBe(false);
         expect(isSheetTagged([], { qInfo: { qId: 'sheet-a' } })).toBe(false);
+    });
+});
+
+describe('runOverSheets', () => {
+    const CTX = {
+        logPrefix: 'TEST PREFIX',
+        appId: 'app-1',
+        action: 'update',
+        ErrorClass: class TestError extends Error {},
+    };
+
+    /**
+     * Builds a sheet with the metadata the error line reads back.
+     *
+     * @param {string} id - Engine object id, also used as the title suffix.
+     *
+     * @returns {object} A sheet object.
+     */
+    const sheet = (id) => ({ qInfo: { qId: id }, qMeta: { title: `Sheet ${id}` } });
+
+    test('runs the worker once per sheet, with 1-based numbering', async () => {
+        const worker = jest.fn();
+
+        await runOverSheets([sheet('a'), sheet('b')], CTX, worker);
+
+        expect(worker.mock.calls.map((call) => call[1])).toEqual([1, 2]);
+    });
+
+    test('counts a sheet the worker acted on as attempted', async () => {
+        const result = await runOverSheets([sheet('a'), sheet('b')], CTX, jest.fn());
+
+        expect(result).toMatchObject({ attempted: 2, failed: 0, skipped: 0 });
+    });
+
+    test('does not count a skipped sheet as attempted', async () => {
+        // Reporting "1 of 5" for an app where four sheets were deliberately left alone
+        // reads as mostly-fine when nothing actually succeeded.
+        const worker = jest.fn(async (s, n) => (n === 1 ? undefined : SHEET_SKIPPED));
+
+        const result = await runOverSheets([sheet('a'), sheet('b'), sheet('c')], CTX, worker);
+
+        expect(result).toMatchObject({ attempted: 1, skipped: 2 });
+    });
+
+    test('treats a worker that returns nothing as having attempted the sheet', async () => {
+        // The safe default: forgetting to return must not silently mark everything skipped.
+        const result = await runOverSheets([sheet('a')], CTX, async () => {});
+
+        expect(result).toMatchObject({ attempted: 1, skipped: 0 });
+    });
+
+    describe('a failing sheet', () => {
+        const failOn = (n) =>
+            jest.fn(async (s, i) => {
+                if (i === n) throw new Error('sheet is read-only');
+            });
+
+        test('does not stop the sheets after it', async () => {
+            const worker = failOn(1);
+
+            await runOverSheets([sheet('a'), sheet('b'), sheet('c')], CTX, worker);
+
+            expect(worker).toHaveBeenCalledTimes(3);
+        });
+
+        test('is counted as both attempted and failed', async () => {
+            const result = await runOverSheets([sheet('a'), sheet('b')], CTX, failOn(1));
+
+            expect(result).toMatchObject({ attempted: 2, failed: 1 });
+        });
+
+        test('is identified in the log by title and engine id, not just position', async () => {
+            // Position is a rank-order number that appears nowhere in the Qlik Sense UI.
+            // Without the title and id an admin cannot find the sheet that failed.
+            await runOverSheets([sheet('abc-123')], CTX, failOn(1));
+
+            expect(errorLog()).toContain('TEST PREFIX');
+            expect(errorLog()).toContain('Sheet abc-123');
+            expect(errorLog()).toContain('abc-123');
+            expect(errorLog()).toContain('app-1');
+            expect(errorLog()).toContain('sheet is read-only');
+        });
+
+        test('survives a sheet with no metadata to name it', async () => {
+            await runOverSheets([{}], CTX, failOn(1));
+
+            expect(errorLog()).toContain('sheet is read-only');
+        });
+    });
+
+    describe('assertAllProcessed', () => {
+        test('passes when every attempted sheet succeeded', async () => {
+            const result = await runOverSheets([sheet('a')], CTX, jest.fn());
+
+            expect(() => result.assertAllProcessed()).not.toThrow();
+        });
+
+        test('passes when every sheet was skipped', async () => {
+            const result = await runOverSheets([sheet('a')], CTX, async () => SHEET_SKIPPED);
+
+            expect(() => result.assertAllProcessed()).not.toThrow();
+        });
+
+        test('counts against sheets attempted, not sheets present', async () => {
+            const worker = jest.fn(async (s, n) => {
+                if (n === 1) throw new Error('boom');
+                return SHEET_SKIPPED;
+            });
+            const result = await runOverSheets(
+                [sheet('a'), sheet('b'), sheet('c'), sheet('d')],
+                CTX,
+                worker
+            );
+
+            expect(() => result.assertAllProcessed()).toThrow('Failed to update 1 of 1 sheet(s)');
+        });
+
+        test('names the app and uses the caller-supplied error type', async () => {
+            const result = await runOverSheets([sheet('a')], CTX, async () => {
+                throw new Error('boom');
+            });
+
+            expect(() => result.assertAllProcessed()).toThrow(CTX.ErrorClass);
+            expect(() => result.assertAllProcessed()).toThrow('app-1');
+        });
     });
 });

--- a/src/lib/util/__tests__/sheet-list.test.js
+++ b/src/lib/util/__tests__/sheet-list.test.js
@@ -1,6 +1,6 @@
 import { describe, test, expect } from '@jest/globals';
 
-import { sortSheetsByRank } from '../sheet-list.js';
+import { isSheetTagged, sortSheetsByRank } from '../sheet-list.js';
 
 /**
  * Builds a sheet shaped like an entry in the engine's `qAppObjectList.qItems`.
@@ -92,5 +92,39 @@ describe('sortSheetsByRank', () => {
         // which is not transitive - the good sheets could come out in any order.
         const sheets = [sheet('c', 3), sheetWithoutQData('broken'), sheet('a', 1), sheet('b', 2)];
         expect(ids(sortSheetsByRank(sheets))).toEqual(['a', 'b', 'c', 'broken']);
+    });
+});
+
+describe('isSheetTagged', () => {
+    test('matches a sheet whose engine id is in the tagged list', () => {
+        const tagged = [{ engineObjectId: 'sheet-a' }, { engineObjectId: 'sheet-b' }];
+
+        expect(isSheetTagged(tagged, { qInfo: { qId: 'sheet-b' } })).toBe(true);
+    });
+
+    test('does not match a sheet absent from the tagged list', () => {
+        const tagged = [{ engineObjectId: 'sheet-a' }];
+
+        expect(isSheetTagged(tagged, { qInfo: { qId: 'sheet-z' } })).toBe(false);
+    });
+
+    test('does not throw for a sheet with no qInfo', () => {
+        // `element.engineObjectId === sheet.qInfo.qId` threw here.
+        expect(() => isSheetTagged([{ engineObjectId: 'sheet-a' }], { qMeta: {} })).not.toThrow();
+        expect(isSheetTagged([{ engineObjectId: 'sheet-a' }], { qMeta: {} })).toBe(false);
+    });
+
+    test('a sheet with no id does not match a tag entry that also has no id', () => {
+        // The documented trap: guarding only the right-hand side turns the crash into
+        // `undefined === undefined`, which is true - so every sheet missing its id would
+        // silently be treated as carrying the tag.
+        expect(isSheetTagged([{ engineObjectId: undefined }], { qInfo: {} })).toBe(false);
+        expect(isSheetTagged([{}], { qMeta: {} })).toBe(false);
+        expect(isSheetTagged([{ engineObjectId: null }], { qInfo: { qId: null } })).toBe(false);
+    });
+
+    test('treats a missing or empty tag list as no match', () => {
+        expect(isSheetTagged(undefined, { qInfo: { qId: 'sheet-a' } })).toBe(false);
+        expect(isSheetTagged([], { qInfo: { qId: 'sheet-a' } })).toBe(false);
     });
 });

--- a/src/lib/util/__tests__/sheet-list.test.js
+++ b/src/lib/util/__tests__/sheet-list.test.js
@@ -11,7 +11,7 @@ jest.unstable_mockModule('../../../globals.js', () => ({
 }));
 
 const { logger } = await import('../../../globals.js');
-const { isSheetTagged, runOverSheets, SHEET_SKIPPED, sortSheetsByRank } =
+const { isSessionLevelFailure, isSheetTagged, runOverSheets, SHEET_SKIPPED, sortSheetsByRank } =
     await import('../sheet-list.js');
 
 /**
@@ -274,5 +274,124 @@ describe('runOverSheets', () => {
             expect(() => result.assertAllProcessed()).toThrow(CTX.ErrorClass);
             expect(() => result.assertAllProcessed()).toThrow('app-1');
         });
+    });
+});
+
+describe('isSessionLevelFailure', () => {
+    test.each([
+        ['a dropped enigma socket', new Error('Socket closed')],
+        ['a closed CDP session', new Error('Protocol error: Session closed.')],
+        [
+            'a closed puppeteer target',
+            new Error('Protocol error (Browser.getVersion): Target closed'),
+        ],
+        ['a websocket error', new Error('WebSocket connection failed')],
+    ])('treats %s as session-level', (_label, err) => {
+        expect(isSessionLevelFailure(err)).toBe(true);
+    });
+
+    test.each([
+        [
+            'a refused connection',
+            Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' }),
+        ],
+        ['a reset connection', Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' })],
+    ])('delegates %s to getErrorCategory', (_label, err) => {
+        expect(isSessionLevelFailure(err)).toBe(true);
+    });
+
+    test.each([
+        ['a read-only sheet', new Error('sheet is read-only')],
+        ['a missing object', new Error('Object not found')],
+        ['a non-Error', 'just a string'],
+        ['nothing', undefined],
+    ])('treats %s as sheet-level', (_label, err) => {
+        expect(isSessionLevelFailure(err)).toBe(false);
+    });
+});
+
+describe('runOverSheets — a lost engine session', () => {
+    const CTX = {
+        logPrefix: 'TEST PREFIX',
+        appId: 'app-1',
+        action: 'update',
+        ErrorClass: class TestError extends Error {},
+    };
+    const sheet = (id) => ({ qInfo: { qId: id }, qMeta: { title: `Sheet ${id}` } });
+
+    test('abandons the remaining sheets instead of failing each one', async () => {
+        // A dropped websocket used to be caught 38 times and reported as 38 broken sheets.
+        const worker = jest.fn(async (s, n) => {
+            if (n >= 2) throw new Error('Socket closed');
+        });
+
+        const result = await runOverSheets(
+            [sheet('a'), sheet('b'), sheet('c'), sheet('d')],
+            CTX,
+            worker
+        );
+
+        expect(worker).toHaveBeenCalledTimes(2);
+        expect(result.failed).toBe(0);
+    });
+
+    test('rethrows the original cause, not a sheet count', async () => {
+        const boom = new Error('Socket closed');
+        const result = await runOverSheets([sheet('a')], CTX, async () => {
+            throw boom;
+        });
+
+        expect(() => result.assertAllProcessed()).toThrow(boom);
+    });
+
+    test('says the session was lost rather than blaming the sheet', async () => {
+        await runOverSheets([sheet('a')], CTX, async () => {
+            throw new Error('Socket closed');
+        });
+
+        expect(errorLog()).toContain('Lost the engine session');
+        expect(errorLog()).not.toContain("Failed to update sheet 1 ('Sheet a'");
+    });
+});
+
+describe('runOverSheets — requireAttempt', () => {
+    const base = {
+        logPrefix: 'TEST PREFIX',
+        appId: 'app-1',
+        action: 'update',
+        ErrorClass: class TestError extends Error {},
+    };
+    const sheet = (id) => ({ qInfo: { qId: id }, qMeta: { title: `Sheet ${id}` } });
+
+    test('fails when work was expected but every sheet was skipped', async () => {
+        // Thumbnails were generated but no sheet matched one - nothing was applied, and
+        // that used to report success.
+        const result = await runOverSheets(
+            [sheet('a'), sheet('b')],
+            { ...base, requireAttempt: true },
+            async () => SHEET_SKIPPED
+        );
+
+        expect(() => result.assertAllProcessed()).toThrow(/no icon was updated/i);
+    });
+
+    test('passes when every sheet was skipped and no work was expected', async () => {
+        const result = await runOverSheets(
+            [sheet('a')],
+            { ...base, requireAttempt: false },
+            async () => SHEET_SKIPPED
+        );
+
+        expect(() => result.assertAllProcessed()).not.toThrow();
+    });
+
+    test('does not fire when at least one sheet was attempted', async () => {
+        const result = await runOverSheets(
+            [sheet('a'), sheet('b')],
+            { ...base, requireAttempt: true },
+            async (s, n) => (n === 1 ? undefined : SHEET_SKIPPED)
+        );
+
+        expect(() => result.assertAllProcessed()).not.toThrow();
     });
 });

--- a/src/lib/util/sheet-list.js
+++ b/src/lib/util/sheet-list.js
@@ -4,6 +4,7 @@
  */
 
 import { logger } from '../../globals.js';
+import { getErrorCategory } from './error-categorizer.js';
 
 /**
  * Sorts a list of app sheets by their engine rank, in place.
@@ -89,6 +90,43 @@ export const isSheetTagged = (taggedSheets, sheet) => {
 export const SHEET_SKIPPED = Symbol('sheet skipped');
 
 /**
+ * Decides whether a failure belongs to one sheet or to the whole app.
+ *
+ * Per-sheet isolation is right for a sheet that cannot be written - read-only, deleted
+ * mid-run, owned by someone else. It is wrong for a dead engine session: every remaining
+ * sheet then fails for the same reason, and the run reports "38 of 40 sheets failed" when
+ * what actually happened is one dropped websocket.
+ *
+ * Net-level classification is delegated to `getErrorCategory`, which already knows about
+ * refused connections, timeouts and resets. The message checks cover enigma.js and the
+ * Chrome DevTools Protocol, whose session deaths carry no `code`.
+ *
+ * @param {Error|unknown} err - Error thrown by a per-sheet worker.
+ *
+ * @returns {boolean} `true` when the failure is session- or connection-level, so continuing
+ *     to the next sheet would only repeat it.
+ */
+export const isSessionLevelFailure = (err) => {
+    if (
+        ['timeout', 'connection_refused', 'host_not_found', 'connection_reset'].includes(
+            getErrorCategory(err)
+        )
+    ) {
+        return true;
+    }
+
+    const message = typeof err?.message === 'string' ? err.message.toLowerCase() : '';
+
+    return (
+        message.includes('socket closed') ||
+        message.includes('session closed') ||
+        message.includes('connection closed') ||
+        message.includes('target closed') ||
+        message.includes('websocket')
+    );
+};
+
+/**
  * Runs a per-sheet worker over an app's sheets, isolating each sheet from the others and
  * keeping count of the ones that failed.
  *
@@ -102,10 +140,16 @@ export const SHEET_SKIPPED = Symbol('sheet skipped');
  * were deliberately left alone and the fifth failed reads as mostly-fine when in fact
  * nothing succeeded.
  *
+ * A session-level failure stops the loop rather than being isolated, and is re-thrown by
+ * `assertAllProcessed()` unchanged - so the operator sees the dropped connection once,
+ * rather than the same message repeated per remaining sheet under a count that blames the
+ * sheets. The loop stops but does not throw immediately, so the caller still closes its
+ * engine session first.
+ *
  * The verdict is deliberately *not* thrown from here. Every caller has an engine session to
  * close first, so they call `assertAllProcessed()` on the result after closing. Returning a
- * bare count instead would put the same five-line assertion at every call site - which is
- * exactly the duplication this helper exists to remove.
+ * bare count instead would put the same assertion at every call site - which is exactly the
+ * duplication this helper exists to remove.
  *
  * @param {Array<object>} sheets - Sheets from `qAppObjectList.qItems`, already sorted.
  * @param {object} ctx - Logging and error context.
@@ -113,6 +157,10 @@ export const SHEET_SKIPPED = Symbol('sheet skipped');
  * @param {string} ctx.appId - App the sheets belong to.
  * @param {string} ctx.action - Verb for messages, e.g. `'update'` or `'remove icons for'`.
  * @param {new (message: string) => Error} ctx.ErrorClass - Platform error type to throw.
+ * @param {boolean} [ctx.requireAttempt] - When true, finishing without attempting a single
+ *     sheet is itself a failure. Callers set this when they know work was expected - the
+ *     update paths pass it when thumbnails were created, since every sheet skipping means
+ *     no icon was applied at all.
  * @param {(sheet: object, iSheetNum: number) => Promise<unknown>} processSheet - Worker
  *     invoked once per sheet, with the 1-based sheet number. Returns `SHEET_SKIPPED` to
  *     record that it did nothing for that sheet.
@@ -121,11 +169,12 @@ export const SHEET_SKIPPED = Symbol('sheet skipped');
  *     The counts, plus a check to call once the engine session has been released.
  */
 export const runOverSheets = async (sheets, ctx, processSheet) => {
-    const { logPrefix, appId, action, ErrorClass } = ctx;
+    const { logPrefix, appId, action, ErrorClass, requireAttempt = false } = ctx;
     let attempted = 0;
     let failed = 0;
     let skipped = 0;
     let iSheetNum = 1;
+    let sessionFailure;
 
     for (const sheet of sheets) {
         try {
@@ -139,6 +188,16 @@ export const runOverSheets = async (sheets, ctx, processSheet) => {
         } catch (err) {
             // A sheet that threw was attempted, whatever it was about to return.
             attempted += 1;
+
+            if (isSessionLevelFailure(err)) {
+                // Not this sheet's fault, and every sheet after it would fail identically.
+                sessionFailure = err;
+                logger.error(
+                    `${logPrefix}: Lost the engine session while processing app ${appId} at sheet ${iSheetNum}, abandoning the remaining sheets: ${err?.message ?? err}`
+                );
+                break;
+            }
+
             failed += 1;
             logger.error(
                 `${logPrefix}: Failed to ${action} sheet ${iSheetNum} ('${sheet?.qMeta?.title}', ID ${sheet?.qInfo?.qId}) in app ${appId}: ${err?.message ?? err}`
@@ -153,13 +212,22 @@ export const runOverSheets = async (sheets, ctx, processSheet) => {
         failed,
         skipped,
         assertAllProcessed: () => {
-            if (failed === 0) {
-                return;
+            // Surface the real cause, not a sheet count that would blame the sheets.
+            if (sessionFailure) {
+                throw sessionFailure;
             }
 
-            throw new ErrorClass(
-                `Failed to ${action} ${failed} of ${attempted} sheet(s) in app ${appId}`
-            );
+            if (failed > 0) {
+                throw new ErrorClass(
+                    `Failed to ${action} ${failed} of ${attempted} sheet(s) in app ${appId}`
+                );
+            }
+
+            if (requireAttempt && attempted === 0) {
+                throw new ErrorClass(
+                    `No sheet in app ${appId} could be matched to a generated thumbnail, so no icon was ${action}d. All ${skipped} sheet(s) were skipped.`
+                );
+            }
         },
     };
 };

--- a/src/lib/util/sheet-list.js
+++ b/src/lib/util/sheet-list.js
@@ -79,29 +79,14 @@ export const isSheetTagged = (taggedSheets, sheet) => {
 };
 
 /**
- * Fails the app when any of its sheets could not be processed.
+ * Sentinel a `runOverSheets` worker returns to say it did no work for this sheet.
  *
- * Exported for direct use only where a caller counts sheets itself; the usual route is
- * the `assertAllProcessed` handle returned by `runOverSheets`.
- *
- * @param {number} failed - How many sheets failed.
- * @param {number} total - How many sheets were attempted.
- * @param {object} ctx - Message context.
- * @param {string} ctx.appId - App the sheets belong to.
- * @param {string} ctx.action - Verb for the message, e.g. `'update'` or `'remove icons for'`.
- * @param {new (message: string) => Error} ctx.ErrorClass - Platform error type to throw.
- *
- * @returns {void}
- *
- * @throws {Error} An instance of `ErrorClass` when `failed` is non-zero.
+ * A symbol rather than a falsy value on purpose: a worker that forgets to return anything
+ * yields `undefined`, and treating that as "skipped" would silently report an app in which
+ * every sheet was updated as one in which nothing was attempted. The safe default is to
+ * count a sheet as attempted unless the worker says otherwise.
  */
-export const assertAllSheetsProcessed = (failed, total, { appId, action, ErrorClass }) => {
-    if (failed === 0) {
-        return;
-    }
-
-    throw new ErrorClass(`Failed to ${action} ${failed} of ${total} sheet(s) in app ${appId}`);
-};
+export const SHEET_SKIPPED = Symbol('sheet skipped');
 
 /**
  * Runs a per-sheet worker over an app's sheets, isolating each sheet from the others and
@@ -110,6 +95,12 @@ export const assertAllSheetsProcessed = (failed, total, { appId, action, ErrorCl
  * The counting is the point. Per-sheet isolation exists so one bad sheet does not abandon
  * the ones after it, but on its own it also swallows the outcome: an app in which every
  * sheet failed used to resolve normally and be counted a success.
+ *
+ * Counts are over sheets **attempted**, not sheets present. A worker that returns
+ * `SHEET_SKIPPED` - the thumbnail-update paths do this for sheets no screenshot was taken
+ * for - is not counted in either figure. Reporting "1 of 5" for an app where four sheets
+ * were deliberately left alone and the fifth failed reads as mostly-fine when in fact
+ * nothing succeeded.
  *
  * The verdict is deliberately *not* thrown from here. Every caller has an engine session to
  * close first, so they call `assertAllProcessed()` on the result after closing. Returning a
@@ -123,34 +114,52 @@ export const assertAllSheetsProcessed = (failed, total, { appId, action, ErrorCl
  * @param {string} ctx.action - Verb for messages, e.g. `'update'` or `'remove icons for'`.
  * @param {new (message: string) => Error} ctx.ErrorClass - Platform error type to throw.
  * @param {(sheet: object, iSheetNum: number) => Promise<unknown>} processSheet - Worker
- *     invoked once per sheet, with the 1-based sheet number.
+ *     invoked once per sheet, with the 1-based sheet number. Returns `SHEET_SKIPPED` to
+ *     record that it did nothing for that sheet.
  *
- * @returns {Promise<{failed: number, total: number, assertAllProcessed: () => void}>} The
- *     counts, plus a check to call once the engine session has been released.
+ * @returns {Promise<{attempted: number, failed: number, skipped: number, assertAllProcessed: () => void}>}
+ *     The counts, plus a check to call once the engine session has been released.
  */
 export const runOverSheets = async (sheets, ctx, processSheet) => {
-    const { logPrefix, appId, action } = ctx;
+    const { logPrefix, appId, action, ErrorClass } = ctx;
+    let attempted = 0;
     let failed = 0;
+    let skipped = 0;
     let iSheetNum = 1;
 
     for (const sheet of sheets) {
         try {
-            await processSheet(sheet, iSheetNum);
+            const outcome = await processSheet(sheet, iSheetNum);
+
+            if (outcome === SHEET_SKIPPED) {
+                skipped += 1;
+            } else {
+                attempted += 1;
+            }
         } catch (err) {
+            // A sheet that threw was attempted, whatever it was about to return.
+            attempted += 1;
             failed += 1;
             logger.error(
-                `${logPrefix}: Failed to ${action} sheet ${iSheetNum} in app ${appId}: ${err?.message ?? err}`
+                `${logPrefix}: Failed to ${action} sheet ${iSheetNum} ('${sheet?.qMeta?.title}', ID ${sheet?.qInfo?.qId}) in app ${appId}: ${err?.message ?? err}`
             );
         }
 
         iSheetNum += 1;
     }
 
-    const total = sheets.length;
-
     return {
+        attempted,
         failed,
-        total,
-        assertAllProcessed: () => assertAllSheetsProcessed(failed, total, ctx),
+        skipped,
+        assertAllProcessed: () => {
+            if (failed === 0) {
+                return;
+            }
+
+            throw new ErrorClass(
+                `Failed to ${action} ${failed} of ${attempted} sheet(s) in app ${appId}`
+            );
+        },
     };
 };

--- a/src/lib/util/sheet-list.js
+++ b/src/lib/util/sheet-list.js
@@ -3,6 +3,8 @@
  * session object, shared by the Qlik Sense Cloud and QSEoW code paths.
  */
 
+import { logger } from '../../globals.js';
+
 /**
  * Sorts a list of app sheets by their engine rank, in place.
  *
@@ -32,34 +34,23 @@
  *
  * @returns {Array<object>} The same array, sorted, so the call can be chained.
  */
-/**
- * Fails the app when any of its sheets could not be processed.
- *
- * Per-sheet isolation exists so one bad sheet does not abandon the ones after it. Without
- * this check that isolation also swallowed the outcome: an app in which every single sheet
- * failed resolved normally, the app loop counted it as a success, and the run exited 0.
- *
- * Call it after the sheet loop and after the engine session has been closed, so a failing
- * app still releases its session.
- *
- * @param {number} failed - How many sheets failed.
- * @param {number} total - How many sheets were attempted.
- * @param {object} ctx - Message context.
- * @param {string} ctx.appId - App the sheets belong to.
- * @param {string} ctx.action - Verb for the message, e.g. `'update'` or `'remove icons for'`.
- * @param {new (message: string) => Error} ctx.ErrorClass - Platform error type to throw.
- *
- * @returns {void}
- *
- * @throws {Error} An instance of `ErrorClass` when `failed` is non-zero.
- */
-export const assertAllSheetsProcessed = (failed, total, { appId, action, ErrorClass }) => {
-    if (failed === 0) {
-        return;
-    }
+export const sortSheetsByRank = (sheets) =>
+    sheets.sort((sheet1, sheet2) => {
+        const rank1 = sheet1?.qData?.rank;
+        const rank2 = sheet2?.qData?.rank;
+        const hasRank1 = rank1 !== undefined && rank1 !== null;
+        const hasRank2 = rank2 !== undefined && rank2 !== null;
 
-    throw new ErrorClass(`Failed to ${action} ${failed} of ${total} sheet(s) in app ${appId}`);
-};
+        // Sheets with no usable rank sort after every sheet that has one, keeping their
+        // own relative order.
+        if (!hasRank1 && !hasRank2) return 0;
+        if (!hasRank1) return 1;
+        if (!hasRank2) return -1;
+
+        if (rank1 < rank2) return -1;
+        if (rank1 > rank2) return 1;
+        return 0;
+    });
 
 /**
  * Reports whether a sheet appears in a list of sheets carrying some QRS tag.
@@ -87,20 +78,79 @@ export const isSheetTagged = (taggedSheets, sheet) => {
     return (taggedSheets ?? []).some((element) => element?.engineObjectId === engineObjectId);
 };
 
-export const sortSheetsByRank = (sheets) =>
-    sheets.sort((sheet1, sheet2) => {
-        const rank1 = sheet1?.qData?.rank;
-        const rank2 = sheet2?.qData?.rank;
-        const hasRank1 = rank1 !== undefined && rank1 !== null;
-        const hasRank2 = rank2 !== undefined && rank2 !== null;
+/**
+ * Fails the app when any of its sheets could not be processed.
+ *
+ * Exported for direct use only where a caller counts sheets itself; the usual route is
+ * the `assertAllProcessed` handle returned by `runOverSheets`.
+ *
+ * @param {number} failed - How many sheets failed.
+ * @param {number} total - How many sheets were attempted.
+ * @param {object} ctx - Message context.
+ * @param {string} ctx.appId - App the sheets belong to.
+ * @param {string} ctx.action - Verb for the message, e.g. `'update'` or `'remove icons for'`.
+ * @param {new (message: string) => Error} ctx.ErrorClass - Platform error type to throw.
+ *
+ * @returns {void}
+ *
+ * @throws {Error} An instance of `ErrorClass` when `failed` is non-zero.
+ */
+export const assertAllSheetsProcessed = (failed, total, { appId, action, ErrorClass }) => {
+    if (failed === 0) {
+        return;
+    }
 
-        // Sheets with no usable rank sort after every sheet that has one, keeping their
-        // own relative order.
-        if (!hasRank1 && !hasRank2) return 0;
-        if (!hasRank1) return 1;
-        if (!hasRank2) return -1;
+    throw new ErrorClass(`Failed to ${action} ${failed} of ${total} sheet(s) in app ${appId}`);
+};
 
-        if (rank1 < rank2) return -1;
-        if (rank1 > rank2) return 1;
-        return 0;
-    });
+/**
+ * Runs a per-sheet worker over an app's sheets, isolating each sheet from the others and
+ * keeping count of the ones that failed.
+ *
+ * The counting is the point. Per-sheet isolation exists so one bad sheet does not abandon
+ * the ones after it, but on its own it also swallows the outcome: an app in which every
+ * sheet failed used to resolve normally and be counted a success.
+ *
+ * The verdict is deliberately *not* thrown from here. Every caller has an engine session to
+ * close first, so they call `assertAllProcessed()` on the result after closing. Returning a
+ * bare count instead would put the same five-line assertion at every call site - which is
+ * exactly the duplication this helper exists to remove.
+ *
+ * @param {Array<object>} sheets - Sheets from `qAppObjectList.qItems`, already sorted.
+ * @param {object} ctx - Logging and error context.
+ * @param {string} ctx.logPrefix - Prefix for per-sheet failure lines, e.g. `'CLOUD UPDATE SHEETS'`.
+ * @param {string} ctx.appId - App the sheets belong to.
+ * @param {string} ctx.action - Verb for messages, e.g. `'update'` or `'remove icons for'`.
+ * @param {new (message: string) => Error} ctx.ErrorClass - Platform error type to throw.
+ * @param {(sheet: object, iSheetNum: number) => Promise<unknown>} processSheet - Worker
+ *     invoked once per sheet, with the 1-based sheet number.
+ *
+ * @returns {Promise<{failed: number, total: number, assertAllProcessed: () => void}>} The
+ *     counts, plus a check to call once the engine session has been released.
+ */
+export const runOverSheets = async (sheets, ctx, processSheet) => {
+    const { logPrefix, appId, action } = ctx;
+    let failed = 0;
+    let iSheetNum = 1;
+
+    for (const sheet of sheets) {
+        try {
+            await processSheet(sheet, iSheetNum);
+        } catch (err) {
+            failed += 1;
+            logger.error(
+                `${logPrefix}: Failed to ${action} sheet ${iSheetNum} in app ${appId}: ${err?.message ?? err}`
+            );
+        }
+
+        iSheetNum += 1;
+    }
+
+    const total = sheets.length;
+
+    return {
+        failed,
+        total,
+        assertAllProcessed: () => assertAllSheetsProcessed(failed, total, ctx),
+    };
+};

--- a/src/lib/util/sheet-list.js
+++ b/src/lib/util/sheet-list.js
@@ -32,6 +32,61 @@
  *
  * @returns {Array<object>} The same array, sorted, so the call can be chained.
  */
+/**
+ * Fails the app when any of its sheets could not be processed.
+ *
+ * Per-sheet isolation exists so one bad sheet does not abandon the ones after it. Without
+ * this check that isolation also swallowed the outcome: an app in which every single sheet
+ * failed resolved normally, the app loop counted it as a success, and the run exited 0.
+ *
+ * Call it after the sheet loop and after the engine session has been closed, so a failing
+ * app still releases its session.
+ *
+ * @param {number} failed - How many sheets failed.
+ * @param {number} total - How many sheets were attempted.
+ * @param {object} ctx - Message context.
+ * @param {string} ctx.appId - App the sheets belong to.
+ * @param {string} ctx.action - Verb for the message, e.g. `'update'` or `'remove icons for'`.
+ * @param {new (message: string) => Error} ctx.ErrorClass - Platform error type to throw.
+ *
+ * @returns {void}
+ *
+ * @throws {Error} An instance of `ErrorClass` when `failed` is non-zero.
+ */
+export const assertAllSheetsProcessed = (failed, total, { appId, action, ErrorClass }) => {
+    if (failed === 0) {
+        return;
+    }
+
+    throw new ErrorClass(`Failed to ${action} ${failed} of ${total} sheet(s) in app ${appId}`);
+};
+
+/**
+ * Reports whether a sheet appears in a list of sheets carrying some QRS tag.
+ *
+ * Both sides of the identity comparison are guarded, and that matters more than it looks.
+ * `element.engineObjectId === sheet.qInfo.qId` throws when a sheet arrives without
+ * `qInfo`; adding optional chaining to only the right-hand side replaces the crash with
+ * `undefined === undefined`, which is `true` - so every sheet missing its id would match
+ * the tag list and be silently excluded or blurred. A sheet with no id matches nothing.
+ *
+ * @param {Array<object>} taggedSheets - Sheets carrying the tag, each exposing
+ *     `engineObjectId`. May be undefined or empty, in which case nothing matches.
+ * @param {object} sheet - Sheet from `qAppObjectList.qItems`.
+ *
+ * @returns {boolean} `true` only when the sheet has an engine id and that id is present in
+ *     the tagged list.
+ */
+export const isSheetTagged = (taggedSheets, sheet) => {
+    const engineObjectId = sheet?.qInfo?.qId;
+
+    if (engineObjectId === undefined || engineObjectId === null) {
+        return false;
+    }
+
+    return (taggedSheets ?? []).some((element) => element?.engineObjectId === engineObjectId);
+};
+
 export const sortSheetsByRank = (sheets) =>
     sheets.sort((sheet1, sheet2) => {
         const rank1 = sheet1?.qData?.rank;


### PR DESCRIPTION
First chunk of #872 part 5b. Three related holes, all the same shape: **a sheet that could not be processed left no mark on the app's verdict.**

Deliberately stops short of the Cloud exclusion-filter rewrite, which is the largest remaining piece of 5b and carries the bulk of the unguarded metadata reads. That is easier to review on its own.

## 1. Both `remove-sheet-icons` twins counted nothing

Per-sheet isolation exists so one bad sheet does not abandon the ones after it — but the isolation also swallowed the outcome. An app in which **every single icon failed to clear** resolved normally, the app loop counted it a success, and the process exited 0. An operator watching exit codes saw a clean run while nothing had been removed.

Both now count failures and fail the app through a shared `assertAllSheetsProcessed()`.

## 2. Neither `updatesheets` module had per-sheet isolation at all

One read-only sheet discarded every update that came after it, and the outer catch then reported success anyway. Both now isolate per sheet, count, and fail the app.

The assertion sits **outside** the outer `try`, deliberately: inside it, the generic handler re-wraps the error and the counts are lost. A test pins the exact message.

## 3. Identity comparison threw on a sheet without `qInfo`

`element.engineObjectId === sheet.qInfo.qId` in `determine-sheet-exclude-status.js` and `qseow-updatesheets.js`. Both now use a shared `isSheetTagged()` that guards **both** sides.

That detail matters. As #872 warns, adding optional chaining to only the right-hand side replaces the crash with `undefined === undefined` — which is `true` — so every sheet missing its id would silently be treated as carrying the tag, and be excluded or blurred. A sheet with no id now matches nothing.

## Verification

- 649 unit tests (up from 641), 49 suites, lint and Prettier clean.
- End to end: a run against an unreachable tenant still exits 1; `browser list-installed` still exits 0.
- **Mutation-tested**: making `assertAllSheetsProcessed` never throw fails 8 tests; removing the per-sheet catch from `cloud-updatesheets` fails 4; dropping the id guard fails a test, as does the right-hand-side-only variant.

Worth flagging: the id-guard mutation **initially survived**. The guard was written before any test pinned it, and only the mutation run caught that. Tests for both variants of the trap were added before moving on.

## Note for reviewers

**Two existing tests are inverted here** — both named `logs a per-sheet failure instead of rejecting`, both asserting `resolves.toBe(true)` when a sheet failed. They encoded the behaviour this PR fixes. The isolation intent they were protecting is preserved and separately asserted; only the verdict flips.

## Still open in 5b

- Blur failure handling. Investigation for this PR found the plan's framing wrong in both halves: QSEoW does not "lose one image", it points the sheet at a `-blurred.png` that was never uploaded, giving a broken icon; Cloud's rethrow was the safer of the two. Agreed direction is to fail the sheet and leave its existing icon alone, on both platforms.
- Per-sheet isolation in `process-cloud-app.js` (0 try blocks in its sheet loop).
- The Cloud exclusion filter rewrite — `shouldProcessSheet` still has zero production callers, and `process-cloud-app.js` still has 35 unguarded `sheet.qMeta/qInfo/qData` reads.
- `saveIfChanged` — 4 bare `doSave()` sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
