### PR TITLE
docs: tell agents how to verify against a live QSEoW environment

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -119,6 +119,17 @@ After making changes, **ALWAYS** test at least one of these scenarios:
 - **Help System**: Verify all help commands work: `--help`, `qseow --help`, `qscloud --help`, `browser --help`
 - **Configuration Loading**: Test with environment variables or config files if modified
 
+### Live QSEoW Verification
+
+Some changes — a thumbnail that should have updated, a login or logout selector, which part of a sheet is captured — can only be confirmed against a real Qlik Sense server. Unit tests cannot show this.
+
+- **ALWAYS** prefer a sandboxed/in-app browser over the user's own signed-in browser, because it starts from a clean profile. Reach for the real browser, with its existing sessions and password manager, only when the task actually needs them. Under Claude Code that ordering is `mcp__Claude_Browser__*` first, `mcp__claude-in-chrome__*` second.
+- **ALWAYS** start from a clean browser session: fresh profile, cleared cache, or incognito. A cached page is the most common reason a "verified" result is really the previous run.
+- **ALWAYS** establish the app URL first — ask the user, or build it from the run's options: `https://<host>/<prefix>/sense/app/<appId>` (omit `/<prefix>` when no virtual proxy is used). The hub is `https://<host>/<prefix>/hub`.
+- **NEVER** type credentials yourself. Click the login button if the form is pre-filled; otherwise ask the user to sign in and wait for confirmation.
+- After signing in, open the specific sheet, hub thumbnail, or content library entry the change affects, and report what you **actually saw**.
+- **NEVER** describe a change as verified when you had no browser available — give the user the URL and what to look for instead.
+
 ## Code Quality and CI Requirements
 
 **ALWAYS** run these before committing or the CI (.github/workflows/ci.yaml) will fail:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,17 @@ This project is indexed by GitNexus as **butler-sheet-icons**. Use the GitNexus 
 - Puppeteer launch options are centralized in `src/lib/browser/` — do not create new browser instances ad hoc
 - Long browser sessions can hold files open; always call `browser.close()` (or use the `try/finally` helpers) to avoid hanging tests
 
+## Verifying against a live QSEoW environment
+
+The section above is about the browser BSI drives. This one is about the browser **you** drive. Some changes — a thumbnail that should have updated, a login or logout selector, which part of a sheet gets captured — can only be confirmed by looking at a real server. Unit tests cannot show this.
+
+- **Reach for the internal browser first.** Claude Code's in-app browser (`mcp__Claude_Browser__*`) starts from a clean profile, which satisfies the next point for free. Fall back to Claude in Chrome (`mcp__claude-in-chrome__*`) only when the task needs the user's existing signed-in session or password manager. Other agents: use whatever equivalent browser tooling you have.
+- **Start from a clean browser session** — a fresh profile, cleared cache, or an incognito/private window. A cached page is the most common reason a "verified" result is really the previous run.
+- **Get the app URL before opening anything.** Ask the user for it, or build it from the run's own options: `https://<host>/<prefix>/sense/app/<appId>`, dropping `/<prefix>` when no virtual proxy is in play. The hub is `https://<host>/<prefix>/hub`.
+- **Never type credentials yourself.** If the login form is already filled in, click the login button. Otherwise ask the user to sign in, and wait until they confirm they are done.
+- **Look at the specific thing that changed** — the sheet, the hub thumbnail, or the content library entry — and report what you actually saw, not what should have happened.
+- **If you have no browser tooling, say so.** Give the user the exact URL and what to look for. Do not describe the change as verified.
+
 ## SEA (Single Executable App)
 
 - SEA config: `build-script/sea-config.json` — bundles `build.cjs` and enigma.js JSON schemas as assets

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,17 @@ If a change adds, alters, or removes behaviour a Butler Sheet Icons user can obs
 
 Internal-only changes — refactors, test changes, build or lint tooling — need no doc page.
 
+## Verifying against a live QSEoW environment
+
+Some changes — a thumbnail that should have updated, a login or logout selector, which part of a sheet gets captured — can only be confirmed by opening a real server in a browser. Unit tests cannot show this.
+
+- **Internal browser first** — the in-app browser (`mcp__Claude_Browser__*`) starts from a clean profile. Fall back to Claude in Chrome (`mcp__claude-in-chrome__*`) only when you need the user's existing signed-in session or password manager.
+- **Start from a clean browser session** — fresh profile, cleared cache, or incognito. A cached page is the most common reason a "verified" result is really the previous run.
+- **Get the app URL first** — ask the user, or build it from the run's options: `https://<host>/<prefix>/sense/app/<appId>` (drop `/<prefix>` when no virtual proxy is used).
+- **Never type credentials yourself.** Click login if the form is pre-filled; otherwise ask the user to sign in and wait for their confirmation.
+- **Look at the specific thing that changed** — the sheet, the hub thumbnail, or the content library entry — and report what you actually saw.
+- **No browser tooling? Say so** — give the user the URL and what to check. Do not call it verified.
+
 ## Workflow
 
 The order is: **branch first, implement, verify, stop and report.**


### PR DESCRIPTION
## Why

Some Butler Sheet Icons changes can only be confirmed against a real Qlik Sense server — a thumbnail that should have updated, a login or logout selector, which part of a sheet gets captured. Unit tests cannot show any of that, so an agent could reasonably report "verified" on the strength of unit tests alone.

The three hand-written agent docs each had a gap:

- `CLAUDE.md` — no testing or browser guidance of any kind.
- `AGENTS.md` — `## Browser / Puppeteer` covers the browser *BSI itself* drives, nothing about an agent looking at a live server.
- `.github/copilot-instructions.md` — `### Manual Testing Scenarios` were all local CLI smoke tests (`--help`, `browser list-installed`); none touch a Qlik Sense server.

## What

Adds the same procedure to all three docs, written in each file's own voice (bullets / terser bullets / `**ALWAYS**`-`**NEVER**`):

- Prefer the sandboxed in-app browser over the user's signed-in one — it starts from a clean profile. Fall back to the real browser only when an existing session or password manager is genuinely needed.
- Start from a clean browser session; a cached page is the most common reason a "verified" result is really the previous run.
- Establish the app URL first.
- Never type credentials — click login if pre-filled, otherwise ask the user to sign in.
- Look at the specific thing that changed, and report what was actually seen.
- If no browser tooling is available, say so rather than describing the change as verified.

The URL shapes are taken from the implementation, not assumed: `qseow-process-app.js` builds `https://<host>/<prefix>/sense/app/<appId>` with no port, and the QSEoW per-sheet URL has no `/state/analysis` suffix — that is the Cloud variant.

## Verification

Docs-only; no symbols touched. 33 insertions, 0 deletions across 3 files — nothing pre-existing moved or was reworded. Both `AGENTS.md` and `CLAUDE.md` additions land after the `gitnexus:end` marker, outside the managed block. Prettier leaves the added lines byte-identical.

No `docs/to-doc-site/` page: agent instructions are internal-only, with no user-observable behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)