### PR TITLE
fix: escape and encode QRS filter values (#872 part 3)

### DIFF
--- a/docs/to-doc-site/qrs-tag-names-with-special-characters.md
+++ b/docs/to-doc-site/qrs-tag-names-with-special-characters.md
@@ -1,0 +1,93 @@
+# Tags and content library names with special characters now work
+
+Butler Sheet Icons looks up apps, sheets and content libraries by asking the Qlik Sense
+Repository Service (QRS) for things matching a name you supply. Until now, a name containing
+certain punctuation was passed to Qlik Sense unprotected, and the lookup either failed outright
+or quietly matched nothing.
+
+This affects `butler-sheet-icons qseow create-sheet-thumbnails` and these options:
+
+| Option                | Environment variable              |
+| --------------------- | --------------------------------- |
+| `--qliksensetag`      | `BSI_QSEOW_CST_QLIKSENSE_TAG`     |
+| `--exclude-sheet-tag` | `BSI_QSEOW_CST_EXCLUDE_SHEET_TAG` |
+| `--contentlibrary`    | `BSI_QSEOW_CST_CONTENT_LIBRARY`   |
+
+## What went wrong before
+
+**An ampersand stopped the command.** A tag named `R&D` produced this, and no apps were
+processed at all:
+
+```
+Received error code: 400::Missing parameter value(s)
+```
+
+The ampersand has a special meaning in the address used to talk to Qlik Sense, so everything
+after it was discarded and Qlik Sense received an incomplete request.
+
+**An apostrophe stopped the command.** A tag named `Q1'25` produced:
+
+```
+400::Cannot parse the expression
+```
+
+Names are wrapped in quotes when sent to Qlik Sense, so an apostrophe inside the name ended
+the name early and left Qlik Sense reading the remainder as gibberish.
+
+**Other punctuation failed in its own way.** Each of these was tested against a real Qlik Sense
+server. If you saw one of these messages and could not work out why, an awkward character in a
+tag or content library name is a likely cause:
+
+| Character in the name | What you would have seen                                       |
+| --------------------- | -------------------------------------------------------------- |
+| `&`                   | `400::Missing parameter value(s)`                              |
+| `'`                   | `400::Cannot parse the expression:` followed by the query      |
+| `#`                   | `403::XSRF prevention check failed. Possible XSRF discovered.` |
+| `?` or `/`            | `Request path contains unescaped characters`                   |
+| `%`                   | `URI malformed`                                                |
+
+Names containing `+`, `=` or `,` did **not** produce an error and were unaffected.
+
+**Several exclude tags matched nothing.** This is the one that failed silently, and it is the
+most likely to have gone unnoticed:
+
+```
+--exclude-sheet-tag "Finance" "HR"
+```
+
+Butler Sheet Icons joined the two tags into the single name `Finance,HR` and asked Qlik Sense
+for sheets carrying a tag with that exact name. No such tag exists, so nothing matched, no
+sheet was excluded, and **every sheet had its icon updated** — including the ones you had
+tagged to keep out. There was no error and no warning; the run looked completely normal.
+
+Supplying a single `--exclude-sheet-tag` never hit _this_ problem — it only appeared once two
+or more tags were given. A single tag containing an ampersand or apostrophe was still affected
+by the two problems above.
+
+## What happens now
+
+Names are protected before being sent to Qlik Sense, so punctuation is treated as part of the
+name rather than as instructions. You can use tags and content library names such as `R&D`,
+`Q1'25`, `Finance/HR` or `Sprint #4` without quoting them any differently on the command line
+than you would any other name containing spaces.
+
+Supplying several `--exclude-sheet-tag` values now excludes sheets carrying **any** of them,
+which is what the option always described.
+
+## What you should check
+
+**If you use two or more `--exclude-sheet-tag` values, review the affected apps.** Sheets you
+intended to exclude have been receiving new icons on every run. After upgrading they will be
+excluded correctly, but icons already replaced are not restored automatically — Butler Sheet
+Icons has no record of what they were before. Use
+`butler-sheet-icons qseow create-sheet-thumbnails` again once the exclusions are working, or
+set the affected sheet icons back by hand.
+
+**If you renamed a tag or content library to work around this, you can rename it back.** A
+common workaround was to strip the punctuation — `R&D` to `RandD`, for example. That is no
+longer necessary. Remember to update the matching `--qliksensetag`, `--exclude-sheet-tag` or
+`--contentlibrary` value, or the environment variable holding it, at the same time.
+
+**No change is needed if your names are plain.** Tags and content libraries made up of
+letters, digits, spaces, hyphens and underscores behaved correctly before and behave
+identically now.

--- a/src/lib/qseow/__tests__/qrs_filter.test.js
+++ b/src/lib/qseow/__tests__/qrs_filter.test.js
@@ -1,0 +1,167 @@
+import { describe, test, expect } from '@jest/globals';
+
+import { qrsFilterValue, qrsFilterAnyOf, qrsPathWithFilter } from '../qrs-filter.js';
+
+/**
+ * Replicates the query-string handling inside `qrs-interact`'s `getFullPath`, so the tests can
+ * assert what QRS actually receives rather than what we handed the library.
+ *
+ * The library only encodes when the string looks un-encoded, and it uses `encodeURI`, which
+ * leaves `&` alone. Both details are why `qrsPathWithFilter` has to pre-encode.
+ *
+ * @param {string} path - Path as handed to `qrsInteract.Get`.
+ *
+ * @returns {string} The path after the library's own encoding step.
+ */
+const throughQrsInteract = (path) => {
+    const indexOfSlash = path.lastIndexOf('/');
+    const indexOfQuery = path.lastIndexOf('?');
+    if (indexOfQuery <= indexOfSlash) {
+        return path;
+    }
+
+    const queryString = path.substr(indexOfQuery + 1);
+    const encoded = queryString === decodeURI(queryString) ? encodeURI(queryString) : queryString;
+
+    return `${path.substring(0, indexOfQuery + 1)}${encoded}`;
+};
+
+/**
+ * Extracts what QRS parses: the `filter` parameter, after the URL layer has decoded it.
+ *
+ * @param {string} path - Path as it goes over the wire.
+ *
+ * @returns {string} The decoded filter expression.
+ */
+const filterAsQrsSeesIt = (path) => {
+    const query = path.substring(path.lastIndexOf('?') + 1);
+    const params = new URLSearchParams(query);
+
+    return params.get('filter');
+};
+
+describe('qrsFilterValue', () => {
+    test('leaves an ordinary value untouched', () => {
+        expect(qrsFilterValue('Finance')).toBe('Finance');
+    });
+
+    test('backslash-escapes a single quote', () => {
+        // Verified against a live QRS: `\'` parses, while the OData `''` and a double-quoted
+        // value are both rejected with 400::Cannot parse the expression.
+        expect(qrsFilterValue("Q1'25")).toBe("Q1\\'25");
+    });
+
+    test('escapes a backslash before escaping quotes', () => {
+        // Naive quote-only escaping would turn `a\` + `'b` into `a\\'b`, where the backslash
+        // added for the quote is itself swallowed by the pre-existing one.
+        expect(qrsFilterValue("a\\'b")).toBe("a\\\\\\'b");
+    });
+
+    test('handles a value that is only quotes', () => {
+        expect(qrsFilterValue("'''")).toBe("\\'\\'\\'");
+    });
+
+    test('coerces non-strings rather than throwing', () => {
+        expect(qrsFilterValue(42)).toBe('42');
+    });
+});
+
+describe('qrsFilterAnyOf', () => {
+    test('single string produces a parenthesised term', () => {
+        // Parenthesised even for one value: a live QRS parses and matches `(name eq 'x')`
+        // identically, and one output shape is easier to compose with than two.
+        expect(qrsFilterAnyOf('tags.name', 'Finance')).toBe("(tags.name eq 'Finance')");
+    });
+
+    test('single-element array produces the same as the bare string', () => {
+        expect(qrsFilterAnyOf('tags.name', ['Finance'])).toBe("(tags.name eq 'Finance')");
+    });
+
+    test('throws on an empty list rather than emitting invalid QRS', () => {
+        // The empty or-group `()` is rejected by QRS with 400::Invalid expression, and any
+        // expression that did parse would match everything - which for the exclude-tag caller
+        // would silently exclude every sheet in the app.
+        expect(() => qrsFilterAnyOf('tags.name', [])).toThrow(/no values supplied/);
+    });
+
+    test('the empty-list guard names the field, so the caller is identifiable', () => {
+        expect(() => qrsFilterAnyOf('tags.name', [])).toThrow(/tags\.name/);
+    });
+
+    test('multiple values become a parenthesised or-group', () => {
+        // The parentheses are load-bearing: this gets `and`-ed with other terms, and without
+        // them `a and b or c` binds the wrong way.
+        expect(qrsFilterAnyOf('tags.name', ['Finance', 'HR'])).toBe(
+            "(tags.name eq 'Finance' or tags.name eq 'HR')"
+        );
+    });
+
+    test('does not collapse an array into one comma-joined literal', () => {
+        // The bug this replaces: `${['Finance','HR']}` produced `tags.name eq 'Finance,HR'`,
+        // a single literal that matches no tag, so nothing was ever excluded.
+        expect(qrsFilterAnyOf('tags.name', ['Finance', 'HR'])).not.toContain("'Finance,HR'");
+    });
+
+    test('escapes each value in a multi-value group', () => {
+        expect(qrsFilterAnyOf('tags.name', ["Q1'25", 'R&D'])).toBe(
+            "(tags.name eq 'Q1\\'25' or tags.name eq 'R&D')"
+        );
+    });
+});
+
+describe('qrsPathWithFilter', () => {
+    test('survives qrs-interact without being double-encoded', () => {
+        const path = qrsPathWithFilter('app/full', qrsFilterAnyOf('tags.name', 'R&D'));
+
+        // The library must pass it through untouched. Pre-encoding only the `&` would trip the
+        // library's guard and turn `%26` into `%2526`.
+        expect(throughQrsInteract(path)).toBe(path);
+        expect(path).not.toContain('%2526');
+    });
+
+    test('QRS receives the ampersand as part of the value, not a new parameter', () => {
+        // Unencoded, this is the reported bug: the `&` starts a new query parameter and QRS
+        // answers 400::Missing parameter value(s).
+        const path = qrsPathWithFilter('app/full', qrsFilterAnyOf('tags.name', 'R&D'));
+
+        expect(filterAsQrsSeesIt(throughQrsInteract(path))).toBe("(tags.name eq 'R&D')");
+    });
+
+    test.each([
+        ['ampersand', 'R&D'],
+        ['plus', 'A+B'],
+        ['hash', 'a#b'],
+        ['question mark', 'a?b'],
+        ['equals', 'a=b'],
+        ['percent', 'a%b'],
+        ['slash', 'a/b'],
+        ['space', 'Sales Team'],
+    ])('round-trips a value containing %s', (_label, value) => {
+        const path = qrsPathWithFilter('app/full', qrsFilterAnyOf('tags.name', value));
+
+        expect(filterAsQrsSeesIt(throughQrsInteract(path))).toBe(`(tags.name eq '${value}')`);
+    });
+
+    test('round-trips a quote as the backslash-escaped form QRS expects', () => {
+        const path = qrsPathWithFilter('app/full', qrsFilterAnyOf('tags.name', "Q1'25"));
+
+        expect(filterAsQrsSeesIt(throughQrsInteract(path))).toBe("(tags.name eq 'Q1\\'25')");
+    });
+
+    test('keeps a compound filter intact', () => {
+        const appId = 'a3e0f5d2-000a-464f-998d-33d333b175d7';
+        const filter = `objectType eq 'sheet' and app.id eq ${appId} and ${qrsFilterAnyOf(
+            'tags.name',
+            ['R&D', "Q1'25"]
+        )}`;
+        const path = qrsPathWithFilter('app/object/full', filter);
+
+        expect(filterAsQrsSeesIt(throughQrsInteract(path))).toBe(filter);
+    });
+
+    test('preserves a leading slash in the endpoint', () => {
+        const path = qrsPathWithFilter('/contentlibrary', qrsFilterAnyOf('name', 'Butler'));
+
+        expect(path.startsWith('/contentlibrary?filter=')).toBe(true);
+    });
+});

--- a/src/lib/qseow/__tests__/qseow_contentlibrary.test.js
+++ b/src/lib/qseow/__tests__/qseow_contentlibrary.test.js
@@ -57,7 +57,33 @@ describe('qseowVerifyContentLibraryExists', () => {
 
         await qseowVerifyContentLibraryExists(OPTIONS);
 
-        expect(Get).toHaveBeenCalledWith("/contentlibrary?filter=name eq 'BSI thumbnails'");
+        // Assert on the decoded filter, i.e. what QRS parses. The path goes out URL-encoded,
+        // so pinning the raw string here would just pin the encoding.
+        expect(decodeURIComponent(Get.mock.calls[0][0])).toBe(
+            "/contentlibrary?filter=(name eq 'BSI thumbnails')"
+        );
+    });
+
+    test('a content library name containing an ampersand survives the query string', async () => {
+        // Unencoded, the `&` starts a new query parameter and QRS answers
+        // 400::Missing parameter value(s) - verified against a live QSEoW.
+        Get.mockResolvedValue({ statusCode: 200, body: [{ name: 'R&D thumbnails' }] });
+
+        await qseowVerifyContentLibraryExists({ ...OPTIONS, contentlibrary: 'R&D thumbnails' });
+
+        const [path] = Get.mock.calls[0];
+        expect(path).toContain('%26');
+        expect(decodeURIComponent(path)).toBe("/contentlibrary?filter=(name eq 'R&D thumbnails')");
+    });
+
+    test('a content library name containing a quote is backslash-escaped for QRS', async () => {
+        Get.mockResolvedValue({ statusCode: 200, body: [] });
+
+        await qseowVerifyContentLibraryExists({ ...OPTIONS, contentlibrary: "Q1'25" });
+
+        expect(decodeURIComponent(Get.mock.calls[0][0])).toBe(
+            "/contentlibrary?filter=(name eq 'Q1\\'25')"
+        );
     });
 
     test('builds the QRS connection from the supplied options', async () => {

--- a/src/lib/qseow/__tests__/qseow_create_thumbnails_app_loop.test.js
+++ b/src/lib/qseow/__tests__/qseow_create_thumbnails_app_loop.test.js
@@ -45,6 +45,7 @@ const runOverApps = jest.fn();
 jest.unstable_mockModule('../../util/run-over-apps.js', () => ({ runOverApps }));
 
 const { logger } = await import('../../../globals.js');
+const qrsInteract = (await import('qrs-interact')).default;
 const { qseowCreateThumbnails } = await import('../qseow-create-thumbnails.js');
 
 const OPTIONS = {
@@ -98,6 +99,43 @@ describe('qseowCreateThumbnails app loop', () => {
 
         expect(runOverApps.mock.calls[0][1].emptySelectionHint).toContain('--qliksensetag');
         expect(runOverApps.mock.calls[0][1].emptySelectionHint).not.toContain('--collectionid');
+    });
+
+    describe('QRS tag lookup', () => {
+        /**
+         * Wires the qrs-interact mock and returns the mock `Get`.
+         *
+         * @returns {jest.Mock} The mock `Get` method.
+         */
+        const wireQrs = () => {
+            const Get = jest.fn().mockResolvedValue({ body: [] });
+            qrsInteract.mockImplementation(() => ({ Get }));
+            return Get;
+        };
+
+        test('encodes the tag so an ampersand cannot truncate the query string', async () => {
+            // Raw, the `&` starts a new query parameter and QRS answers
+            // 400::Missing parameter value(s) - verified against a live QSEoW.
+            const Get = wireQrs();
+            runOverApps.mockResolvedValue(true);
+
+            await qseowCreateThumbnails({ ...OPTIONS, appid: '', qliksensetag: 'R&D' });
+
+            const [path] = Get.mock.calls[0];
+            expect(path).toContain('%26');
+            expect(decodeURIComponent(path)).toBe("app/full?filter=(tags.name eq 'R&D')");
+        });
+
+        test('backslash-escapes a quote in the tag', async () => {
+            const Get = wireQrs();
+            runOverApps.mockResolvedValue(true);
+
+            await qseowCreateThumbnails({ ...OPTIONS, appid: '', qliksensetag: "Q1'25" });
+
+            expect(decodeURIComponent(Get.mock.calls[0][0])).toBe(
+                "app/full?filter=(tags.name eq 'Q1\\'25')"
+            );
+        });
     });
 
     test('catches a rejection from the loop rather than letting it escape', async () => {

--- a/src/lib/qseow/__tests__/qseow_process_app.test.js
+++ b/src/lib/qseow/__tests__/qseow_process_app.test.js
@@ -212,7 +212,11 @@ describe('qseow-process-app.js — puppeteer launch and click options', () => {
      * @returns {void}
      */
     function wireQrsGetSequence(mockGet) {
-        mockGet.mockImplementation((path) => {
+        mockGet.mockImplementation((encodedPath) => {
+            // Match on the decoded filter, i.e. what QRS parses, rather than on the wire
+            // encoding. Filters are URL-encoded before they leave, so matching the raw path
+            // would tie these mocks to that encoding.
+            const path = decodeURIComponent(encodedPath);
             if (path.includes('app?filter=id eq')) {
                 return Promise.resolve({
                     body: [{ id: 'test-app-id', name: 'Test App', published: true }],
@@ -300,6 +304,28 @@ describe('qseow-process-app.js — puppeteer launch and click options', () => {
         puppeteer.launch.mockResolvedValue(browser);
         return browser;
     }
+
+    test('queries QRS with an or-group when several exclude tags are given', async () => {
+        // --exclude-sheet-tag is variadic, so this arrives as an array. Interpolating it
+        // produced `tags.name eq 'a,b'` - one literal matching no tag, so nothing was excluded.
+        const mockGet = jest.fn();
+        qrsInteract.mockImplementation(() => ({ Get: mockGet }));
+        wireQrsGetSequence(mockGet);
+        wireEnigmaSession();
+        puppeteer.launch.mockResolvedValue(buildMockBrowser());
+
+        await qseowProcessApp('test-app-id', {
+            ...defaultOptions,
+            excludeSheetTag: ['exclude-thumbnail', 'R&D'],
+        });
+
+        const tagQuery = mockGet.mock.calls
+            .map(([path]) => decodeURIComponent(path))
+            .find((path) => path.includes('tags.name eq'));
+
+        expect(tagQuery).toContain("(tags.name eq 'exclude-thumbnail' or tags.name eq 'R&D')");
+        expect(tagQuery).not.toContain("'exclude-thumbnail,R&D'");
+    });
 
     test('launches puppeteer with v25-compatible options (headless: true, no acceptInsecureCerts)', async () => {
         setupHappyPath();
@@ -433,7 +459,11 @@ describe('qseow-process-app.js — a sheet with no metadata does not abort the a
         qseowUploadToContentLibrary.mockResolvedValue(true);
         qseowUpdateSheetThumbnails.mockResolvedValue(true);
 
-        const mockGet = jest.fn().mockImplementation((path) => {
+        const mockGet = jest.fn().mockImplementation((encodedPath) => {
+            // Match on the decoded filter, i.e. what QRS parses, rather than on the wire
+            // encoding. Filters are URL-encoded before they leave, so matching the raw path
+            // would tie these mocks to that encoding.
+            const path = decodeURIComponent(encodedPath);
             if (path.includes('app?filter=id eq')) {
                 return Promise.resolve({
                     body: [{ id: 'test-app-id', name: 'Test App', published: true }],
@@ -553,7 +583,11 @@ describe('qseow-process-app.js — a blurred thumbnail that cannot be created', 
         qseowUploadToContentLibrary.mockResolvedValue(true);
         qseowUpdateSheetThumbnails.mockResolvedValue(true);
 
-        const mockGet = jest.fn().mockImplementation((path) => {
+        const mockGet = jest.fn().mockImplementation((encodedPath) => {
+            // Match on the decoded filter, i.e. what QRS parses, rather than on the wire
+            // encoding. Filters are URL-encoded before they leave, so matching the raw path
+            // would tie these mocks to that encoding.
+            const path = decodeURIComponent(encodedPath);
             if (path.includes('app?filter=id eq')) {
                 return Promise.resolve({
                     body: [{ id: 'test-app-id', name: 'Test App', published: true }],

--- a/src/lib/qseow/__tests__/qseow_remove_sheet_icons.test.js
+++ b/src/lib/qseow/__tests__/qseow_remove_sheet_icons.test.js
@@ -329,7 +329,25 @@ describe('qseowRemoveSheetIcons', () => {
                 qliksensetag: 'BSI',
             });
 
-            expect(Get).toHaveBeenCalledWith("app/full?filter=tags.name eq 'BSI'");
+            // Decoded, because the path goes out URL-encoded.
+            expect(decodeURIComponent(Get.mock.calls[0][0])).toBe(
+                "app/full?filter=(tags.name eq 'BSI')"
+            );
+        });
+
+        test('a tag containing an ampersand is not truncated by the query string', async () => {
+            wireEnigma([makeSheet('sheet-1', 1)]);
+            Get.mockResolvedValue({ body: [] });
+
+            await qseowRemoveSheetIcons({
+                ...BASE_OPTIONS,
+                appid: '',
+                qliksensetag: 'R&D',
+            });
+
+            const [path] = Get.mock.calls[0];
+            expect(path).toContain('%26');
+            expect(decodeURIComponent(path)).toBe("app/full?filter=(tags.name eq 'R&D')");
         });
 
         test('processes an app named by both --appid and the tag only once', async () => {

--- a/src/lib/qseow/qrs-filter.js
+++ b/src/lib/qseow/qrs-filter.js
@@ -1,0 +1,87 @@
+/**
+ * Helpers for building QRS (Qlik Sense Repository Service) filter queries safely.
+ *
+ * Two separate things have to be right, and getting either wrong fails silently or with an
+ * unhelpful 400. Both behaviours below were verified against a live QSEoW 4242 endpoint
+ * rather than inferred - the obvious guesses turned out to be wrong.
+ *
+ * 1. QRS filter syntax. Values sit inside single quotes, and a quote in the value ends the
+ *    literal early. QRS escapes with a backslash: `name eq 'Q1\'25'`. The OData convention of
+ *    doubling the quote (`''`) and the alternative of double-quoting the value are both
+ *    rejected with `400::Cannot parse the expression`.
+ *
+ * 2. URL encoding. `qrs-interact` runs the query string through `encodeURI`, which leaves `&`
+ *    alone - so a tag named `R&D` truncates the query string and QRS answers
+ *    `400::Missing parameter value(s)`. Pre-encoding only the `&` does not help either:
+ *    `decodeURI` does not decode reserved-character escapes, so the library's
+ *    `stringToEncode == decodeURI(stringToEncode)` guard still passes and `encodeURI` turns the
+ *    `%` of `%26` into `%2526`.
+ *
+ *    The way through is to encode the whole filter with `encodeURIComponent`. Spaces become
+ *    `%20`, which `decodeURI` *does* decode, so the library's guard fails and it passes the
+ *    query string along untouched. Hence `qrsPathWithFilter` - every filter must go through it,
+ *    or the double-encoding comes back.
+ */
+
+/**
+ * Escapes a value for use inside a single-quoted QRS filter literal.
+ *
+ * Backslashes are escaped first, so an existing backslash cannot combine with the escape
+ * character added for a following quote.
+ *
+ * @param {string} value - Raw value, e.g. a tag or content library name.
+ *
+ * @returns {string} The value with `\` and `'` backslash-escaped, safe to place between quotes.
+ */
+export const qrsFilterValue = (value) => String(value).replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+
+/**
+ * Builds a filter term matching a field against any one of the supplied values.
+ *
+ * The result is always a parenthesised `or` group, even for a single value. The parentheses
+ * matter: these terms get `and`-ed with others, and without them `a and b or c` binds the wrong
+ * way. Parenthesising unconditionally costs nothing - a live QRS parses and matches
+ * `(name eq 'x')` exactly as it does the bare term - and it keeps one output shape rather than
+ * two.
+ *
+ * An empty list throws rather than producing a filter. There is no QRS expression meaning
+ * "match none": the empty `or` group `()` is rejected with `400::Invalid expression`, and
+ * anything that parses would match *everything*, which for the exclude-tag caller would silently
+ * exclude every sheet in the app. Whether an absent list means "skip the query" is the caller's
+ * decision, so this refuses to guess.
+ *
+ * @param {string} field - QRS field name, e.g. `'tags.name'`.
+ * @param {string|string[]} values - One value, or a non-empty array of them. Variadic Commander
+ *     options arrive as arrays; interpolating one directly produced `tags.name eq 'A,B'`, a
+ *     single literal that matches no tag at all.
+ *
+ * @returns {string} A parenthesised QRS filter expression.
+ *
+ * @throws {Error} When `values` is an empty array.
+ */
+export const qrsFilterAnyOf = (field, values) => {
+    const list = Array.isArray(values) ? values : [values];
+
+    if (list.length === 0) {
+        throw new Error(
+            `qrsFilterAnyOf: no values supplied for '${field}'. An empty list has no QRS ` +
+                `equivalent - the caller has to decide whether to skip the query instead.`
+        );
+    }
+
+    const terms = list.map((value) => `${field} eq '${qrsFilterValue(value)}'`);
+
+    return `(${terms.join(' or ')})`;
+};
+
+/**
+ * Joins a QRS endpoint to a filter expression, encoding the filter so `qrs-interact` leaves it
+ * alone.
+ *
+ * @param {string} endpoint - QRS endpoint, e.g. `'app/full'`.
+ * @param {string} filter - Filter expression, built with the helpers above.
+ *
+ * @returns {string} Path ready to hand to `qrsInteract.Get`.
+ */
+export const qrsPathWithFilter = (endpoint, filter) =>
+    `${endpoint}?filter=${encodeURIComponent(filter)}`;

--- a/src/lib/qseow/qseow-app-lookup.js
+++ b/src/lib/qseow/qseow-app-lookup.js
@@ -1,0 +1,41 @@
+import qrsInteract from 'qrs-interact';
+
+import { logger } from '../../globals.js';
+import { setupQseowQrsConnection } from './qseow-qrs.js';
+import { qrsFilterAnyOf, qrsPathWithFilter } from './qrs-filter.js';
+
+/**
+ * Looks up the IDs of all QSEoW apps carrying a given tag.
+ *
+ * Shared by the two commands that accept `--qliksensetag`. They previously held byte-identical
+ * copies of this block, which is the drift this repo keeps paying for - and duplication the
+ * quality gate counts.
+ *
+ * @param {object} options - QSEoW options, as passed to the command.
+ * @param {string|string[]} options.qliksensetag - Tag(s) an app must carry to be included.
+ *     Callers are expected to have checked this is non-empty; an empty list throws rather than
+ *     quietly selecting nothing or everything.
+ * @param {string} options.host - Qlik Sense server hostname.
+ * @param {number} options.qrsport - QRS port number.
+ * @param {string} options.certfile - Path to the certificate file.
+ * @param {string} options.certkeyfile - Path to the certificate key file.
+ *
+ * @returns {Promise<string[]>} IDs of the matching apps, empty if the tag matched nothing.
+ */
+export const getAppIdsByTag = async (options) => {
+    const qseowConfigQrs = setupQseowQrsConnection(options);
+
+    const qrsInteractInstance = new qrsInteract(qseowConfigQrs);
+    logger.debug(`QSEoW QRS config: ${JSON.stringify(qseowConfigQrs, null, 2)}`);
+
+    const filter = qrsFilterAnyOf('tags.name', options.qliksensetag);
+
+    // Logged unencoded: this line exists so an administrator can see why a tag matched nothing,
+    // and the percent-encoded form is least readable in exactly the case they are chasing - a
+    // tag containing punctuation.
+    logger.debug(`GETAPPS 1: app/full?filter=${filter}`);
+
+    const result = await qrsInteractInstance.Get(qrsPathWithFilter('app/full', filter));
+
+    return result.body.map((app) => app.id);
+};

--- a/src/lib/qseow/qseow-app-lookup.js
+++ b/src/lib/qseow/qseow-app-lookup.js
@@ -26,8 +26,11 @@ export const getAppIdsByTag = async (options) => {
     const qseowConfigQrs = setupQseowQrsConnection(options);
 
     const qrsInteractInstance = new qrsInteract(qseowConfigQrs);
-    logger.debug(`QSEoW QRS config: ${JSON.stringify(qseowConfigQrs, null, 2)}`);
 
+    // The QRS config is deliberately not dumped here. Both callers reach qseow-process-app.js
+    // or qseow-upload.js in the same run, and both log it there, so repeating it adds nothing -
+    // and CodeQL flags the pattern as clear-text logging of environment-derived values
+    // (js/clear-text-logging). Not worth adding a fourth copy to earn a fourth alert.
     const filter = qrsFilterAnyOf('tags.name', options.qliksensetag);
 
     // Logged unencoded: this line exists so an administrator can see why a tag matched nothing,

--- a/src/lib/qseow/qseow-contentlibrary.js
+++ b/src/lib/qseow/qseow-contentlibrary.js
@@ -2,6 +2,7 @@ import qrsInteract from 'qrs-interact';
 
 import { logger } from '../../globals.js';
 import { setupQseowQrsConnection } from './qseow-qrs.js';
+import { qrsFilterAnyOf, qrsPathWithFilter } from './qrs-filter.js';
 
 /**
  * Verifies if a specified content library exists in Qlik Sense Enterprise on Windows (QSEoW).
@@ -23,7 +24,7 @@ export const qseowVerifyContentLibraryExists = async (options) => {
 
         const { contentlibrary } = options;
 
-        const apiUrl = `/contentlibrary?filter=name eq '${contentlibrary}'`;
+        const apiUrl = qrsPathWithFilter('/contentlibrary', qrsFilterAnyOf('name', contentlibrary));
         logger.debug(`API URL: ${apiUrl}`);
 
         // Test if content library already exists

--- a/src/lib/qseow/qseow-create-thumbnails.js
+++ b/src/lib/qseow/qseow-create-thumbnails.js
@@ -1,12 +1,10 @@
-import qrsInteract from 'qrs-interact';
-
 import { logger, setLoggingLevel, bsiExecutablePath, isSea } from '../../globals.js';
 import { redactOptions } from '../util/redact-secrets.js';
 import { qseowVerifyContentLibraryExists } from './qseow-contentlibrary.js';
 import { qseowVerifyCertificatesExist } from './qseow-certificates.js';
-import { setupQseowQrsConnection } from './qseow-qrs.js';
 import { qseowProcessApp } from './qseow-process-app.js';
 import { runOverApps } from '../util/run-over-apps.js';
+import { getAppIdsByTag } from './qseow-app-lookup.js';
 
 /**
  * Create thumbnails for Qlik Sense Enterprise on Windows (QSEoW).
@@ -83,21 +81,7 @@ export const qseowCreateThumbnails = async (options) => {
         // If --qliksensetag does not exist the app specified by --appid should be processed.
         if (options.qliksensetag && options.qliksensetag.length > 0) {
             // Get all apps matching the tag in --qliksensetag
-            const qseowConfigQrs = setupQseowQrsConnection(options);
-
-            const qrsInteractInstance = new qrsInteract(qseowConfigQrs);
-            logger.debug(`QSEoW QRS config: ${JSON.stringify(qseowConfigQrs, null, 2)}`);
-
-            logger.debug(`GETAPPS 1: app/full?filter=tags.name eq '${options.qliksensetag}'`);
-            const result = await qrsInteractInstance.Get(
-                `app/full?filter=tags.name eq '${options.qliksensetag}'`
-            );
-
-            // Add all apps with this tag
-
-            for (const app of result.body) {
-                appIdsToProcess.push(app.id);
-            }
+            appIdsToProcess.push(...(await getAppIdsByTag(options)));
         }
 
         return await runOverApps(

--- a/src/lib/qseow/qseow-process-app.js
+++ b/src/lib/qseow/qseow-process-app.js
@@ -12,6 +12,7 @@ import { determineSheetExcludeStatus } from './determine-sheet-exclude-status.js
 import { QseowError } from '../util/errors.js';
 import { launchBrowserForApp } from '../browser/browser-launch.js';
 import { sortSheetsByRank } from '../util/sheet-list.js';
+import { qrsFilterAnyOf, qrsPathWithFilter } from './qrs-filter.js';
 
 const selectorLoginPageUserName = '#username-input';
 const selectorLoginPageUserPwd = '#password-input';
@@ -171,22 +172,26 @@ export const qseowProcessApp = async (appId, options) => {
         logger.debug(`QSEoW QRS config: ${JSON.stringify(qseowConfigQrs, null, 2)}`);
 
         // Get app top level metadata
-        logger.debug(`GET app top level metadata: app?filter=id eq ${appId}`);
-        let appMetadata = await qrsInteractInstance.Get(`app?filter=id eq ${appId}`);
+        const appMetadataPath = qrsPathWithFilter('app', `id eq ${appId}`);
+        logger.debug(`GET app top level metadata: ${appMetadataPath}`);
+        let appMetadata = await qrsInteractInstance.Get(appMetadataPath);
         appMetadata = appMetadata.body;
 
-        // Get metadata for the app sheets that should be exclude, blur etc based on sheet tags
-        logger.debug(
-            `GET tagSheetAppMetadata: app/object/full?filter=objectType eq 'sheet' and app.id eq ${appId} and tags.name eq '${options.excludeSheetTag}'`
+        // Get metadata for the app sheets that should be exclude, blur etc based on sheet tags.
+        // --exclude-sheet-tag is variadic, so this has to be an `or` group over every tag given:
+        // interpolating the array produced `tags.name eq 'A,B'`, one literal matching no tag.
+        const appSheetsFilter = `objectType eq 'sheet' and app.id eq ${appId}`;
+        const tagSheetPath = qrsPathWithFilter(
+            'app/object/full',
+            `${appSheetsFilter} and ${qrsFilterAnyOf('tags.name', options.excludeSheetTag)}`
         );
-        let tagSheetAppMetadata = await qrsInteractInstance.Get(
-            `app/object/full?filter=objectType eq 'sheet' and app.id eq ${appId} and tags.name eq '${options.excludeSheetTag}'`
-        );
+        logger.debug(`GET tagSheetAppMetadata: ${tagSheetPath}`);
+        let tagSheetAppMetadata = await qrsInteractInstance.Get(tagSheetPath);
         tagSheetAppMetadata = tagSheetAppMetadata.body;
 
         // Create mapping between repo db sheet id and engine sheet id
         let mapRepoEngineSheetIdTmp1 = await qrsInteractInstance.Get(
-            `app/object/full?filter=objectType eq 'sheet' and app.id eq ${appId}`
+            qrsPathWithFilter('app/object/full', appSheetsFilter)
         );
         mapRepoEngineSheetIdTmp1 = mapRepoEngineSheetIdTmp1.body;
 

--- a/src/lib/qseow/qseow-remove-sheet-icons.js
+++ b/src/lib/qseow/qseow-remove-sheet-icons.js
@@ -1,14 +1,13 @@
 import enigma from 'enigma.js';
-import qrsInteract from 'qrs-interact';
 
 import { setupEnigmaConnection } from './qseow-enigma.js';
 import { logger, setLoggingLevel, bsiExecutablePath, isSea } from '../../globals.js';
 import { redactOptions } from '../util/redact-secrets.js';
 import { qseowVerifyCertificatesExist } from './qseow-certificates.js';
-import { setupQseowQrsConnection } from './qseow-qrs.js';
 import { QseowError } from '../util/errors.js';
 import { runOverSheets, sortSheetsByRank, saveIfChanged } from '../util/sheet-list.js';
 import { runOverApps } from '../util/run-over-apps.js';
+import { getAppIdsByTag } from './qseow-app-lookup.js';
 
 /**
  * Removes all sheet icons from a Qlik Sense Enterprise on Windows (QSEoW) application.
@@ -192,21 +191,7 @@ export const qseowRemoveSheetIcons = async (options) => {
         // If --qliksensetag does not exist the app specified by --appid should be processed.
         if (options.qliksensetag && options.qliksensetag.length > 0) {
             // Get all apps matching the tag in --qliksensetag
-            const qseowConfigQrs = setupQseowQrsConnection(options);
-
-            const qrsInteractInstance = new qrsInteract(qseowConfigQrs);
-            logger.debug(`QSEoW QRS config: ${JSON.stringify(qseowConfigQrs, null, 2)}`);
-
-            logger.debug(`GETAPPS 1: app/full?filter=tags.name eq '${options.qliksensetag}'`);
-            const result = await qrsInteractInstance.Get(
-                `app/full?filter=tags.name eq '${options.qliksensetag}'`
-            );
-
-            // Add all apps with this tag
-
-            for (const app of result.body) {
-                appIdsToProcess.push(app.id);
-            }
+            appIdsToProcess.push(...(await getAppIdsByTag(options)));
         }
 
         return await runOverApps(


### PR DESCRIPTION
Closes part of #872 (Part 3 — messages: QRS tag escaping).

## Two bugs, one expression

**Punctuation in a name broke the QRS lookup.** Tag and content library names were interpolated straight into filter queries. An ampersand truncated the query string; an apostrophe ended the quoted literal.

**Several `--exclude-sheet-tag` values silently matched nothing.** The option is variadic, so the array was joined into the single literal `tags.name eq 'A,B'`, which matches no tag. Sheets the operator had tagged for exclusion received new icons on every run, with no error and no warning. This is the more serious of the two — it is silent, and it publishes sheet icons the operator asked to keep out.

## Measured, not assumed

Both the escape syntax and the encoding strategy were established against a live QSEoW, and the obvious guess was wrong in both cases.

| | |
|---|---|
| Quote escaping | QRS uses a **backslash** (`name eq 'Q1\'25'`). The OData `''` and a double-quoted value are both rejected with `400::Cannot parse the expression`. |
| Encoding | Must cover the **whole filter**. `qrs-interact` runs the query string through `encodeURI` (which leaves `&` alone) but only when it looks un-encoded — so pre-encoding just the `&` passes that guard and `encodeURI` turns `%26` into `%2526`. |

Per-character behaviour before the fix, probed individually:

| Character | Result |
|---|---|
| `&` | `400::Missing parameter value(s)` |
| `'` | `400::Cannot parse the expression` |
| `#` | `403::XSRF prevention check failed` |
| `?` `/` | `Request path contains unescaped characters` |
| `%` | `URI malformed` |
| `+` `=` `,` | unaffected |

End-to-end, same input, fixed vs unfixed:

| | tag `R&D` |
|---|---|
| Before | `Error: Received error code: 400::Missing parameter value(s)` |
| After | `No apps to process. Check the --appid and --qliksensetag options.` |

## What changed

- New `src/lib/qseow/qrs-filter.js` — `qrsFilterValue`, `qrsFilterAnyOf`, `qrsPathWithFilter`. All four QRS call sites route through it.
- An empty value list **throws** rather than emitting the empty or-group `()`, which QRS rejects with `400::Invalid expression`. Returning something that parses was rejected deliberately: any such expression matches *everything*, which for the exclude-tag caller means silently excluding every sheet.
- New `src/lib/qseow/qseow-app-lookup.js` — extracts the byte-identical tag lookup both `--qliksensetag` commands carried. Each twin drops 15 duplicated lines to one call.
- The `GETAPPS 1:` debug line logs the filter **unencoded** — it exists so an administrator can see why a tag matched nothing, and the percent-encoded form is least readable in exactly that case.
- Doc page staged in `docs/to-doc-site/`, every claim traced to a live-server observation.

## Verification

- **751 unit tests**, lint and Prettier clean
- **QSEoW integration 2/2** against a live server
- **10 mutations, all caught** — including after the shared-helper extraction, since moving code can orphan the tests covering it
- Always-parenthesising was verified to still **match** (rows=1 on a real app name; the real content library resolves `true` through the actual code path), not merely to avoid erroring

## Known, deliberately not in scope

- The exclude-tag QRS query is unconditional, so a run with no `--exclude-sheet-tag` still costs one lookup per app for the literal tag `undefined`. Changes control flow in the app loop rather than filter construction.
- `qrs_filter.test.js` asserts against a hand-written replica of `qrs-interact`'s private `getFullPath`. `^6.3.1` permits a minor upgrade to change it while the suite stays green. A seam exists (`Get` hands the path to node's `https`).

Only `qseow create-sheet-thumbnails` is registered in the QSEoW CLI, so `qseow-remove-sheet-icons.js` was fixed for twin symmetry but is not mentioned in the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)