### PR TITLE
refactor: convert the process-app twins, and stop leaking the browser (#872 part 2)

### DIFF
--- a/src/lib/browser/__tests__/browser_launch.test.js
+++ b/src/lib/browser/__tests__/browser_launch.test.js
@@ -38,7 +38,7 @@ jest.unstable_mockModule('node:fs', () => ({
 }));
 const fs = await import('node:fs');
 
-const { launchBrowserForApp, buildBrowserArgs, resolveBrowserExecutablePath } =
+const { launchBrowserForApp, buildBrowserArgs, resolveBrowserExecutablePath, closeBrowserQuietly } =
     await import('../browser-launch.js');
 
 /** Stand-in typed error, matching the (message, { cause }) shape of the real ones. */
@@ -188,5 +188,41 @@ describe('launchBrowserForApp', () => {
         await launchBrowserForApp(OPTIONS, CONTEXT).catch(() => undefined);
 
         expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('no display available'));
+    });
+});
+
+describe('closeBrowserQuietly', () => {
+    test('closes the browser', async () => {
+        const browser = { close: jest.fn().mockResolvedValue(undefined) };
+
+        await closeBrowserQuietly(browser, 'QSEOW');
+
+        expect(browser.close).toHaveBeenCalledTimes(1);
+    });
+
+    test('swallows a close failure rather than throwing', async () => {
+        // This runs from a finally that may already be unwinding a real failure. Throwing here
+        // would replace the cause the operator needs to see.
+        const browser = { close: jest.fn().mockRejectedValue(new Error('browser is wedged')) };
+
+        await expect(closeBrowserQuietly(browser, 'QSEOW')).resolves.toBeUndefined();
+    });
+
+    test('logs the failure with the caller prefix, so it is not lost silently', async () => {
+        const browser = { close: jest.fn().mockRejectedValue(new Error('browser is wedged')) };
+
+        await closeBrowserQuietly(browser, 'CLOUD APP');
+
+        const logged = logger.error.mock.calls.map((call) => String(call[0])).join('\n');
+        expect(logged).toContain('CLOUD APP');
+        expect(logged).toContain('browser is wedged');
+    });
+
+    test.each([
+        ['undefined', undefined],
+        ['null', null],
+    ])('ignores a %s browser, so a failed launch can share the finally', async (_l, browser) => {
+        await expect(closeBrowserQuietly(browser, 'QSEOW')).resolves.toBeUndefined();
+        expect(logger.error).not.toHaveBeenCalled();
     });
 });

--- a/src/lib/browser/browser-launch.js
+++ b/src/lib/browser/browser-launch.js
@@ -179,3 +179,36 @@ export const launchBrowserForApp = async (options, { appId, logPrefix, appLabel,
         });
     }
 };
+
+/**
+ * Closes a virtual browser, swallowing and logging any failure.
+ *
+ * Belongs in a `finally`. Both screenshot paths launched the browser and closed it ~290 lines
+ * later on the happy path only, so any failure in between - navigation, login, a screenshot,
+ * image processing - stranded a Chrome process for the life of the run, once per failing app.
+ * Each of those holds hundreds of MB.
+ *
+ * Failures are logged rather than thrown on purpose: this runs on the way out of a region that
+ * may already be unwinding, and a throw here would replace the real cause. That mirrors what the
+ * two hand-written copies did, minus the drifted log prefix.
+ *
+ * @param {object} browser - Puppeteer browser handle. A nullish value is ignored, so callers can
+ *     put this in a `finally` that also covers a failed launch.
+ * @param {string} logPrefix - Prefix for the error line, e.g. `'QSEOW'`.
+ *
+ * @returns {Promise<void>} Resolves once the browser is closed, or the failure is logged.
+ */
+export const closeBrowserQuietly = async (browser, logPrefix) => {
+    if (!browser) {
+        return;
+    }
+
+    try {
+        await browser.close();
+        logger.verbose('Closed virtual browser');
+    } catch (err) {
+        logger.error(
+            `${logPrefix}: Could not close virtual browser: ${err?.stack || err?.message || err}`
+        );
+    }
+};

--- a/src/lib/cloud/__tests__/process_cloud_app.test.js
+++ b/src/lib/cloud/__tests__/process_cloud_app.test.js
@@ -262,6 +262,7 @@ describe('process-cloud-app.js — puppeteer launch and click options', () => {
             on: jest.fn(),
         };
         enigma.create.mockResolvedValue(mockSession);
+        mockSession._app = mockApp;
 
         return mockSession;
     }
@@ -331,6 +332,111 @@ describe('process-cloud-app.js — puppeteer launch and click options', () => {
         // resolves close() truthy, so it only ever fired on a misreading of the contract.
         const logged = logger.error.mock.calls.map((call) => String(call[0])).join('\n');
         expect(logged).not.toContain('Error closing session');
+    });
+
+    describe('session and sheet-list wiring', () => {
+        beforeEach(() => {
+            jest.clearAllMocks();
+            detectAvailableBrowser.mockResolvedValue({
+                executablePath: '/test/browser',
+                source: 'system',
+                browser: 'chrome',
+                buildId: 'system-installed',
+            });
+            browserInstall.mockReset();
+        });
+
+        test('asks the engine for showCondition, which sheet exclusion depends on', async () => {
+            // The screenshot paths need a wider projection than the other callers. Requesting the
+            // default set would leave qData.showCondition undefined on every sheet, which reads as
+            // "no show condition" rather than as an error - silently disabling that exclusion rule.
+            const session = wireEnigmaSession();
+            wireSaasGet();
+            puppeteer.launch.mockResolvedValue(buildMockBrowser());
+
+            await processCloudApp('test-app-id', defaultSaasInstance, defaultOptions);
+
+            const qData = session._app.createSessionObject.mock.calls[0][0].qAppObjectListDef.qData;
+            expect(qData).toHaveProperty('showCondition', '/showCondition');
+            expect(qData).toHaveProperty('rank', '/rank');
+            expect(qData).toHaveProperty('title', '/qMetaDef/title');
+        });
+
+        test('logs the created session at info, the level operators see by default', async () => {
+            // The four non-screenshot callers log this at verbose; these two always logged it at
+            // info, and the default log level is info. Letting the shared helper demote it would
+            // remove a line from every run.
+            wireEnigmaSession();
+            wireSaasGet();
+            puppeteer.launch.mockResolvedValue(buildMockBrowser());
+
+            await processCloudApp('test-app-id', defaultSaasInstance, defaultOptions);
+
+            const atInfo = logger.info.mock.calls.map((call) => String(call[0])).join('\n');
+            expect(atInfo).toContain(
+                'Created session to Qlik Sense Cloud tenant test-tenant.eu.qlikcloud.com'
+            );
+            expect(atInfo).toContain('engine version is');
+        });
+    });
+
+    describe('the virtual browser is released when the app fails', () => {
+        beforeEach(() => {
+            jest.clearAllMocks();
+            detectAvailableBrowser.mockResolvedValue({
+                executablePath: '/test/browser',
+                source: 'system',
+                browser: 'chrome',
+                buildId: 'system-installed',
+            });
+            browserInstall.mockReset();
+        });
+
+        test('closes the browser when a page operation throws', async () => {
+            // The browser was launched ~290 lines above its close and released on the happy
+            // path only, so any failure in between stranded a Chrome process for the life of
+            // the run - once per failing app, at hundreds of MB each.
+            const browser = setupHappyPath();
+            browser._page.goto.mockRejectedValue(new Error('navigation timed out'));
+
+            await expect(
+                processCloudApp('test-app-id', defaultSaasInstance, defaultOptions)
+            ).rejects.toThrow();
+
+            expect(browser.close).toHaveBeenCalledTimes(1);
+        });
+
+        test('closes the browser when creating the page throws', async () => {
+            const browser = setupHappyPath();
+            browser.newPage.mockRejectedValue(new Error('no page for you'));
+
+            await expect(
+                processCloudApp('test-app-id', defaultSaasInstance, defaultOptions)
+            ).rejects.toThrow();
+
+            expect(browser.close).toHaveBeenCalledTimes(1);
+        });
+
+        test('a browser that will not close does not mask the real failure', async () => {
+            const browser = setupHappyPath();
+            browser._page.goto.mockRejectedValue(new Error('navigation timed out'));
+            browser.close.mockRejectedValue(new Error('browser is wedged'));
+
+            await expect(
+                processCloudApp('test-app-id', defaultSaasInstance, defaultOptions)
+            ).rejects.toThrow();
+
+            const logged = logger.error.mock.calls.map((call) => String(call[0])).join('\n');
+            expect(logged).toContain('navigation timed out');
+        });
+
+        test('closes the browser exactly once on a clean run', async () => {
+            const browser = setupHappyPath();
+
+            await processCloudApp('test-app-id', defaultSaasInstance, defaultOptions);
+
+            expect(browser.close).toHaveBeenCalledTimes(1);
+        });
     });
 
     describe('the engine session is released when the app fails', () => {

--- a/src/lib/cloud/process-cloud-app.js
+++ b/src/lib/cloud/process-cloud-app.js
@@ -1,4 +1,3 @@
-import enigma from 'enigma.js';
 import fs from 'fs';
 import { setupEnigmaConnection } from './cloud-enigma.js';
 import { logger, sleep } from '../../globals.js';
@@ -7,8 +6,15 @@ import { qscloudUpdateSheetThumbnails } from './cloud-updatesheets.js';
 import { deleteCloudAppThumbnail } from './cloud-delete-thumbnails.js';
 import { takeSheetScreenshot } from './sheet-screenshot.js';
 import { CloudError } from '../util/errors.js';
-import { launchBrowserForApp } from '../browser/browser-launch.js';
-import { runOverSheets, SHEET_SKIPPED, sortSheetsByRank } from '../util/sheet-list.js';
+import { launchBrowserForApp, closeBrowserQuietly } from '../browser/browser-launch.js';
+import {
+    runOverSheets,
+    SHEET_SKIPPED,
+    sortSheetsByRank,
+    getSheetList,
+    SHEET_LIST_FIELDS_WITH_SHOW_CONDITION,
+} from '../util/sheet-list.js';
+import { withEngineSession } from '../util/engine-session.js';
 import { determineSheetExcludeStatus } from './determine-sheet-exclude-status.js';
 
 // Selector paths to elements on login page
@@ -100,201 +106,160 @@ export const processCloudApp = async (appId, saasInstance, options) => {
         // Configure Enigma.js
         const configEnigma = setupEnigmaConnection(appId, options);
         const imgDir = options.imagedir;
-        const session = await enigma.create(configEnigma);
-        if (options.loglevel === 'silly') {
-            session.on('traffic:sent', (data) => console.log('sent:', data));
-            session.on('traffic:received', (data) =>
-                console.log('received:', JSON.stringify(data, null, 2))
-            );
-        }
-
         const createdFiles = [];
 
-        try {
-            const global = await session.open();
-            const engineVersion = await global.engineVersion();
-            logger.info(
-                `Created session to Qlik Sense Cloud tenant ${options.tenanturl}, engine version is ${engineVersion.qComponentVersion}`
-            );
-            const app = await global.openDoc(appId, '', '', '', false);
-            logger.info(`Opened app ${appId}`);
-            logger.info(`App name: "${appMetadata.attributes.name}"`);
-            logger.info(`App is published: ${appMetadata.attributes.published}`);
+        await withEngineSession(
+            configEnigma,
+            {
+                logPrefix: 'CLOUD PROCESS APP',
+                loglevel: options.loglevel,
+                connectionLabel: `Qlik Sense Cloud tenant ${options.tenanturl}`,
+                // These two logged the session line at info, and the default level is
+                // info - demoting it would drop a line operators see on every run.
+                sessionLogLevel: 'info',
+            },
+            async (global) => {
+                const app = await global.openDoc(appId, '', '', '', false);
+                logger.info(`Opened app ${appId}`);
+                logger.info(`App name: "${appMetadata.attributes.name}"`);
+                logger.info(`App is published: ${appMetadata.attributes.published}`);
 
-            // Get list of app sheets
-            const appSheetsCall = {
-                qInfo: {
-                    qId: 'SheetList',
-                    qType: 'SheetList',
-                },
-                qAppObjectListDef: {
-                    qType: 'sheet',
-                    qData: {
-                        title: '/qMetaDef/title',
-                        description: '/qMetaDef/description',
-                        thumbnail: '/thumbnail',
-                        cells: '/cells',
-                        rank: '/rank',
-                        columns: '/columns',
-                        rows: '/rows',
-                        showCondition: '/showCondition',
-                    },
-                },
-            };
-            const genericListObj = await app.createSessionObject(appSheetsCall);
-            const sheetListObj = await genericListObj.getLayout();
+                // Get list of app sheets
+                const sheets = await getSheetList(app, SHEET_LIST_FIELDS_WITH_SHOW_CONDITION);
 
-            if (sheetListObj.qAppObjectList.qItems.length > 0) {
-                // sheetListObj.qAppObjectList.qItems[] now contains array of app sheets.
-                logger.info(
-                    `Number of sheets in app: ${sheetListObj.qAppObjectList.qItems.length}`
-                );
+                if (sheets.length > 0) {
+                    // sheets[] now contains array of app sheets.
+                    logger.info(`Number of sheets in app: ${sheets.length}`);
 
-                const browser = await launchBrowserForApp(options, {
-                    appId,
-                    logPrefix: 'CLOUD APP:',
-                    appLabel: 'Qlik Sense Cloud app',
-                    ErrorClass: CloudError,
-                });
-
-                const page = await browser.newPage();
-                // Thumbnails should be 410x270 pixels, so set the viewport to a multiple of this.
-                await page.setViewport({
-                    width: 1230,
-                    height: 810,
-                    deviceScaleFactor: 1,
-                });
-                // Set default timeout for all page operations to 90 seconds
-                await page.setDefaultTimeout(pageTimeout);
-
-                // Qlik Sense cloud URL format:
-                // https://<tenant FQDN>/sense/app/<app ID>>
-                const appUrl = `https://${options.tenanturl}/sense/app/${appId}`;
-                logger.debug(`App URL: ${appUrl}`);
-                await Promise.all([
-                    page.goto(appUrl, { waitUntil: 'networkidle2', timeout: pageTimeout }),
-                ]);
-                await sleep(options.pagewait * 1000);
-                await page.screenshot({ path: `${imgDir}/cloud/${appId}/loginpage-1.png` });
-                // Should login be skipped?
-                if (options.skiplogin === true) {
-                    logger.info('Skipping login as --skip-login is set to true');
-                } else {
-                    // Enter credentials
-                    // User
-                    await page.click(selectorLoginPageUserName, {
-                        button: 'left',
-                        delay: 10,
-                    });
-                    const user = `${options.logonuserid}`;
-                    await page.keyboard.type(user);
-                    // Pwd
-                    await page.click(selectorLoginPageUserPwd, {
-                        button: 'left',
-                        delay: 10,
-                    });
-                    await page.keyboard.type(options.logonpwd);
-                    await page.screenshot({ path: `${imgDir}/cloud/${appId}/loginpage-2.png` });
-                    // Click login button and wait for page to load
-                    await Promise.all([
-                        page.click(selectorLoginPageLoginButton, {
-                            button: 'left',
-                            delay: 10,
-                        }),
-                        page.waitForNavigation({ waitUntil: 'networkidle2', timeout: pageTimeout }),
-                    ]);
-                    await sleep(options.pagewait * 1000);
-                }
-                // Take screenshot of app overview page
-                await page.screenshot({ path: `${imgDir}/cloud/${appId}/overview-1.png` });
-                // Sort sheets
-                sortSheetsByRank(sheetListObj.qAppObjectList.qItems);
-
-                // Loop over all sheets in app
-                sheetRun = await runOverSheets(
-                    sheetListObj.qAppObjectList.qItems,
-                    {
-                        logPrefix: 'CLOUD APP',
+                    const browser = await launchBrowserForApp(options, {
                         appId,
-                        action: 'create a thumbnail for',
+                        logPrefix: 'CLOUD APP:',
+                        appLabel: 'Qlik Sense Cloud app',
                         ErrorClass: CloudError,
-                    },
-                    async (sheet, iSheetNum) => {
-                        // Should this sheet be processed, or is it on exclude list?
-                        // Options are
-                        // --exclude-sheet-number <number...>
-                        // --exclude-sheet-title <title...>
-                        // --exclude-sheet-status <status...>
-                        const { excludeSheet, sheetIsHidden } = await determineSheetExcludeStatus(
-                            app,
-                            sheet,
-                            options,
-                            appIsPublished,
-                            iSheetNum,
-                            logger
-                        );
+                    });
 
-                        if (excludeSheet === true) {
-                            logger.info(
-                                `Excluded sheet: ${iSheetNum}: '${sheet?.qMeta?.title}', ID ${sheet?.qInfo?.qId}, description '${sheet?.qMeta?.description}', approved '${sheet?.qMeta?.approved === true}', published '${sheet?.qMeta?.published === true}', hidden '${sheetIsHidden}'`
-                            );
+                    try {
+                        const page = await browser.newPage();
+                        // Thumbnails should be 410x270 pixels, so set the viewport to a multiple of this.
+                        await page.setViewport({
+                            width: 1230,
+                            height: 810,
+                            deviceScaleFactor: 1,
+                        });
+                        // Set default timeout for all page operations to 90 seconds
+                        await page.setDefaultTimeout(pageTimeout);
 
-                            return SHEET_SKIPPED;
+                        // Qlik Sense cloud URL format:
+                        // https://<tenant FQDN>/sense/app/<app ID>>
+                        const appUrl = `https://${options.tenanturl}/sense/app/${appId}`;
+                        logger.debug(`App URL: ${appUrl}`);
+                        await Promise.all([
+                            page.goto(appUrl, { waitUntil: 'networkidle2', timeout: pageTimeout }),
+                        ]);
+                        await sleep(options.pagewait * 1000);
+                        await page.screenshot({ path: `${imgDir}/cloud/${appId}/loginpage-1.png` });
+                        // Should login be skipped?
+                        if (options.skiplogin === true) {
+                            logger.info('Skipping login as --skip-login is set to true');
+                        } else {
+                            // Enter credentials
+                            // User
+                            await page.click(selectorLoginPageUserName, {
+                                button: 'left',
+                                delay: 10,
+                            });
+                            const user = `${options.logonuserid}`;
+                            await page.keyboard.type(user);
+                            // Pwd
+                            await page.click(selectorLoginPageUserPwd, {
+                                button: 'left',
+                                delay: 10,
+                            });
+                            await page.keyboard.type(options.logonpwd);
+                            await page.screenshot({
+                                path: `${imgDir}/cloud/${appId}/loginpage-2.png`,
+                            });
+                            // Click login button and wait for page to load
+                            await Promise.all([
+                                page.click(selectorLoginPageLoginButton, {
+                                    button: 'left',
+                                    delay: 10,
+                                }),
+                                page.waitForNavigation({
+                                    waitUntil: 'networkidle2',
+                                    timeout: pageTimeout,
+                                }),
+                            ]);
+                            await sleep(options.pagewait * 1000);
                         }
+                        // Take screenshot of app overview page
+                        await page.screenshot({ path: `${imgDir}/cloud/${appId}/overview-1.png` });
+                        // Sort sheets
+                        sortSheetsByRank(sheets);
 
-                        logger.info(
-                            `Processing sheet ${iSheetNum}: '${sheet?.qMeta?.title}', ID ${sheet?.qInfo?.qId}, description '${sheet?.qMeta?.description}', approved '${sheet?.qMeta?.approved === true}', published '${sheet?.qMeta?.published === true}', hidden '${sheetIsHidden}'`
-                        );
+                        // Loop over all sheets in app
+                        sheetRun = await runOverSheets(
+                            sheets,
+                            {
+                                logPrefix: 'CLOUD APP',
+                                appId,
+                                action: 'create a thumbnail for',
+                                ErrorClass: CloudError,
+                            },
+                            async (sheet, iSheetNum) => {
+                                // Should this sheet be processed, or is it on exclude list?
+                                // Options are
+                                // --exclude-sheet-number <number...>
+                                // --exclude-sheet-title <title...>
+                                // --exclude-sheet-status <status...>
+                                const { excludeSheet, sheetIsHidden } =
+                                    await determineSheetExcludeStatus(
+                                        app,
+                                        sheet,
+                                        options,
+                                        appIsPublished,
+                                        iSheetNum,
+                                        logger
+                                    );
 
-                        const createdFile = await takeSheetScreenshot(
-                            page,
-                            appUrl,
-                            imgDir,
-                            appId,
-                            sheet,
-                            iSheetNum,
-                            options,
-                            logger
-                        );
+                                if (excludeSheet === true) {
+                                    logger.info(
+                                        `Excluded sheet: ${iSheetNum}: '${sheet?.qMeta?.title}', ID ${sheet?.qInfo?.qId}, description '${sheet?.qMeta?.description}', approved '${sheet?.qMeta?.approved === true}', published '${sheet?.qMeta?.published === true}', hidden '${sheetIsHidden}'`
+                                    );
 
-                        // Only reached when the screenshot, and any blur of it, succeeded. A
-                        // sheet whose thumbnail could not be produced is left out of
-                        // createdFiles entirely, so nothing later repoints it at an image that
-                        // does not exist - it keeps the icon it already had.
-                        createdFiles.push(createdFile);
+                                    return SHEET_SKIPPED;
+                                }
 
-                        return undefined;
-                    }
-                );
-                try {
-                    await browser.close();
-                    logger.verbose('Closed virtual browser');
-                } catch (err) {
-                    if (err.stack) {
-                        logger.error(
-                            `CLOUD APP: Could not close virtual browser (stack): ${err.stack}`
+                                logger.info(
+                                    `Processing sheet ${iSheetNum}: '${sheet?.qMeta?.title}', ID ${sheet?.qInfo?.qId}, description '${sheet?.qMeta?.description}', approved '${sheet?.qMeta?.approved === true}', published '${sheet?.qMeta?.published === true}', hidden '${sheetIsHidden}'`
+                                );
+
+                                const createdFile = await takeSheetScreenshot(
+                                    page,
+                                    appUrl,
+                                    imgDir,
+                                    appId,
+                                    sheet,
+                                    iSheetNum,
+                                    options,
+                                    logger
+                                );
+
+                                // Only reached when the screenshot, and any blur of it, succeeded. A
+                                // sheet whose thumbnail could not be produced is left out of
+                                // createdFiles entirely, so nothing later repoints it at an image that
+                                // does not exist - it keeps the icon it already had.
+                                createdFiles.push(createdFile);
+
+                                return undefined;
+                            }
                         );
-                    } else if (err.message) {
-                        logger.error(
-                            `CLOUD APP: Could not close virtual browser (message): ${err.message}`
-                        );
-                    } else {
-                        logger.error(`CLOUD APP: Could not close virtual browser: ${err}`);
+                    } finally {
+                        await closeBrowserQuietly(browser, 'CLOUD APP');
                     }
                 }
             }
-        } finally {
-            // Everything above it - browser launch, login, navigation, screenshots, image
-            // processing - can throw, and without this the engine websocket was left open for
-            // the life of the process, once per failing app. The other four session-holding
-            // modules got this in #885; these two were missed.
-            //
-            // Closed here rather than at the end of the function: the update step below opens
-            // its own session to the same app, and overlapping them would hold two engine
-            // sessions per app.
-            // enigma.js always resolves close() truthy; a real failure rejects into the catch below.
-            await session.close();
-        }
+        );
         logger.verbose(
             `Closed session after generating sheet thumbnail images for all sheets in QS Cloud app ${appId} on tenant ${options.tenanturl}`
         );

--- a/src/lib/qseow/__tests__/qseow_process_app.test.js
+++ b/src/lib/qseow/__tests__/qseow_process_app.test.js
@@ -287,6 +287,7 @@ describe('qseow-process-app.js — puppeteer launch and click options', () => {
             on: jest.fn(),
         };
         enigma.create.mockResolvedValue(mockSession);
+        mockSession._app = mockApp;
 
         return mockSession;
     }
@@ -445,6 +446,107 @@ describe('qseow-process-app.js — puppeteer launch and click options', () => {
         const logged = logger.error.mock.calls.map((call) => String(call[0])).join('\n');
         expect(logged).toContain('Failed to install a browser for QSEoW app test-app-id');
         expect(puppeteer.launch).not.toHaveBeenCalled();
+    });
+
+    describe('session and sheet-list wiring', () => {
+        beforeEach(() => {
+            jest.clearAllMocks();
+            detectAvailableBrowser.mockResolvedValue({
+                executablePath: '/test/browser',
+                source: 'system',
+                browser: 'chrome',
+                buildId: 'system-installed',
+            });
+            browserInstall.mockReset();
+        });
+
+        test('asks the engine for showCondition, which sheet exclusion depends on', async () => {
+            // The screenshot paths need a wider projection than the other callers. Requesting the
+            // default set would leave qData.showCondition undefined on every sheet, which reads as
+            // "no show condition" rather than as an error - silently disabling that exclusion rule.
+            const session = wireEnigmaSession();
+            const mockGet = jest.fn();
+            qrsInteract.mockImplementation(() => ({ Get: mockGet }));
+            wireQrsGetSequence(mockGet);
+            puppeteer.launch.mockResolvedValue(buildMockBrowser());
+
+            await qseowProcessApp('test-app-id', defaultOptions);
+
+            const qData = session._app.createSessionObject.mock.calls[0][0].qAppObjectListDef.qData;
+            expect(qData).toHaveProperty('showCondition', '/showCondition');
+            expect(qData).toHaveProperty('rank', '/rank');
+            expect(qData).toHaveProperty('title', '/qMetaDef/title');
+        });
+
+        test('logs the created session at info, the level operators see by default', async () => {
+            // The four non-screenshot callers log this at verbose; these two always logged it at
+            // info, and the default log level is info. Letting the shared helper demote it would
+            // remove a line from every run.
+            wireEnigmaSession();
+            const mockGet = jest.fn();
+            qrsInteract.mockImplementation(() => ({ Get: mockGet }));
+            wireQrsGetSequence(mockGet);
+            puppeteer.launch.mockResolvedValue(buildMockBrowser());
+
+            await qseowProcessApp('test-app-id', defaultOptions);
+
+            const atInfo = logger.info.mock.calls.map((call) => String(call[0])).join('\n');
+            expect(atInfo).toContain('Created session to server test-server.example.com');
+            expect(atInfo).toContain('engine version is');
+        });
+    });
+
+    describe('the virtual browser is released when the app fails', () => {
+        beforeEach(() => {
+            jest.clearAllMocks();
+            detectAvailableBrowser.mockResolvedValue({
+                executablePath: '/test/browser',
+                source: 'system',
+                browser: 'chrome',
+                buildId: 'system-installed',
+            });
+            browserInstall.mockReset();
+        });
+
+        test('closes the browser when a page operation throws', async () => {
+            // The browser was launched ~290 lines above its close and released on the happy
+            // path only, so any failure in between stranded a Chrome process for the life of
+            // the run - once per failing app, at hundreds of MB each.
+            const browser = setupHappyPath();
+            browser._page.goto.mockRejectedValue(new Error('navigation timed out'));
+
+            await expect(qseowProcessApp('test-app-id', defaultOptions)).rejects.toThrow();
+
+            expect(browser.close).toHaveBeenCalledTimes(1);
+        });
+
+        test('closes the browser when creating the page throws', async () => {
+            const browser = setupHappyPath();
+            browser.newPage.mockRejectedValue(new Error('no page for you'));
+
+            await expect(qseowProcessApp('test-app-id', defaultOptions)).rejects.toThrow();
+
+            expect(browser.close).toHaveBeenCalledTimes(1);
+        });
+
+        test('a browser that will not close does not mask the real failure', async () => {
+            const browser = setupHappyPath();
+            browser._page.goto.mockRejectedValue(new Error('navigation timed out'));
+            browser.close.mockRejectedValue(new Error('browser is wedged'));
+
+            await expect(qseowProcessApp('test-app-id', defaultOptions)).rejects.toThrow();
+
+            const logged = logger.error.mock.calls.map((call) => String(call[0])).join('\n');
+            expect(logged).toContain('navigation timed out');
+        });
+
+        test('closes the browser exactly once on a clean run', async () => {
+            const browser = setupHappyPath();
+
+            await qseowProcessApp('test-app-id', defaultOptions);
+
+            expect(browser.close).toHaveBeenCalledTimes(1);
+        });
     });
 
     describe('the engine session is released when the app fails', () => {

--- a/src/lib/qseow/qseow-process-app.js
+++ b/src/lib/qseow/qseow-process-app.js
@@ -1,4 +1,3 @@
-import enigma from 'enigma.js';
 import fs from 'fs';
 import qrsInteract from 'qrs-interact';
 import { Jimp } from 'jimp';
@@ -10,8 +9,13 @@ import { qseowUpdateSheetThumbnails } from './qseow-updatesheets.js';
 import { setupQseowQrsConnection } from './qseow-qrs.js';
 import { determineSheetExcludeStatus } from './determine-sheet-exclude-status.js';
 import { QseowError } from '../util/errors.js';
-import { launchBrowserForApp } from '../browser/browser-launch.js';
-import { sortSheetsByRank } from '../util/sheet-list.js';
+import { launchBrowserForApp, closeBrowserQuietly } from '../browser/browser-launch.js';
+import {
+    sortSheetsByRank,
+    getSheetList,
+    SHEET_LIST_FIELDS_WITH_SHOW_CONDITION,
+} from '../util/sheet-list.js';
+import { withEngineSession } from '../util/engine-session.js';
 import { qrsFilterAnyOf, qrsPathWithFilter, toFilterValueList } from './qrs-filter.js';
 
 const selectorLoginPageUserName = '#username-input';
@@ -224,389 +228,352 @@ export const qseowProcessApp = async (appId, options) => {
         // Configure Enigma.js
         const configEnigma = setupEnigmaConnection(appId, options);
         const imgDir = options.imagedir;
-        const session = await enigma.create(configEnigma);
-
-        if (options.loglevel === 'silly') {
-            session.on('traffic:sent', (data) => console.log('sent:', data));
-            session.on('traffic:received', (data) =>
-                console.log('received:', JSON.stringify(data, null, 2))
-            );
-        }
-
         const createdFiles = [];
 
-        try {
-            const global = await session.open();
+        await withEngineSession(
+            configEnigma,
+            {
+                logPrefix: 'QSEOW PROCESS APP',
+                loglevel: options.loglevel,
+                connectionLabel: `server ${options.host}`,
+                // These two logged the session line at info, and the default level is
+                // info - demoting it would drop a line operators see on every run.
+                sessionLogLevel: 'info',
+            },
+            async (global) => {
+                const app = await global.openDoc(appId, '', '', '', false);
+                logger.info(`Opened app ${appId}`);
+                logger.info(`App name: "${appMetadata[0].name}"`);
+                logger.info(`App is published: ${appMetadata[0].published}`);
 
-            const engineVersion = await global.engineVersion();
-            logger.info(
-                `Created session to server ${options.host}, engine version is ${engineVersion.qComponentVersion}`
-            );
+                // Get list of app sheets
+                const sheets = await getSheetList(app, SHEET_LIST_FIELDS_WITH_SHOW_CONDITION);
 
-            const app = await global.openDoc(appId, '', '', '', false);
-            logger.info(`Opened app ${appId}`);
-            logger.info(`App name: "${appMetadata[0].name}"`);
-            logger.info(`App is published: ${appMetadata[0].published}`);
+                if (sheets.length > 0) {
+                    // sheets[] now contains array of app sheets.
+                    logger.info(`Number of sheets in app: ${sheets.length}`);
 
-            // Get list of app sheets
-            const appSheetsCall = {
-                qInfo: {
-                    qId: 'SheetList',
-                    qType: 'SheetList',
-                },
-                qAppObjectListDef: {
-                    qType: 'sheet',
-                    qData: {
-                        title: '/qMetaDef/title',
-                        description: '/qMetaDef/description',
-                        thumbnail: '/thumbnail',
-                        cells: '/cells',
-                        rank: '/rank',
-                        columns: '/columns',
-                        rows: '/rows',
-                        showCondition: '/showCondition',
-                    },
-                },
-            };
+                    let iSheetNum = 1;
 
-            const genericListObj = await app.createSessionObject(appSheetsCall);
-            const sheetListObj = await genericListObj.getLayout();
+                    const browser = await launchBrowserForApp(options, {
+                        appId,
+                        logPrefix: 'QSEOW',
+                        appLabel: 'QSEoW app',
+                        ErrorClass: QseowError,
+                    });
 
-            if (sheetListObj.qAppObjectList.qItems.length > 0) {
-                // sheetListObj.qAppObjectList.qItems[] now contains array of app sheets.
-                logger.info(
-                    `Number of sheets in app: ${sheetListObj.qAppObjectList.qItems.length}`
-                );
+                    try {
+                        const page = await browser.newPage();
 
-                let iSheetNum = 1;
+                        // Thumbnails should be 410x270 pixels, so set the viewport to a multiple of this.
+                        await page.setViewport({
+                            width: 1230,
+                            height: 810,
+                            deviceScaleFactor: 1,
+                        });
 
-                const browser = await launchBrowserForApp(options, {
-                    appId,
-                    logPrefix: 'QSEOW',
-                    appLabel: 'QSEoW app',
-                    ErrorClass: QseowError,
-                });
+                        // Set default timeout for all page operations to 90 seconds
+                        // https://stackoverflow.com/questions/52163547/node-js-puppeteer-how-to-set-navigation-timeout
+                        await page.setDefaultTimeout(pageTimeout);
 
-                const page = await browser.newPage();
+                        // Assigned unconditionally just below; the empty initialiser was dead. It only passed
+                        // lint before because no-useless-assignment skips code inside a try block, and the
+                        // enclosing try is now the session callback.
+                        let appUrl;
+                        let hubUrl;
 
-                // Thumbnails should be 410x270 pixels, so set the viewport to a multiple of this.
-                await page.setViewport({
-                    width: 1230,
-                    height: 810,
-                    deviceScaleFactor: 1,
-                });
+                        if (options.secure === 'true' || options.secure === true) {
+                            appUrl = 'https://';
+                        } else {
+                            appUrl = 'http://';
+                        }
+                        hubUrl = appUrl;
 
-                // Set default timeout for all page operations to 90 seconds
-                // https://stackoverflow.com/questions/52163547/node-js-puppeteer-how-to-set-navigation-timeout
-                await page.setDefaultTimeout(pageTimeout);
+                        if (options.prefix && options.prefix.length > 0) {
+                            appUrl = `${appUrl + options.host}/${options.prefix}/sense/app/${appId}`;
+                            hubUrl = `${hubUrl + options.host}/${options.prefix}/hub`;
+                        } else {
+                            appUrl = `${appUrl + options.host}/sense/app/${appId}`;
+                            hubUrl = `${hubUrl + options.host}/hub`;
+                        }
 
-                let appUrl = '';
-                let hubUrl = '';
+                        logger.debug(`App URL: ${appUrl}`);
+                        logger.debug(`Hub URL: ${hubUrl}`);
 
-                if (options.secure === 'true' || options.secure === true) {
-                    appUrl = 'https://';
-                } else {
-                    appUrl = 'http://';
-                }
-                hubUrl = appUrl;
-
-                if (options.prefix && options.prefix.length > 0) {
-                    appUrl = `${appUrl + options.host}/${options.prefix}/sense/app/${appId}`;
-                    hubUrl = `${hubUrl + options.host}/${options.prefix}/hub`;
-                } else {
-                    appUrl = `${appUrl + options.host}/sense/app/${appId}`;
-                    hubUrl = `${hubUrl + options.host}/hub`;
-                }
-
-                logger.debug(`App URL: ${appUrl}`);
-                logger.debug(`Hub URL: ${hubUrl}`);
-
-                await Promise.all([
-                    page.goto(appUrl, { waitUntil: 'networkidle2', timeout: pageTimeout }),
-                ]);
-
-                await sleep(options.pagewait * 1000);
-                await page.screenshot({ path: `${imgDir}/qseow/${appId}/loginpage-1.png` });
-
-                // Enter credentials
-                // User
-                await page.click(selectorLoginPageUserName, {
-                    button: 'left',
-                    delay: 10,
-                });
-
-                const user = `${options.logonuserdir}\\${options.logonuserid}`;
-                await page.keyboard.type(user);
-
-                // Pwd
-                await page.click(selectorLoginPageUserPwd, {
-                    button: 'left',
-                    delay: 10,
-                });
-                await page.keyboard.type(options.logonpwd);
-
-                await page.screenshot({ path: `${imgDir}/qseow/${appId}/loginpage-2.png` });
-
-                // Click login button and wait for page to load
-                await Promise.all([
-                    page.click(selectorLoginPageLoginButton, {
-                        button: 'left',
-                        delay: 10,
-                    }),
-                    page.waitForNavigation({ waitUntil: 'networkidle2' }),
-                ]);
-
-                await sleep(options.pagewait * 1000);
-
-                // Take screenshot of app overview page
-                await page.screenshot({ path: `${imgDir}/qseow/${appId}/overview-1.png` });
-
-                // Sort sheets
-                sortSheetsByRank(sheetListObj.qAppObjectList.qItems);
-
-                // Loop over all sheets in app, processing each one unless excluded
-                for (const sheet of sheetListObj.qAppObjectList.qItems) {
-                    // Get repository db sheet id from mapRepoEngineSheetIdTmp1, using sheet.qInfo.qId as key
-                    const repoDbSheetId = mapRepoEngineSheetId.get(sheet.qInfo.qId);
-                    const engineSheetId = sheet.qInfo.qId;
-
-                    // Should this sheet be processed, or is it on exclude list?
-                    // Options are
-                    // --exclude-sheet-tag <value>
-                    // --exclude-sheet-number <number...>
-                    // --exclude-sheet-title <title...>
-                    // --exclude-sheet-status <status...>
-
-                    let { excludeSheet, sheetIsHidden } = await determineSheetExcludeStatus(
-                        app,
-                        sheet,
-                        options,
-                        tagSheetAppMetadata,
-                        iSheetNum,
-                        repoDbSheetId,
-                        engineSheetId,
-                        logger
-                    );
-
-                    if (excludeSheet === true) {
-                        logger.info(
-                            `Excluded sheet: ${iSheetNum}: '${sheet.qMeta.title}', sheet id '${repoDbSheetId}', engine sheet id '${engineSheetId}', description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}', hidden '${sheetIsHidden}'`
-                        );
-                    } else {
-                        logger.info(
-                            `Processing sheet ${iSheetNum}: '${sheet.qMeta.title}', sheet id '${repoDbSheetId}', engine sheet id '${engineSheetId}', description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}', hidden '${sheetIsHidden}'`
-                        );
-
-                        // Build URL to current sheet
-                        const sheetUrl = `${appUrl}/sheet/${sheet.qInfo.qId}`;
-                        logger.debug(`Sheet URL: ${sheetUrl}`);
-
-                        // Open sheet in browser, then take screen shot
                         await Promise.all([
-                            page.goto(sheetUrl, {
-                                waitUntil: 'networkidle2',
-                                timeout: pageTimeout,
+                            page.goto(appUrl, { waitUntil: 'networkidle2', timeout: pageTimeout }),
+                        ]);
+
+                        await sleep(options.pagewait * 1000);
+                        await page.screenshot({ path: `${imgDir}/qseow/${appId}/loginpage-1.png` });
+
+                        // Enter credentials
+                        // User
+                        await page.click(selectorLoginPageUserName, {
+                            button: 'left',
+                            delay: 10,
+                        });
+
+                        const user = `${options.logonuserdir}\\${options.logonuserid}`;
+                        await page.keyboard.type(user);
+
+                        // Pwd
+                        await page.click(selectorLoginPageUserPwd, {
+                            button: 'left',
+                            delay: 10,
+                        });
+                        await page.keyboard.type(options.logonpwd);
+
+                        await page.screenshot({ path: `${imgDir}/qseow/${appId}/loginpage-2.png` });
+
+                        // Click login button and wait for page to load
+                        await Promise.all([
+                            page.click(selectorLoginPageLoginButton, {
+                                button: 'left',
+                                delay: 10,
                             }),
+                            page.waitForNavigation({ waitUntil: 'networkidle2' }),
                         ]);
 
                         await sleep(options.pagewait * 1000);
 
-                        const fileName = `${imgDir}/qseow/${appId}/thumbnail-${appId}-${iSheetNum}.png`;
-                        const fileNameShort = `thumbnail-${appId}-${iSheetNum}.png`;
+                        // Take screenshot of app overview page
+                        await page.screenshot({ path: `${imgDir}/qseow/${appId}/overview-1.png` });
 
-                        let selector = '';
-                        if (options.includesheetpart === '1') {
-                            // 1: Only chart part of sheet (no sheet title, selections or app info)
-                            selector = '#grid-wrap';
-                        } else if (options.includesheetpart === '2') {
-                            // 2: Include sheet title  (no selections or app info)
-                            selector = '#qv-stage-container > div > div.qv-panel-content.flex-row';
-                        } else if (options.includesheetpart === '3') {
-                            // 3: Include sheet title and selection bar (no app info)
-                            selector = '#qv-stage-container > div';
-                        } else if (options.includesheetpart === '4') {
-                            // 4: Take screen shot of entire sheet, including sheet title, top menu and status bars.
-                            // or: await page.screenshot({ path: fileName });
-                            selector = '#qv-page-container';
-                        }
+                        // Sort sheets
+                        sortSheetsByRank(sheets);
 
-                        // Ensure that the element we're interested in is loaded
-                        await page.waitForSelector(selector);
-                        const sheetMainPart = await page.$(selector);
-                        await sheetMainPart.screenshot({
-                            path: fileName,
-                        });
-                        createdFiles.push({ sheetPos: iSheetNum, blurred: false, fileNameShort });
+                        // Loop over all sheets in app, processing each one unless excluded
+                        for (const sheet of sheets) {
+                            // Get repository db sheet id from mapRepoEngineSheetIdTmp1, using sheet.qInfo.qId as key
+                            const repoDbSheetId = mapRepoEngineSheetId.get(sheet.qInfo.qId);
+                            const engineSheetId = sheet.qInfo.qId;
 
-                        // Blur image and store as separate file
-                        const fileNameBlurred = `${imgDir}/qseow/${appId}/thumbnail-${appId}-${iSheetNum}-blurred.png`;
-                        const fileNameShortBlurred = `thumbnail-${appId}-${iSheetNum}-blurred.png`;
+                            // Should this sheet be processed, or is it on exclude list?
+                            // Options are
+                            // --exclude-sheet-tag <value>
+                            // --exclude-sheet-number <number...>
+                            // --exclude-sheet-title <title...>
+                            // --exclude-sheet-status <status...>
 
-                        // Create blurred image from the already taken screenshot
-                        // Load the image from disk, blur it, then save it back to disk with new name
-                        try {
-                            let blurFactor;
+                            let { excludeSheet, sheetIsHidden } = await determineSheetExcludeStatus(
+                                app,
+                                sheet,
+                                options,
+                                tagSheetAppMetadata,
+                                iSheetNum,
+                                repoDbSheetId,
+                                engineSheetId,
+                                logger
+                            );
 
-                            // Blur factor should be between 1 and 100
-                            if (options?.blurFactor < 1) {
-                                blurFactor = 1; // Min blur value
-                            } else if (options?.blurFactor > 100) {
-                                blurFactor = 100; // Max blur value
-                            } else {
-                                blurFactor = parseInt(options?.blurFactor, 10);
-                            }
-
-                            // Use Jimp instead of Sharp
-                            const image = await Jimp.read(fileName);
-                            await image.blur(blurFactor).write(fileNameBlurred);
-
-                            createdFiles.push({
-                                sheetPos: iSheetNum,
-                                blurred: true,
-                                fileNameShort: fileNameShortBlurred,
-                            });
-                            logger.verbose(`Created blurred image: ${fileNameBlurred}`);
-                        } catch (err) {
-                            logger.error(`Failed to create blurred image: ${err}`);
-                            if (err.message) {
-                                logger.error(
-                                    `QSEOW CREATE BLURRED IMAGE (message): ${err.message}`
+                            if (excludeSheet === true) {
+                                logger.info(
+                                    `Excluded sheet: ${iSheetNum}: '${sheet.qMeta.title}', sheet id '${repoDbSheetId}', engine sheet id '${engineSheetId}', description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}', hidden '${sheetIsHidden}'`
                                 );
-                            }
-                            if (err.stack) {
-                                logger.error(`QSEOW CREATE BLURRED IMAGE (stack): ${err.stack}`);
-                            }
+                            } else {
+                                logger.info(
+                                    `Processing sheet ${iSheetNum}: '${sheet.qMeta.title}', sheet id '${repoDbSheetId}', engine sheet id '${engineSheetId}', description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}', hidden '${sheetIsHidden}'`
+                                );
 
-                            // Drop this sheet entirely rather than leave the unblurred entry
-                            // behind. The blur decision is made later, in updatesheets, from
-                            // the CLI options alone - so leaving the entry meant the sheet was
-                            // repointed at a `-blurred.png` that was never created, giving a
-                            // broken icon. Dropping it means updatesheets skips the sheet and
-                            // it keeps the icon it already had.
-                            //
-                            // --blur-sheet-* is a redaction control, so falling back to the
-                            // plain screenshot is not an option either: it would publish the
-                            // unredacted image the operator asked to hide.
-                            for (let i = createdFiles.length - 1; i >= 0; i -= 1) {
-                                if (createdFiles[i].sheetPos === iSheetNum) {
-                                    createdFiles.splice(i, 1);
+                                // Build URL to current sheet
+                                const sheetUrl = `${appUrl}/sheet/${sheet.qInfo.qId}`;
+                                logger.debug(`Sheet URL: ${sheetUrl}`);
+
+                                // Open sheet in browser, then take screen shot
+                                await Promise.all([
+                                    page.goto(sheetUrl, {
+                                        waitUntil: 'networkidle2',
+                                        timeout: pageTimeout,
+                                    }),
+                                ]);
+
+                                await sleep(options.pagewait * 1000);
+
+                                const fileName = `${imgDir}/qseow/${appId}/thumbnail-${appId}-${iSheetNum}.png`;
+                                const fileNameShort = `thumbnail-${appId}-${iSheetNum}.png`;
+
+                                let selector = '';
+                                if (options.includesheetpart === '1') {
+                                    // 1: Only chart part of sheet (no sheet title, selections or app info)
+                                    selector = '#grid-wrap';
+                                } else if (options.includesheetpart === '2') {
+                                    // 2: Include sheet title  (no selections or app info)
+                                    selector =
+                                        '#qv-stage-container > div > div.qv-panel-content.flex-row';
+                                } else if (options.includesheetpart === '3') {
+                                    // 3: Include sheet title and selection bar (no app info)
+                                    selector = '#qv-stage-container > div';
+                                } else if (options.includesheetpart === '4') {
+                                    // 4: Take screen shot of entire sheet, including sheet title, top menu and status bars.
+                                    // or: await page.screenshot({ path: fileName });
+                                    selector = '#qv-page-container';
+                                }
+
+                                // Ensure that the element we're interested in is loaded
+                                await page.waitForSelector(selector);
+                                const sheetMainPart = await page.$(selector);
+                                await sheetMainPart.screenshot({
+                                    path: fileName,
+                                });
+                                createdFiles.push({
+                                    sheetPos: iSheetNum,
+                                    blurred: false,
+                                    fileNameShort,
+                                });
+
+                                // Blur image and store as separate file
+                                const fileNameBlurred = `${imgDir}/qseow/${appId}/thumbnail-${appId}-${iSheetNum}-blurred.png`;
+                                const fileNameShortBlurred = `thumbnail-${appId}-${iSheetNum}-blurred.png`;
+
+                                // Create blurred image from the already taken screenshot
+                                // Load the image from disk, blur it, then save it back to disk with new name
+                                try {
+                                    let blurFactor;
+
+                                    // Blur factor should be between 1 and 100
+                                    if (options?.blurFactor < 1) {
+                                        blurFactor = 1; // Min blur value
+                                    } else if (options?.blurFactor > 100) {
+                                        blurFactor = 100; // Max blur value
+                                    } else {
+                                        blurFactor = parseInt(options?.blurFactor, 10);
+                                    }
+
+                                    // Use Jimp instead of Sharp
+                                    const image = await Jimp.read(fileName);
+                                    await image.blur(blurFactor).write(fileNameBlurred);
+
+                                    createdFiles.push({
+                                        sheetPos: iSheetNum,
+                                        blurred: true,
+                                        fileNameShort: fileNameShortBlurred,
+                                    });
+                                    logger.verbose(`Created blurred image: ${fileNameBlurred}`);
+                                } catch (err) {
+                                    logger.error(`Failed to create blurred image: ${err}`);
+                                    if (err.message) {
+                                        logger.error(
+                                            `QSEOW CREATE BLURRED IMAGE (message): ${err.message}`
+                                        );
+                                    }
+                                    if (err.stack) {
+                                        logger.error(
+                                            `QSEOW CREATE BLURRED IMAGE (stack): ${err.stack}`
+                                        );
+                                    }
+
+                                    // Drop this sheet entirely rather than leave the unblurred entry
+                                    // behind. The blur decision is made later, in updatesheets, from
+                                    // the CLI options alone - so leaving the entry meant the sheet was
+                                    // repointed at a `-blurred.png` that was never created, giving a
+                                    // broken icon. Dropping it means updatesheets skips the sheet and
+                                    // it keeps the icon it already had.
+                                    //
+                                    // --blur-sheet-* is a redaction control, so falling back to the
+                                    // plain screenshot is not an option either: it would publish the
+                                    // unredacted image the operator asked to hide.
+                                    for (let i = createdFiles.length - 1; i >= 0; i -= 1) {
+                                        if (createdFiles[i].sheetPos === iSheetNum) {
+                                            createdFiles.splice(i, 1);
+                                        }
+                                    }
+
+                                    blurFailures += 1;
+                                    logger.error(
+                                        `QSEOW APP: Sheet ${iSheetNum} in app ${appId} was left unchanged because its blurred thumbnail could not be created`
+                                    );
                                 }
                             }
-
-                            blurFailures += 1;
-                            logger.error(
-                                `QSEOW APP: Sheet ${iSheetNum} in app ${appId} was left unchanged because its blurred thumbnail could not be created`
-                            );
+                            iSheetNum += 1;
                         }
-                    }
-                    iSheetNum += 1;
-                }
 
-                logger.verbose(`QSEoW APP: Done creating thumbnails. Opening hub at ${hubUrl}`);
+                        logger.verbose(
+                            `QSEoW APP: Done creating thumbnails. Opening hub at ${hubUrl}`
+                        );
 
-                try {
-                    // Log out
-                    await Promise.all([
-                        page.goto(hubUrl, { waitUntil: 'networkidle2', timeout: pageTimeout }),
-                    ]);
-                } catch (err) {
-                    if (err.stack) {
-                        logger.error(
-                            `QSEOW: Could not open hub after generating thumbnail images (stack): ${err.stack}`
-                        );
-                    } else if (err.message) {
-                        logger.error(
-                            `QSEOW: Could not open hub after generating thumbnail images (message): ${err.message}`
-                        );
-                    } else {
-                        logger.error(
-                            `QSEOW: Could not open hub after generating thumbnail images: ${err}`
-                        );
-                    }
-                }
+                        try {
+                            // Log out
+                            await Promise.all([
+                                page.goto(hubUrl, {
+                                    waitUntil: 'networkidle2',
+                                    timeout: pageTimeout,
+                                }),
+                            ]);
+                        } catch (err) {
+                            if (err.stack) {
+                                logger.error(
+                                    `QSEOW: Could not open hub after generating thumbnail images (stack): ${err.stack}`
+                                );
+                            } else if (err.message) {
+                                logger.error(
+                                    `QSEOW: Could not open hub after generating thumbnail images (message): ${err.message}`
+                                );
+                            } else {
+                                logger.error(
+                                    `QSEOW: Could not open hub after generating thumbnail images: ${err}`
+                                );
+                            }
+                        }
 
-                let elementHandle;
-                try {
-                    // wait for user button to become visible, then click it to open the user menu
-                    await page.waitForSelector(xpathHubUserPageButton);
-                    // evaluate XPath expression of the target selector (it returns array of ElementHandle)
-                    elementHandle = await page.$$(xpathHubUserPageButton);
+                        let elementHandle;
+                        try {
+                            // wait for user button to become visible, then click it to open the user menu
+                            await page.waitForSelector(xpathHubUserPageButton);
+                            // evaluate XPath expression of the target selector (it returns array of ElementHandle)
+                            elementHandle = await page.$$(xpathHubUserPageButton);
 
-                    await sleep(options.pagewait * 1000);
+                            await sleep(options.pagewait * 1000);
 
-                    // Click user button and wait for page to load
-                    await Promise.all([elementHandle[0].click()]);
-                } catch (err) {
-                    if (err.stack) {
-                        logger.error(
-                            `QSEOW: Error waiting for, or clicking, user button in hub default view (stack): ${err.stack}`
-                        );
-                    } else if (err.message) {
-                        logger.error(
-                            `QSEOW: Error waiting for, or clicking, user button in hub default view (message): ${err.message}`
-                        );
-                    } else {
-                        logger.error(
-                            `QSEOW: Error waiting for, or clicking, user button in hub default view: ${err}`
-                        );
-                    }
-                }
+                            // Click user button and wait for page to load
+                            await Promise.all([elementHandle[0].click()]);
+                        } catch (err) {
+                            if (err.stack) {
+                                logger.error(
+                                    `QSEOW: Error waiting for, or clicking, user button in hub default view (stack): ${err.stack}`
+                                );
+                            } else if (err.message) {
+                                logger.error(
+                                    `QSEOW: Error waiting for, or clicking, user button in hub default view (message): ${err.message}`
+                                );
+                            } else {
+                                logger.error(
+                                    `QSEOW: Error waiting for, or clicking, user button in hub default view: ${err}`
+                                );
+                            }
+                        }
 
-                try {
-                    // Wait for logout button to become visible, then click it
-                    await page.waitForSelector(xpathLogoutButton);
-                    elementHandle = await page.$$(xpathLogoutButton);
+                        try {
+                            // Wait for logout button to become visible, then click it
+                            await page.waitForSelector(xpathLogoutButton);
+                            elementHandle = await page.$$(xpathLogoutButton);
 
-                    await sleep(options.pagewait * 1000);
+                            await sleep(options.pagewait * 1000);
 
-                    // Click logout button and wait for page to load
-                    await Promise.all([elementHandle[0].click()]);
-                    await sleep(options.pagewait * 1000);
-                } catch (err) {
-                    if (err.stack) {
-                        logger.error(
-                            `QSEOW: Error while waiting for, or clicking, logout button in hub's user menu (stack): ${err.stack}`
-                        );
-                    } else if (err.message) {
-                        logger.error(
-                            `QSEOW: Error while waiting for, or clicking, logout button in hub's user menu (message): ${err.message}`
-                        );
-                    } else {
-                        logger.error(
-                            `QSEOW: Error while waiting for, or clicking, logout button in hub's user menu: ${err}`
-                        );
-                    }
-                }
-
-                try {
-                    await browser.close();
-                    logger.verbose('Closed virtual browser');
-                } catch (err) {
-                    if (err.stack) {
-                        logger.error(
-                            `QSEOW: Could not close virtual browser (stack): ${err.stack}`
-                        );
-                    } else if (err.message) {
-                        logger.error(
-                            `QSEOW: Could not close virtual browser (message): ${err.message}`
-                        );
-                    } else {
-                        logger.error(`QSEOW: Could not close virtual browser: ${err}`);
+                            // Click logout button and wait for page to load
+                            await Promise.all([elementHandle[0].click()]);
+                            await sleep(options.pagewait * 1000);
+                        } catch (err) {
+                            if (err.stack) {
+                                logger.error(
+                                    `QSEOW: Error while waiting for, or clicking, logout button in hub's user menu (stack): ${err.stack}`
+                                );
+                            } else if (err.message) {
+                                logger.error(
+                                    `QSEOW: Error while waiting for, or clicking, logout button in hub's user menu (message): ${err.message}`
+                                );
+                            } else {
+                                logger.error(
+                                    `QSEOW: Error while waiting for, or clicking, logout button in hub's user menu: ${err}`
+                                );
+                            }
+                        }
+                    } finally {
+                        await closeBrowserQuietly(browser, 'QSEOW');
                     }
                 }
             }
-        } finally {
-            // Everything above it - browser launch, login, navigation, screenshots, image
-            // processing - can throw, and without this the engine websocket was left open for
-            // the life of the process, once per failing app. The other four session-holding
-            // modules got this in #885; these two were missed.
-            //
-            // Closed here rather than at the end of the function: the update step below opens
-            // its own session to the same app, and overlapping them would hold two engine
-            // sessions per app.
-            // enigma.js always resolves close() truthy; a real failure rejects into the catch below.
-            await session.close();
-        }
+        );
         logger.verbose(
             `Closed session after generating sheet thumbnail images for all sheets in QSEoW app ${appId} on host ${options.host}`
         );

--- a/src/lib/util/engine-session.js
+++ b/src/lib/util/engine-session.js
@@ -30,6 +30,11 @@ import { logger } from '../../globals.js';
  * @param {string} ctx.connectionLabel - What was connected to, e.g. `'server sense.example.com'`
  *     or `'Qlik Sense Cloud tenant foo.eu.qlikcloud.com'`. Rendered into the existing
  *     `Created session to …, engine version is …` line.
+ * @param {string} [ctx.sessionLogLevel] - Level for that line. Defaults to `'verbose'`, which is
+ *     what four of the six callers used. The two screenshot paths pass `'info'`, because that is
+ *     what they logged before and the default log level is `info` - quietly demoting it would
+ *     remove a line operators see on every run. The inconsistency is deliberate to preserve here,
+ *     and belongs with the rest of the message work in #872 part 3.
  * @param {Function} fn - Async callback receiving the enigma `global` object. Its resolved value
  *     is returned.
  *
@@ -39,7 +44,7 @@ import { logger } from '../../globals.js';
  *     otherwise successful run throws.
  */
 export const withEngineSession = async (configEnigma, ctx, fn) => {
-    const { logPrefix, loglevel, connectionLabel } = ctx;
+    const { logPrefix, loglevel, connectionLabel, sessionLogLevel = 'verbose' } = ctx;
 
     // Outside the try: if this throws there is no session to release.
     const session = await enigma.create(configEnigma);
@@ -62,7 +67,7 @@ export const withEngineSession = async (configEnigma, ctx, fn) => {
         const global = await session.open();
 
         const engineVersion = await global.engineVersion();
-        logger.verbose(
+        logger[sessionLogLevel](
             `Created session to ${connectionLabel}, engine version is ${engineVersion.qComponentVersion}`
         );
 

--- a/src/lib/util/sheet-list.js
+++ b/src/lib/util/sheet-list.js
@@ -29,6 +29,18 @@ export const SHEET_LIST_FIELDS_EXTENDED = {
 };
 
 /**
+ * What the screenshot paths ask for: the wider projection plus the sheet's show condition.
+ *
+ * Only these two callers evaluate show conditions, so the field is not folded into
+ * {@link SHEET_LIST_FIELDS_EXTENDED} - spelled as an extension of it, because that is the
+ * relationship, and a hand-copied superset is how the three variants drifted apart originally.
+ */
+export const SHEET_LIST_FIELDS_WITH_SHOW_CONDITION = {
+    ...SHEET_LIST_FIELDS_EXTENDED,
+    showCondition: '/showCondition',
+};
+
+/**
  * Fetches an app's sheets through a `SheetList` session object.
  *
  * The same ~15-line session-object literal was written out in all six modules that walk an app's


### PR DESCRIPTION
Completes #872 Part 2, after #902 (session leak) and #903 (`withEngineSession` + `getSheetList`).

Three things land together because they touch the same region — separating them would mean re-indenting ~300 lines twice.

## 1. `withEngineSession` — the last two hand-rolled session blocks

The callback deliberately **ends before** the upload and update steps. `qseowUpdateSheetThumbnails` / `qscloudUpdateSheetThumbnails` open their own session to the same app; pulling them inside would hold two engine sessions per app — doubling licence consumption, and failing at a per-user session ceiling *after* screenshots were taken. Tests pin that **ordering**, not merely that the close happens.

## 2. `getSheetList` — the `SheetList` literal

These two need a wider projection than the other four, so `SHEET_LIST_FIELDS_WITH_SHOW_CONDITION` is spelled as an extension of the existing set rather than a fourth hand-copied superset — a hand-copied superset is how the three variants drifted apart originally. Verified byte-identical, and in the same field order, against `main`.

Both twins now assert `showCondition` is requested. Without it every sheet reads as having no show condition, **silently disabling that exclusion rule** — the projection is exactly the kind of thing a passing suite will not notice.

## 3. The browser leak — the last live bug in this series

The browser was launched ~290 lines above its close and released **on the happy path only**, mirroring the session bug #902 fixed. Any failure in between stranded a Chrome process for the life of the run, once per failing app, at hundreds of MB each.

`closeBrowserQuietly` — the close-and-log block both twins already carried, minus the drifted prefix — now runs from a `finally`. It swallows rather than throws, because it runs while a real failure may already be unwinding; a throw there would replace the cause. Launch stays outside the `try`, so a failed launch has nothing to close.

## Preserved deliberately, not tidied

- **These two log the session line at `info`** while the other four use `verbose`, and the default level *is* `info`. The helper gained `sessionLogLevel` so the line does not silently vanish from every run. Unifying belongs with Part 3's message work.
- Removing the enclosing `try` exposed a dead `let appUrl = ''`, which only passed lint before because `no-useless-assignment` skips code inside a `try`.

## Verification

- **814 unit tests / 51 suites**, lint and Prettier clean
- **QSEoW 2/2** and **Cloud 1/1** integration against live servers
- Eleven mutations. **Two escaped the first pass and are worth naming**: dropping `sessionLogLevel` and requesting the wrong projection both left the suite green. Both now fail a test on each twin — exactly the two behaviour-preservation claims this PR makes.

| Mutation | QSEoW | Cloud |
|---|---|---|
| Browser `finally` → happy-path close only | 2 failed | 2 failed |
| `closeBrowserQuietly` never closes | 8 failed across suites | |
| `closeBrowserQuietly` rethrows | 2 failed | |
| `sessionLogLevel` dropped | 1 failed | 1 failed |
| Wrong sheet-list projection | 1 failed | 1 failed |

Review with `git diff -w`: the structural change is small; most of the diff is Prettier rewrapping under the added indentation.

## Duplication

#902 was merged with the gate red on two pre-existing twin blocks — the session preamble and the `SheetList` literal. **This PR removes both**, plus the 16-line browser-close block, so that number should come down rather than persist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)