### PR TITLE
fix: save each app once instead of once per sheet (#872 part 5b)

### DIFF
--- a/docs/to-doc-site/exit-code-now-reflects-failures.md
+++ b/docs/to-doc-site/exit-code-now-reflects-failures.md
@@ -82,3 +82,9 @@ Failed to update 1 of 2 sheet(s) in app 97089caf
 The count is of sheets Butler Sheet Icons **tried** to update. Sheets deliberately left alone — because you excluded them, or because no thumbnail was generated for them — are not counted in either figure. So "1 of 2" means two sheets were attempted and one of them failed, regardless of how many sheets the app has in total.
 
 The per-sheet line names the sheet by title and ID, which is what you need to find it in Qlik Sense. The number is the sheet's position in the app, counting from 1.
+
+## App versions
+
+Butler Sheet Icons saves each app **once** at the end of processing it, rather than once per sheet. An app with forty sheets used to gain forty versions in Qlik Sense on every run; it now gains one. An app where nothing needed changing gains none at all.
+
+The save happens only after every sheet has been dealt with, so if it fails — a published app, or one the account running Butler Sheet Icons cannot write — **nothing is changed at all** and the sheets keep the icons they had. Previously the sheets processed before the failure had already been written, leaving the app with a mix of old and new icons. Re-running after a failure is therefore now a clean retry rather than a resume.

--- a/src/lib/cloud/__tests__/cloud_remove_sheet_icons.test.js
+++ b/src/lib/cloud/__tests__/cloud_remove_sheet_icons.test.js
@@ -174,12 +174,47 @@ describe('qscloudRemoveSheetIcons', () => {
             });
         });
 
-        test('saves the app once per sheet', async () => {
+        test('saves the app once, not once per sheet', async () => {
+            // Saving inside the loop wrote the app N times for N sheets and produced N
+            // app versions.
             const { app } = wireEnigma([makeSheet('sheet-1', 1), makeSheet('sheet-2', 2)]);
 
             await qscloudRemoveSheetIcons({ ...BASE_OPTIONS });
 
-            expect(app.doSave).toHaveBeenCalledTimes(2);
+            expect(app.doSave).toHaveBeenCalledTimes(1);
+        });
+
+        test('does not save an app whose sheets were all left alone', async () => {
+            // An app with no sheets changed nothing, so it must not get a new version.
+            const { app } = wireEnigma([]);
+
+            await qscloudRemoveSheetIcons({ ...BASE_OPTIONS });
+
+            expect(app.doSave).not.toHaveBeenCalled();
+        });
+
+        test('releases the engine session even when the save fails', async () => {
+            // Without a finally around save-and-close the websocket leaked once per app
+            // whose save was refused - a published app, or one the account cannot write.
+            const { app, session } = wireEnigma([makeSheet('sheet-1', 1)]);
+            app.doSave.mockRejectedValue(new Error('app is published and cannot be saved'));
+
+            // The command reports failure rather than rejecting - runOverApps catches the
+            // per-app error. What matters here is that the session was still released.
+            await expect(qscloudRemoveSheetIcons({ ...BASE_OPTIONS })).resolves.toBe(false);
+
+            expect(session.close).toHaveBeenCalledTimes(1);
+        });
+
+        test('saves before closing the engine session', async () => {
+            const { app, session } = wireEnigma([makeSheet('sheet-1', 1)]);
+            const order = [];
+            app.doSave.mockImplementation(async () => order.push('save'));
+            session.close.mockImplementation(async () => order.push('close'));
+
+            await qscloudRemoveSheetIcons({ ...BASE_OPTIONS });
+
+            expect(order).toEqual(['save', 'close']);
         });
 
         test('processes sheets in rank order', async () => {
@@ -237,6 +272,50 @@ describe('qscloudRemoveSheetIcons', () => {
             await qscloudRemoveSheetIcons({ ...BASE_OPTIONS });
 
             expect(session.close).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('ordering of the media-library cleanup', () => {
+        test('deletes the image files only after the app has been saved', async () => {
+            // Deleting first meant a failed save left every sheet pointing at images that
+            // no longer existed - broken icons on every sheet rather than none.
+            const { app } = wireEnigma([makeSheet('sheet-1', 1)]);
+            Get.mockImplementation(async (path) => {
+                if (path.endsWith('/media/list'))
+                    return [{ type: 'directory', name: 'thumbnails' }];
+                if (path.endsWith('/media/list/thumbnails')) {
+                    return [{ type: 'image', name: 'thumbnail-1.png' }];
+                }
+                return [];
+            });
+
+            const order = [];
+            app.doSave.mockImplementation(async () => order.push('save'));
+            Delete.mockImplementation(async () => {
+                order.push('delete');
+                return { statusCode: 204 };
+            });
+
+            await qscloudRemoveSheetIcons({ ...BASE_OPTIONS });
+
+            expect(order).toEqual(['save', 'delete']);
+        });
+
+        test('does not delete the image files when the save failed', async () => {
+            const { app } = wireEnigma([makeSheet('sheet-1', 1)]);
+            Get.mockImplementation(async (path) => {
+                if (path.endsWith('/media/list'))
+                    return [{ type: 'directory', name: 'thumbnails' }];
+                if (path.endsWith('/media/list/thumbnails')) {
+                    return [{ type: 'image', name: 'thumbnail-1.png' }];
+                }
+                return [];
+            });
+            app.doSave.mockRejectedValue(new Error('app is published and cannot be saved'));
+
+            await expect(qscloudRemoveSheetIcons({ ...BASE_OPTIONS })).resolves.toBe(false);
+
+            expect(Delete).not.toHaveBeenCalled();
         });
     });
 

--- a/src/lib/cloud/__tests__/cloud_updatesheets.test.js
+++ b/src/lib/cloud/__tests__/cloud_updatesheets.test.js
@@ -471,3 +471,28 @@ describe('qscloudUpdateSheetThumbnails', () => {
         });
     });
 });
+
+describe('qscloudUpdateSheetThumbnails — saving the app', () => {
+    test('saves before closing the engine session', async () => {
+        const { app, session } = wireEnigma([makeSheet()]);
+        const order = [];
+        app.doSave.mockImplementation(async () => order.push('save'));
+        session.close.mockImplementation(async () => order.push('close'));
+
+        await qscloudUpdateSheetThumbnails(CREATED_FILES, APP_ID, BASE_OPTIONS);
+
+        expect(order).toEqual(['save', 'close']);
+    });
+
+    test('releases the engine session even when the save fails', async () => {
+        // Without a finally around save-and-close the websocket leaked once per failing app.
+        const { app, session } = wireEnigma([makeSheet()]);
+        app.doSave.mockRejectedValue(new Error('app is locked'));
+
+        await expect(
+            qscloudUpdateSheetThumbnails(CREATED_FILES, APP_ID, BASE_OPTIONS)
+        ).rejects.toThrow();
+
+        expect(session.close).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/lib/cloud/cloud-remove-sheet-icons.js
+++ b/src/lib/cloud/cloud-remove-sheet-icons.js
@@ -7,7 +7,7 @@ import QlikSaas from './cloud-repo.js';
 import { qscloudTestConnection } from './cloud-test-connection.js';
 import { runOverApps } from '../util/run-over-apps.js';
 import { CloudError } from '../util/errors.js';
-import { runOverSheets, sortSheetsByRank } from '../util/sheet-list.js';
+import { runOverSheets, sortSheetsByRank, saveIfChanged } from '../util/sheet-list.js';
 
 /**
  * Removes all sheet icons from a Qlik Sense Cloud app.
@@ -30,36 +30,6 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
     let sheetRun;
 
     try {
-        // Does the app have a thumbnail folder in its media library?
-        const mediaList = await saasInstance.Get(`apps/${appId}/media/list`);
-
-        if (
-            mediaList.find((item) => {
-                const thumbnailFolderExists =
-                    item.type === 'directory' && item.name === 'thumbnails';
-                return thumbnailFolderExists;
-            })
-        ) {
-            // "thumbnails" folder exists in app's media library
-            // Remove all existing thumbnail images from this app
-            const existingThumbnails = await saasInstance.Get(
-                `apps/${appId}/media/list/thumbnails`
-            );
-
-            for (const thumbnailImg of existingThumbnails) {
-                if (thumbnailImg.type === 'image') {
-                    const result = await saasInstance.Delete(
-                        `apps/${appId}/media/files/thumbnails/${thumbnailImg.name}`
-                    );
-                    logger.debug(
-                        `Deleted existing file ${JSON.stringify(
-                            thumbnailImg.name
-                        )}, result=${JSON.stringify(result)}`
-                    );
-                }
-            }
-        }
-
         // Configure Enigma.js
         const configEnigma = setupEnigmaConnection(appId, options);
         const session = await enigma.create(configEnigma);
@@ -133,18 +103,63 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
 
                     const res = await sheetObj.setProperties(sheetProperties);
                     logger.debug(`Set thumbnail result: ${JSON.stringify(res, null, 2)}`);
-                    await app.doSave();
                 }
             );
         }
 
-        // Closed outside the sheet-count guard: an app with no sheets still holds an open
-        // engine session that has to be released.
-        // enigma.js always resolves close() truthy; a real failure rejects into the catch below.
-        await session.close();
+        // The close sits in a finally: the save can reject - a published app, or one the
+        // service account may not write - and without this the engine websocket would be
+        // left open for the life of the process, once per failing app.
+        try {
+            await saveIfChanged(
+                app,
+                { logPrefix: 'CLOUD REMOVE SHEET ICONS', appId },
+                sheetRun?.changed ?? 0
+            );
+        } finally {
+            // Closed outside the sheet-count guard: an app with no sheets still holds an open
+            // engine session that has to be released.
+            // enigma.js always resolves close() truthy; a real failure rejects into the catch below.
+            await session.close();
+        }
         logger.verbose(
             `Closed session after updating sheet thumbnail images in QS Cloud app ${appId} on host ${options.host}`
         );
+
+        // Deleted only after the sheets have been repointed and the app saved. Doing it
+        // first meant a failed save left every sheet pointing at images that no longer
+        // existed - broken icons on every sheet, where the old behaviour of saving per
+        // sheet had at least persisted the ones processed before the failure. Clearing the
+        // reference and then removing the file is the order that degrades safely.
+        // Does the app have a thumbnail folder in its media library?
+        const mediaList = await saasInstance.Get(`apps/${appId}/media/list`);
+
+        if (
+            mediaList.find((item) => {
+                const thumbnailFolderExists =
+                    item.type === 'directory' && item.name === 'thumbnails';
+                return thumbnailFolderExists;
+            })
+        ) {
+            // "thumbnails" folder exists in app's media library
+            // Remove all existing thumbnail images from this app
+            const existingThumbnails = await saasInstance.Get(
+                `apps/${appId}/media/list/thumbnails`
+            );
+
+            for (const thumbnailImg of existingThumbnails) {
+                if (thumbnailImg.type === 'image') {
+                    const result = await saasInstance.Delete(
+                        `apps/${appId}/media/files/thumbnails/${thumbnailImg.name}`
+                    );
+                    logger.debug(
+                        `Deleted existing file ${JSON.stringify(
+                            thumbnailImg.name
+                        )}, result=${JSON.stringify(result)}`
+                    );
+                }
+            }
+        }
 
         logger.info(`Done processing app ${appId}`);
     } catch (err) {

--- a/src/lib/cloud/cloud-updatesheets.js
+++ b/src/lib/cloud/cloud-updatesheets.js
@@ -3,7 +3,12 @@ import enigma from 'enigma.js';
 import { setupEnigmaConnection } from './cloud-enigma.js';
 import { logger } from '../../globals.js';
 import { CloudError } from '../util/errors.js';
-import { runOverSheets, SHEET_SKIPPED, sortSheetsByRank } from '../util/sheet-list.js';
+import {
+    runOverSheets,
+    SHEET_SKIPPED,
+    sortSheetsByRank,
+    saveIfChanged,
+} from '../util/sheet-list.js';
 
 /**
  * Updates sheet thumbnails in a Qlik Sense Cloud app.
@@ -201,14 +206,24 @@ export const qscloudUpdateSheetThumbnails = async (createdFiles, appId, options)
                         // Set & save new sheet thumbnail
                         const res = await sheetObj.setProperties(sheetProperties);
                         logger.debug(`Set thumbnail result: ${JSON.stringify(res, null, 2)}`);
-                        await app.doSave();
                     }
                 }
             );
         }
 
-        // enigma.js always resolves close() truthy; a real failure rejects into the catch below.
-        await session.close();
+        // The close sits in a finally: the save can reject - a published app, or one the
+        // service account may not write - and without this the engine websocket would be
+        // left open for the life of the process, once per failing app.
+        try {
+            await saveIfChanged(
+                app,
+                { logPrefix: 'CLOUD UPDATE SHEETS', appId },
+                sheetRun?.changed ?? 0
+            );
+        } finally {
+            // enigma.js always resolves close() truthy; a real failure rejects into the catch below.
+            await session.close();
+        }
         logger.verbose(
             `Closed session after updating sheet thumbnail images in QS Cloud app ${appId} on host ${options.host}`
         );

--- a/src/lib/qseow/__tests__/qseow_remove_sheet_icons.test.js
+++ b/src/lib/qseow/__tests__/qseow_remove_sheet_icons.test.js
@@ -173,13 +173,47 @@ describe('qseowRemoveSheetIcons', () => {
             });
         });
 
-        test('saves the app once per sheet', async () => {
+        test('saves the app once, not once per sheet', async () => {
+            // Saving inside the loop wrote the app N times for N sheets and produced N
+            // app versions.
             const sheets = [makeSheet('sheet-1', 1), makeSheet('sheet-2', 2)];
             const { app } = wireEnigma(sheets);
 
             await qseowRemoveSheetIcons(BASE_OPTIONS);
 
-            expect(app.doSave).toHaveBeenCalledTimes(2);
+            expect(app.doSave).toHaveBeenCalledTimes(1);
+        });
+
+        test('does not save an app whose sheets were all left alone', async () => {
+            const { app } = wireEnigma([]);
+
+            await qseowRemoveSheetIcons(BASE_OPTIONS);
+
+            expect(app.doSave).not.toHaveBeenCalled();
+        });
+
+        test('releases the engine session even when the save fails', async () => {
+            // Without a finally around save-and-close the websocket leaked once per app
+            // whose save was refused - a published app, or one the account cannot write.
+            const { app, session } = wireEnigma([makeSheet('sheet-1', 1)]);
+            app.doSave.mockRejectedValue(new Error('app is published and cannot be saved'));
+
+            // The command reports failure rather than rejecting - runOverApps catches the
+            // per-app error. What matters here is that the session was still released.
+            await expect(qseowRemoveSheetIcons(BASE_OPTIONS)).resolves.toBe(false);
+
+            expect(session.close).toHaveBeenCalledTimes(1);
+        });
+
+        test('saves before closing the engine session', async () => {
+            const { app, session } = wireEnigma([makeSheet('sheet-1', 1)]);
+            const order = [];
+            app.doSave.mockImplementation(async () => order.push('save'));
+            session.close.mockImplementation(async () => order.push('close'));
+
+            await qseowRemoveSheetIcons(BASE_OPTIONS);
+
+            expect(order).toEqual(['save', 'close']);
         });
 
         test('processes sheets in rank order', async () => {

--- a/src/lib/qseow/__tests__/qseow_updatesheets.test.js
+++ b/src/lib/qseow/__tests__/qseow_updatesheets.test.js
@@ -366,3 +366,104 @@ describe('qseowUpdateSheetThumbnails — a sheet that cannot be updated', () => 
         ).rejects.toThrow(QseowError);
     });
 });
+
+describe('qseowUpdateSheetThumbnails — saving the app', () => {
+    /**
+     * Wires the enigma chain over one updatable sheet, exposing the app and session so
+     * tests can assert on doSave and close.
+     *
+     * @returns {{app: object, session: object, sheetObj: object}} The mock handles.
+     */
+    function wire() {
+        const sheetObj = {
+            getProperties: jest
+                .fn()
+                .mockResolvedValue({ thumbnail: { qStaticContentUrlDef: { qUrl: '' } } }),
+            setProperties: jest.fn().mockResolvedValue({ ok: true }),
+        };
+
+        const app = {
+            createSessionObject: jest.fn().mockResolvedValue({
+                getLayout: jest.fn().mockResolvedValue({
+                    qAppObjectList: {
+                        qItems: [
+                            {
+                                qInfo: { qId: 'engine-sheet-1' },
+                                qMeta: { title: 'Sheet 1', description: 'first' },
+                                qData: { rank: 1 },
+                            },
+                        ],
+                    },
+                }),
+            }),
+            getObject: jest.fn().mockResolvedValue(sheetObj),
+            doSave: jest.fn().mockResolvedValue(true),
+        };
+
+        const session = {
+            open: jest.fn().mockResolvedValue({
+                engineVersion: jest.fn().mockResolvedValue({ qComponentVersion: '12.0.0' }),
+                openDoc: jest.fn().mockResolvedValue(app),
+            }),
+            close: jest.fn().mockResolvedValue(true),
+            on: jest.fn(),
+        };
+        enigma.create.mockResolvedValue(session);
+
+        return { app, session, sheetObj };
+    }
+
+    test('saves the app once, not once per sheet', async () => {
+        const { app, sheetObj } = wire();
+
+        await qseowUpdateSheetThumbnails(CREATED_FILES, 'test-app-id', { ...BASE_OPTIONS });
+
+        expect(sheetObj.setProperties).toHaveBeenCalledTimes(1);
+        expect(app.doSave).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not save when there was no thumbnail to apply', async () => {
+        const { app } = wire();
+
+        await qseowUpdateSheetThumbnails([], 'test-app-id', { ...BASE_OPTIONS });
+
+        expect(app.doSave).not.toHaveBeenCalled();
+    });
+
+    test('does not save when thumbnails were made but no sheet matched one', async () => {
+        // requireAttempt makes this a failure - work was expected and none happened - but
+        // the app must not be written either way.
+        const { app } = wire();
+
+        await expect(
+            qseowUpdateSheetThumbnails([{ sheetPos: 99 }], 'test-app-id', { ...BASE_OPTIONS })
+        ).rejects.toThrow(/No sheet in app .* could be matched to a generated thumbnail/);
+
+        expect(app.doSave).not.toHaveBeenCalled();
+    });
+
+    test('saves before closing the engine session', async () => {
+        // Saving after the close would persist nothing, and no test caught that here.
+        const { app, session } = wire();
+        const order = [];
+        app.doSave.mockImplementation(async () => order.push('save'));
+        session.close.mockImplementation(async () => order.push('close'));
+
+        await qseowUpdateSheetThumbnails(CREATED_FILES, 'test-app-id', { ...BASE_OPTIONS });
+
+        expect(order).toEqual(['save', 'close']);
+    });
+
+    test('releases the engine session even when the save fails', async () => {
+        // The save sits above the close; without a finally the websocket leaked once per
+        // failing app, against a QSEoW session ceiling.
+        const { app, session } = wire();
+        app.doSave.mockRejectedValue(new Error('app is published and cannot be saved'));
+
+        await expect(
+            qseowUpdateSheetThumbnails(CREATED_FILES, 'test-app-id', { ...BASE_OPTIONS })
+        ).rejects.toThrow();
+
+        expect(session.close).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/lib/qseow/qseow-remove-sheet-icons.js
+++ b/src/lib/qseow/qseow-remove-sheet-icons.js
@@ -7,7 +7,7 @@ import { redactOptions } from '../util/redact-secrets.js';
 import { qseowVerifyCertificatesExist } from './qseow-certificates.js';
 import { setupQseowQrsConnection } from './qseow-qrs.js';
 import { QseowError } from '../util/errors.js';
-import { runOverSheets, sortSheetsByRank } from '../util/sheet-list.js';
+import { runOverSheets, sortSheetsByRank, saveIfChanged } from '../util/sheet-list.js';
 import { runOverApps } from '../util/run-over-apps.js';
 
 /**
@@ -105,15 +105,25 @@ const removeSheetIconsQSEoWApp = async (appId, g, options) => {
 
                     const res = await sheetObj.setProperties(sheetProperties);
                     logger.debug(`Set thumbnail result: ${JSON.stringify(res, null, 2)}`);
-                    await app.doSave();
                 }
             );
         }
 
-        // Closed outside the sheet-count guard: an app with no sheets still holds an open
-        // engine session that has to be released.
-        // enigma.js always resolves close() truthy; a real failure rejects into the catch below.
-        await session.close();
+        // The close sits in a finally: the save can reject - a published app, or one the
+        // service account may not write - and without this the engine websocket would be
+        // left open for the life of the process, once per failing app.
+        try {
+            // Closed outside the sheet-count guard: an app with no sheets still holds an open
+            // engine session that has to be released.
+            await saveIfChanged(
+                app,
+                { logPrefix: 'QSEOW REMOVE SHEET ICONS', appId },
+                sheetRun?.changed ?? 0
+            );
+        } finally {
+            // enigma.js always resolves close() truthy; a real failure rejects into the catch below.
+            await session.close();
+        }
         logger.verbose(
             `Closed session after generating sheet thumbnail images for all sheets in QSEoW app ${appId} on host ${options.host}`
         );

--- a/src/lib/qseow/qseow-updatesheets.js
+++ b/src/lib/qseow/qseow-updatesheets.js
@@ -8,6 +8,7 @@ import {
     runOverSheets,
     SHEET_SKIPPED,
     sortSheetsByRank,
+    saveIfChanged,
 } from '../util/sheet-list.js';
 
 /**
@@ -211,14 +212,24 @@ export const qseowUpdateSheetThumbnails = async (
                         // Set & save new sheet thumbnail
                         const res = await sheetObj.setProperties(sheetProperties);
                         logger.debug(`Set thumbnail result: ${JSON.stringify(res, null, 2)}`);
-                        await app.doSave();
                     }
                 }
             );
         }
 
-        // enigma.js always resolves close() truthy; a real failure rejects into the catch below.
-        await session.close();
+        // The close sits in a finally: the save can reject - a published app, or one the
+        // service account may not write - and without this the engine websocket would be
+        // left open for the life of the process, once per failing app.
+        try {
+            await saveIfChanged(
+                app,
+                { logPrefix: 'QSEOW UPDATE SHEETS', appId },
+                sheetRun?.changed ?? 0
+            );
+        } finally {
+            // enigma.js always resolves close() truthy; a real failure rejects into the catch below.
+            await session.close();
+        }
         logger.verbose(
             `Closed session after updating sheet thumbnail images in QSEoW app ${appId} on host ${options.host}`
         );

--- a/src/lib/util/__tests__/sheet-list.test.js
+++ b/src/lib/util/__tests__/sheet-list.test.js
@@ -11,8 +11,14 @@ jest.unstable_mockModule('../../../globals.js', () => ({
 }));
 
 const { logger } = await import('../../../globals.js');
-const { isSessionLevelFailure, isSheetTagged, runOverSheets, SHEET_SKIPPED, sortSheetsByRank } =
-    await import('../sheet-list.js');
+const {
+    isSessionLevelFailure,
+    isSheetTagged,
+    runOverSheets,
+    saveIfChanged,
+    SHEET_SKIPPED,
+    sortSheetsByRank,
+} = await import('../sheet-list.js');
 
 /**
  * Joins everything logged at error level, for substring assertions.
@@ -393,5 +399,80 @@ describe('runOverSheets — requireAttempt', () => {
         );
 
         expect(() => result.assertAllProcessed()).not.toThrow();
+    });
+});
+
+describe('saveIfChanged', () => {
+    const CTX = { logPrefix: 'TEST PREFIX', appId: 'app-1' };
+
+    test('saves when at least one sheet was changed', async () => {
+        const app = { doSave: jest.fn().mockResolvedValue(true) };
+
+        await expect(saveIfChanged(app, CTX, 3)).resolves.toBe(true);
+        expect(app.doSave).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not save when nothing was changed', async () => {
+        // A run that changed nothing must not produce a new app version.
+        const app = { doSave: jest.fn().mockResolvedValue(true) };
+
+        await expect(saveIfChanged(app, CTX, 0)).resolves.toBe(false);
+        expect(app.doSave).not.toHaveBeenCalled();
+    });
+
+    test('saves once regardless of how many sheets changed', async () => {
+        const app = { doSave: jest.fn().mockResolvedValue(true) };
+
+        await saveIfChanged(app, CTX, 40);
+
+        expect(app.doSave).toHaveBeenCalledTimes(1);
+    });
+
+    test.each([
+        ['undefined', undefined],
+        ['null', null],
+        ['NaN', NaN],
+        ['a negative count', -1],
+    ])('does not save for %s', async (_label, count) => {
+        // `changedCount === 0` let every one of these through to doSave. Unreachable from
+        // the four current callers, but free to rule out.
+        const app = { doSave: jest.fn().mockResolvedValue(true) };
+
+        await expect(saveIfChanged(app, CTX, count)).resolves.toBe(false);
+        expect(app.doSave).not.toHaveBeenCalled();
+    });
+
+    test('lets a failed save reach the caller', async () => {
+        const app = { doSave: jest.fn().mockRejectedValue(new Error('app is locked')) };
+
+        await expect(saveIfChanged(app, CTX, 1)).rejects.toThrow('app is locked');
+    });
+});
+
+describe('runOverSheets — changed count', () => {
+    const CTX = {
+        logPrefix: 'TEST PREFIX',
+        appId: 'app-1',
+        action: 'update',
+        ErrorClass: class TestError extends Error {},
+    };
+    const sheet = (id) => ({ qInfo: { qId: id }, qMeta: { title: `Sheet ${id}` } });
+
+    test('counts sheets whose properties were actually written', async () => {
+        const worker = jest.fn(async (s, n) => {
+            if (n === 1) throw new Error('read-only');
+            if (n === 2) return SHEET_SKIPPED;
+            return undefined;
+        });
+
+        const result = await runOverSheets([sheet('a'), sheet('b'), sheet('c')], CTX, worker);
+
+        expect(result).toMatchObject({ attempted: 2, failed: 1, skipped: 1, changed: 1 });
+    });
+
+    test('reports nothing changed when every sheet was skipped', async () => {
+        const result = await runOverSheets([sheet('a')], CTX, async () => SHEET_SKIPPED);
+
+        expect(result.changed).toBe(0);
     });
 });

--- a/src/lib/util/sheet-list.js
+++ b/src/lib/util/sheet-list.js
@@ -99,7 +99,9 @@ export const SHEET_SKIPPED = Symbol('sheet skipped');
  *
  * Net-level classification is delegated to `getErrorCategory`, which already knows about
  * refused connections, timeouts and resets. The message checks cover enigma.js and the
- * Chrome DevTools Protocol, whose session deaths carry no `code`.
+ * Chrome DevTools Protocol, whose session deaths carry no `code`. They are deliberately
+ * whole phrases: matching a bare `websocket` also caught per-sheet engine errors that merely
+ * mention the transport, aborting the loop on a session that was still alive.
  *
  * @param {Error|unknown} err - Error thrown by a per-sheet worker.
  *
@@ -122,7 +124,8 @@ export const isSessionLevelFailure = (err) => {
         message.includes('session closed') ||
         message.includes('connection closed') ||
         message.includes('target closed') ||
-        message.includes('websocket')
+        message.includes('websocket connection') ||
+        message.includes('websocket is not open')
     );
 };
 
@@ -165,12 +168,15 @@ export const isSessionLevelFailure = (err) => {
  *     invoked once per sheet, with the 1-based sheet number. Returns `SHEET_SKIPPED` to
  *     record that it did nothing for that sheet.
  *
- * @returns {Promise<{attempted: number, failed: number, skipped: number, assertAllProcessed: () => void}>}
- *     The counts, plus a check to call once the engine session has been released.
+ * @returns {Promise<{attempted: number, failed: number, skipped: number, changed: number, assertAllProcessed: () => void}>}
+ *     The counts - `changed` being only the sheets the worker completed, so neither a failed
+ *     sheet nor the one that killed the session is included - plus a check to call once the
+ *     engine session has been released.
  */
 export const runOverSheets = async (sheets, ctx, processSheet) => {
     const { logPrefix, appId, action, ErrorClass, requireAttempt = false } = ctx;
     let attempted = 0;
+    let changed = 0;
     let failed = 0;
     let skipped = 0;
     let iSheetNum = 1;
@@ -184,6 +190,7 @@ export const runOverSheets = async (sheets, ctx, processSheet) => {
                 skipped += 1;
             } else {
                 attempted += 1;
+                changed += 1;
             }
         } catch (err) {
             // A sheet that threw was attempted, whatever it was about to return.
@@ -211,6 +218,7 @@ export const runOverSheets = async (sheets, ctx, processSheet) => {
         attempted,
         failed,
         skipped,
+        changed,
         assertAllProcessed: () => {
             // Surface the real cause, not a sheet count that would blame the sheets.
             if (sessionFailure) {
@@ -230,4 +238,44 @@ export const runOverSheets = async (sheets, ctx, processSheet) => {
             }
         },
     };
+};
+
+/**
+ * Persists an app, but only when a sheet was actually changed.
+ *
+ * `app.doSave()` used to be called once per sheet, from inside the loop. That wrote the app
+ * N times for N sheets, and wrote it even when every sheet had been skipped - a run that
+ * changed nothing still produced a new app version.
+ *
+ * The count is passed in rather than tracked here, so there is no way to end up with an
+ * unbound placeholder in the message. An earlier attempt at this shipped a literal `{n}` to
+ * operators in two of its four copies.
+ *
+ * Trade-off worth knowing: saving once at the end means a session lost mid-loop persists
+ * nothing, where per-sheet saving left the sheets processed so far already written. That is
+ * deliberate - it matches how a failed app is reported everywhere else here, all-or-nothing
+ * with the old icons intact, rather than a mix of old and new nobody asked for.
+ *
+ * @param {object} app - Open engine app handle.
+ * @param {object} ctx - Logging context.
+ * @param {string} ctx.logPrefix - Prefix for the log line, e.g. `'CLOUD UPDATE SHEETS'`.
+ * @param {string} ctx.appId - App being saved.
+ * @param {number} changedCount - How many sheets had their properties written. Anything that
+ *     is not a positive number suppresses the save, so an accidental `undefined` cannot
+ *     write an app nothing touched.
+ *
+ * @returns {Promise<boolean>} `true` if the app was saved, `false` if there was nothing to save.
+ */
+export const saveIfChanged = async (app, { logPrefix, appId }, changedCount) => {
+    if (!(changedCount > 0)) {
+        logger.verbose(
+            `${logPrefix}: No sheet in app ${appId} was changed, so the app was not saved`
+        );
+        return false;
+    }
+
+    await app.doSave();
+    logger.verbose(`${logPrefix}: Saved app ${appId} after changing ${changedCount} sheet(s)`);
+
+    return true;
 };


### PR DESCRIPTION
Last item of #872 part 5b. Independent of #884 — the four files it touches are disjoint from that PR's.

`app.doSave()` was called from inside the sheet loop in all four modules, so an app with forty sheets was written forty times and gained forty versions. It was also written when nothing had changed: a run where every sheet was skipped still produced a new version.

A single `saveIfChanged(app, ctx, changedCount)` now runs after the loop and before the session closes, and does nothing when the count is zero. `runOverSheets` already knew the count — `changed` is the sheets whose properties were actually written, so failed and skipped sheets are excluded and no caller has to track it. Passing the count in rather than tracking it inside also means there is no placeholder to leave unbound; an earlier attempt at this shipped a literal `{n}` to operators in two of its four copies.

## The one thing worth arguing about

Saving once at the end means **a session lost mid-loop persists nothing**, where per-sheet saving left the sheets processed so far already written.

That is deliberate: it matches how a failed app is reported everywhere else in this series — all-or-nothing, with the old icons intact — rather than a mix of old and new nobody asked for. But it is a real behaviour change with a real downside, and it is the part of this PR I would most want a second opinion on. If you would rather keep partial progress durable, the alternative is to save per sheet but skip the save when that sheet was skipped, which fixes the no-change case without changing the failure semantics.

## Verification

- 693 unit tests, 49 suites, lint and Prettier clean. Exit codes still 1 on failure, 0 on success.
- **Mutation-tested**: removing the no-change guard fails 3 tests, counting failed sheets as changed fails 1, moving the save after the session close fails 1.
- Integration tests have **not** been run against this branch.

## Note for reviewers

Two tests named `saves the app once per sheet` pinned the old behaviour and are inverted here, alongside new tests for the no-change case and for save happening before the session closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)