### PR TITLE
fix: make log messages name the operation actually running (#872 part 3)

### DIFF
--- a/docs/to-doc-site/log-messages-name-the-right-operation.md
+++ b/docs/to-doc-site/log-messages-name-the-right-operation.md
@@ -1,0 +1,64 @@
+# Log messages now name the right operation
+
+Several log lines described an operation Butler Sheet Icons was not performing, or labelled it
+inconsistently between Qlik Sense Enterprise on Windows and Qlik Sense Cloud. The wording has
+been corrected.
+
+Nothing about how Butler Sheet Icons behaves has changed — only what it writes to the log. This
+page matters if you search your logs for these lines, or if log monitoring alerts on them.
+
+## Removing sheet icons no longer claims to be updating them
+
+When removing sheet icons, the log said the icons had been updated or generated:
+
+| Command                      | Old text                                                                 | New text                                                      |
+| ---------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| `qscloud remove-sheet-icons` | `Closed session after updating sheet thumbnail images in QS Cloud app …` | `Closed session after removing sheet icons in QS Cloud app …` |
+
+Neither "updating" nor "generating" describes removing an icon. The same wording is used
+internally on the Qlik Sense Enterprise on Windows side, where it has been corrected too, though
+no command exposes it there yet.
+
+## Per-app failures name the command that failed
+
+When one app in a multi-app run fails, the failure line is prefixed with the command. One of
+those prefixes was wrong:
+
+| Command                      | Old prefix                                     | New prefix                                          |
+| ---------------------------- | ---------------------------------------------- | --------------------------------------------------- |
+| `qscloud remove-sheet-icons` | `CLOUD PROCESS APP 2: Failed to process app …` | `CLOUD REMOVE SHEET ICONS: Failed to process app …` |
+
+The `2` was a leftover, and it did not name the command actually running.
+
+**If you have log monitoring that matches on `CLOUD PROCESS APP 2`, update it.** The old prefixes
+no longer appear.
+
+## Browser errors are punctuated the same way on both platforms
+
+A failure to start the built-in browser was written differently depending on platform — Qlik
+Sense Cloud used a colon after the prefix, Qlik Sense Enterprise on Windows did not:
+
+```
+CLOUD APP: Could not launch virtual browser: …
+QSEOW Could not launch virtual browser: …
+```
+
+Both now use the colon.
+
+## One line appears at the default log level that did not before
+
+Running `qscloud remove-sheet-icons`, this line was written at `verbose` and so was hidden at the
+default log level of `info`:
+
+```
+Created session to <server or tenant>, engine version is <version>
+```
+
+It is now written at `info`, matching every other command that works on an app you named, and
+matching the `Opened app …` line that the same command already wrote at `info`.
+
+If you run with `--loglevel info` (the default) you will see one extra line per app. Set
+`--loglevel warn` to suppress it along with the other progress messages.
+
+Commands that re-open an app already reported by the step above them — the internal thumbnail
+update — still log at `verbose`, so an app is not announced twice in the same run.

--- a/src/lib/browser/__tests__/browser_launch.test.js
+++ b/src/lib/browser/__tests__/browser_launch.test.js
@@ -57,7 +57,7 @@ class TestError extends Error {
 
 const CONTEXT = {
     appId: 'test-app-id',
-    logPrefix: 'TEST:',
+    logPrefix: 'TEST',
     appLabel: 'test app',
     ErrorClass: TestError,
 };
@@ -224,5 +224,21 @@ describe('closeBrowserQuietly', () => {
     ])('ignores a %s browser, so a failed launch can share the finally', async (_l, browser) => {
         await expect(closeBrowserQuietly(browser, 'QSEOW')).resolves.toBeUndefined();
         expect(logger.error).not.toHaveBeenCalled();
+    });
+});
+
+describe('log prefix shape', () => {
+    test('adds the colon itself, so both platforms render the same shape', async () => {
+        // QSEoW passed 'QSEOW' and Cloud passed 'CLOUD APP:', against a template with no colon.
+        // QSEoW therefore logged "QSEOW Could not launch ..." while Cloud logged
+        // "CLOUD APP: Could not launch ...". The colon belongs in one place.
+        puppeteer.launch.mockRejectedValue(new Error('no browser here'));
+
+        await expect(launchBrowserForApp(OPTIONS, CONTEXT)).rejects.toThrow();
+
+        const logged = logger.error.mock.calls.map((call) => String(call[0])).join('\n');
+        expect(logged).toContain('TEST: Could not launch virtual browser');
+        expect(logged).not.toContain('TEST Could not launch');
+        expect(logged).not.toContain('TEST:: Could not launch');
     });
 });

--- a/src/lib/browser/browser-launch.js
+++ b/src/lib/browser/browser-launch.js
@@ -135,7 +135,8 @@ export const resolveBrowserExecutablePath = async (options) => {
  * to browser detection and install.
  * @param {object} context - Platform-specific labelling and error construction.
  * @param {string} context.appId - App being processed, used in error messages.
- * @param {string} context.logPrefix - Log line prefix, e.g. `QSEOW` or `CLOUD APP:`.
+ * @param {string} context.logPrefix - Log line prefix without a trailing colon, e.g. `'QSEOW'`
+ *     or `'CLOUD APP'`. The colon is added here, so both platforms render the same shape.
  * @param {string} context.appLabel - Human-readable app description, e.g. `QSEoW app`.
  * @param {Function} context.ErrorClass - Typed error to throw, e.g. `QseowError` or `CloudError`.
  *
@@ -171,7 +172,7 @@ export const launchBrowserForApp = async (options, { appId, logPrefix, appLabel,
         // Falls back to the value itself so a non-Error throw still logs something useful
         // rather than "undefined".
         logger.error(
-            `${logPrefix} Could not launch virtual browser: ${err?.stack || err?.message || err}`
+            `${logPrefix}: Could not launch virtual browser: ${err?.stack || err?.message || err}`
         );
 
         throw new ErrorClass(`Failed to launch virtual browser for ${appLabel} ${appId}`, {

--- a/src/lib/cloud/__tests__/cloud_remove_sheet_icons.test.js
+++ b/src/lib/cloud/__tests__/cloud_remove_sheet_icons.test.js
@@ -206,6 +206,20 @@ describe('qscloudRemoveSheetIcons', () => {
             expect(session.close).toHaveBeenCalledTimes(1);
         });
 
+        test('names the removal command in the per-app failure line', async () => {
+            // The app loop was told 'CLOUD PROCESS APP 2' and 'QSEOW PROCESS APP: Remove sheet
+            // icons' respectively - a stray counter on one, a double colon on the other, and
+            // neither naming the command actually running.
+            const { app } = wireEnigma([makeSheet('sheet-1', 1)]);
+            app.doSave.mockRejectedValue(new Error('app is published and cannot be saved'));
+
+            await expect(qscloudRemoveSheetIcons({ ...BASE_OPTIONS })).resolves.toBe(false);
+
+            const errors = logger.error.mock.calls.map((call) => String(call[0])).join('\n');
+            expect(errors).toContain('CLOUD REMOVE SHEET ICONS: Failed to process app');
+            expect(errors).not.toContain('CLOUD PROCESS APP 2');
+        });
+
         test('saves before closing the engine session', async () => {
             const { app, session } = wireEnigma([makeSheet('sheet-1', 1)]);
             const order = [];
@@ -645,6 +659,34 @@ describe('qscloudRemoveSheetIcons', () => {
             const logged = logger.verbose.mock.calls.map((call) => String(call[0])).join('\n');
             expect(logged).toContain(`on tenant ${BASE_OPTIONS.tenanturl}`);
             expect(logged).not.toContain('on host undefined');
+        });
+
+        test('says it removed icons, not that it updated or generated them', async () => {
+            // This command clears sheet icons. The two twins previously claimed "updating" and
+            // "generating" respectively - neither of which it does, and they disagreed with
+            // each other about which wrong verb to use.
+            wireEnigma([makeSheet('sheet-1', 1)]);
+
+            await qscloudRemoveSheetIcons({ ...BASE_OPTIONS });
+
+            const logged = [...logger.info.mock.calls, ...logger.verbose.mock.calls]
+                .map((call) => String(call[0]))
+                .join('\n');
+            expect(logged).toContain('Closed session after removing sheet icons in QS Cloud app');
+            expect(logged).not.toContain('after updating sheet thumbnail');
+            expect(logged).not.toContain('after generating sheet thumbnail');
+        });
+
+        test('reports the created session at info, like the other top-level commands', async () => {
+            // A command working on an app the operator named. Its own "Opened app" line is
+            // already info and the default log level is info, so the session line belongs there
+            // too - only the update step, which re-opens an already-reported app, stays verbose.
+            wireEnigma([makeSheet('sheet-1', 1)]);
+
+            await qscloudRemoveSheetIcons({ ...BASE_OPTIONS });
+
+            const atInfo = logger.info.mock.calls.map((call) => String(call[0])).join('\n');
+            expect(atInfo).toContain('Created session to');
         });
 
         test('returns false when the SaaS client cannot be built', async () => {

--- a/src/lib/cloud/cloud-remove-sheet-icons.js
+++ b/src/lib/cloud/cloud-remove-sheet-icons.js
@@ -41,6 +41,10 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
             configEnigma,
             {
                 logPrefix: 'CLOUD REMOVE SHEET ICONS',
+                // A top-level command, like the two process-app paths: its own "Opened app" line
+                // is already info, and the default log level is info. Only the update step,
+                // which re-opens an app process-app already reported, stays at verbose.
+                sessionLogLevel: 'info',
                 loglevel: options.loglevel,
                 connectionLabel: `Qlik Sense Cloud tenant ${options.tenanturl}`,
             },
@@ -95,7 +99,7 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
             }
         );
         logger.verbose(
-            `Closed session after updating sheet thumbnail images in QS Cloud app ${appId} on tenant ${options.tenanturl}`
+            `Closed session after removing sheet icons in QS Cloud app ${appId} on tenant ${options.tenanturl}`
         );
 
         // Deleted only after the sheets have been repointed and the app saved. Doing it
@@ -251,7 +255,7 @@ export const qscloudRemoveSheetIcons = async (options) => {
         return await runOverApps(
             appIdsToProcess,
             {
-                logPrefix: 'CLOUD PROCESS APP 2',
+                logPrefix: 'CLOUD REMOVE SHEET ICONS',
                 emptySelectionHint: 'Check the --appid and --collectionid options.',
             },
             (appId) => removeSheetIconsCloudApp(appId, saasInstance, options)

--- a/src/lib/cloud/process-cloud-app.js
+++ b/src/lib/cloud/process-cloud-app.js
@@ -133,7 +133,7 @@ export const processCloudApp = async (appId, saasInstance, options) => {
 
                     const browser = await launchBrowserForApp(options, {
                         appId,
-                        logPrefix: 'CLOUD APP:',
+                        logPrefix: 'CLOUD APP',
                         appLabel: 'Qlik Sense Cloud app',
                         ErrorClass: CloudError,
                     });

--- a/src/lib/qseow/__tests__/qseow_remove_sheet_icons.test.js
+++ b/src/lib/qseow/__tests__/qseow_remove_sheet_icons.test.js
@@ -161,6 +161,48 @@ describe('qseowRemoveSheetIcons', () => {
             await expect(qseowRemoveSheetIcons(BASE_OPTIONS)).resolves.toBe(true);
         });
 
+        test('says it removed icons, not that it updated or generated them', async () => {
+            // This command clears sheet icons. The two twins previously claimed "updating" and
+            // "generating" respectively - neither of which it does, and they disagreed with
+            // each other about which wrong verb to use.
+            wireEnigma([makeSheet('sheet-1', 1)]);
+
+            await qseowRemoveSheetIcons(BASE_OPTIONS);
+
+            const logged = [...logger.info.mock.calls, ...logger.verbose.mock.calls]
+                .map((call) => String(call[0]))
+                .join('\n');
+            expect(logged).toContain('Closed session after removing sheet icons in QSEoW app');
+            expect(logged).not.toContain('after updating sheet thumbnail');
+            expect(logged).not.toContain('after generating sheet thumbnail');
+        });
+
+        test('reports the created session at info, like the other top-level commands', async () => {
+            // A command working on an app the operator named. Its own "Opened app" line is
+            // already info and the default log level is info, so the session line belongs there
+            // too - only the update step, which re-opens an already-reported app, stays verbose.
+            wireEnigma([makeSheet('sheet-1', 1)]);
+
+            await qseowRemoveSheetIcons(BASE_OPTIONS);
+
+            const atInfo = logger.info.mock.calls.map((call) => String(call[0])).join('\n');
+            expect(atInfo).toContain('Created session to');
+        });
+
+        test('names the removal command in the per-app failure line', async () => {
+            // The app loop was told 'CLOUD PROCESS APP 2' and 'QSEOW PROCESS APP: Remove sheet
+            // icons' respectively - a stray counter on one, a double colon on the other, and
+            // neither naming the command actually running.
+            const { app } = wireEnigma([makeSheet('sheet-1', 1)]);
+            app.doSave.mockRejectedValue(new Error('app is published and cannot be saved'));
+
+            await expect(qseowRemoveSheetIcons(BASE_OPTIONS)).resolves.toBe(false);
+
+            const errors = logger.error.mock.calls.map((call) => String(call[0])).join('\n');
+            expect(errors).toContain('QSEOW REMOVE SHEET ICONS: Failed to process app');
+            expect(errors).not.toContain('QSEOW PROCESS APP');
+        });
+
         test('clears the thumbnail URL on every sheet', async () => {
             const sheets = [makeSheet('sheet-1', 1), makeSheet('sheet-2', 2)];
             wireEnigma(sheets);

--- a/src/lib/qseow/qseow-remove-sheet-icons.js
+++ b/src/lib/qseow/qseow-remove-sheet-icons.js
@@ -42,6 +42,10 @@ const removeSheetIconsQSEoWApp = async (appId, g, options) => {
             configEnigma,
             {
                 logPrefix: 'QSEOW REMOVE SHEET ICONS',
+                // A top-level command, like the two process-app paths: its own "Opened app" line
+                // is already info, and the default log level is info. Only the update step,
+                // which re-opens an app process-app already reported, stays at verbose.
+                sessionLogLevel: 'info',
                 loglevel: options.loglevel,
                 connectionLabel: `server ${options.host}`,
             },
@@ -98,7 +102,7 @@ const removeSheetIconsQSEoWApp = async (appId, g, options) => {
             }
         );
         logger.verbose(
-            `Closed session after generating sheet thumbnail images for all sheets in QSEoW app ${appId} on host ${options.host}`
+            `Closed session after removing sheet icons in QSEoW app ${appId} on host ${options.host}`
         );
 
         logger.info(`Done processing app ${appId}`);
@@ -171,7 +175,7 @@ export const qseowRemoveSheetIcons = async (options) => {
         return await runOverApps(
             appIdsToProcess,
             {
-                logPrefix: 'QSEOW PROCESS APP: Remove sheet icons',
+                logPrefix: 'QSEOW REMOVE SHEET ICONS',
                 emptySelectionHint: 'Check the --appid and --qliksensetag options.',
             },
             (appId) => removeSheetIconsQSEoWApp(appId, global, options)

--- a/src/lib/util/engine-session.js
+++ b/src/lib/util/engine-session.js
@@ -30,11 +30,22 @@ import { logger } from '../../globals.js';
  * @param {string} ctx.connectionLabel - What was connected to, e.g. `'server sense.example.com'`
  *     or `'Qlik Sense Cloud tenant foo.eu.qlikcloud.com'`. Rendered into the existing
  *     `Created session to …, engine version is …` line.
- * @param {string} [ctx.sessionLogLevel] - Level for that line. Defaults to `'verbose'`, which is
- *     what four of the six callers used. The two screenshot paths pass `'info'`, because that is
- *     what they logged before and the default log level is `info` - quietly demoting it would
- *     remove a line operators see on every run. The inconsistency is deliberate to preserve here,
- *     and belongs with the rest of the message work in #872 part 3.
+ * @param {string} [ctx.sessionLogLevel] - Level for that line, following the convention below.
+ *     Defaults to `'verbose'`, so a caller that does not think about it stays quiet.
+ *
+ *     The rule is **who opened the app first**, not which platform or command:
+ *
+ *     - A command working on an app the operator named logs at `'info'` - the two screenshot
+ *       paths and the two icon-removal commands. The default log level is `info`, so this is the
+ *       line that tells an operator the run reached their app.
+ *     - A step re-opening an app already reported by the caller above it logs at `'verbose'`.
+ *       Only the two `*-updatesheets` modules qualify: they are called solely from the
+ *       screenshot paths, which have already announced the same app. Repeating it at `info`
+ *       would print every app twice on a default-level run.
+ *
+ *     Each module's `Opened app …` line follows the same rule, so the two lines in a module
+ *     always agree. The removal commands used to mix them - session at `verbose`, `Opened app`
+ *     at `info` - which is what made the split look accidental.
  * @param {Function} fn - Async callback receiving the enigma `global` object. Its resolved value
  *     is returned.
  *


### PR DESCRIPTION
Closes the message work in #872 Part 3. Small, all operator-facing, all in code the earlier parts centralised enough to fix once.

## Four defects

**Removing icons claimed to be updating or generating them** — and the twins didn't agree on which wrong verb:

| Module | Said |
|---|---|
| `cloud-remove-sheet-icons` | `Closed session after updating sheet thumbnail images …` |
| `qseow-remove-sheet-icons` | `Closed session after generating sheet thumbnail images …` |

Both now say `Closed session after removing sheet icons …`.

**The app loop was given prefixes naming neither the command nor anything coherent** — `CLOUD PROCESS APP 2` (leftover counter) and `QSEOW PROCESS APP: Remove sheet icons` (renders a double colon). Both now use the module's own prefix.

**`launchBrowserForApp` built its line as `${logPrefix} Could not launch`, with no colon**, while Cloud passed a prefix ending in one and QSEoW did not:

```
CLOUD APP: Could not launch virtual browser: …
QSEOW Could not launch virtual browser: …
```

The colon now lives in the template.

**The `Created session to …` line is now `info` for the two icon-removal commands.** Their own `Opened app` line was already `info` and the default level *is* `info`, so the session line was the odd one out within its own module.

## The verbose/info split is principled — I had this wrong

In the step-3 handover I described the level split as "looking deliberate and not being". Checking the call graph rather than the levels shows the opposite: `*-updatesheets` is called **only** from `process-app`, so it is a secondary re-open of an app the caller already announced. Every module is internally consistent — session line and `Opened app` at the same level — except the two removal commands, which mixed them.

So this is a two-module fix, not the sweeping unification I proposed. The rule is now written down on `withEngineSession`:

- A command working on an app the operator named → `info`
- A step re-opening an app the caller above it already announced → `verbose`, so a default-level run does not name the same app twice

## Verification

- **821 unit tests / 51 suites**, lint and Prettier clean
- **QSEoW 2/2** and **Cloud 1/1** integration against live servers
- Seven mutations, all caught

**Every one of these was unpinned.** The full suite stayed green through each change until I added tests — which is exactly how `CLOUD PROCESS APP 2` and a verb describing the wrong operation survived this long.

## Doc page

`docs/to-doc-site/log-messages-name-the-right-operation.md`. Log output is explicitly in the CLAUDE.md doc trigger list, and an admin with log-based monitoring matching `CLOUD PROCESS APP 2` needs to know it is gone.

Every claim was verified against the code, and that caught a real drafting error: my first draft documented the QSEoW removal messages too, but **`qseow remove-sheet-icons` is not a registered command** (#894) — verified by running `qseow --help`. An admin can never have seen those lines, so the page now covers only `qscloud remove-sheet-icons`, and says plainly that the QSEoW side was corrected but is not yet exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)