### PR TITLE
fix: stop the macOS signing scripts hijacking the user's keychain, and instrument --single-process

### DIFF
--- a/.github/workflows/browser-flag-canary.yaml
+++ b/.github/workflows/browser-flag-canary.yaml
@@ -1,0 +1,191 @@
+name: browser-flag-canary
+
+# Evidence gathering for issue #913 - "--single-process makes every screenshot hang on macOS
+# depending on machine state".
+#
+# The failure has never been seen in CI, and that is not luck: test-browser-macos takes no
+# screenshot at all, test-qscloud-macos runs on a hosted runner with no display to fall asleep, and
+# test-qseow-macos runs on the self-hosted Mac, which has so far only been asked to work while
+# somebody was logged in and using it. Every observation of the failure comes from that same Mac
+# late at night.
+#
+# This workflow puts the machine into the suspected state deliberately and runs the A/B, so the
+# decision to keep or drop the flag rests on a measurement. It changes no product code and touches
+# no Qlik environment.
+#
+# A job goes red only when screenshots fail *without* the flag. Reproducing the failure *with* the
+# flag is the expected result and is reported, not failed - a canary that is red for its own
+# findings gets ignored.
+
+on:
+  workflow_dispatch:
+    inputs:
+      browser_version:
+        description: 'Browser version to probe, e.g. recommended, stable, or a build id'
+        required: false
+        default: 'recommended'
+      suspend_session:
+        description: >-
+          Also probe with the GUI session suspended to the login window (fast user switching).
+          Disruptive: whoever is at the build Mac is switched out and has to log back in.
+        required: false
+        type: boolean
+        default: false
+  # The build Mac is idle and its display asleep in the small hours, which is exactly the state
+  # under suspicion - so a nightly run observes the failure without having to force anything.
+  # Remove this schedule once #913 is settled.
+  schedule:
+    - cron: '0 1 * * *'
+
+permissions: {}
+
+concurrency:
+  group: browser-flag-canary
+  cancel-in-progress: false
+
+jobs:
+  # The machine that has actually failed. Both legs run here, serialised by the runner itself.
+  probe-self-hosted:
+    permissions:
+      contents: read
+    # MUST stay in sync with test-qseow-macos in ci.yaml - the point is to probe the Mac that
+    # runs the real screenshot suite.
+    runs-on:
+      - self-hosted
+      - macos
+      - arm64
+      - mac-build2
+      - sp53
+    strategy:
+      fail-fast: false
+      matrix:
+        state:
+          # Whatever the machine happens to be in. On a scheduled 01:00 UTC run that is the
+          # unattended overnight state; on a manual run it is usually "somebody is logged in".
+          - as-is
+          - display-asleep
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: ''
+
+      # See the note on the other jobs: pins npm so the install is identical on every runner.
+      - name: Pin npm
+        # zizmor: ignore[adhoc-packages] - setup-node has no npm-version input, so npm 12
+        # cannot arrive any other way. Pinned to an exact version rather than a range.
+        run: | # zizmor: ignore[adhoc-packages]
+          npm install -g npm@12.0.2
+          npm --version
+
+      - name: Install dependencies
+        run: npm ci --include=dev --include=prod
+
+      - name: Report host state before the probe
+        run: |
+          sw_vers
+          echo "arch            : $(uname -m)"
+          echo "console user    : $(stat -f%Su /dev/console)"
+          echo "launchd session : $(launchctl managername)"
+          echo "--- pmset -g ---"
+          pmset -g
+          echo "--- last display transitions ---"
+          pmset -g log | grep 'Display is turned' | tail -5
+
+      # pmset displaysleepnow needs no privileges and is undone by any input event, or by the
+      # caffeinate call in the always() step below.
+      - name: Put the display to sleep
+        if: matrix.state == 'display-asleep'
+        run: |
+          echo 'Sleeping the display, then settling for 20 s before probing.'
+          pmset displaysleepnow
+          sleep 20
+          pmset -g log | grep 'Display is turned' | tail -2
+
+      - name: Suspend the GUI session to the login window
+        if: matrix.state == 'display-asleep' && inputs.suspend_session
+        run: |
+          echo 'Switching to the login window - the session stays logged in, the runner keeps running.'
+          '/System/Library/CoreServices/Menu Extras/User.menu/Contents/Resources/CGSession' -suspend
+          sleep 10
+
+      # Both values travel via env rather than being interpolated into the script: browser_version
+      # is workflow_dispatch input, i.e. attacker-controllable text, and pasting it into a shell
+      # line is the template-injection pattern zizmor exists to catch.
+      - name: Run the A/B probe
+        env:
+          PROBE_LABEL: ${{ matrix.state }}
+          PROBE_BROWSER_VERSION: ${{ inputs.browser_version || 'recommended' }}
+        run: |
+          node scripts/diag/browser-flag-probe.mjs \
+            --label "$PROBE_LABEL" \
+            --timeout 20000 \
+            --browser-version "$PROBE_BROWSER_VERSION" \
+            --artifact-dir "$RUNNER_TEMP/flag-probe"
+
+      # Unconditional: a probe that failed must not leave the build Mac with its display asleep for
+      # the next job, and the artifacts are most interesting precisely when the step above failed.
+      - name: Wake the display
+        if: always()
+        run: caffeinate -u -t 1
+
+      - name: Upload stack samples
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: flag-probe-self-hosted-${{ matrix.state }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/flag-probe/
+          if-no-files-found: ignore
+          retention-days: 14
+
+  # Control. A hosted runner has no display to put to sleep and no persistent session, so this leg
+  # is expected to stay green throughout - which is what makes it worth having. If it ever goes
+  # red, the trigger is not the one we think it is.
+  probe-hosted:
+    permissions:
+      contents: read
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+
+      # See the note on the other jobs: pins npm so the install is identical on every runner.
+      - name: Pin npm
+        # zizmor: ignore[adhoc-packages] - setup-node has no npm-version input, so npm 12
+        # cannot arrive any other way. Pinned to an exact version rather than a range.
+        run: | # zizmor: ignore[adhoc-packages]
+          npm install -g npm@12.0.2
+          npm --version
+
+      - name: Install dependencies
+        run: npm ci --include=dev --include=prod
+
+      - name: Run the A/B probe
+        env:
+          PROBE_BROWSER_VERSION: ${{ inputs.browser_version || 'recommended' }}
+        run: |
+          node scripts/diag/browser-flag-probe.mjs \
+            --label hosted-control \
+            --timeout 20000 \
+            --browser-version "$PROBE_BROWSER_VERSION" \
+            --artifact-dir "$RUNNER_TEMP/flag-probe"
+
+      - name: Upload stack samples
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: flag-probe-hosted-${{ github.run_id }}
+          path: ${{ runner.temp }}/flag-probe/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/macos-signing-canary.yaml
+++ b/.github/workflows/macos-signing-canary.yaml
@@ -7,9 +7,17 @@ name: macos-signing-canary
 # This job runs the very same script on the very same runner image, but stops short of publishing:
 # nothing is uploaded to a release and no tag is touched.
 #
-# Run it after changing scripts/release-macos.sh, after changing the runner image in
-# release-macos-arm64, or periodically to catch GitHub retiring the pinned macOS image before a
-# release does.
+# Run it after changing scripts/release-macos.sh or scripts/lib/macos-signing-keychain.sh, after
+# changing the runner image in release-macos-arm64, or periodically to catch GitHub retiring the
+# pinned macOS image before a release does.
+#
+# It runs on two runners, and the second one is the point of the pairing. A hosted runner is
+# ephemeral: it has no desktop session, nobody is logged in, and any mess the signing script makes
+# of the user's keychain configuration disappears with the VM. The self-hosted build Mac is the
+# opposite - a real logged-in desktop where the same script previously made its throwaway keychain
+# the user's *default* keychain for the length of every build, which is what made Google Drive ask
+# the person sitting there for a password it could not know. Only the self-hosted leg can observe
+# that class of bug, so only the self-hosted leg carries the watchdog.
 
 on:
   workflow_dispatch:
@@ -18,14 +26,32 @@ permissions: {}
 
 jobs:
   sign-and-notarize:
-    # MUST stay in sync with release-macos-arm64 in ci.yaml - proving that image is the point.
-    runs-on: macos-15
+    name: sign-and-notarize (${{ matrix.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # MUST stay in sync with release-macos-arm64 in ci.yaml - proving that image is the point.
+          - name: hosted
+            runner: macos-15
+            self_hosted: false
+          # MUST stay in sync with the mac leg of insiders-build.yaml - that is the job which runs
+          # this signing script on every push to main, on a Mac somebody is logged in to.
+          - name: build-mac
+            runner:
+              - self-hosted
+              - macos
+              - arm64
+              - mac-build2
+              - sp53
+            self_hosted: true
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
     env:
       DIST_FILE_NAME: butler-sheet-icons
       # scripts/release-macos.sh names the archive "${RELEASE_VERSION}-macos-arm64.zip".
-      RELEASE_VERSION: canary-${{ github.run_id }}
+      RELEASE_VERSION: canary-${{ github.run_id }}-${{ matrix.name }}
       MACOS_CERTIFICATE: ${{ secrets.PROD_MACOS_CERTIFICATE_BASE64_CODESIGN }}
       MACOS_CERTIFICATE_PWD: ${{ secrets.PROD_MACOS_CERTIFICATE_CODESIGN_PWD }}
       MACOS_CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_CODESIGN_NAME }}
@@ -43,6 +69,7 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
+          cache: ''
       # The npm bundled with Node 24 is 11.x, and 11.x resolves this lockfile differently between
       # patch releases - a second Windows runner picking up a newer Node installed 53 fewer
       # packages and could not resolve jest-circus. Pinning npm here makes the install identical
@@ -55,23 +82,73 @@ jobs:
           npm install -g npm@12.0.2
           npm --version
 
-      # The release script snapshots the user keychain list and expands it unguarded under
-      # `set -u`. An empty list is the one input that breaks it, so record what this host reports
-      # before the script runs - it turns a confusing mid-script exit into an obvious cause.
       - name: Report host details
         run: |
           sw_vers
           echo "arch          : $(uname -m)"
           echo "bash          : ${BASH_VERSION:-unknown} at $(command -v bash)"
           echo "node          : $(node --version) at $(command -v node)"
-          echo "--- security list-keychains -d user ---"
-          security list-keychains -d user
+
+      # A build must start from a healthy host. If a previous run left a signing keychain behind,
+      # that is worth knowing before this run's cleanup silently absorbs it - the whole class of
+      # bug is about state surviving between builds.
+      - name: Audit the keychain before signing
+        run: bash scripts/diag/macos-keychain-check.sh
+
+      - name: Record the keychain state before signing
+        run: |
+          set -euo pipefail
+          {
+            echo '--- search list ---'
+            security list-keychains -d user
+            echo '--- default keychain ---'
+            security default-keychain -d user
+          } | tee "$RUNNER_TEMP/keychains-before.txt"
 
       - name: Install dependencies
         run: npm ci --include=dev --include=prod
 
+      # The regression test for the Google Drive dialog. The damage was never visible before or
+      # after a build - only *during* it, in the minutes between the keychain being created and
+      # deleted. So sample the configuration once a second for the whole signing step and fail if
+      # a signing keychain ever becomes the default, or ever gets ahead of the login keychain.
+      - name: Start the keychain watchdog
+        if: matrix.self_hosted
+        run: |
+          set -euo pipefail
+          : > "$RUNNER_TEMP/keychain-violations.log"
+          cat > "$RUNNER_TEMP/watchdog.sh" <<'SH'
+          #!/usr/bin/env bash
+          while :; do
+            if ! bash scripts/diag/macos-keychain-check.sh --during-build --quiet >> "$VIOLATIONS" 2>&1; then
+              echo "  (observed at $(date -u +%Y-%m-%dT%H:%M:%SZ))" >> "$VIOLATIONS"
+            fi
+            sleep 1
+          done
+          SH
+          chmod +x "$RUNNER_TEMP/watchdog.sh"
+          VIOLATIONS="$RUNNER_TEMP/keychain-violations.log" nohup "$RUNNER_TEMP/watchdog.sh" >/dev/null 2>&1 &
+          echo $! > "$RUNNER_TEMP/watchdog.pid"
+          echo "watchdog running as pid $(cat "$RUNNER_TEMP/watchdog.pid")"
+
       - name: Build, sign and notarize
         run: bash ./scripts/release-macos.sh
+
+      - name: Stop the keychain watchdog and report
+        if: always() && matrix.self_hosted
+        run: |
+          set -uo pipefail
+          if [ -f "$RUNNER_TEMP/watchdog.pid" ]; then
+            kill "$(cat "$RUNNER_TEMP/watchdog.pid")" 2>/dev/null || true
+          fi
+
+          if [ -s "$RUNNER_TEMP/keychain-violations.log" ]; then
+            echo '::error::the signing script interfered with the user keychain configuration during the build'
+            cat "$RUNNER_TEMP/keychain-violations.log"
+            exit 1
+          fi
+
+          echo 'No keychain violations observed while signing.'
 
       # codesign -dv writes to stderr, hence the redirect. Assert the two properties that actually
       # matter and that a wrong signing identity would silently get wrong: the Developer ID
@@ -98,9 +175,30 @@ jobs:
           echo "Signature OK. Check the notarization status printed by notarytool in the"
           echo "'Build, sign and notarize' step above - it must read 'status: Accepted'."
 
+      # Unconditional: a failed or cancelled signing run is exactly the case where the keychain is
+      # most likely to have been left behind, so that is when the assertion matters most.
+      - name: Assert the keychain state was restored
+        if: always()
+        run: |
+          set -euo pipefail
+          {
+            echo '--- search list ---'
+            security list-keychains -d user
+            echo '--- default keychain ---'
+            security default-keychain -d user
+          } > "$RUNNER_TEMP/keychains-after.txt"
+
+          if ! diff -u "$RUNNER_TEMP/keychains-before.txt" "$RUNNER_TEMP/keychains-after.txt"; then
+            echo '::error::the keychain configuration was not restored to what it was before the build'
+            exit 1
+          fi
+
+          bash scripts/diag/macos-keychain-check.sh
+          echo 'Keychain configuration restored exactly.'
+
       - name: Upload the signed archive for inspection
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: macos-signing-canary-${{ github.run_id }}
+          name: macos-signing-canary-${{ matrix.name }}-${{ github.run_id }}
           path: ./*-macos-arm64.zip
           retention-days: 3

--- a/scripts/diag/browser-flag-probe.mjs
+++ b/scripts/diag/browser-flag-probe.mjs
@@ -1,0 +1,417 @@
+#!/usr/bin/env node
+/**
+ * Diagnostic probe for issue #913 - "--single-process makes every screenshot hang on macOS
+ * depending on machine state".
+ *
+ * The failure is not reproducible on demand: the same machine, the same Chrome build and the same
+ * code passed a few hours before it failed. Every data point so far lines up with the state of the
+ * host's display and login session, but that is correlation. This probe exists to turn it into
+ * evidence, so the flag is removed on a measurement rather than on a hunch.
+ *
+ * What it does, per trial:
+ *
+ *   1. Records the host session state - console user, screen lock, Aqua vs background launchd
+ *      session, power assertions, and the last display on/off transition. A trial result is
+ *      worthless without knowing which state the machine was in when it ran.
+ *   2. Launches the browser Butler Sheet Icons would actually launch, using the product's own
+ *      resolution and argument list, with and without `--single-process`.
+ *   3. Screenshots `about:blank`. No Qlik, no network, no BSI code - the reporter isolated the
+ *      failure this far already, and anything more would reintroduce variables.
+ *   4. On a hang, samples the browser process with `sample(1)` before killing it. That stack is the
+ *      whole point: it names what the single-process browser is blocked on, which is the difference
+ *      between "we removed a flag that correlated with failures" and knowing why.
+ *
+ * The trial order is off / on / off. Running both variants inside one invocation is deliberate -
+ * machine state drifts, and two runs minutes apart are not a controlled comparison.
+ *
+ * Usage:
+ *   node scripts/diag/browser-flag-probe.mjs [--label <text>] [--timeout <ms>]
+ *                                            [--browser <name>] [--browser-version <version>]
+ *                                            [--artifact-dir <dir>]
+ *
+ * Exit code: 0 when every trial *without* the flag succeeded. A trial with the flag is reported
+ * but never fails the run - observing that failure is the objective, and a canary that goes red
+ * for the expected finding trains people to ignore it. Reporting is via stdout and, when present,
+ * $GITHUB_STEP_SUMMARY.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, appendFileSync } from 'node:fs';
+import path from 'node:path';
+import puppeteer from 'puppeteer-core';
+
+import { BASE_BROWSER_ARGS, resolveBrowserExecutablePath } from '../../src/lib/browser/browser-launch.js';
+import { VERSION_RECOMMENDED } from '../../src/lib/browser/browser-version.js';
+
+const SINGLE_PROCESS = '--single-process';
+
+/**
+ * Parses `--key value` pairs into an object, applying defaults for anything not supplied.
+ *
+ * Hand-rolled rather than pulled from commander: this script is run by CI and by hand on a build
+ * host, and it should stay runnable straight from a checkout without caring whether dev
+ * dependencies are installed.
+ *
+ * @param {string[]} argv - Raw arguments, i.e. `process.argv.slice(2)`.
+ *
+ * @returns {object} Parsed options with defaults applied.
+ */
+const parseArgs = (argv) => {
+    const options = {
+        label: 'unspecified',
+        timeout: 20000,
+        browser: 'chrome',
+        browserVersion: VERSION_RECOMMENDED,
+        artifactDir: path.join(process.cwd(), 'flag-probe-artifacts'),
+    };
+
+    const keys = {
+        '--label': 'label',
+        '--timeout': 'timeout',
+        '--browser': 'browser',
+        '--browser-version': 'browserVersion',
+        '--artifact-dir': 'artifactDir',
+    };
+
+    for (let i = 0; i < argv.length; i += 2) {
+        const key = keys[argv[i]];
+        if (!key) {
+            throw new Error(`Unknown argument: ${argv[i]}`);
+        }
+        options[key] = key === 'timeout' ? Number(argv[i + 1]) : argv[i + 1];
+    }
+
+    return options;
+};
+
+/**
+ * Runs a command and returns its trimmed output, or a marker when it is unavailable.
+ *
+ * Every state probe below is best-effort by design. `ioreg`, `pmset` and friends differ between
+ * macOS releases and between Apple Silicon and Intel, and a probe that crashed because one
+ * diagnostic is missing on the host would lose the trial it was meant to describe.
+ *
+ * @param {string} command - Executable to run.
+ * @param {string[]} args - Arguments for the command.
+ *
+ * @returns {string} Trimmed stdout, or `'(unavailable)'` if the command could not run.
+ */
+const capture = (command, args) => {
+    try {
+        return execFileSync(command, args, { encoding: 'utf8', timeout: 15000 }).trim();
+    } catch {
+        return '(unavailable)';
+    }
+};
+
+/**
+ * Reads the last display power transition out of the power management log.
+ *
+ * There is no cheap direct query for this on Apple Silicon - `IODisplayWrangler` does not exist
+ * and `pmset -g powerstate` fails - so the log is the reliable source. It costs about a second.
+ *
+ * @returns {string} The last `Display is turned on|off` line, or a marker.
+ */
+const lastDisplayTransition = () => {
+    const log = capture('/bin/sh', ['-c', "pmset -g log | grep 'Display is turned' | tail -1"]);
+    return log === '' ? '(no transition logged)' : log;
+};
+
+/**
+ * Snapshots everything about the host that could plausibly gate the failure.
+ *
+ * `launchctl managername` is the one worth calling out: it reports `Aqua` for a process inside a
+ * logged-in GUI session and `Background` for one without. A self-hosted runner installed as a
+ * LaunchAgent moves between those, and that is a candidate trigger the display state alone does
+ * not distinguish.
+ *
+ * @returns {object} Named state readings, all strings.
+ */
+const captureHostState = () => ({
+    consoleUser: capture('/usr/bin/stat', ['-f%Su', '/dev/console']),
+    launchdSession: capture('/bin/launchctl', ['managername']),
+    screenLocked: capture('/bin/sh', [
+        '-c',
+        "ioreg -n Root -d1 -r -k CGSSessionScreenIsLocked | grep -c CGSSessionScreenIsLocked || true",
+    ]).trim() === '0'
+        ? 'no'
+        : 'yes',
+    lastDisplayEvent: lastDisplayTransition(),
+    userIsActive: capture('/bin/sh', [
+        '-c',
+        "pmset -g assertions | awk '/UserIsActive/ {print $2; exit}'",
+    ]),
+    loginwindowRunning: capture('/bin/sh', ['-c', 'pgrep -x loginwindow >/dev/null && echo yes || echo no']),
+});
+
+/**
+ * Rejects after `ms` milliseconds, so a hung CDP call fails in seconds instead of puppeteer's
+ * 180 s default.
+ *
+ * The launch-level `protocolTimeout` already bounds the protocol call, but it does not bound
+ * `page.goto`'s own waiting, and a probe that takes three minutes per trial is one nobody runs.
+ *
+ * @param {number} ms - Timeout in milliseconds.
+ * @param {string} what - Operation name, used in the rejection message.
+ *
+ * @returns {{promise: Promise<never>, cancel: () => void}} The timer promise and its canceller.
+ * The caller must cancel, or Node keeps the timer alive and the process will not exit.
+ */
+const deadline = (ms, what) => {
+    let timer;
+    const promise = new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${what} did not complete within ${ms} ms`)), ms);
+    });
+    return { promise, cancel: () => clearTimeout(timer) };
+};
+
+/**
+ * Races an operation against a deadline.
+ *
+ * @param {Promise} operation - The operation to bound.
+ * @param {number} ms - Timeout in milliseconds.
+ * @param {string} what - Operation name for the error message.
+ *
+ * @returns {Promise<*>} The operation's value, or a rejection once the deadline passes.
+ */
+const withDeadline = async (operation, ms, what) => {
+    const timer = deadline(ms, what);
+    try {
+        return await Promise.race([operation, timer.promise]);
+    } finally {
+        timer.cancel();
+    }
+};
+
+/**
+ * Captures a user-space stack trace of a browser process that stopped responding.
+ *
+ * This is the diagnostic the investigation is missing. `Page.captureScreenshot timed out` says
+ * nothing about why; a `sample` taken while the process is still wedged shows which thread is
+ * blocked and on what, which is what distinguishes a compositor starved of frames from, say, a
+ * deadlock on a window server connection.
+ *
+ * `spindump` would say more but needs root, which a runner does not have. `sample` works on a
+ * process the caller owns.
+ *
+ * @param {number} pid - Process id of the wedged browser.
+ * @param {string} artifactDir - Directory to write the sample into.
+ * @param {string} trialName - Used to name the file.
+ *
+ * @returns {string|undefined} Path to the sample file, or `undefined` if sampling failed.
+ */
+const sampleWedgedProcess = (pid, artifactDir, trialName) => {
+    mkdirSync(artifactDir, { recursive: true });
+    const outFile = path.join(artifactDir, `sample-${trialName}-pid${pid}.txt`);
+
+    try {
+        execFileSync('/usr/bin/sample', [String(pid), '5', '-file', outFile], {
+            encoding: 'utf8',
+            timeout: 60000,
+        });
+        return outFile;
+    } catch (err) {
+        console.error(`  could not sample pid ${pid}: ${err.message}`);
+        return undefined;
+    }
+};
+
+/**
+ * Runs one trial: launch, health check, navigate, screenshot.
+ *
+ * Every step is bounded and reported separately, because *where* it stalls is itself evidence.
+ * The reporter saw the hang wander between the first screenshot and a mid-sheet
+ * `Runtime.callFunctionOn`, which suggests whatever needs the renderer first is what blocks - so
+ * the probe records the first step that failed rather than just pass/fail.
+ *
+ * @param {object} params - Trial parameters.
+ * @param {string} params.executablePath - Browser binary to launch.
+ * @param {boolean} params.singleProcess - Whether to add `--single-process`.
+ * @param {number} params.timeout - Per-step deadline in milliseconds.
+ * @param {string} params.artifactDir - Where to write a sample if the browser wedges.
+ *
+ * @returns {Promise<object>} Trial result: `{ name, singleProcess, ok, failedAt, detail, timings,
+ * samplePath, state }`.
+ */
+const runTrial = async ({ executablePath, singleProcess, timeout, artifactDir }) => {
+    const name = singleProcess ? 'with-single-process' : 'without-single-process';
+    const args = singleProcess ? [...BASE_BROWSER_ARGS, SINGLE_PROCESS] : [...BASE_BROWSER_ARGS];
+    const state = captureHostState();
+    const timings = {};
+
+    console.log(`\n=== trial: ${name} ===`);
+    console.log(
+        `  host: consoleUser=${state.consoleUser} session=${state.launchdSession} ` +
+            `locked=${state.screenLocked} userIsActive=${state.userIsActive}`
+    );
+    console.log(`  last display event: ${state.lastDisplayEvent}`);
+
+    let browser;
+    let pid;
+    let failedAt;
+    let detail;
+    let samplePath;
+
+    try {
+        let t0 = Date.now();
+        browser = await withDeadline(
+            puppeteer.launch({
+                executablePath,
+                headless: true,
+                ignoreHTTPSErrors: true,
+                protocolTimeout: timeout,
+                args,
+            }),
+            timeout,
+            'launch'
+        );
+        timings.launch = Date.now() - t0;
+        pid = browser.process()?.pid;
+
+        // Browser.getVersion never reaches the renderer. It is included because it is what the
+        // product's own health check does today, and showing it passing while the screenshot hangs
+        // is the argument for making that check render something (issue #913, point 3).
+        t0 = Date.now();
+        const version = await withDeadline(browser.version(), timeout, 'browser.version()');
+        timings.version = Date.now() - t0;
+        detail = version;
+
+        t0 = Date.now();
+        const page = await withDeadline(browser.newPage(), timeout, 'newPage()');
+        timings.newPage = Date.now() - t0;
+
+        t0 = Date.now();
+        await withDeadline(page.goto('about:blank'), timeout, 'goto(about:blank)');
+        timings.goto = Date.now() - t0;
+
+        t0 = Date.now();
+        await withDeadline(
+            page.screenshot({ encoding: 'base64' }),
+            timeout,
+            'Page.captureScreenshot'
+        );
+        timings.screenshot = Date.now() - t0;
+
+        console.log(`  PASS  ${JSON.stringify(timings)}`);
+        return { name, singleProcess, ok: true, timings, detail, state };
+    } catch (err) {
+        failedAt = err.message;
+        console.error(`  FAIL  ${failedAt}`);
+
+        if (pid) {
+            samplePath = sampleWedgedProcess(pid, artifactDir, name);
+            if (samplePath) {
+                console.error(`  stack sample written to ${samplePath}`);
+            }
+        }
+
+        return { name, singleProcess, ok: false, failedAt, timings, detail, samplePath, state };
+    } finally {
+        // A wedged browser will not close politely - browser.close() waits on the same protocol
+        // that just timed out. Try the clean path briefly, then kill, so the next trial starts
+        // against a machine that is not hosting a stuck Chromium.
+        if (browser) {
+            try {
+                await withDeadline(browser.close(), 5000, 'browser.close()');
+            } catch {
+                browser.process()?.kill('SIGKILL');
+            }
+        }
+    }
+};
+
+/**
+ * Renders the trial results as a GitHub-flavoured markdown table.
+ *
+ * @param {object[]} results - Trial results from `runTrial`.
+ * @param {string} label - The state label supplied by the caller, e.g. `display-asleep`.
+ *
+ * @returns {string} Markdown ready for a step summary.
+ */
+const renderSummary = (results, label) => {
+    const state = results[0]?.state ?? {};
+    const lines = [
+        `### Browser flag probe - \`${label}\``,
+        '',
+        `- console user: \`${state.consoleUser}\``,
+        `- launchd session: \`${state.launchdSession}\``,
+        `- screen locked: \`${state.screenLocked}\``,
+        `- UserIsActive assertion: \`${state.userIsActive}\``,
+        `- last display event: \`${state.lastDisplayEvent}\``,
+        '',
+        '| Trial | `--single-process` | Result | Detail |',
+        '| --- | --- | --- | --- |',
+    ];
+
+    for (const result of results) {
+        const outcome = result.ok
+            ? `screenshot OK in ${result.timings.screenshot} ms`
+            : `**FAILED** - ${result.failedAt}`;
+        lines.push(
+            `| ${result.name} | ${result.singleProcess ? 'yes' : 'no'} | ${result.ok ? 'pass' : 'fail'} | ${outcome} |`
+        );
+    }
+
+    return `${lines.join('\n')}\n`;
+};
+
+/**
+ * Resolves the browser, runs the off/on/off trial sequence and reports.
+ *
+ * @returns {Promise<void>} Resolves once results are written; sets `process.exitCode` on failure.
+ */
+const main = async () => {
+    const options = parseArgs(process.argv.slice(2));
+
+    console.log(`Butler Sheet Icons browser flag probe - label "${options.label}"`);
+    console.log(`platform=${process.platform} arch=${process.arch} node=${process.version}`);
+
+    const { executablePath, buildId, source } = await resolveBrowserExecutablePath(options);
+    console.log(`browser: ${options.browser} ${buildId} (${source})`);
+    console.log(`base args: ${BASE_BROWSER_ARGS.join(' ')}`);
+
+    const results = [];
+    for (const singleProcess of [false, true, false]) {
+        results.push(
+            // eslint-disable-next-line no-await-in-loop -- the trials must be sequential; two
+            // browsers competing for the same machine is not the thing being measured.
+            await runTrial({
+                executablePath,
+                singleProcess,
+                timeout: options.timeout,
+                artifactDir: options.artifactDir,
+            })
+        );
+    }
+
+    const summary = renderSummary(results, options.label);
+    console.log(`\n${summary}`);
+
+    if (process.env.GITHUB_STEP_SUMMARY) {
+        appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary);
+    }
+
+    const controlFailed = results.some((result) => !result.singleProcess && !result.ok);
+    const flaggedFailed = results.some((result) => result.singleProcess && !result.ok);
+
+    if (controlFailed) {
+        console.error(
+            'CONTROL FAILED: screenshots hang in this state even without --single-process. ' +
+                'Removing the flag would not fix issue #913 on its own.'
+        );
+        process.exitCode = 1;
+        return;
+    }
+
+    if (flaggedFailed) {
+        console.log(
+            'REPRODUCED: --single-process hangs in this state while the same machine, at the same ' +
+                'moment, screenshots fine without it. This is the evidence issue #913 needs.'
+        );
+        return;
+    }
+
+    console.log('No difference observed in this state - the machine was not in the failing state.');
+};
+
+await main();

--- a/scripts/diag/macos-keychain-check.sh
+++ b/scripts/diag/macos-keychain-check.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Read-only audit of the user's keychain configuration on a macOS build host.
+#
+# The signing scripts create a throwaway keychain for the Developer ID certificate. An earlier
+# version of them put that keychain at the head of the user's search list and made it the user's
+# *default* keychain for the whole build, which is what produced "Google Drive wants to use the
+# build keychain" on the self-hosted Mac - and, when a run was killed, left the machine in that
+# state permanently.
+#
+# This script asserts that none of that is happening. It changes nothing: repair belongs to
+# scripts/lib/macos-signing-keychain.sh, which runs at the start of every build. Keeping the audit
+# read-only means it can be run on a developer's own Mac without consequences, and means a CI
+# failure here reports a real state rather than one the checker just fixed.
+#
+# Modes:
+#   (default)       Between builds. No signing keychain may be present at all.
+#   --during-build  While a build is signing. A signing keychain may be on the search list, but it
+#                   must not be the default keychain and must not come before the login keychain.
+#
+# Exit code 0 when the host is healthy, 1 when it is not.
+
+DURING_BUILD=""
+QUIET=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --during-build) DURING_BUILD="yes" ;;
+    --quiet) QUIET="yes" ;;
+    *) echo "usage: $0 [--during-build] [--quiet]" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+FAILURES=0
+LOGIN_KEYCHAIN="${HOME}/Library/Keychains/login.keychain-db"
+
+# Reports a problem and marks the run failed. Always printed, even under --quiet: the point of
+# --quiet is to stay silent while healthy, not to hide findings.
+fail() {
+  echo "FAIL: $1"
+  FAILURES=$((FAILURES + 1))
+}
+
+# Prints progress, unless --quiet was requested.
+note() {
+  [ -n "$QUIET" ] || echo "$1"
+}
+
+# Reports whether a keychain path belongs to a Butler Sheet Icons build.
+#
+# `build.keychain` is the name used by the older scripts; `bsi-signing-` is the current one. Both
+# are recognised so that a host still carrying old debris is diagnosed correctly.
+is_signing_keychain() {
+  case "$1" in
+    *"/build.keychain"*) return 0 ;;
+    *"/bsi-signing-"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+note "--- keychain audit on $(hostname -s), user $(id -un) ---"
+
+# ---------------------------------------------------------------------------------------------
+# The default keychain. This is the one that caused the dialog: it is where applications create
+# new items, so pointing it at a keychain locked with a CI-only password makes macOS ask a human.
+# ---------------------------------------------------------------------------------------------
+DEFAULT_KEYCHAIN=$(security default-keychain -d user 2>/dev/null | tr -d '"' | xargs || true)
+note "default keychain: ${DEFAULT_KEYCHAIN:-(none)}"
+
+if [ -z "$DEFAULT_KEYCHAIN" ]; then
+  # Reachable by deleting a keychain while it is the default - which is precisely what the old
+  # scripts did to a host that had already leaked one.
+  fail "this host has no default keychain at all"
+elif is_signing_keychain "$DEFAULT_KEYCHAIN"; then
+  fail "a build signing keychain is the user's default keychain: $DEFAULT_KEYCHAIN"
+elif [ ! -f "$DEFAULT_KEYCHAIN" ]; then
+  fail "the default keychain does not exist on disk: $DEFAULT_KEYCHAIN"
+fi
+
+# ---------------------------------------------------------------------------------------------
+# The search list. Order matters: an application looking up its own credential should reach the
+# login keychain before anything a build added.
+# ---------------------------------------------------------------------------------------------
+POSITION=0
+LOGIN_POSITION=""
+SIGNING_POSITION=""
+
+note "search list:"
+while IFS= read -r keychain; do
+  [ -n "$keychain" ] || continue
+  POSITION=$((POSITION + 1))
+  note "  $POSITION. $keychain"
+
+  if [ ! -f "$keychain" ]; then
+    fail "search list entry $POSITION does not exist on disk: $keychain"
+  fi
+
+  if [ "$keychain" = "$LOGIN_KEYCHAIN" ] && [ -z "$LOGIN_POSITION" ]; then
+    LOGIN_POSITION=$POSITION
+  fi
+
+  if is_signing_keychain "$keychain"; then
+    [ -n "$SIGNING_POSITION" ] || SIGNING_POSITION=$POSITION
+
+    if [ -z "$DURING_BUILD" ]; then
+      fail "a build signing keychain is still on the search list: $keychain"
+    fi
+  fi
+done < <(security list-keychains -d user | tr -d '"' | xargs -n1 || true)
+
+# During a build the signing keychain is expected to be present - but appended, never ahead of the
+# user's own keychain. This is the assertion that would have caught the original bug.
+if [ -n "$DURING_BUILD" ] && [ -n "$SIGNING_POSITION" ] && [ -n "$LOGIN_POSITION" ]; then
+  if [ "$SIGNING_POSITION" -lt "$LOGIN_POSITION" ]; then
+    fail "a signing keychain (position $SIGNING_POSITION) precedes the login keychain (position $LOGIN_POSITION)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------------------------
+# Debris on disk. A file here outlives the search list and keeps prompting long after the build.
+# ---------------------------------------------------------------------------------------------
+if [ -f "${HOME}/Library/Keychains/build.keychain-db" ]; then
+  fail "leftover ~/Library/Keychains/build.keychain-db from an older build script"
+fi
+
+if [ "$FAILURES" -eq 0 ]; then
+  note "keychain configuration is healthy"
+  exit 0
+fi
+
+echo "$FAILURES keychain problem(s) found." >&2
+echo "Repair: the next macOS build clears this automatically, or run" >&2
+echo "  security delete-keychain build.keychain" >&2
+echo "  security list-keychains -d user -s \"$LOGIN_KEYCHAIN\"" >&2
+echo "  security default-keychain -d user -s \"$LOGIN_KEYCHAIN\"" >&2
+exit 1

--- a/scripts/insider-build-mac.sh
+++ b/scripts/insider-build-mac.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Keychain handling lives in a shared library because release-macos.sh needs exactly the same
+# thing, and the two hand-maintained copies had already drifted apart. This script runs on the
+# self-hosted build Mac on every push to main, in a live desktop session - see the library for why
+# that made the old approach untenable.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/macos-signing-keychain.sh
+. "${SCRIPT_DIR}/lib/macos-signing-keychain.sh"
+
 # Inject git SHA into package.json
 GIT_SHA=$(git rev-parse --short HEAD)
 CURRENT_VERSION=$(node -p "require('./package.json').version")
@@ -24,28 +32,9 @@ codesign --remove-signature ${DIST_FILE_NAME}
 # Inject the blob
 npx postject ${DIST_FILE_NAME} NODE_SEA_BLOB ./build/sea-prep.blob --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2 --macho-segment-name NODE_SEA
 
-ORIGINAL_KEYCHAINS=()
-while IFS= read -r keychain; do
-  if [ -n "$keychain" ]; then
-    ORIGINAL_KEYCHAINS+=("$keychain")
-  fi
-done < <(security list-keychains -d user | tr -d '"' | xargs -n1 || true)
-ORIGINAL_DEFAULT_KEYCHAIN=$(security default-keychain -d user | tr -d '"' | xargs || true)
-
-cleanup() {
-  security delete-keychain build.keychain >/dev/null 2>&1 || true
-  if [ "${#ORIGINAL_KEYCHAINS[@]}" -gt 0 ]; then
-    security list-keychains -d user -s "${ORIGINAL_KEYCHAINS[@]}" >/dev/null 2>&1 || true
-  fi
-  if [ -n "${ORIGINAL_DEFAULT_KEYCHAIN:-}" ]; then
-    security default-keychain -d user -s "${ORIGINAL_DEFAULT_KEYCHAIN}" >/dev/null 2>&1 || true
-  fi
-  rm -f certificate.p12
-}
-
-trap cleanup EXIT
-
-security delete-keychain build.keychain >/dev/null 2>&1 || true
+# Wired to the signals as well as EXIT: a cancelled workflow run is killed, not exited, and the
+# old EXIT-only trap is how a build could leave its keychain behind on this Mac.
+trap bsi_keychain_teardown EXIT INT TERM HUP
 
 pwd
 ls -la
@@ -57,30 +46,22 @@ ls -la
 printf '%s' "$MACOS_CERTIFICATE" | base64 --decode > certificate.p12
 
 # -------------------
-# We need to create a new keychain, otherwise using the certificate will prompt
-# with a UI dialog asking for the certificate password, which we can't
-# use in a headless CI environment
-security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
-# GitHub's macOS runners execute this under /bin/bash 3.2, where expanding an empty array under
-# `set -u` is a fatal "unbound variable" - so the ${arr[@]+...} guard is what keeps this working
-# if `security list-keychains` ever comes back empty. cleanup() already guards the same
-# expansion; this line was the one that did not.
-security list-keychains -d user -s build.keychain ${ORIGINAL_KEYCHAINS[@]+"${ORIGINAL_KEYCHAINS[@]}"}
-security default-keychain -d user -s build.keychain
-security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
-security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign -A
+# We need a keychain of our own, otherwise using the certificate will prompt with a UI dialog
+# asking for the certificate password, which we can't answer in a headless CI environment.
+bsi_keychain_setup "$MACOS_CI_KEYCHAIN_PWD"
+
+security import certificate.p12 -k "$BSI_KEYCHAIN_PATH" -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign -A
 
 # Import Apple Developer ID G2 intermediate CA to allow building the cert chain
 curl -f -L -sS -o DeveloperIDG2CA.cer https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer
-security import DeveloperIDG2CA.cer -k build.keychain
+security import DeveloperIDG2CA.cer -k "$BSI_KEYCHAIN_PATH"
 rm DeveloperIDG2CA.cer
 
-# Prevent keychain from locking during CI
-security set-keychain-settings -t 3600 -l build.keychain
+security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" "$BSI_KEYCHAIN_PATH"
 
-security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" build.keychain
-
-codesign --force -s "$MACOS_CERTIFICATE_NAME" -v "./${DIST_FILE_NAME}" --deep --strict --options=runtime --timestamp --entitlements ./release-config/${DIST_FILE_NAME}.entitlements
+# --keychain names where the signing identity must come from. The certificate chain is still built
+# from the full search list, which is why the keychain is on it - see the library for the details.
+codesign --force -s "$MACOS_CERTIFICATE_NAME" --keychain "$BSI_KEYCHAIN_PATH" -v "./${DIST_FILE_NAME}" --deep --strict --options=runtime --timestamp --entitlements ./release-config/${DIST_FILE_NAME}.entitlements
 
 # Verify code signature
 codesign -vvv --deep --strict "./${DIST_FILE_NAME}"
@@ -103,9 +84,8 @@ echo "Notarize insider app"
 xcrun notarytool submit "./${DIST_FILE_NAME}--macos-arm64--${GITHUB_SHA}.zip" --apple-id "$PROD_MACOS_NOTARIZATION_APPLE_ID" --team-id "$PROD_MACOS_NOTARIZATION_TEAM_ID" --password "$PROD_MACOS_NOTARIZATION_PWD" --wait
 
 # -------------------
-# Clean up
-# Delete build keychain
-security delete-keychain build.keychain
+# Clean up. The keychain and the search list are the trap's job, so that they are restored whether
+# this script finishes, fails, or is killed.
 rm ./build/build.cjs ./build/sea-prep.blob
 
 ls -la

--- a/scripts/lib/macos-signing-keychain.sh
+++ b/scripts/lib/macos-signing-keychain.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Keychain lifecycle for the macOS signing scripts. Sourced, never executed.
+#
+# Both release-macos.sh and insider-build-mac.sh need a throwaway keychain holding the Developer ID
+# certificate. They each used to carry their own copy of this logic, and that copy did three things
+# that are fine on an ephemeral hosted runner and actively hostile on a self-hosted Mac somebody
+# is logged in to:
+#
+#   1. It created the keychain as ~/Library/Keychains/build.keychain, next to the user's own.
+#   2. It put that keychain at the *head* of the user's keychain search list.
+#   3. It made it the user's *default* keychain for the whole build - three to eighteen minutes,
+#      on every push to main.
+#
+# (3) is why "Google Drive wants to use the build keychain" appeared on the build Mac. The default
+# keychain is where applications create new items; any app refreshing a credential during a build
+# landed on a keychain locked with a CI-only password and asked the human for it. No crash or leak
+# was needed - it happened on every successful build.
+#
+# (3) also made the failure self-perpetuating. If a run was killed before its cleanup ran, the
+# build keychain stayed both in the search list and as the default. The next run then snapshotted
+# that poisoned state as "the original", deleted the keychain, and on exit faithfully restored a
+# search-list entry and a default keychain that no longer existed. Nothing ever recovered it.
+#
+# So: the keychain now lives in the runner's temp directory, it is appended to the search list
+# rather than prepended, and the default keychain is never touched at all. Nothing needs it -
+# `security import`, `unlock-keychain` and `set-key-partition-list` all name the keychain
+# explicitly, `codesign` resolves the identity from the search list, and `notarytool` authenticates
+# with --apple-id/--password.
+#
+# It stays *on* the search list because it has to: `man codesign` is explicit that a keychain given
+# via --keychain is not searched when building the certificate chain unless it is also on the
+# user's list.
+#
+# Written for bash 3.2 - GitHub's macOS runners still execute these scripts under /bin/bash 3.2,
+# where expanding an empty array under `set -u` is a fatal error. Hence the ${arr[@]+"${arr[@]}"}
+# guards.
+
+# Absolute path of the keychain this build owns. Callers pass it to `security import`,
+# `set-key-partition-list` and `codesign --keychain`.
+BSI_KEYCHAIN_PATH=""
+
+# The user's keychain search list as found, minus anything of ours. Restored verbatim on teardown.
+BSI_ORIGINAL_KEYCHAINS=()
+
+# Legacy keychain created by the previous version of these scripts. Recognised so that debris left
+# on a build host by an interrupted old run can be cleaned up instead of inherited.
+BSI_LEGACY_KEYCHAIN_NAME="build.keychain"
+
+# Guards teardown against running twice - it is wired to four signals plus EXIT.
+BSI_KEYCHAIN_TORN_DOWN=""
+
+# Reports whether a search-list entry is one of ours, or debris from the old scheme.
+#
+# $1 - keychain path as reported by `security list-keychains`.
+#
+# Returns 0 when the entry must not be carried into the restored search list.
+bsi_keychain_is_ours() {
+  case "$1" in
+    *"/${BSI_LEGACY_KEYCHAIN_NAME}"*) return 0 ;;
+    *"/bsi-signing-"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Snapshots the user's keychain search list, dropping entries that must not be restored.
+#
+# Two kinds are dropped. Ours - a stale build.keychain or bsi-signing keychain from a run that
+# never cleaned up - because restoring those is what made the old bug permanent. And paths that no
+# longer exist, because a search list containing a dangling path is the state the old cleanup left
+# behind, and quietly writing it back would preserve it.
+bsi_keychain_snapshot() {
+  local keychain
+
+  BSI_ORIGINAL_KEYCHAINS=()
+
+  while IFS= read -r keychain; do
+    [ -n "$keychain" ] || continue
+
+    if bsi_keychain_is_ours "$keychain"; then
+      echo "keychain: dropping stale signing keychain from the search list: $keychain"
+      continue
+    fi
+
+    if [ ! -f "$keychain" ]; then
+      echo "keychain: dropping search-list entry that no longer exists: $keychain"
+      continue
+    fi
+
+    BSI_ORIGINAL_KEYCHAINS+=("$keychain")
+  done < <(security list-keychains -d user | tr -d '"' | xargs -n1 || true)
+
+  echo "keychain: search list to preserve: ${BSI_ORIGINAL_KEYCHAINS[*]:-(empty)}"
+}
+
+# Removes debris left by the previous version of these scripts, and repairs the default keychain.
+#
+# The old scheme could leave ~/Library/Keychains/build.keychain-db behind, and could leave it named
+# as the user's default keychain. Neither state heals on its own, and both keep prompting the
+# person at that Mac long after the build that caused them finished.
+#
+# Order matters here, and getting it wrong is how the old scripts made things worse: deleting a
+# keychain that is currently the default leaves the user with *no* default keychain at all, which
+# is a stranger state than the one being repaired. `security default-keychain -d user` then answers
+# with an error rather than a path. So the default is repaired *after* the delete, and an empty
+# answer counts as needing repair just as much as a stale one.
+bsi_keychain_clear_legacy_state() {
+  local default_keychain
+  local login_keychain="${HOME}/Library/Keychains/login.keychain-db"
+
+  if [ -f "${HOME}/Library/Keychains/${BSI_LEGACY_KEYCHAIN_NAME}-db" ]; then
+    echo "keychain: found leftover ${BSI_LEGACY_KEYCHAIN_NAME} from an earlier build - deleting it"
+    security delete-keychain "${BSI_LEGACY_KEYCHAIN_NAME}" >/dev/null 2>&1 || true
+  fi
+
+  default_keychain=$(security default-keychain -d user 2>/dev/null | tr -d '"' | xargs || true)
+
+  # The only case where this script writes the default keychain at all: it points at our debris, at
+  # a file that is gone, or at nothing. Anything the user chose deliberately is left alone.
+  if [ -z "$default_keychain" ]; then
+    echo "keychain: this host has no default keychain - pointing it at the login keychain"
+    security default-keychain -d user -s "$login_keychain" >/dev/null 2>&1 || true
+  elif bsi_keychain_is_ours "$default_keychain" || [ ! -f "$default_keychain" ]; then
+    echo "keychain: default keychain is stale ($default_keychain) - restoring the login keychain"
+    security default-keychain -d user -s "$login_keychain" >/dev/null 2>&1 || true
+  fi
+}
+
+# Creates the signing keychain and makes it usable by codesign.
+#
+# $1 - password to lock the new keychain with.
+#
+# Sets BSI_KEYCHAIN_PATH. The caller is expected to have installed bsi_keychain_teardown as a trap
+# before calling this.
+bsi_keychain_setup() {
+  local keychain_password="$1"
+  local keychain_dir="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+
+  bsi_keychain_snapshot
+  bsi_keychain_clear_legacy_state
+
+  # Outside ~/Library/Keychains on purpose: it never shows up in Keychain Access, it cannot collide
+  # with a stale build.keychain, and on a runner it is swept with RUNNER_TEMP even if this script
+  # is killed hard enough that no trap runs.
+  BSI_KEYCHAIN_PATH="${keychain_dir%/}/bsi-signing-$$.keychain-db"
+
+  echo "keychain: creating $BSI_KEYCHAIN_PATH"
+  security create-keychain -p "$keychain_password" "$BSI_KEYCHAIN_PATH"
+
+  # A keychain straight from `security create-keychain` reports "lock-on-sleep timeout=300s" - it
+  # relocks after five idle minutes and whenever the machine sleeps. release-macos.sh never changed
+  # that and so signed under a five-minute clock; insider-build-mac.sh passed `-t 3600 -l` under a
+  # comment claiming it prevented locking, but -l is what *enables* lock-on-sleep, so it only ever
+  # extended the timeout. Omitting -l clears the sleep trigger, and six hours outlasts any build.
+  security set-keychain-settings -t 21600 "$BSI_KEYCHAIN_PATH"
+
+  # Appended, not prepended. The login keychain keeps its place at the head of the list, so an
+  # application looking up its own credential still finds it there first.
+  security list-keychains -d user -s \
+    ${BSI_ORIGINAL_KEYCHAINS[@]+"${BSI_ORIGINAL_KEYCHAINS[@]}"} "$BSI_KEYCHAIN_PATH"
+
+  security unlock-keychain -p "$keychain_password" "$BSI_KEYCHAIN_PATH"
+
+  echo "keychain: search list is now"
+  security list-keychains -d user
+  echo "keychain: default keychain left at $(security default-keychain -d user 2>/dev/null | tr -d '"' | xargs)"
+}
+
+# Deletes the signing keychain and puts the search list back exactly as it was found.
+#
+# Idempotent and silent about failures: it runs on the way out of a script that may already be
+# unwinding from a real error, and losing that error behind a cleanup failure helps nobody.
+bsi_keychain_teardown() {
+  [ -z "$BSI_KEYCHAIN_TORN_DOWN" ] || return 0
+  BSI_KEYCHAIN_TORN_DOWN="yes"
+
+  if [ -n "$BSI_KEYCHAIN_PATH" ]; then
+    security delete-keychain "$BSI_KEYCHAIN_PATH" >/dev/null 2>&1 || true
+    rm -f "$BSI_KEYCHAIN_PATH"
+  fi
+
+  if [ "${#BSI_ORIGINAL_KEYCHAINS[@]}" -gt 0 ]; then
+    security list-keychains -d user -s "${BSI_ORIGINAL_KEYCHAINS[@]}" >/dev/null 2>&1 || true
+  fi
+
+  rm -f certificate.p12
+}

--- a/scripts/release-macos.sh
+++ b/scripts/release-macos.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Keychain handling lives in a shared library because insider-build-mac.sh needs exactly the same
+# thing, and the two hand-maintained copies had already drifted apart. See that file for why the
+# default keychain is never touched.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/macos-signing-keychain.sh
+. "${SCRIPT_DIR}/lib/macos-signing-keychain.sh"
+
 # Create build directory if it doesn't exist
 mkdir -p ./build
 
@@ -19,49 +26,25 @@ codesign --remove-signature ${DIST_FILE_NAME}
 # Inject the blob
 npx postject@1.0.0-alpha.6 ${DIST_FILE_NAME} NODE_SEA_BLOB ./build/sea-prep.blob --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2 --macho-segment-name NODE_SEA
 
-ORIGINAL_KEYCHAINS=()
-while IFS= read -r keychain; do
-  if [ -n "$keychain" ]; then
-    ORIGINAL_KEYCHAINS+=("$keychain")
-  fi
-done < <(security list-keychains -d user | tr -d '"' | xargs -n1 || true)
-ORIGINAL_DEFAULT_KEYCHAIN=$(security default-keychain -d user | tr -d '"' | xargs || true)
-
-cleanup() {
-  security delete-keychain build.keychain >/dev/null 2>&1 || true
-  if [ "${#ORIGINAL_KEYCHAINS[@]}" -gt 0 ]; then
-    security list-keychains -d user -s "${ORIGINAL_KEYCHAINS[@]}" >/dev/null 2>&1 || true
-  fi
-  if [ -n "${ORIGINAL_DEFAULT_KEYCHAIN:-}" ]; then
-    security default-keychain -d user -s "${ORIGINAL_DEFAULT_KEYCHAIN}" >/dev/null 2>&1 || true
-  fi
-  rm -f certificate.p12
-}
-
-trap cleanup EXIT
-
-security delete-keychain build.keychain >/dev/null 2>&1 || true
+# Wired to the signals as well as EXIT: a cancelled workflow run is killed, not exited, and the
+# old EXIT-only trap is how a build could leave its keychain behind on a self-hosted Mac.
+trap bsi_keychain_teardown EXIT INT TERM HUP
 
 # -------------------
 # Turn our base64-encoded certificate back to a regular .p12 file
 printf '%s' "$MACOS_CERTIFICATE" | base64 --decode > certificate.p12
 
 # -------------------
-# We need to create a new keychain, otherwise using the certificate will prompt
-# with a UI dialog asking for the certificate password, which we can't
-# use in a headless CI environment
-security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
-# GitHub's macOS runners execute this under /bin/bash 3.2, where expanding an empty array under
-# `set -u` is a fatal "unbound variable" - so the ${arr[@]+...} guard is what keeps this working
-# if `security list-keychains` ever comes back empty. cleanup() already guards the same
-# expansion; this line was the one that did not.
-security list-keychains -d user -s build.keychain ${ORIGINAL_KEYCHAINS[@]+"${ORIGINAL_KEYCHAINS[@]}"}
-security default-keychain -d user -s build.keychain
-security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
-security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
-security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" build.keychain
+# We need a keychain of our own, otherwise using the certificate will prompt with a UI dialog
+# asking for the certificate password, which we can't answer in a headless CI environment.
+bsi_keychain_setup "$MACOS_CI_KEYCHAIN_PWD"
 
-codesign --force -s "$MACOS_CERTIFICATE_NAME" -v "./${DIST_FILE_NAME}" --deep --strict --options=runtime --timestamp --entitlements ./release-config/${DIST_FILE_NAME}.entitlements
+security import certificate.p12 -k "$BSI_KEYCHAIN_PATH" -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
+security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" "$BSI_KEYCHAIN_PATH"
+
+# --keychain names where the signing identity must come from. The certificate chain is still built
+# from the full search list, which is why the keychain is on it - see the library for the details.
+codesign --force -s "$MACOS_CERTIFICATE_NAME" --keychain "$BSI_KEYCHAIN_PATH" -v "./${DIST_FILE_NAME}" --deep --strict --options=runtime --timestamp --entitlements ./release-config/${DIST_FILE_NAME}.entitlements
 
 # -------------------
 # We can't notarize an app bundle directly, but we need to compress it as an archive.
@@ -77,9 +60,8 @@ echo "Notarize release app"
 xcrun notarytool submit "./${RELEASE_VERSION}-macos-arm64.zip" --apple-id "$PROD_MACOS_NOTARIZATION_APPLE_ID" --team-id "$PROD_MACOS_NOTARIZATION_TEAM_ID" --password "$PROD_MACOS_NOTARIZATION_PWD" --wait
 
 # -------------------
-# Clean up
-# Delete build keychain
-security delete-keychain build.keychain >/dev/null 2>&1 || true
+# Clean up. The keychain and the search list are the trap's job, so that they are restored whether
+# this script finishes, fails, or is killed.
 rm ./build/build.cjs ./build/sea-prep.blob
 
 ls -la

--- a/src/lib/browser/browser-launch.js
+++ b/src/lib/browser/browser-launch.js
@@ -20,8 +20,11 @@ import { markReported } from '../util/reported-error.js';
  *
  * Copied verbatim from the two process-app modules this was extracted from; the list was
  * already identical in both.
+ *
+ * Exported so `scripts/diag/browser-flag-probe.mjs` can A/B the real launch arguments rather than
+ * a hand-copied list. A diagnostic that has drifted from the product proves nothing.
  */
-const BASE_BROWSER_ARGS = [
+export const BASE_BROWSER_ARGS = [
     '--proxy-bypass-list=*',
     '--disable-gpu',
     '--disable-dev-shm-usage',


### PR DESCRIPTION
Two independent macOS problems that surfaced the same night. One is fixed here; the other gets the instrumentation it needs before anything is changed.

## 1. The signing scripts hijacked the user's keychain (fixed)

`insider-build-mac.sh` runs on the self-hosted build Mac on **every push to `main`**, as a logged-in desktop user. It made its throwaway `build.keychain` the user's **default keychain** for the whole 3-18 minute build, and put it at the head of the search list. The default keychain is where applications create new items, so anything refreshing a credential during that window hit a keychain locked with a CI-only password - which is the "Google Drive wants to use the *build* keychain" prompt. This fired on every *successful* build; no crash or leak was required. `release-macos.sh` carried the identical line.

Three further defects in the same code, two of which only showed up under test:

- **Self-perpetuating leak.** A run killed before cleanup left the keychain on the search list and as the default. The next run snapshotted that as "the original", deleted the keychain, and restored a search-list entry and a default keychain that no longer existed.
- **Deleting a keychain while it is the default leaves the host with no default keychain at all.** The old scripts did exactly this on any host that had already leaked once, so they degraded the state they meant to restore.
- **`set-keychain-settings -t 3600 -l`** was commented "Prevent keychain from locking during CI", but `-l` is what *enables* lock-on-sleep. And a keychain straight from `security create-keychain` reports `lock-on-sleep timeout=300s`, which `release-macos.sh` never changed - so it has been signing under a five-minute clock that also trips on sleep.

The fix moves keychain handling into `scripts/lib/macos-signing-keychain.sh`, shared by both scripts because the two copies had already drifted and this is the third bug out of that. The keychain now lives in `RUNNER_TEMP`, is **appended** to the search list rather than prepended, and **the default keychain is never written** except to repair it when it points at our own debris or at nothing. Nothing needed it: `import`, `unlock-keychain` and `set-key-partition-list` all name the keychain explicitly, `codesign` resolves the identity from the search list, and `notarytool` authenticates with `--apple-id`/`--password`. A host already carrying debris from the old scheme is repaired on the next build.

`macos-signing-canary.yaml` gains a job on the self-hosted Mac - the hosted runner is ephemeral and structurally cannot observe this class of bug - carrying a watchdog that samples the keychain configuration once a second during signing and fails if a signing keychain ever becomes the default or overtakes the login keychain.

## 2. `--single-process` on macOS (measured, not changed)

Re-running the isolation from #913 on the same Mac the next morning showed no difference at all: 33 ms with the flag, 25 ms without. So the report is real *and* the "macOS CI has always passed" objection is real - they are compatible because the failing state is one CI has never been in.

Every data point lines up with the host's display state (four for four), but that is still correlation, and no mechanism has been captured. `scripts/diag/browser-flag-probe.mjs` plus `browser-flag-canary.yaml` supply the missing evidence: an off/on/off cycle inside a single invocation, using the product's own browser resolution and argument list, recording host session state per trial, and - on a hang - taking a `sample(1)` stack of the wedged browser before killing it. A job fails only when screenshots fail *without* the flag, since that is the decision-relevant question.

**No product behaviour changes in this PR.** The only `src/` change is exporting `BASE_BROWSER_ARGS` so the probe cannot drift from what BSI actually launches. Removing the flag waits on what the canary reports.

## Verification

- `codesign` was made to sign a real binary with a throwaway identity in a temp keychain that is **last** in the search list and **not** the default - the one assumption that needed proving, since `man codesign` warns the chain is built from the search list.
- Round-trip test under `/bin/bash` 3.2 (what GitHub's macOS runners use): search list restored byte-identically, default keychain untouched.
- Simulated the leaked state and confirmed the library repairs it rather than inheriting it. This is what caught the no-default-keychain defect.
- Watchdog verified in both directions: silent for the new library, fires for the old behaviour.
- Probe run end-to-end locally. `npm run test:unit` 948 passing, lint and prettier clean, `bash -n` and shellcheck clean on all three scripts.

`workflow_dispatch` workflows only appear once they are on the default branch, so both canaries become runnable when this merges.

## Note on CI

CI on this merge is expected to be red for unrelated reasons: #915 - the Docker image runs as uid 100 and cannot write to a bind-mounted `--imagedir` on a Linux host. That is a pre-existing failure that only became visible when #877 made the exit code reflect failures; it is not caused by this branch.

Related: #913, #915

🤖 Generated with [Claude Code](https://claude.com/claude-code)
