### PR TITLE
refactor: extract withEngineSession and adopt it in four modules (#872 part 2)

### DIFF
--- a/src/lib/cloud/__tests__/cloud_remove_sheet_icons.test.js
+++ b/src/lib/cloud/__tests__/cloud_remove_sheet_icons.test.js
@@ -635,6 +635,18 @@ describe('qscloudRemoveSheetIcons', () => {
             expect(session.close).toHaveBeenCalledTimes(1);
         });
 
+        test('names the tenant when reporting the closed session, not an undefined host', async () => {
+            // Twin of the cloud_updatesheets assertion. This line interpolated options.host,
+            // which Qlik Sense Cloud has no such option for, so it logged "on host undefined".
+            wireEnigma([makeSheet('sheet-1', 1)]);
+
+            await qscloudRemoveSheetIcons({ ...BASE_OPTIONS });
+
+            const logged = logger.verbose.mock.calls.map((call) => String(call[0])).join('\n');
+            expect(logged).toContain(`on tenant ${BASE_OPTIONS.tenanturl}`);
+            expect(logged).not.toContain('on host undefined');
+        });
+
         test('returns false when the SaaS client cannot be built', async () => {
             QlikSaas.mockImplementationOnce(() => {
                 throw new Error('API token parameter is required');

--- a/src/lib/cloud/__tests__/cloud_updatesheets.test.js
+++ b/src/lib/cloud/__tests__/cloud_updatesheets.test.js
@@ -495,4 +495,17 @@ describe('qscloudUpdateSheetThumbnails — saving the app', () => {
 
         expect(session.close).toHaveBeenCalledTimes(1);
     });
+
+    test('names the tenant when reporting the closed session, not an undefined host', async () => {
+        // This line interpolated options.host, which Qlik Sense Cloud has no such option for -
+        // every run logged "on host undefined". Nothing covered it, which is how it survived.
+        wireEnigma([makeSheet()]);
+
+        await qscloudUpdateSheetThumbnails(CREATED_FILES, APP_ID, BASE_OPTIONS);
+
+        const logged = logger.verbose.mock.calls.map((call) => String(call[0])).join('\n');
+        expect(logged).toContain('Closed session after updating sheet thumbnail images');
+        expect(logged).toContain(`on tenant ${BASE_OPTIONS.tenanturl}`);
+        expect(logged).not.toContain('undefined');
+    });
 });

--- a/src/lib/cloud/cloud-remove-sheet-icons.js
+++ b/src/lib/cloud/cloud-remove-sheet-icons.js
@@ -5,7 +5,13 @@ import QlikSaas from './cloud-repo.js';
 import { qscloudTestConnection } from './cloud-test-connection.js';
 import { runOverApps } from '../util/run-over-apps.js';
 import { CloudError } from '../util/errors.js';
-import { runOverSheets, sortSheetsByRank, saveIfChanged } from '../util/sheet-list.js';
+import {
+    runOverSheets,
+    sortSheetsByRank,
+    saveIfChanged,
+    getSheetList,
+    SHEET_LIST_FIELDS_EXTENDED,
+} from '../util/sheet-list.js';
 import { withEngineSession } from '../util/engine-session.js';
 
 /**
@@ -43,39 +49,17 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
                 logger.info(`Opened app ${appId}`);
 
                 // Get list of app sheets
-                const appSheetsCall = {
-                    qInfo: {
-                        qId: 'SheetList',
-                        qType: 'SheetList',
-                    },
-                    qAppObjectListDef: {
-                        qType: 'sheet',
-                        qData: {
-                            title: '/qMetaDef/title',
-                            description: '/qMetaDef/description',
-                            thumbnail: '/thumbnail',
-                            cells: '/cells',
-                            rank: '/rank',
-                            columns: '/columns',
-                            rows: '/rows',
-                        },
-                    },
-                };
+                const sheets = await getSheetList(app, SHEET_LIST_FIELDS_EXTENDED);
 
-                const genericListObj = await app.createSessionObject(appSheetsCall);
-                const sheetListObj = await genericListObj.getLayout();
-
-                if (sheetListObj.qAppObjectList.qItems.length > 0) {
-                    // sheetListObj.qAppObjectList.qItems[] now contains array of app sheets.
-                    logger.info(
-                        `Number of sheets in app: ${sheetListObj.qAppObjectList.qItems.length}`
-                    );
+                if (sheets.length > 0) {
+                    // sheets[] now contains array of app sheets.
+                    logger.info(`Number of sheets in app: ${sheets.length}`);
 
                     // Sort sheets
-                    sortSheetsByRank(sheetListObj.qAppObjectList.qItems);
+                    sortSheetsByRank(sheets);
 
                     sheetRun = await runOverSheets(
-                        sheetListObj.qAppObjectList.qItems,
+                        sheets,
                         {
                             logPrefix: 'CLOUD REMOVE SHEET ICONS',
                             appId,

--- a/src/lib/cloud/cloud-remove-sheet-icons.js
+++ b/src/lib/cloud/cloud-remove-sheet-icons.js
@@ -1,5 +1,3 @@
-import enigma from 'enigma.js';
-
 import { setupEnigmaConnection } from './cloud-enigma.js';
 import { logger, setLoggingLevel, bsiExecutablePath, isSea } from '../../globals.js';
 import { redactOptions } from '../util/redact-secrets.js';
@@ -8,6 +6,7 @@ import { qscloudTestConnection } from './cloud-test-connection.js';
 import { runOverApps } from '../util/run-over-apps.js';
 import { CloudError } from '../util/errors.js';
 import { runOverSheets, sortSheetsByRank, saveIfChanged } from '../util/sheet-list.js';
+import { withEngineSession } from '../util/engine-session.js';
 
 /**
  * Removes all sheet icons from a Qlik Sense Cloud app.
@@ -32,98 +31,87 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
     try {
         // Configure Enigma.js
         const configEnigma = setupEnigmaConnection(appId, options);
-        const session = await enigma.create(configEnigma);
-
-        if (options.loglevel === 'silly') {
-            session.on('traffic:sent', (data) => console.log('sent:', data));
-            session.on('traffic:received', (data) =>
-                console.log('received:', JSON.stringify(data, null, 2))
-            );
-        }
-
-        const global = await session.open();
-
-        const engineVersion = await global.engineVersion();
-        logger.verbose(
-            `Created session to Qlik Sense Cloud tenant ${options.tenanturl}, engine version is ${engineVersion.qComponentVersion}`
-        );
-
-        const app = await global.openDoc(appId, '', '', '', false);
-        logger.info(`Opened app ${appId}`);
-
-        // Get list of app sheets
-        const appSheetsCall = {
-            qInfo: {
-                qId: 'SheetList',
-                qType: 'SheetList',
+        await withEngineSession(
+            configEnigma,
+            {
+                logPrefix: 'CLOUD REMOVE SHEET ICONS',
+                loglevel: options.loglevel,
+                connectionLabel: `Qlik Sense Cloud tenant ${options.tenanturl}`,
             },
-            qAppObjectListDef: {
-                qType: 'sheet',
-                qData: {
-                    title: '/qMetaDef/title',
-                    description: '/qMetaDef/description',
-                    thumbnail: '/thumbnail',
-                    cells: '/cells',
-                    rank: '/rank',
-                    columns: '/columns',
-                    rows: '/rows',
-                },
-            },
-        };
+            async (global) => {
+                const app = await global.openDoc(appId, '', '', '', false);
+                logger.info(`Opened app ${appId}`);
 
-        const genericListObj = await app.createSessionObject(appSheetsCall);
-        const sheetListObj = await genericListObj.getLayout();
+                // Get list of app sheets
+                const appSheetsCall = {
+                    qInfo: {
+                        qId: 'SheetList',
+                        qType: 'SheetList',
+                    },
+                    qAppObjectListDef: {
+                        qType: 'sheet',
+                        qData: {
+                            title: '/qMetaDef/title',
+                            description: '/qMetaDef/description',
+                            thumbnail: '/thumbnail',
+                            cells: '/cells',
+                            rank: '/rank',
+                            columns: '/columns',
+                            rows: '/rows',
+                        },
+                    },
+                };
 
-        if (sheetListObj.qAppObjectList.qItems.length > 0) {
-            // sheetListObj.qAppObjectList.qItems[] now contains array of app sheets.
-            logger.info(`Number of sheets in app: ${sheetListObj.qAppObjectList.qItems.length}`);
+                const genericListObj = await app.createSessionObject(appSheetsCall);
+                const sheetListObj = await genericListObj.getLayout();
 
-            // Sort sheets
-            sortSheetsByRank(sheetListObj.qAppObjectList.qItems);
-
-            sheetRun = await runOverSheets(
-                sheetListObj.qAppObjectList.qItems,
-                {
-                    logPrefix: 'CLOUD REMOVE SHEET ICONS',
-                    appId,
-                    action: 'remove icons for',
-                    ErrorClass: CloudError,
-                },
-                async (sheet, iSheetNum) => {
+                if (sheetListObj.qAppObjectList.qItems.length > 0) {
+                    // sheetListObj.qAppObjectList.qItems[] now contains array of app sheets.
                     logger.info(
-                        `Removing icon for sheet ${iSheetNum}: Name '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
+                        `Number of sheets in app: ${sheetListObj.qAppObjectList.qItems.length}`
                     );
 
-                    // Get properties of current sheet
-                    const sheetObj = await app.getObject(sheet.qInfo.qId);
-                    const sheetProperties = await sheetObj.getProperties();
+                    // Sort sheets
+                    sortSheetsByRank(sheetListObj.qAppObjectList.qItems);
 
-                    // Clear sheet icon
-                    sheetProperties.thumbnail.qStaticContentUrlDef.qUrl = '';
+                    sheetRun = await runOverSheets(
+                        sheetListObj.qAppObjectList.qItems,
+                        {
+                            logPrefix: 'CLOUD REMOVE SHEET ICONS',
+                            appId,
+                            action: 'remove icons for',
+                            ErrorClass: CloudError,
+                        },
+                        async (sheet, iSheetNum) => {
+                            logger.info(
+                                `Removing icon for sheet ${iSheetNum}: Name '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
+                            );
 
-                    const res = await sheetObj.setProperties(sheetProperties);
-                    logger.debug(`Set thumbnail result: ${JSON.stringify(res, null, 2)}`);
+                            // Get properties of current sheet
+                            const sheetObj = await app.getObject(sheet.qInfo.qId);
+                            const sheetProperties = await sheetObj.getProperties();
+
+                            // Clear sheet icon
+                            sheetProperties.thumbnail.qStaticContentUrlDef.qUrl = '';
+
+                            const res = await sheetObj.setProperties(sheetProperties);
+                            logger.debug(`Set thumbnail result: ${JSON.stringify(res, null, 2)}`);
+                        }
+                    );
                 }
-            );
-        }
 
-        // The close sits in a finally: the save can reject - a published app, or one the
-        // service account may not write - and without this the engine websocket would be
-        // left open for the life of the process, once per failing app.
-        try {
-            await saveIfChanged(
-                app,
-                { logPrefix: 'CLOUD REMOVE SHEET ICONS', appId },
-                sheetRun?.changed ?? 0
-            );
-        } finally {
-            // Closed outside the sheet-count guard: an app with no sheets still holds an open
-            // engine session that has to be released.
-            // enigma.js always resolves close() truthy; a real failure rejects into the catch below.
-            await session.close();
-        }
+                // Saved inside the session callback: withEngineSession closes the session once
+                // this resolves or throws, so a save that rejects - a published app, or one the
+                // service account may not write - still releases the websocket.
+                await saveIfChanged(
+                    app,
+                    { logPrefix: 'CLOUD REMOVE SHEET ICONS', appId },
+                    sheetRun?.changed ?? 0
+                );
+            }
+        );
         logger.verbose(
-            `Closed session after updating sheet thumbnail images in QS Cloud app ${appId} on host ${options.host}`
+            `Closed session after updating sheet thumbnail images in QS Cloud app ${appId} on tenant ${options.tenanturl}`
         );
 
         // Deleted only after the sheets have been repointed and the app saved. Doing it

--- a/src/lib/cloud/cloud-updatesheets.js
+++ b/src/lib/cloud/cloud-updatesheets.js
@@ -7,6 +7,7 @@ import {
     SHEET_SKIPPED,
     sortSheetsByRank,
     saveIfChanged,
+    getSheetList,
 } from '../util/sheet-list.js';
 
 /**
@@ -54,32 +55,17 @@ export const qscloudUpdateSheetThumbnails = async (createdFiles, appId, options)
                 logger.verbose(`Opened app ${appId}`);
 
                 // Get list of app sheets
-                const appSheetsCall = {
-                    qInfo: {
-                        qId: 'SheetList',
-                        qType: 'SheetList',
-                    },
-                    qAppObjectListDef: {
-                        qType: 'sheet',
-                        qData: {
-                            thumbnail: '/thumbnail',
-                            rank: '/rank',
-                        },
-                    },
-                };
+                const sheets = await getSheetList(app);
 
-                const genericListObj = await app.createSessionObject(appSheetsCall);
-                const sheetListObj = await genericListObj.getLayout();
-
-                if (sheetListObj.qAppObjectList.qItems.length > 0) {
+                if (sheets.length > 0) {
                     // dimObj.qAppObjectList.qItems[] now contains array of app sheets.
-                    logger.info(`Number of sheets: ${sheetListObj.qAppObjectList.qItems.length}`);
+                    logger.info(`Number of sheets: ${sheets.length}`);
 
                     // Sort sheets
-                    sortSheetsByRank(sheetListObj.qAppObjectList.qItems);
+                    sortSheetsByRank(sheets);
 
                     sheetRun = await runOverSheets(
-                        sheetListObj.qAppObjectList.qItems,
+                        sheets,
                         {
                             logPrefix: 'CLOUD UPDATE SHEETS',
                             appId,

--- a/src/lib/cloud/cloud-updatesheets.js
+++ b/src/lib/cloud/cloud-updatesheets.js
@@ -1,8 +1,7 @@
-import enigma from 'enigma.js';
-
 import { setupEnigmaConnection } from './cloud-enigma.js';
 import { logger } from '../../globals.js';
 import { CloudError } from '../util/errors.js';
+import { withEngineSession } from '../util/engine-session.js';
 import {
     runOverSheets,
     SHEET_SKIPPED,
@@ -43,189 +42,185 @@ export const qscloudUpdateSheetThumbnails = async (createdFiles, appId, options)
         // Configure Enigma.js
         const configEnigma = setupEnigmaConnection(appId, options);
 
-        const session = await enigma.create(configEnigma);
-        if (options.loglevel === 'silly') {
-            session.on('traffic:sent', (data) => console.log('sent:', data));
-
-            session.on('traffic:received', (data) => console.log('received:', data));
-        }
-
-        const global = await session.open();
-
-        const engineVersion = await global.engineVersion();
-        logger.verbose(
-            `Created session to Qlik Sense Cloud tenant ${options.tenanturl}, engine version is ${engineVersion.qComponentVersion}`
-        );
-
-        const app = await global.openDoc(appId, '', '', '', false);
-        logger.verbose(`Opened app ${appId}`);
-
-        // Get list of app sheets
-        const appSheetsCall = {
-            qInfo: {
-                qId: 'SheetList',
-                qType: 'SheetList',
+        await withEngineSession(
+            configEnigma,
+            {
+                logPrefix: 'CLOUD UPDATE SHEETS',
+                loglevel: options.loglevel,
+                connectionLabel: `Qlik Sense Cloud tenant ${options.tenanturl}`,
             },
-            qAppObjectListDef: {
-                qType: 'sheet',
-                qData: {
-                    thumbnail: '/thumbnail',
-                    rank: '/rank',
-                },
-            },
-        };
+            async (global) => {
+                const app = await global.openDoc(appId, '', '', '', false);
+                logger.verbose(`Opened app ${appId}`);
 
-        const genericListObj = await app.createSessionObject(appSheetsCall);
-        const sheetListObj = await genericListObj.getLayout();
+                // Get list of app sheets
+                const appSheetsCall = {
+                    qInfo: {
+                        qId: 'SheetList',
+                        qType: 'SheetList',
+                    },
+                    qAppObjectListDef: {
+                        qType: 'sheet',
+                        qData: {
+                            thumbnail: '/thumbnail',
+                            rank: '/rank',
+                        },
+                    },
+                };
 
-        if (sheetListObj.qAppObjectList.qItems.length > 0) {
-            // dimObj.qAppObjectList.qItems[] now contains array of app sheets.
-            logger.info(`Number of sheets: ${sheetListObj.qAppObjectList.qItems.length}`);
+                const genericListObj = await app.createSessionObject(appSheetsCall);
+                const sheetListObj = await genericListObj.getLayout();
 
-            // Sort sheets
-            sortSheetsByRank(sheetListObj.qAppObjectList.qItems);
+                if (sheetListObj.qAppObjectList.qItems.length > 0) {
+                    // dimObj.qAppObjectList.qItems[] now contains array of app sheets.
+                    logger.info(`Number of sheets: ${sheetListObj.qAppObjectList.qItems.length}`);
 
-            sheetRun = await runOverSheets(
-                sheetListObj.qAppObjectList.qItems,
-                {
-                    logPrefix: 'CLOUD UPDATE SHEETS',
-                    appId,
-                    action: 'update',
-                    requireAttempt: createdFiles.length > 0,
-                    ErrorClass: CloudError,
-                },
-                async (sheet, iSheetNum) => {
-                    const createdFile = createdFiles.find(
-                        (element) => element.sheetPos === iSheetNum
+                    // Sort sheets
+                    sortSheetsByRank(sheetListObj.qAppObjectList.qItems);
+
+                    sheetRun = await runOverSheets(
+                        sheetListObj.qAppObjectList.qItems,
+                        {
+                            logPrefix: 'CLOUD UPDATE SHEETS',
+                            appId,
+                            action: 'update',
+                            requireAttempt: createdFiles.length > 0,
+                            ErrorClass: CloudError,
+                        },
+                        async (sheet, iSheetNum) => {
+                            const createdFile = createdFiles.find(
+                                (element) => element.sheetPos === iSheetNum
+                            );
+                            if (!createdFile) {
+                                // Guarded: this line is inside the counted region, so an unguarded
+                                // dereference here would fail the app over a sheet nobody was
+                                // going to touch.
+                                logger.info(
+                                    `Skipping update of sheet ${iSheetNum}: Name '${sheet?.qMeta?.title}', ID ${sheet?.qInfo?.qId}, description '${sheet?.qMeta?.description}'`
+                                );
+
+                                return SHEET_SKIPPED;
+                            } else {
+                                // Should blurred sheet thumbnail be used?
+                                // Options are
+                                // --blur-sheet-number <number...>
+                                // --blur-sheet-title <title...>
+                                // --blur-sheet-status <status...>
+
+                                let blurSheet = false;
+
+                                // Get published status of sheet
+                                let sheetPublished;
+                                if (
+                                    sheet.qMeta?.published === undefined ||
+                                    sheet.qMeta.published === false
+                                ) {
+                                    sheetPublished = false;
+                                } else {
+                                    sheetPublished = true;
+                                }
+
+                                // Get approved status of sheet
+                                let sheetApproved;
+                                if (
+                                    sheet.qMeta?.approved === undefined ||
+                                    sheet.qMeta.approved === false
+                                ) {
+                                    sheetApproved = false;
+                                } else {
+                                    sheetApproved = true;
+                                }
+
+                                // Should this sheet be blurred based on its published status?
+                                // Public sheets
+                                if (
+                                    sheetApproved === true &&
+                                    sheetPublished === true &&
+                                    options.blurSheetStatus &&
+                                    options.blurSheetStatus.includes('public')
+                                ) {
+                                    blurSheet = true;
+                                    logger.verbose(
+                                        `Blurred sheet thumbnail (status public): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
+                                    );
+                                }
+
+                                // Published sheets
+                                if (
+                                    sheetApproved === false &&
+                                    sheetPublished === true &&
+                                    options.blurSheetStatus &&
+                                    options.blurSheetStatus.includes('published')
+                                ) {
+                                    blurSheet = true;
+                                    logger.verbose(
+                                        `Blurred sheet thumbnail (status published): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
+                                    );
+                                }
+
+                                // Should this sheet be blurred based on its position/sheet number?
+                                if (options.blurSheetNumber && blurSheet === false) {
+                                    // Does the sheet number match any of the numbers in options.blurSheetNumber array?
+                                    // Take into account that iSheetNum is an integer, so we need to convert it to a string
+                                    if (options.blurSheetNumber.includes(iSheetNum.toString())) {
+                                        blurSheet = true;
+                                        logger.verbose(
+                                            `Blurred sheet thumbnail (via sheet number): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
+                                        );
+                                    }
+                                }
+
+                                // Should this sheet be blurred based on its title?
+                                if (options.blurSheetTitle && blurSheet === false) {
+                                    // Does the sheet title match any of the titles options.blurSheetTitle array?
+                                    if (options.blurSheetTitle.includes(sheet.qMeta.title)) {
+                                        blurSheet = true;
+                                        logger.verbose(
+                                            `Blurred sheet thumbnail (via sheet title): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
+                                        );
+                                    }
+                                }
+
+                                // Get properties of current sheet
+                                const sheetObj = await app.getObject(sheet.qInfo.qId);
+                                const sheetProperties = await sheetObj.getProperties();
+
+                                if (blurSheet === true && createdFile.fileNameShortBlurred) {
+                                    logger.info(
+                                        `Using blurred thumbnail for sheet ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
+                                    );
+
+                                    sheetProperties.thumbnail.qStaticContentUrlDef.qUrl = `/api/v1/apps/${appId}/media/files/thumbnails/${createdFile.fileNameShortBlurred}`;
+                                } else {
+                                    logger.info(
+                                        `Using regular thumbnail for sheet ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
+                                    );
+
+                                    sheetProperties.thumbnail.qStaticContentUrlDef.qUrl = `/api/v1/apps/${appId}/media/files/thumbnails/${createdFile.fileNameShort}`;
+                                }
+
+                                // Set & save new sheet thumbnail
+                                const res = await sheetObj.setProperties(sheetProperties);
+                                logger.debug(
+                                    `Set thumbnail result: ${JSON.stringify(res, null, 2)}`
+                                );
+                            }
+                        }
                     );
-                    if (!createdFile) {
-                        // Guarded: this line is inside the counted region, so an unguarded
-                        // dereference here would fail the app over a sheet nobody was
-                        // going to touch.
-                        logger.info(
-                            `Skipping update of sheet ${iSheetNum}: Name '${sheet?.qMeta?.title}', ID ${sheet?.qInfo?.qId}, description '${sheet?.qMeta?.description}'`
-                        );
-
-                        return SHEET_SKIPPED;
-                    } else {
-                        // Should blurred sheet thumbnail be used?
-                        // Options are
-                        // --blur-sheet-number <number...>
-                        // --blur-sheet-title <title...>
-                        // --blur-sheet-status <status...>
-
-                        let blurSheet = false;
-
-                        // Get published status of sheet
-                        let sheetPublished;
-                        if (
-                            sheet.qMeta?.published === undefined ||
-                            sheet.qMeta.published === false
-                        ) {
-                            sheetPublished = false;
-                        } else {
-                            sheetPublished = true;
-                        }
-
-                        // Get approved status of sheet
-                        let sheetApproved;
-                        if (sheet.qMeta?.approved === undefined || sheet.qMeta.approved === false) {
-                            sheetApproved = false;
-                        } else {
-                            sheetApproved = true;
-                        }
-
-                        // Should this sheet be blurred based on its published status?
-                        // Public sheets
-                        if (
-                            sheetApproved === true &&
-                            sheetPublished === true &&
-                            options.blurSheetStatus &&
-                            options.blurSheetStatus.includes('public')
-                        ) {
-                            blurSheet = true;
-                            logger.verbose(
-                                `Blurred sheet thumbnail (status public): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
-                            );
-                        }
-
-                        // Published sheets
-                        if (
-                            sheetApproved === false &&
-                            sheetPublished === true &&
-                            options.blurSheetStatus &&
-                            options.blurSheetStatus.includes('published')
-                        ) {
-                            blurSheet = true;
-                            logger.verbose(
-                                `Blurred sheet thumbnail (status published): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
-                            );
-                        }
-
-                        // Should this sheet be blurred based on its position/sheet number?
-                        if (options.blurSheetNumber && blurSheet === false) {
-                            // Does the sheet number match any of the numbers in options.blurSheetNumber array?
-                            // Take into account that iSheetNum is an integer, so we need to convert it to a string
-                            if (options.blurSheetNumber.includes(iSheetNum.toString())) {
-                                blurSheet = true;
-                                logger.verbose(
-                                    `Blurred sheet thumbnail (via sheet number): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
-                                );
-                            }
-                        }
-
-                        // Should this sheet be blurred based on its title?
-                        if (options.blurSheetTitle && blurSheet === false) {
-                            // Does the sheet title match any of the titles options.blurSheetTitle array?
-                            if (options.blurSheetTitle.includes(sheet.qMeta.title)) {
-                                blurSheet = true;
-                                logger.verbose(
-                                    `Blurred sheet thumbnail (via sheet title): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
-                                );
-                            }
-                        }
-
-                        // Get properties of current sheet
-                        const sheetObj = await app.getObject(sheet.qInfo.qId);
-                        const sheetProperties = await sheetObj.getProperties();
-
-                        if (blurSheet === true && createdFile.fileNameShortBlurred) {
-                            logger.info(
-                                `Using blurred thumbnail for sheet ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
-                            );
-
-                            sheetProperties.thumbnail.qStaticContentUrlDef.qUrl = `/api/v1/apps/${appId}/media/files/thumbnails/${createdFile.fileNameShortBlurred}`;
-                        } else {
-                            logger.info(
-                                `Using regular thumbnail for sheet ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
-                            );
-
-                            sheetProperties.thumbnail.qStaticContentUrlDef.qUrl = `/api/v1/apps/${appId}/media/files/thumbnails/${createdFile.fileNameShort}`;
-                        }
-
-                        // Set & save new sheet thumbnail
-                        const res = await sheetObj.setProperties(sheetProperties);
-                        logger.debug(`Set thumbnail result: ${JSON.stringify(res, null, 2)}`);
-                    }
                 }
-            );
-        }
 
-        // The close sits in a finally: the save can reject - a published app, or one the
-        // service account may not write - and without this the engine websocket would be
-        // left open for the life of the process, once per failing app.
-        try {
-            await saveIfChanged(
-                app,
-                { logPrefix: 'CLOUD UPDATE SHEETS', appId },
-                sheetRun?.changed ?? 0
-            );
-        } finally {
-            // enigma.js always resolves close() truthy; a real failure rejects into the catch below.
-            await session.close();
-        }
+                // Saved inside the session callback: withEngineSession closes the session once
+                // this resolves or throws, so a save that rejects - a published app, or one the
+                // service account may not write - still releases the websocket.
+                await saveIfChanged(
+                    app,
+                    { logPrefix: 'CLOUD UPDATE SHEETS', appId },
+                    sheetRun?.changed ?? 0
+                );
+            }
+        );
         logger.verbose(
-            `Closed session after updating sheet thumbnail images in QS Cloud app ${appId} on host ${options.host}`
+            `Closed session after updating sheet thumbnail images in QS Cloud app ${appId} on tenant ${options.tenanturl}`
         );
     } catch (err) {
         if (err.stack) {

--- a/src/lib/qseow/qseow-remove-sheet-icons.js
+++ b/src/lib/qseow/qseow-remove-sheet-icons.js
@@ -3,7 +3,13 @@ import { logger, setLoggingLevel, bsiExecutablePath, isSea } from '../../globals
 import { redactOptions } from '../util/redact-secrets.js';
 import { qseowVerifyCertificatesExist } from './qseow-certificates.js';
 import { QseowError } from '../util/errors.js';
-import { runOverSheets, sortSheetsByRank, saveIfChanged } from '../util/sheet-list.js';
+import {
+    runOverSheets,
+    sortSheetsByRank,
+    saveIfChanged,
+    getSheetList,
+    SHEET_LIST_FIELDS_EXTENDED,
+} from '../util/sheet-list.js';
 import { runOverApps } from '../util/run-over-apps.js';
 import { getAppIdsByTag } from './qseow-app-lookup.js';
 import { withEngineSession } from '../util/engine-session.js';
@@ -44,39 +50,17 @@ const removeSheetIconsQSEoWApp = async (appId, g, options) => {
                 logger.info(`Opened app ${appId}`);
 
                 // Get list of app sheets
-                const appSheetsCall = {
-                    qInfo: {
-                        qId: 'SheetList',
-                        qType: 'SheetList',
-                    },
-                    qAppObjectListDef: {
-                        qType: 'sheet',
-                        qData: {
-                            title: '/qMetaDef/title',
-                            description: '/qMetaDef/description',
-                            thumbnail: '/thumbnail',
-                            cells: '/cells',
-                            rank: '/rank',
-                            columns: '/columns',
-                            rows: '/rows',
-                        },
-                    },
-                };
+                const sheets = await getSheetList(app, SHEET_LIST_FIELDS_EXTENDED);
 
-                const genericListObj = await app.createSessionObject(appSheetsCall);
-                const sheetListObj = await genericListObj.getLayout();
-
-                if (sheetListObj.qAppObjectList.qItems.length > 0) {
-                    // sheetListObj.qAppObjectList.qItems[] now contains array of app sheets.
-                    logger.info(
-                        `Number of sheets in app: ${sheetListObj.qAppObjectList.qItems.length}`
-                    );
+                if (sheets.length > 0) {
+                    // sheets[] now contains array of app sheets.
+                    logger.info(`Number of sheets in app: ${sheets.length}`);
 
                     // Sort sheets
-                    sortSheetsByRank(sheetListObj.qAppObjectList.qItems);
+                    sortSheetsByRank(sheets);
 
                     sheetRun = await runOverSheets(
-                        sheetListObj.qAppObjectList.qItems,
+                        sheets,
                         {
                             logPrefix: 'QSEOW REMOVE SHEET ICONS',
                             appId,

--- a/src/lib/qseow/qseow-remove-sheet-icons.js
+++ b/src/lib/qseow/qseow-remove-sheet-icons.js
@@ -1,5 +1,3 @@
-import enigma from 'enigma.js';
-
 import { setupEnigmaConnection } from './qseow-enigma.js';
 import { logger, setLoggingLevel, bsiExecutablePath, isSea } from '../../globals.js';
 import { redactOptions } from '../util/redact-secrets.js';
@@ -8,6 +6,7 @@ import { QseowError } from '../util/errors.js';
 import { runOverSheets, sortSheetsByRank, saveIfChanged } from '../util/sheet-list.js';
 import { runOverApps } from '../util/run-over-apps.js';
 import { getAppIdsByTag } from './qseow-app-lookup.js';
+import { withEngineSession } from '../util/engine-session.js';
 
 /**
  * Removes all sheet icons from a Qlik Sense Enterprise on Windows (QSEoW) application.
@@ -33,96 +32,87 @@ const removeSheetIconsQSEoWApp = async (appId, g, options) => {
     try {
         // Configure Enigma.js
         const configEnigma = setupEnigmaConnection(appId, options);
-        const session = await enigma.create(configEnigma);
-
-        if (options.loglevel === 'silly') {
-            session.on('traffic:sent', (data) => console.log('sent:', data));
-            session.on('traffic:received', (data) =>
-                console.log('received:', JSON.stringify(data, null, 2))
-            );
-        }
-
-        const global = await session.open();
-
-        const engineVersion = await global.engineVersion();
-        logger.verbose(
-            `Created session to server ${options.host}, engine version is ${engineVersion.qComponentVersion}`
-        );
-
-        const app = await global.openDoc(appId, '', '', '', false);
-        logger.info(`Opened app ${appId}`);
-
-        // Get list of app sheets
-        const appSheetsCall = {
-            qInfo: {
-                qId: 'SheetList',
-                qType: 'SheetList',
+        await withEngineSession(
+            configEnigma,
+            {
+                logPrefix: 'QSEOW REMOVE SHEET ICONS',
+                loglevel: options.loglevel,
+                connectionLabel: `server ${options.host}`,
             },
-            qAppObjectListDef: {
-                qType: 'sheet',
-                qData: {
-                    title: '/qMetaDef/title',
-                    description: '/qMetaDef/description',
-                    thumbnail: '/thumbnail',
-                    cells: '/cells',
-                    rank: '/rank',
-                    columns: '/columns',
-                    rows: '/rows',
-                },
-            },
-        };
+            async (global) => {
+                const app = await global.openDoc(appId, '', '', '', false);
+                logger.info(`Opened app ${appId}`);
 
-        const genericListObj = await app.createSessionObject(appSheetsCall);
-        const sheetListObj = await genericListObj.getLayout();
+                // Get list of app sheets
+                const appSheetsCall = {
+                    qInfo: {
+                        qId: 'SheetList',
+                        qType: 'SheetList',
+                    },
+                    qAppObjectListDef: {
+                        qType: 'sheet',
+                        qData: {
+                            title: '/qMetaDef/title',
+                            description: '/qMetaDef/description',
+                            thumbnail: '/thumbnail',
+                            cells: '/cells',
+                            rank: '/rank',
+                            columns: '/columns',
+                            rows: '/rows',
+                        },
+                    },
+                };
 
-        if (sheetListObj.qAppObjectList.qItems.length > 0) {
-            // sheetListObj.qAppObjectList.qItems[] now contains array of app sheets.
-            logger.info(`Number of sheets in app: ${sheetListObj.qAppObjectList.qItems.length}`);
+                const genericListObj = await app.createSessionObject(appSheetsCall);
+                const sheetListObj = await genericListObj.getLayout();
 
-            // Sort sheets
-            sortSheetsByRank(sheetListObj.qAppObjectList.qItems);
-
-            sheetRun = await runOverSheets(
-                sheetListObj.qAppObjectList.qItems,
-                {
-                    logPrefix: 'QSEOW REMOVE SHEET ICONS',
-                    appId,
-                    action: 'remove icons for',
-                    ErrorClass: QseowError,
-                },
-                async (sheet, iSheetNum) => {
+                if (sheetListObj.qAppObjectList.qItems.length > 0) {
+                    // sheetListObj.qAppObjectList.qItems[] now contains array of app sheets.
                     logger.info(
-                        `Removing icon for sheet: ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
+                        `Number of sheets in app: ${sheetListObj.qAppObjectList.qItems.length}`
                     );
 
-                    // Get properties of current sheet
-                    const sheetObj = await app.getObject(sheet.qInfo.qId);
-                    const sheetProperties = await sheetObj.getProperties();
+                    // Sort sheets
+                    sortSheetsByRank(sheetListObj.qAppObjectList.qItems);
 
-                    // Clear sheet icon
-                    sheetProperties.thumbnail.qStaticContentUrlDef.qUrl = '';
+                    sheetRun = await runOverSheets(
+                        sheetListObj.qAppObjectList.qItems,
+                        {
+                            logPrefix: 'QSEOW REMOVE SHEET ICONS',
+                            appId,
+                            action: 'remove icons for',
+                            ErrorClass: QseowError,
+                        },
+                        async (sheet, iSheetNum) => {
+                            logger.info(
+                                `Removing icon for sheet: ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
+                            );
 
-                    const res = await sheetObj.setProperties(sheetProperties);
-                    logger.debug(`Set thumbnail result: ${JSON.stringify(res, null, 2)}`);
+                            // Get properties of current sheet
+                            const sheetObj = await app.getObject(sheet.qInfo.qId);
+                            const sheetProperties = await sheetObj.getProperties();
+
+                            // Clear sheet icon
+                            sheetProperties.thumbnail.qStaticContentUrlDef.qUrl = '';
+
+                            const res = await sheetObj.setProperties(sheetProperties);
+                            logger.debug(`Set thumbnail result: ${JSON.stringify(res, null, 2)}`);
+                        }
+                    );
                 }
-            );
-        }
 
-        // The close sits in a finally: the save can reject - a published app, or one the
-        // service account may not write - and without this the engine websocket would be
-        // left open for the life of the process, once per failing app.
-        try {
-            // Closed outside the sheet-count guard: an app with no sheets still holds an open
-            // engine session that has to be released.
-            await saveIfChanged(
-                app,
-                { logPrefix: 'QSEOW REMOVE SHEET ICONS', appId },
-                sheetRun?.changed ?? 0
-            );
-        } finally {
-            // enigma.js always resolves close() truthy; a real failure rejects into the catch below.
-            await session.close();
-        }
+                // Saved inside the session callback: withEngineSession closes the session once
+                // this resolves or throws, so a save that rejects - a published app, or one the
+                // service account may not write - still releases the websocket.
+                // Called outside the sheet-count guard: an app with no sheets is still saved
+                // through the same path, and the session is released either way.
+                await saveIfChanged(
+                    app,
+                    { logPrefix: 'QSEOW REMOVE SHEET ICONS', appId },
+                    sheetRun?.changed ?? 0
+                );
+            }
+        );
         logger.verbose(
             `Closed session after generating sheet thumbnail images for all sheets in QSEoW app ${appId} on host ${options.host}`
         );

--- a/src/lib/qseow/qseow-updatesheets.js
+++ b/src/lib/qseow/qseow-updatesheets.js
@@ -1,8 +1,7 @@
-import enigma from 'enigma.js';
-
 import { setupEnigmaConnection } from './qseow-enigma.js';
 import { logger } from '../../globals.js';
 import { QseowError } from '../util/errors.js';
+import { withEngineSession } from '../util/engine-session.js';
 import {
     isSheetTagged,
     runOverSheets,
@@ -52,184 +51,179 @@ export const qseowUpdateSheetThumbnails = async (
         // Configure Enigma.js
         const configEnigma = setupEnigmaConnection(appId, options);
 
-        const session = await enigma.create(configEnigma);
-        if (options.loglevel === 'silly') {
-            session.on('traffic:sent', (data) => console.log('sent:', data));
-            session.on('traffic:received', (data) => console.log('received:', data));
-        }
-
-        const global = await session.open();
-
-        const engineVersion = await global.engineVersion();
-        logger.verbose(
-            `Created session to server ${options.host}, engine version is ${engineVersion.qComponentVersion}`
-        );
-
-        const app = await global.openDoc(appId, '', '', '', false);
-        logger.verbose(`Opened app ${appId}`);
-
-        // Get list of app sheets
-        const appSheetsCall = {
-            qInfo: {
-                qId: 'SheetList',
-                qType: 'SheetList',
+        await withEngineSession(
+            configEnigma,
+            {
+                logPrefix: 'QSEOW UPDATE SHEETS',
+                loglevel: options.loglevel,
+                connectionLabel: `server ${options.host}`,
             },
-            qAppObjectListDef: {
-                qType: 'sheet',
-                qData: {
-                    thumbnail: '/thumbnail',
-                    rank: '/rank',
-                },
-            },
-        };
+            async (global) => {
+                const app = await global.openDoc(appId, '', '', '', false);
+                logger.verbose(`Opened app ${appId}`);
 
-        const genericListObj = await app.createSessionObject(appSheetsCall);
-        const sheetListObj = await genericListObj.getLayout();
+                // Get list of app sheets
+                const appSheetsCall = {
+                    qInfo: {
+                        qId: 'SheetList',
+                        qType: 'SheetList',
+                    },
+                    qAppObjectListDef: {
+                        qType: 'sheet',
+                        qData: {
+                            thumbnail: '/thumbnail',
+                            rank: '/rank',
+                        },
+                    },
+                };
 
-        if (sheetListObj.qAppObjectList.qItems.length > 0) {
-            // dimObj.qAppObjectList.qItems[] now contains array of app sheets.
-            logger.info(`Number of sheets: ${sheetListObj.qAppObjectList.qItems.length}`);
+                const genericListObj = await app.createSessionObject(appSheetsCall);
+                const sheetListObj = await genericListObj.getLayout();
 
-            // Sort sheets
-            sortSheetsByRank(sheetListObj.qAppObjectList.qItems);
+                if (sheetListObj.qAppObjectList.qItems.length > 0) {
+                    // dimObj.qAppObjectList.qItems[] now contains array of app sheets.
+                    logger.info(`Number of sheets: ${sheetListObj.qAppObjectList.qItems.length}`);
 
-            sheetRun = await runOverSheets(
-                sheetListObj.qAppObjectList.qItems,
-                {
-                    logPrefix: 'QSEOW UPDATE SHEETS',
-                    appId,
-                    action: 'update',
-                    requireAttempt: createdFiles.length > 0,
-                    ErrorClass: QseowError,
-                },
-                async (sheet, iSheetNum) => {
-                    // Is this sheet among those that should be updated?
+                    // Sort sheets
+                    sortSheetsByRank(sheetListObj.qAppObjectList.qItems);
 
-                    if (
-                        createdFiles.find((element) => element.sheetPos === iSheetNum) === undefined
-                    ) {
-                        // No thumbnail for this sheet, skip. Guarded: this line is inside
-                        // the counted region, so an unguarded dereference here would fail
-                        // the app over a sheet nobody was going to touch.
-                        logger.info(
-                            `Skipping update of sheet sheet ${iSheetNum}: Name '${sheet?.qMeta?.title}', ID ${sheet?.qInfo?.qId}, description '${sheet?.qMeta?.description}'`
-                        );
+                    sheetRun = await runOverSheets(
+                        sheetListObj.qAppObjectList.qItems,
+                        {
+                            logPrefix: 'QSEOW UPDATE SHEETS',
+                            appId,
+                            action: 'update',
+                            requireAttempt: createdFiles.length > 0,
+                            ErrorClass: QseowError,
+                        },
+                        async (sheet, iSheetNum) => {
+                            // Is this sheet among those that should be updated?
 
-                        return SHEET_SKIPPED;
-                    } else {
-                        // Should blurred sheet thumbnail be used?
-                        // Options are
-                        // --blur-sheet-tag <value>
-                        // --blur-sheet-number <number...>
-                        // --blur-sheet-title <title...>
-                        // --blur-sheet-status <status...>
+                            if (
+                                createdFiles.find((element) => element.sheetPos === iSheetNum) ===
+                                undefined
+                            ) {
+                                // No thumbnail for this sheet, skip. Guarded: this line is inside
+                                // the counted region, so an unguarded dereference here would fail
+                                // the app over a sheet nobody was going to touch.
+                                logger.info(
+                                    `Skipping update of sheet sheet ${iSheetNum}: Name '${sheet?.qMeta?.title}', ID ${sheet?.qInfo?.qId}, description '${sheet?.qMeta?.description}'`
+                                );
 
-                        let blurSheet = false;
+                                return SHEET_SKIPPED;
+                            } else {
+                                // Should blurred sheet thumbnail be used?
+                                // Options are
+                                // --blur-sheet-tag <value>
+                                // --blur-sheet-number <number...>
+                                // --blur-sheet-title <title...>
+                                // --blur-sheet-status <status...>
 
-                        // Should this sheet be blurred based on its published status?
-                        // Public sheets
-                        if (
-                            sheet.qMeta.approved === true &&
-                            sheet.qMeta.published === true &&
-                            options.blurSheetStatus &&
-                            options.blurSheetStatus.includes('public')
-                        ) {
-                            blurSheet = true;
-                            logger.verbose(
-                                `Blurred sheet thumbnail (status public): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
-                            );
-                        }
+                                let blurSheet = false;
 
-                        // Published sheets
-                        if (
-                            sheet.qMeta.approved === false &&
-                            sheet.qMeta.published === true &&
-                            options.blurSheetStatus &&
-                            options.blurSheetStatus.includes('published')
-                        ) {
-                            blurSheet = true;
-                            logger.verbose(
-                                `Blurred sheet thumbnail (status published): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
-                            );
-                        }
+                                // Should this sheet be blurred based on its published status?
+                                // Public sheets
+                                if (
+                                    sheet.qMeta.approved === true &&
+                                    sheet.qMeta.published === true &&
+                                    options.blurSheetStatus &&
+                                    options.blurSheetStatus.includes('public')
+                                ) {
+                                    blurSheet = true;
+                                    logger.verbose(
+                                        `Blurred sheet thumbnail (status public): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
+                                    );
+                                }
 
-                        // Should this sheet be blurred based on tags?
-                        // tagSheetAppMetadata is an array of sheet objects, each exposing engineObjectId.
-                        // It arrives empty unless the caller looked the tag up, which nothing does yet -
-                        // see issue #840. Until then the rule matches nothing rather than throwing.
-                        if (options.blurSheetTag && blurSheet === false) {
-                            blurSheet = isSheetTagged(tagSheetAppMetadata, sheet);
-                            if (blurSheet) {
-                                logger.verbose(
-                                    `Blurred sheet thumbnail (via tags): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
+                                // Published sheets
+                                if (
+                                    sheet.qMeta.approved === false &&
+                                    sheet.qMeta.published === true &&
+                                    options.blurSheetStatus &&
+                                    options.blurSheetStatus.includes('published')
+                                ) {
+                                    blurSheet = true;
+                                    logger.verbose(
+                                        `Blurred sheet thumbnail (status published): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
+                                    );
+                                }
+
+                                // Should this sheet be blurred based on tags?
+                                // tagSheetAppMetadata is an array of sheet objects, each exposing engineObjectId.
+                                // It arrives empty unless the caller looked the tag up, which nothing does yet -
+                                // see issue #840. Until then the rule matches nothing rather than throwing.
+                                if (options.blurSheetTag && blurSheet === false) {
+                                    blurSheet = isSheetTagged(tagSheetAppMetadata, sheet);
+                                    if (blurSheet) {
+                                        logger.verbose(
+                                            `Blurred sheet thumbnail (via tags): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
+                                        );
+                                    }
+                                }
+
+                                // Should this sheet be blurred based on its position/sheet number?
+                                if (options.blurSheetNumber && blurSheet === false) {
+                                    // Does the sheet number match any of the numbers in options.blurSheetNumber array?
+                                    // Take into account that iSheetNum is an integer, so we need to convert it to a string
+                                    if (options.blurSheetNumber.includes(iSheetNum.toString())) {
+                                        blurSheet = true;
+                                        logger.verbose(
+                                            `Blurred sheet thumbnail (via sheet number): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
+                                        );
+                                    }
+                                }
+
+                                // Should this sheet be blurred based on its title?
+                                if (options.blurSheetTitle && blurSheet === false) {
+                                    // Does the sheet title match any of the titles options.blurSheetTitle array?
+                                    if (options.blurSheetTitle.includes(sheet.qMeta.title)) {
+                                        blurSheet = true;
+                                        logger.verbose(
+                                            `Blurred sheet thumbnail (via sheet title): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
+                                        );
+                                    }
+                                }
+
+                                // Get properties of current sheet
+                                const sheetObj = await app.getObject(sheet.qInfo.qId);
+                                const sheetProperties = await sheetObj.getProperties();
+
+                                if (blurSheet === true) {
+                                    logger.info(
+                                        `Using blurred thumbnail for sheet ${iSheetNum}: Name '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
+                                    );
+
+                                    // Set new sheet thumbnail
+                                    sheetProperties.thumbnail.qStaticContentUrlDef.qUrl = `/content/${options.contentlibrary}/thumbnail-${appId}-${iSheetNum}-blurred.png`;
+                                } else {
+                                    logger.info(
+                                        `Using regular thumbnail for sheet ${iSheetNum}: Name '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
+                                    );
+
+                                    // Set new sheet thumbnail
+                                    sheetProperties.thumbnail.qStaticContentUrlDef.qUrl = `/content/${options.contentlibrary}/thumbnail-${appId}-${iSheetNum}.png`;
+                                }
+
+                                // Set & save new sheet thumbnail
+                                const res = await sheetObj.setProperties(sheetProperties);
+                                logger.debug(
+                                    `Set thumbnail result: ${JSON.stringify(res, null, 2)}`
                                 );
                             }
                         }
-
-                        // Should this sheet be blurred based on its position/sheet number?
-                        if (options.blurSheetNumber && blurSheet === false) {
-                            // Does the sheet number match any of the numbers in options.blurSheetNumber array?
-                            // Take into account that iSheetNum is an integer, so we need to convert it to a string
-                            if (options.blurSheetNumber.includes(iSheetNum.toString())) {
-                                blurSheet = true;
-                                logger.verbose(
-                                    `Blurred sheet thumbnail (via sheet number): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
-                                );
-                            }
-                        }
-
-                        // Should this sheet be blurred based on its title?
-                        if (options.blurSheetTitle && blurSheet === false) {
-                            // Does the sheet title match any of the titles options.blurSheetTitle array?
-                            if (options.blurSheetTitle.includes(sheet.qMeta.title)) {
-                                blurSheet = true;
-                                logger.verbose(
-                                    `Blurred sheet thumbnail (via sheet title): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
-                                );
-                            }
-                        }
-
-                        // Get properties of current sheet
-                        const sheetObj = await app.getObject(sheet.qInfo.qId);
-                        const sheetProperties = await sheetObj.getProperties();
-
-                        if (blurSheet === true) {
-                            logger.info(
-                                `Using blurred thumbnail for sheet ${iSheetNum}: Name '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
-                            );
-
-                            // Set new sheet thumbnail
-                            sheetProperties.thumbnail.qStaticContentUrlDef.qUrl = `/content/${options.contentlibrary}/thumbnail-${appId}-${iSheetNum}-blurred.png`;
-                        } else {
-                            logger.info(
-                                `Using regular thumbnail for sheet ${iSheetNum}: Name '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
-                            );
-
-                            // Set new sheet thumbnail
-                            sheetProperties.thumbnail.qStaticContentUrlDef.qUrl = `/content/${options.contentlibrary}/thumbnail-${appId}-${iSheetNum}.png`;
-                        }
-
-                        // Set & save new sheet thumbnail
-                        const res = await sheetObj.setProperties(sheetProperties);
-                        logger.debug(`Set thumbnail result: ${JSON.stringify(res, null, 2)}`);
-                    }
+                    );
                 }
-            );
-        }
 
-        // The close sits in a finally: the save can reject - a published app, or one the
-        // service account may not write - and without this the engine websocket would be
-        // left open for the life of the process, once per failing app.
-        try {
-            await saveIfChanged(
-                app,
-                { logPrefix: 'QSEOW UPDATE SHEETS', appId },
-                sheetRun?.changed ?? 0
-            );
-        } finally {
-            // enigma.js always resolves close() truthy; a real failure rejects into the catch below.
-            await session.close();
-        }
+                // Saved inside the session callback: withEngineSession closes the session once
+                // this resolves or throws, so a save that rejects - a published app, or one the
+                // service account may not write - still releases the websocket.
+                await saveIfChanged(
+                    app,
+                    { logPrefix: 'QSEOW UPDATE SHEETS', appId },
+                    sheetRun?.changed ?? 0
+                );
+            }
+        );
         logger.verbose(
             `Closed session after updating sheet thumbnail images in QSEoW app ${appId} on host ${options.host}`
         );

--- a/src/lib/qseow/qseow-updatesheets.js
+++ b/src/lib/qseow/qseow-updatesheets.js
@@ -8,6 +8,7 @@ import {
     SHEET_SKIPPED,
     sortSheetsByRank,
     saveIfChanged,
+    getSheetList,
 } from '../util/sheet-list.js';
 
 /**
@@ -63,32 +64,17 @@ export const qseowUpdateSheetThumbnails = async (
                 logger.verbose(`Opened app ${appId}`);
 
                 // Get list of app sheets
-                const appSheetsCall = {
-                    qInfo: {
-                        qId: 'SheetList',
-                        qType: 'SheetList',
-                    },
-                    qAppObjectListDef: {
-                        qType: 'sheet',
-                        qData: {
-                            thumbnail: '/thumbnail',
-                            rank: '/rank',
-                        },
-                    },
-                };
+                const sheets = await getSheetList(app);
 
-                const genericListObj = await app.createSessionObject(appSheetsCall);
-                const sheetListObj = await genericListObj.getLayout();
-
-                if (sheetListObj.qAppObjectList.qItems.length > 0) {
+                if (sheets.length > 0) {
                     // dimObj.qAppObjectList.qItems[] now contains array of app sheets.
-                    logger.info(`Number of sheets: ${sheetListObj.qAppObjectList.qItems.length}`);
+                    logger.info(`Number of sheets: ${sheets.length}`);
 
                     // Sort sheets
-                    sortSheetsByRank(sheetListObj.qAppObjectList.qItems);
+                    sortSheetsByRank(sheets);
 
                     sheetRun = await runOverSheets(
-                        sheetListObj.qAppObjectList.qItems,
+                        sheets,
                         {
                             logPrefix: 'QSEOW UPDATE SHEETS',
                             appId,

--- a/src/lib/util/__tests__/engine-session.test.js
+++ b/src/lib/util/__tests__/engine-session.test.js
@@ -1,0 +1,216 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+jest.unstable_mockModule('enigma.js', () => ({ default: { create: jest.fn() } }));
+
+jest.unstable_mockModule('../../../globals.js', () => ({
+    logger: {
+        info: jest.fn(),
+        verbose: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+    },
+}));
+
+const enigma = (await import('enigma.js')).default;
+const { logger } = await import('../../../globals.js');
+const { withEngineSession } = await import('../engine-session.js');
+
+const CTX = {
+    logPrefix: 'TEST',
+    loglevel: 'info',
+    connectionLabel: 'server sense.example.com',
+};
+
+/**
+ * Builds a mock enigma session and registers it with the mocked `enigma.create`.
+ *
+ * @param {object} overrides - Overrides for the session or global mocks.
+ * @param {object} overrides.global - Replacement enigma `global` object.
+ * @param {object} overrides.session - Extra properties merged onto the session.
+ *
+ * @returns {object} `{ session, global }` for assertions.
+ */
+const wireSession = ({ global: globalOverride, session: sessionOverride } = {}) => {
+    const mockGlobal = globalOverride ?? {
+        engineVersion: jest.fn().mockResolvedValue({ qComponentVersion: '12.34.5' }),
+    };
+    const session = {
+        open: jest.fn().mockResolvedValue(mockGlobal),
+        close: jest.fn().mockResolvedValue(true),
+        on: jest.fn(),
+        ...sessionOverride,
+    };
+    enigma.create.mockResolvedValue(session);
+
+    return { session, global: mockGlobal };
+};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    enigma.create.mockReset();
+});
+
+describe('withEngineSession', () => {
+    test('hands the callback the enigma global object', async () => {
+        const { global } = wireSession();
+        const seen = [];
+
+        await withEngineSession({ url: 'wss://x' }, CTX, async (g) => {
+            seen.push(g);
+        });
+
+        expect(seen).toEqual([global]);
+    });
+
+    test('returns whatever the callback resolves to', async () => {
+        wireSession();
+
+        await expect(withEngineSession({}, CTX, async () => 'the-result')).resolves.toBe(
+            'the-result'
+        );
+    });
+
+    test('closes the session on the happy path', async () => {
+        const { session } = wireSession();
+
+        await withEngineSession({}, CTX, async () => true);
+
+        expect(session.close).toHaveBeenCalledTimes(1);
+    });
+
+    test('closes the session when the callback throws', async () => {
+        // The leak this helper exists to make impossible.
+        const { session } = wireSession();
+
+        await expect(
+            withEngineSession({}, CTX, async () => {
+                throw new Error('body blew up');
+            })
+        ).rejects.toThrow('body blew up');
+
+        expect(session.close).toHaveBeenCalledTimes(1);
+    });
+
+    test('closes the session when opening it fails', async () => {
+        const { session } = wireSession();
+        session.open.mockRejectedValue(new Error('handshake refused'));
+
+        await expect(withEngineSession({}, CTX, async () => true)).rejects.toThrow(
+            'handshake refused'
+        );
+
+        expect(session.close).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not call the callback when the session cannot be opened', async () => {
+        const { session } = wireSession();
+        session.open.mockRejectedValue(new Error('handshake refused'));
+        const fn = jest.fn();
+
+        await expect(withEngineSession({}, CTX, fn)).rejects.toThrow();
+
+        expect(fn).not.toHaveBeenCalled();
+    });
+
+    test('propagates a create failure without trying to close', async () => {
+        // create() is outside the try on purpose - there is no session to release.
+        enigma.create.mockRejectedValue(new Error('cannot reach engine'));
+
+        await expect(withEngineSession({}, CTX, async () => true)).rejects.toThrow(
+            'cannot reach engine'
+        );
+    });
+
+    test('closes the session exactly once', async () => {
+        const { session } = wireSession();
+
+        await withEngineSession({}, CTX, async () => true);
+
+        expect(session.close).toHaveBeenCalledTimes(1);
+    });
+
+    describe('a close that fails', () => {
+        test('does not mask the error the callback threw', async () => {
+            // Without this, `try { throw ORIGINAL } finally { await reject(CLOSE) }` propagates
+            // CLOSE, and the operator is told the session would not close instead of why the app
+            // actually failed.
+            const { session } = wireSession();
+            session.close.mockRejectedValue(new Error('close failed'));
+
+            await expect(
+                withEngineSession({}, CTX, async () => {
+                    throw new Error('ORIGINAL failure');
+                })
+            ).rejects.toThrow('ORIGINAL failure');
+        });
+
+        test('is logged when it is swallowed, so it is not lost silently', async () => {
+            const { session } = wireSession();
+            session.close.mockRejectedValue(new Error('close failed'));
+
+            await expect(
+                withEngineSession({}, CTX, async () => {
+                    throw new Error('ORIGINAL failure');
+                })
+            ).rejects.toThrow();
+
+            const logged = logger.error.mock.calls.map((c) => String(c[0])).join('\n');
+            expect(logged).toContain('close failed');
+            expect(logged).toContain('TEST');
+        });
+
+        test('still propagates when the callback succeeded', async () => {
+            // Nothing to mask here, so the close failure is the app's failure - as before.
+            const { session } = wireSession();
+            session.close.mockRejectedValue(new Error('close failed'));
+
+            await expect(withEngineSession({}, CTX, async () => 'ok')).rejects.toThrow(
+                'close failed'
+            );
+        });
+    });
+
+    describe('silly traffic logging', () => {
+        test('attaches no traffic handlers below silly', async () => {
+            const { session } = wireSession();
+
+            await withEngineSession({}, { ...CTX, loglevel: 'debug' }, async () => true);
+
+            expect(session.on).not.toHaveBeenCalled();
+        });
+
+        test('attaches both traffic handlers at silly', async () => {
+            const { session } = wireSession();
+
+            await withEngineSession({}, { ...CTX, loglevel: 'silly' }, async () => true);
+
+            expect(session.on).toHaveBeenCalledWith('traffic:sent', expect.any(Function));
+            expect(session.on).toHaveBeenCalledWith('traffic:received', expect.any(Function));
+        });
+
+        test('pretty-prints received traffic, settling the 4-vs-2 split', async () => {
+            // Four modules pretty-printed received traffic and two logged the raw object. The
+            // majority form wins, so `silly` output is now identical everywhere.
+            const { session } = wireSession();
+            const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+            await withEngineSession({}, { ...CTX, loglevel: 'silly' }, async () => true);
+            const received = session.on.mock.calls.find(([e]) => e === 'traffic:received')[1];
+            received({ a: 1 });
+
+            expect(log).toHaveBeenCalledWith('received:', JSON.stringify({ a: 1 }, null, 2));
+            log.mockRestore();
+        });
+    });
+
+    test('logs the engine version against the supplied connection label', async () => {
+        wireSession();
+
+        await withEngineSession({}, CTX, async () => true);
+
+        const logged = logger.verbose.mock.calls.map((c) => String(c[0])).join('\n');
+        expect(logged).toContain('Created session to server sense.example.com');
+        expect(logged).toContain('engine version is 12.34.5');
+    });
+});

--- a/src/lib/util/__tests__/sheet-list.test.js
+++ b/src/lib/util/__tests__/sheet-list.test.js
@@ -18,6 +18,9 @@ const {
     saveIfChanged,
     SHEET_SKIPPED,
     sortSheetsByRank,
+    getSheetList,
+    SHEET_LIST_FIELDS,
+    SHEET_LIST_FIELDS_EXTENDED,
 } = await import('../sheet-list.js');
 
 /**
@@ -474,5 +477,79 @@ describe('runOverSheets — changed count', () => {
         const result = await runOverSheets([sheet('a')], CTX, async () => SHEET_SKIPPED);
 
         expect(result.changed).toBe(0);
+    });
+});
+
+describe('getSheetList', () => {
+    /**
+     * Builds a mock app whose session object serves the supplied sheet items.
+     *
+     * @param {object[]} items - Sheet list items to return.
+     *
+     * @returns {object} The mock app.
+     */
+    const appReturning = (items) => ({
+        createSessionObject: jest.fn().mockResolvedValue({
+            getLayout: jest.fn().mockResolvedValue({ qAppObjectList: { qItems: items } }),
+        }),
+    });
+
+    test('returns the sheet items rather than the engine envelope', async () => {
+        const items = [{ qInfo: { qId: 'a' } }];
+
+        await expect(getSheetList(appReturning(items))).resolves.toEqual(items);
+    });
+
+    test('asks for a SheetList session object', async () => {
+        const app = appReturning([]);
+
+        await getSheetList(app);
+
+        expect(app.createSessionObject).toHaveBeenCalledWith(
+            expect.objectContaining({
+                qInfo: { qId: 'SheetList', qType: 'SheetList' },
+                qAppObjectListDef: expect.objectContaining({ qType: 'sheet' }),
+            })
+        );
+    });
+
+    test('requests the minimal projection by default', async () => {
+        // These field sets were verified byte-identical to the six hand-written copies they
+        // replace. Asking for the wrong ones would leave qData fields undefined downstream,
+        // which reads as "sheet has no rank" rather than as an error.
+        const app = appReturning([]);
+
+        await getSheetList(app);
+
+        expect(app.createSessionObject.mock.calls[0][0].qAppObjectListDef.qData).toEqual({
+            thumbnail: '/thumbnail',
+            rank: '/rank',
+        });
+    });
+
+    test('requests the wider projection when asked', async () => {
+        const app = appReturning([]);
+
+        await getSheetList(app, SHEET_LIST_FIELDS_EXTENDED);
+
+        expect(app.createSessionObject.mock.calls[0][0].qAppObjectListDef.qData).toEqual({
+            title: '/qMetaDef/title',
+            description: '/qMetaDef/description',
+            thumbnail: '/thumbnail',
+            cells: '/cells',
+            rank: '/rank',
+            columns: '/columns',
+            rows: '/rows',
+        });
+    });
+
+    test('the wider projection is a superset of the default', async () => {
+        Object.entries(SHEET_LIST_FIELDS).forEach(([key, value]) => {
+            expect(SHEET_LIST_FIELDS_EXTENDED[key]).toBe(value);
+        });
+    });
+
+    test('an app with no sheets yields an empty list, not a throw', async () => {
+        await expect(getSheetList(appReturning([]))).resolves.toEqual([]);
     });
 });

--- a/src/lib/util/engine-session.js
+++ b/src/lib/util/engine-session.js
@@ -1,0 +1,99 @@
+import enigma from 'enigma.js';
+
+import { logger } from '../../globals.js';
+
+/**
+ * Opens an engine session, hands the callback the global object, and always releases the session.
+ *
+ * Six modules hand-rolled this create/open/close sequence, and the copies had already drifted:
+ * four pretty-printed received traffic at `silly` level while two logged the raw object, and two
+ * of them closed only on the happy path, leaking the websocket for the life of the process on
+ * every failing app.
+ *
+ * The session is closed in a `finally`, so the callback cannot leak it. That is also why the
+ * callback should contain everything that needs the session and nothing that does not: in the
+ * two `process-app` modules the thumbnail-update step opens its own session to the same app, and
+ * pulling it inside this callback would hold two engine sessions per app - doubling licence
+ * consumption, and failing at a per-user session ceiling after screenshots were already taken.
+ * Keep such work after the call, not inside it.
+ *
+ * A close that rejects while the callback is already throwing is logged rather than thrown.
+ * Otherwise it would replace the real cause, and the operator would be told the session could not
+ * be closed instead of why the app failed. When the callback succeeded there is nothing to mask,
+ * so a failing close still propagates, as it did before.
+ *
+ * @param {object} configEnigma - Fully-built enigma.js config. Built by the caller, because the
+ *     two platforms construct it differently.
+ * @param {object} ctx - Logging context.
+ * @param {string} ctx.logPrefix - Prefix for error output, e.g. `'QSEOW UPDATE SHEETS'`.
+ * @param {string} ctx.loglevel - Active log level; `'silly'` attaches the traffic handlers.
+ * @param {string} ctx.connectionLabel - What was connected to, e.g. `'server sense.example.com'`
+ *     or `'Qlik Sense Cloud tenant foo.eu.qlikcloud.com'`. Rendered into the existing
+ *     `Created session to …, engine version is …` line.
+ * @param {Function} fn - Async callback receiving the enigma `global` object. Its resolved value
+ *     is returned.
+ *
+ * @returns {Promise<unknown>} Whatever `fn` resolves to.
+ *
+ * @throws {Error} Whatever `fn` throws, or whatever `enigma.create`, `open()` or a close on an
+ *     otherwise successful run throws.
+ */
+export const withEngineSession = async (configEnigma, ctx, fn) => {
+    const { logPrefix, loglevel, connectionLabel } = ctx;
+
+    // Outside the try: if this throws there is no session to release.
+    const session = await enigma.create(configEnigma);
+
+    let result;
+    let bodyFailed = false;
+    let bodyError;
+
+    try {
+        // Inside the try, so that nothing between create and close can leak the session -
+        // attaching a handler is not expected to throw, but the point of this helper is that
+        // the answer does not depend on that.
+        if (loglevel === 'silly') {
+            session.on('traffic:sent', (data) => console.log('sent:', data));
+            session.on('traffic:received', (data) =>
+                console.log('received:', JSON.stringify(data, null, 2))
+            );
+        }
+
+        const global = await session.open();
+
+        const engineVersion = await global.engineVersion();
+        logger.verbose(
+            `Created session to ${connectionLabel}, engine version is ${engineVersion.qComponentVersion}`
+        );
+
+        result = await fn(global);
+    } catch (err) {
+        // Recorded rather than rethrown here, so the close below runs exactly once on every
+        // path. A `finally` would do the same, but throwing the close error out of a `finally`
+        // silently discards whichever completion was already pending - the very masking this
+        // guards against, and what `no-unsafe-finally` warns about.
+        bodyFailed = true;
+        bodyError = err;
+    }
+
+    try {
+        // enigma.js always resolves close() truthy; a real failure rejects.
+        await session.close();
+    } catch (closeErr) {
+        if (!bodyFailed) {
+            throw closeErr;
+        }
+
+        logger.error(
+            `${logPrefix}: The app failed, and the engine session could not be closed either: ${closeErr?.message ?? closeErr}`
+        );
+    }
+
+    if (bodyFailed) {
+        // A separate flag rather than a truthiness check on bodyError: a thrown `undefined` is
+        // still a failure, and must not be reported as success.
+        throw bodyError;
+    }
+
+    return result;
+};

--- a/src/lib/util/sheet-list.js
+++ b/src/lib/util/sheet-list.js
@@ -7,6 +7,58 @@ import { logger } from '../../globals.js';
 import { getErrorCategory } from './error-categorizer.js';
 
 /**
+ * The `qData` projection every caller needs: enough to place a sheet and see its thumbnail.
+ */
+export const SHEET_LIST_FIELDS = {
+    thumbnail: '/thumbnail',
+    rank: '/rank',
+};
+
+/**
+ * The wider projection the icon-removal paths ask for. Kept as a distinct constant rather than
+ * always requesting the superset, so no caller silently starts pulling fields it does not read.
+ */
+export const SHEET_LIST_FIELDS_EXTENDED = {
+    title: '/qMetaDef/title',
+    description: '/qMetaDef/description',
+    thumbnail: '/thumbnail',
+    cells: '/cells',
+    rank: '/rank',
+    columns: '/columns',
+    rows: '/rows',
+};
+
+/**
+ * Fetches an app's sheets through a `SheetList` session object.
+ *
+ * The same ~15-line session-object literal was written out in all six modules that walk an app's
+ * sheets, in two variants that differed only in which `qData` fields they asked for. Sonar
+ * counted it as the largest duplicated block between the twins.
+ *
+ * @param {object} app - Open engine app handle.
+ * @param {object} [qData] - The `qData` projection to request. Defaults to
+ *     {@link SHEET_LIST_FIELDS}; the removal paths pass {@link SHEET_LIST_FIELDS_EXTENDED}.
+ *
+ * @returns {Promise<object[]>} The sheet list items, in the order the engine returned them.
+ *     Sort with {@link sortSheetsByRank} before assigning sheet numbers.
+ */
+export const getSheetList = async (app, qData = SHEET_LIST_FIELDS) => {
+    const genericListObj = await app.createSessionObject({
+        qInfo: {
+            qId: 'SheetList',
+            qType: 'SheetList',
+        },
+        qAppObjectListDef: {
+            qType: 'sheet',
+            qData,
+        },
+    });
+    const sheetListObj = await genericListObj.getLayout();
+
+    return sheetListObj.qAppObjectList.qItems;
+};
+
+/**
  * Sorts a list of app sheets by their engine rank, in place.
  *
  * Sheet order matters beyond presentation: it assigns each sheet its 1-based sheet


### PR DESCRIPTION
Second of three steps toward #872 Part 2. Step 1 (#902) fixed the session leak in the two `process-app` twins; this introduces the shared helper and adopts it where the shape already fits. Step 3 converts the two `process-app` modules.

## What the six copies had drifted into

| Divergence | Before |
|---|---|
| `silly` received traffic | 4 modules pretty-printed, 2 logged the raw object |
| Session release | 4 closed in a `finally`, 2 only on the happy path (fixed in #902) |
| `Created session to …` | Same sentence, written out six times |

`withEngineSession(configEnigma, ctx, fn)` owns create, the `silly` handlers, `open()`, the engine-version log, and the close. The enigma config is still built by the caller, because the two platforms construct it differently.

Adopted in the four modules that already closed in a `finally`. **Net 33 fewer lines** in those four.

## Two defects that centralising fixes

**A rejecting `close()` no longer replaces the real error.** Verified by execution: `try { throw ORIGINAL } finally { await reject(CLOSE) }` propagates `CLOSE`. So an app that failed at a refused save would report that the session could not be closed, and the operator never sees why it actually failed. Now the close error is logged when the callback already threw, and still propagates when it did not — there is nothing to mask in that case.

The close deliberately runs **outside any `finally`**. Throwing from a `finally` silently discards whichever completion was pending, which is the same masking in a different disguise — ESLint's `no-unsafe-finally` flagged my first attempt, correctly. The four outcomes are now explicit and verified as a truth table against the real module:

| | close ok | close fails |
|---|---|---|
| **callback ok** | returns result | throws close error |
| **callback fails** | throws callback error | throws callback error *(close logged)* |

`close` is called exactly once in all four.

**Two Cloud modules logged `on host undefined`.** They interpolated `options.host`; Qlik Sense Cloud has no such option — nothing under `src/lib/commands/qscloud` defines one, and the integration test supplies only `tenanturl`. Fixed to `on tenant …`. Nothing covered those lines, which is how it survived: the full suite stayed green through the change. Both twins now assert it, and reverting either fails a test.

## Behaviour changes

- Received traffic at `silly` is pretty-printed in all six modules (was 4 pretty / 2 raw).
- The Cloud session-closed line names the tenant instead of `undefined`.

Both `Created session to …` variants are rendered from a caller-supplied label and were verified **byte-identical** to the originals. No other operator-facing string changed — checked by diffing every removed `logger.*` line against what remains.

No doc page: the only observable differences are `silly`-level traffic formatting and a fixed verbose line, neither of which an administrator acts on.

## Verification

- **783 unit tests / 51 suites**, lint and Prettier clean
- **QSEoW 2/2** and **Cloud 1/1** integration against live servers, re-run on the final state (an earlier run overlapped with later edits, so it did not describe the final code)
- Eight mutations, all caught. The one that matters: **removing the close from the helper fails 24 tests across the four callers**, so the extraction did not erode their existing coverage.

## Watch the duplication gate

#902 tripped `new_duplicated_lines_density` on pre-existing twin duplication, one block of which was **exactly the session preamble this helper replaces**. If this PR is also flagged, the likely cause is the four near-identical call preambles, and the fix would be thin `withQseowSession` / `withCloudSession` wrappers owning the config build and the label — collapsing each site to one line, and paying off again for the two step-3 callers. Left out deliberately rather than added speculatively; the Sonar run decides it.

## Known, not in scope

- Both remove modules log the wrong verb on close ("updating" / "generating" when removing) — Part 3 message work.
- `openDoc` is duplicated across all four with a `verbose` / `info` split that looks deliberate and is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)