### PR TITLE
fix: skip the exclude-tag QRS lookup when no tags were given (#872 part 3)

### DIFF
--- a/src/lib/qseow/__tests__/qrs_filter.test.js
+++ b/src/lib/qseow/__tests__/qrs_filter.test.js
@@ -1,6 +1,11 @@
 import { describe, test, expect } from '@jest/globals';
 
-import { qrsFilterValue, qrsFilterAnyOf, qrsPathWithFilter } from '../qrs-filter.js';
+import {
+    qrsFilterValue,
+    qrsFilterAnyOf,
+    qrsPathWithFilter,
+    toFilterValueList,
+} from '../qrs-filter.js';
 
 /**
  * Replicates the query-string handling inside `qrs-interact`'s `getFullPath`, so the tests can
@@ -63,6 +68,28 @@ describe('qrsFilterValue', () => {
 
     test('coerces non-strings rather than throwing', () => {
         expect(qrsFilterValue(42)).toBe('42');
+    });
+});
+
+describe('toFilterValueList', () => {
+    test.each([
+        ['absent option', undefined, []],
+        ['null', null, []],
+        ['empty string', '', []],
+        ['empty array', [], []],
+        ['blank entry from an empty env var', [''], []],
+        ['single string', 'Finance', ['Finance']],
+        ['single-element array', ['Finance'], ['Finance']],
+        ['several values', ['Finance', 'HR'], ['Finance', 'HR']],
+        ['drops only the blanks', ['Finance', '', 'HR'], ['Finance', 'HR']],
+    ])('%s', (_label, input, expected) => {
+        expect(toFilterValueList(input)).toEqual(expected);
+    });
+
+    test('keeps a value that is only whitespace', () => {
+        // A tag cannot usefully be named ' ', but trimming here would silently change what the
+        // operator asked for. Only genuinely empty values are dropped.
+        expect(toFilterValueList([' '])).toEqual([' ']);
     });
 });
 

--- a/src/lib/qseow/__tests__/qseow_process_app.test.js
+++ b/src/lib/qseow/__tests__/qseow_process_app.test.js
@@ -305,6 +305,54 @@ describe('qseow-process-app.js — puppeteer launch and click options', () => {
         return browser;
     }
 
+    /**
+     * Runs qseowProcessApp against a wired-up happy path and returns every QRS path it asked
+     * for, decoded.
+     *
+     * @param {object} overrides - Option overrides merged over `defaultOptions`.
+     *
+     * @returns {Promise<string[]>} The decoded QRS paths requested.
+     */
+    async function qrsPathsFor(overrides) {
+        const mockGet = jest.fn();
+        qrsInteract.mockImplementation(() => ({ Get: mockGet }));
+        wireQrsGetSequence(mockGet);
+        wireEnigmaSession();
+        puppeteer.launch.mockResolvedValue(buildMockBrowser());
+
+        await qseowProcessApp('test-app-id', { ...defaultOptions, ...overrides });
+
+        return mockGet.mock.calls.map(([path]) => decodeURIComponent(path));
+    }
+
+    test.each([
+        ['the option is absent', undefined],
+        ['an empty environment variable yields a blank entry', ['']],
+        ['an empty array is passed programmatically', []],
+    ])('skips the tagged-sheet lookup entirely when %s', async (_label, excludeSheetTag) => {
+        // This query used to run for every app whatever was passed. With no tags it asked for a
+        // tag literally named `undefined` - a wasted round trip per app, and a real exclusion on
+        // any site that happens to have a tag by that name.
+        const paths = await qrsPathsFor({ excludeSheetTag });
+
+        expect(paths.some((path) => path.includes('tags.name eq'))).toBe(false);
+        expect(paths.some((path) => path.includes("'undefined'"))).toBe(false);
+    });
+
+    test('still fetches the sheet-id mapping when the tag lookup is skipped', async () => {
+        // Skipping must not take the neighbouring query with it - the repo-to-engine sheet id
+        // map is unconditional and everything downstream needs it.
+        const paths = await qrsPathsFor({ excludeSheetTag: undefined });
+
+        expect(paths.some((path) => path.includes("objectType eq 'sheet'"))).toBe(true);
+    });
+
+    test('still queries when exclude tags are supplied', async () => {
+        const paths = await qrsPathsFor({ excludeSheetTag: ['exclude-thumbnail'] });
+
+        expect(paths.some((path) => path.includes("tags.name eq 'exclude-thumbnail'"))).toBe(true);
+    });
+
     test('queries QRS with an or-group when several exclude tags are given', async () => {
         // --exclude-sheet-tag is variadic, so this arrives as an array. Interpolating it
         // produced `tags.name eq 'a,b'` - one literal matching no tag, so nothing was excluded.

--- a/src/lib/qseow/qrs-filter.js
+++ b/src/lib/qseow/qrs-filter.js
@@ -36,6 +36,23 @@
 export const qrsFilterValue = (value) => String(value).replace(/\\/g, '\\\\').replace(/'/g, "\\'");
 
 /**
+ * Normalises a CLI option into the list of values worth querying for.
+ *
+ * Commander hands the same option over in several shapes: absent options arrive as `undefined`,
+ * a variadic option set from an empty environment variable arrives as `['']`, and a plain one
+ * arrives as a bare string. None of the empty shapes name a real tag, so they all collapse to an
+ * empty list and let the caller skip the query rather than ask QRS about nothing.
+ *
+ * @param {string|string[]|undefined} values - Raw option value.
+ *
+ * @returns {string[]} The values worth querying for, possibly empty.
+ */
+export const toFilterValueList = (values) =>
+    (Array.isArray(values) ? values : [values]).filter(
+        (value) => value !== undefined && value !== null && value !== ''
+    );
+
+/**
  * Builds a filter term matching a field against any one of the supplied values.
  *
  * The result is always a parenthesised `or` group, even for a single value. The parentheses

--- a/src/lib/qseow/qseow-process-app.js
+++ b/src/lib/qseow/qseow-process-app.js
@@ -12,7 +12,7 @@ import { determineSheetExcludeStatus } from './determine-sheet-exclude-status.js
 import { QseowError } from '../util/errors.js';
 import { launchBrowserForApp } from '../browser/browser-launch.js';
 import { sortSheetsByRank } from '../util/sheet-list.js';
-import { qrsFilterAnyOf, qrsPathWithFilter } from './qrs-filter.js';
+import { qrsFilterAnyOf, qrsPathWithFilter, toFilterValueList } from './qrs-filter.js';
 
 const selectorLoginPageUserName = '#username-input';
 const selectorLoginPageUserPwd = '#password-input';
@@ -177,17 +177,35 @@ export const qseowProcessApp = async (appId, options) => {
         let appMetadata = await qrsInteractInstance.Get(appMetadataPath);
         appMetadata = appMetadata.body;
 
-        // Get metadata for the app sheets that should be exclude, blur etc based on sheet tags.
+        const appSheetsFilter = `objectType eq 'sheet' and app.id eq ${appId}`;
+
+        // Get metadata for the app sheets that should be excluded based on sheet tags.
+        //
+        // Only worth asking when tags were actually supplied. This used to run for every app
+        // whatever the operator passed: with --exclude-sheet-tag absent it queried for a tag
+        // literally named `undefined`, which costs a round trip per app and, on a site that
+        // happens to have a tag by that name, would have excluded sheets nobody asked to exclude.
+        //
         // --exclude-sheet-tag is variadic, so this has to be an `or` group over every tag given:
         // interpolating the array produced `tags.name eq 'A,B'`, one literal matching no tag.
-        const appSheetsFilter = `objectType eq 'sheet' and app.id eq ${appId}`;
-        const tagSheetPath = qrsPathWithFilter(
-            'app/object/full',
-            `${appSheetsFilter} and ${qrsFilterAnyOf('tags.name', options.excludeSheetTag)}`
-        );
-        logger.debug(`GET tagSheetAppMetadata: ${tagSheetPath}`);
-        let tagSheetAppMetadata = await qrsInteractInstance.Get(tagSheetPath);
-        tagSheetAppMetadata = tagSheetAppMetadata.body;
+        const excludeSheetTags = toFilterValueList(options.excludeSheetTag);
+        let tagSheetAppMetadata = [];
+
+        if (excludeSheetTags.length > 0) {
+            const tagFilter = `${appSheetsFilter} and ${qrsFilterAnyOf(
+                'tags.name',
+                excludeSheetTags
+            )}`;
+            logger.debug(`GET tagSheetAppMetadata: app/object/full?filter=${tagFilter}`);
+            const tagSheetResponse = await qrsInteractInstance.Get(
+                qrsPathWithFilter('app/object/full', tagFilter)
+            );
+            tagSheetAppMetadata = tagSheetResponse.body;
+        } else {
+            logger.debug(
+                'No --exclude-sheet-tag supplied, skipping the QRS lookup for tagged sheets'
+            );
+        }
 
         // Create mapping between repo db sheet id and engine sheet id
         let mapRepoEngineSheetIdTmp1 = await qrsInteractInstance.Get(


### PR DESCRIPTION
Follow-up to #899, from its `/code-review max` pass. Closes the last Part 3 item I intended to take from #872.

## The bug

The tagged-sheet QRS lookup in `qseow-process-app.js` ran for **every app, on every run**, regardless of what the operator passed. With `--exclude-sheet-tag` absent it asked QRS for a tag literally named `undefined`.

Two costs:

- **A wasted round trip per app.** On the test server here that is 518 lookups for a tag-wide run, none of which can usefully match.
- **A real, silent exclusion** on any site that happens to have a tag named `undefined`. Probed against a live QSEoW: that filter is accepted and returns rows — it came back empty only because no such tag exists there.

## The fix

The lookup runs only when tags were actually supplied, and `tagSheetAppMetadata` defaults to `[]`.

The "no tags" case arrives in more shapes than it looks, so the normalisation is its own tested helper:

| Input | `toFilterValueList` |
|---|---|
| option absent | `undefined` → `[]` |
| **empty env var** | `['']` → `[]` |
| empty array | `[]` → `[]` |
| bare string | `'A'` → `['A']` |
| variadic | `['A','B']` → `['A','B']` |

The `['']` row is the non-obvious one — an empty environment variable does not produce an empty array.

## Safety

`tagSheetAppMetadata` has exactly one consumer, `determineSheetExcludeStatus`. It is deliberately **not** passed to the blur path (see #840), so skipping the lookup cannot change blur behaviour.

## Verification

- **766 unit tests**, lint and Prettier clean
- **QSEoW integration 2/2** against a live server
- The integration suite never sets `--exclude-sheet-tag`, so it exercises the new skip path directly. Coverage from that run shows the query body (lines 195–203) **uncovered** and the `else` covered — the round trip demonstrably did not happen against the real server.
- Three mutations, all caught: removing the skip guard fails 8 tests; making `toFilterValueList` stop dropping blanks fails 6; breaking the neighbouring sheet-id mapping query fails 1. That last mutation exists because the mapping query is unconditional and sits immediately beside the guard — easy to remove by accident.
- `gitnexus_detect_changes`: LOW risk, 7 symbols, zero affected processes.

## Also here

The rewritten debug line logs its filter unencoded, matching `qseow-app-lookup.js` from #899. That completes the log-readability finding — #899 fixed the shared helper, this call site still emitted `%20`.

## No doc page

The observable surface is a faster run and one changed debug line, neither of which an administrator acts on. The `undefined`-tag false match is user-visible in principle but only on a site with a tag by that name. Internal by the `CLAUDE.md` test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)