### PR TITLE
docs: require per-file approval before publishing doc site drafts

### DIFF
--- a/docs/to-doc-site/README.md
+++ b/docs/to-doc-site/README.md
@@ -11,10 +11,12 @@ This folder is a **staging area, not the published source**. The published site 
 | Local clone | `/Users/goran/code/butler-sheet-icons-docs` |
 | Site generator | [VitePress](https://vitepress.dev) |
 | Hosting | Cloudflare Pages — builds and publishes automatically on every push |
-| `main` branch | Documents the **currently released** BSI version. Public. |
-| `next` branch | Documents the **upcoming, unreleased** BSI version. Preview URL only. |
+| `next` branch | Where **all** doc site work goes. Preview URL only. |
+| `main` branch | Production. What the public site serves. Reached only by merging `next` at BSI release time. |
 
-The doc site is **single-version**: one copy of the docs, no per-release archive. Anything merged to its `main` is published to the public site within minutes and is presented as documentation for the current release, whatever version it actually describes. Choosing the right branch is therefore part of publishing — see "Git workflow" below.
+The doc site is **single-version**: one copy of the docs, no per-release archive. Anything merged to its `main` is published to the public site within minutes and is presented as documentation for the current release, whatever version it actually describes.
+
+**Everything published from this folder therefore goes to `next`, never to `main`.** There is no per-file branch decision to make.
 
 ## Audience
 
@@ -60,9 +62,29 @@ Processed files stay in `done/` for traceability until there is a deliberate cle
 
 ## Publishing to the doc site
 
-This is the standing instruction for "update the doc site from `docs/to-doc-site`". Work through every unprefixed file directly in this folder. Ignore the `done/` subfolder — it is already processed.
+This is the standing instruction for "update the doc site from `docs/to-doc-site`". It covers the unprefixed files directly in this folder. Ignore the `done/` subfolder — it is already processed.
 
-### 1. Review each file critically
+**This is not a bulk pass.** Every file is approved individually before anything is written — see step 1.
+
+### 1. Inventory the pending drafts and get approval
+
+Before reading deeply, before editing anything, list what is there and get a decision on each file.
+
+Work through steps 2–4 far enough to form a recommendation, then present a table covering **every** unprefixed file:
+
+| Draft | Recommendation | Target page(s) | Why |
+|---|---|---|---|
+| `example-draft.md` | Publish | `/reference/commands`, `/guide/advanced/ci-cd` | New behaviour, nothing on the site covers it |
+| `another-draft.md` | Skip | — | Internal refactor, no user-visible change |
+
+Then **stop and wait.**
+
+- **No file is written, moved, or committed until that specific file has been approved.**
+- Approval is per file. Approving one file says nothing about the others in the list — do not treat a general "yes" as covering the whole table.
+- Approval to publish is **not** approval to commit or push. The rule in step 7 still applies.
+- If a draft turns out to be larger or more entangled than the recommendation suggested, come back and say so rather than expanding the work unilaterally.
+
+### 2. Review each file critically
 
 For each unprefixed file, answer three questions before writing anything:
 
@@ -70,7 +92,7 @@ For each unprefixed file, answer three questions before writing anything:
 2. **Where does it fit?** See "Site structure" below. Strongly prefer **editing an existing page** over adding a new one — a fact stated in two places drifts out of sync. A draft's suggested target page is a starting point, not a decision.
 3. **What is the right wording and cross-linking?** Rewrite in the doc site's voice rather than pasting the draft. Add cross-links both ways: from the concept page to the reference page, and back.
 
-### 2. Verify every claim against the implementation
+### 3. Verify every claim against the implementation
 
 **Do not trust the draft.** Drafts are written from intent and can be wrong about detail. Read the actual source in this repo and confirm:
 
@@ -80,9 +102,9 @@ For each unprefixed file, answer three questions before writing anything:
 
 Correct the draft's technical errors in the published page. If a processed file is left in `done/` with a claim that turned out to be wrong, add a short HTML comment noting the correction so the error does not resurface later.
 
-### 3. Establish which BSI version the behaviour ships in
+### 4. Establish which BSI version the behaviour ships in
 
-Two later decisions depend on this: the version gate on the page, and **which doc site branch the change goes to**. Determine it before writing.
+This sets the version gate on the page. It does **not** affect which branch the change goes to — that is always `next`.
 
 - **Already released** — the behaviour is in the latest published GitHub release of this repo.
 - **Not released yet** — the change is merged to `main` here but still sits in the open `release-please` PR. That PR's title states the upcoming version (`chore(main): release butler-sheet-icons X.Y.Z`), which follows from the unreleased commit types. Do not guess a bump, and do not invent a version number.
@@ -97,7 +119,7 @@ In earlier versions ...
 :::
 ```
 
-### 4. Site structure
+### 5. Site structure
 
 Content lives under `docs/` in the doc site repo:
 
@@ -117,7 +139,7 @@ VitePress conventions used on the site:
 - Callouts: `::: tip` / `::: warning` / `::: danger`, closed with `:::`
 - Per-shell examples use `::: code-group` with ` ```powershell [PowerShell] ` and ` ```bash [Bash] ` fences
 
-### 5. Verify the build
+### 6. Verify the build
 
 From the doc site repo:
 
@@ -135,39 +157,46 @@ grep -o 'id="[^"]*"' docs/.vitepress/dist/guide/concepts/<page>.html | sort -u
 
 Watch for headings containing typographic characters. Several pages use the non-breaking hyphen `‑` (U+2011) rather than `-`, and it survives into the anchor — so `#strategy-3-use-a-pre-cached-browser-semi-offline` silently misses a heading that reads identically. Normalise the heading to plain ASCII hyphens rather than copying the unicode into the link.
 
-### 6. Git workflow
+### 7. Git workflow
 
 Both repositories follow the same rule: **branch first, implement, verify, then stop and report.**
 
 #### Which doc site branch to target
 
-Decided by step 3, not by convenience:
+**`next`. Always.** There is no decision to make and no case in which a draft from this folder goes to `main`.
 
-| Behaviour being documented | Branch off | PR into |
-|---|---|---|
-| Already in the latest BSI release | `main` | `main` |
-| Not released yet (still in the open `release-please` PR) | `next` | `next` |
-
-Getting this wrong has a real consequence in one direction: the doc site is single-version and Cloudflare Pages publishes `main` automatically, so unreleased documentation merged to `main` goes live on the public site immediately — labelled with the *previous* version number, describing a version nobody can download yet. `next` publishes to a preview URL instead and is merged into `main` when the BSI release actually ships.
-
-If a draft mixes released and unreleased material, split it: the released part can go to `main`, the rest to `next`. Do not hold back a correction to shipped documentation because it happens to sit next to a new feature.
+The doc site is single-version and Cloudflare Pages publishes `main` automatically, so anything merged there is live on the public site within minutes. `next` publishes to a preview URL instead, and is merged into `main` when a BSI release ships. Routing everything through `next` means documentation cannot reach the public site ahead of the release it describes.
 
 #### Rules
 
-- Create a feature branch in the doc site repo off an up-to-date `main` **or** `next` before the first edit. Never work directly on either.
+- Create a feature branch in the doc site repo off an up-to-date `next` before the first edit. Never work directly on `next` itself, and never on `main`.
 - Do the doc site edits and the `done/` moves in this repo as separate branches — they are separate repositories and separate pull requests.
 - **Never commit, push, open a pull request, or merge unless explicitly asked.** Authorisation is per request and does not carry over.
 - Commit messages in both repos use [Conventional Commits](https://www.conventionalcommits.org/). Doc site changes are `docs:`.
 
 Merging `next` into `main` at release time is a separate maintenance step owned by the doc site repo, not part of a publishing pass. It is documented in that repo's `README_DEPLOY.md`.
 
-### 7. Mark the drafts as published
+### 8. Mark the drafts as published
 
-Move each processed file to `docs/to-doc-site/done/` with the `done_` prefix added, using `git mv` so history follows the file. See "Processing status" above. This applies to files that were deliberately skipped as well as to files that were published.
+Move each processed file to `docs/to-doc-site/done/` with the `done_` prefix added, using `git mv` so history follows the file. See "Processing status" above. This applies to files that were approved and deliberately skipped as well as to files that were published.
 
-### 8. Report
+A file that was **not approved** in step 1 is not processed. Leave it unprefixed and in place — it is still pending.
 
-State per file: published or skipped, which pages changed, **which doc site branch it went to and why**, what was corrected against the implementation, and that the build passed. Then weigh what is left — rough cost, value, and one recommended next step.
+### 9. Report
+
+Report in two views, because they answer different questions.
+
+**Per draft** — published or skipped, what was corrected against the implementation, and where the content ended up.
+
+**Per doc site page** — this is the one that makes the change reviewable without diffing the branch. For every page on `next` that was created or edited:
+
+| Page | Created / edited | What changed | From which draft |
+|---|---|---|---|
+| `/reference/commands` | Edited | New "Exit codes" section | `exit-code-now-reflects-failures.md` |
+
+Also state the `done/` moves made, and that `npm run docs:build` passed.
+
+Then weigh what is left — rough cost, value, and one recommended next step. Files left unapproved from step 1 are part of what is left; list them.
 
 ## Ownership
 


### PR DESCRIPTION
## Why

`docs/to-doc-site/README.md` is the standing instruction for publishing staged drafts to the doc site. It authorised a **bulk pass** — "Work through every unprefixed file directly in this folder" — with no checkpoint. Six drafts are currently pending.

## What changed

**Per-file approval gate (new step 1).** Inventory every pending draft, present a table with a publish/skip recommendation and target page(s) for each, then stop and wait.

- No file is written, moved or committed until that specific file is approved.
- Approval is per file — a general "yes" is not approval of the whole table.
- Approval to publish is not approval to commit or push.
- A draft that turns out larger than the recommendation implied goes back for a decision rather than expanding the work unilaterally.
- An unapproved file stays unprefixed and in place; it is not moved to `done/`.

**Single branch rule.** Content published from this folder always goes to the doc site's `next` branch, never `main`. This replaces the conditional released-vs-unreleased table added in 370e78f, which put a judgment call in the one place a wrong answer is unrecoverable — `main` publishes to the public site within minutes. Section 4 no longer frames the version determination as driving the branch choice; it only sets the `::: warning Requires BSI X.Y.Z or later` gate.

**Per-page reporting (step 9).** The report now covers both views: per draft, and per doc site page changed on `next` — so a publishing pass is reviewable without diffing the branch.

Sections renumbered 1–9; all internal cross-references checked.

## Related

The doc site side of this is ptarmiganlabs/butler-sheet-icons-docs#35, which adds the matching `CLAUDE.md` and the `next` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)