### PR TITLE
fix: let the Docker image write to a bind-mounted image directory on Linux

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -578,6 +578,32 @@ jobs:
             --log-level verbose \
             --imagedir ./img
 
+      # No --user flag anywhere above: the image adopting the mount's owner by itself is the fix
+      # for issue #915, and this job passing unmodified is what proves it.
+      #
+      # Checking only that the command succeeded is not enough. It would also pass if the
+      # entrypoint had quietly run everything as root, which is the outcome most worth catching -
+      # root can write anywhere, and the thumbnails would land on the host owned by root.
+      - name: Assert the thumbnails are owned by the runner user
+        run: |
+          set -euo pipefail
+          IMG_DIR="$RUNNER_TEMP/bsi-img"
+          EXPECTED_UID=$(id -u)
+
+          if [ -z "$(find "$IMG_DIR" -type f -print -quit)" ]; then
+            echo "::error::no files were written to $IMG_DIR"
+            exit 1
+          fi
+
+          WRONG_OWNER=$(find "$IMG_DIR" -type f ! -uid "$EXPECTED_UID" -print -quit)
+          if [ -n "$WRONG_OWNER" ]; then
+            echo "::error::files under $IMG_DIR are not owned by uid $EXPECTED_UID"
+            find "$IMG_DIR" -type f ! -uid "$EXPECTED_UID" -exec ls -ln {} + | head -5
+            exit 1
+          fi
+
+          echo "Every file under $IMG_DIR is owned by uid $EXPECTED_UID."
+
   docker-qscloud-amd64:
     needs:
       - docker-build-on-ubuntu-amd64
@@ -629,6 +655,28 @@ jobs:
             --appid "$BSI_CLOUD_APP_ID" \
             --log-level verbose \
             --imagedir ./img
+
+      # See the same step in docker-qscloud-arm64 for why ownership is asserted and not just exit
+      # status.
+      - name: Assert the thumbnails are owned by the runner user
+        run: |
+          set -euo pipefail
+          IMG_DIR="$RUNNER_TEMP/bsi-img"
+          EXPECTED_UID=$(id -u)
+
+          if [ -z "$(find "$IMG_DIR" -type f -print -quit)" ]; then
+            echo "::error::no files were written to $IMG_DIR"
+            exit 1
+          fi
+
+          WRONG_OWNER=$(find "$IMG_DIR" -type f ! -uid "$EXPECTED_UID" -print -quit)
+          if [ -n "$WRONG_OWNER" ]; then
+            echo "::error::files under $IMG_DIR are not owned by uid $EXPECTED_UID"
+            find "$IMG_DIR" -type f ! -uid "$EXPECTED_UID" -exec ls -ln {} + | head -5
+            exit 1
+          fi
+
+          echo "Every file under $IMG_DIR is owned by uid $EXPECTED_UID."
 
   docker-qseow-arm64:
     needs:
@@ -779,6 +827,10 @@ jobs:
           printf '%s\n' "$QS_CLIENT_KEY_PEM" > "$CERT_DIR/client_key.pem"
           chmod 600 "$CERT_DIR"/client*.pem
 
+      # See the assertion step below, and the same one in docker-qscloud-arm64. This job is the one
+      # that used to fail with "Missing certificate file(s)" rather than a permission error: the
+      # client certificate is written chmod 600 owned by the runner user, and the container user
+      # could not read it. Same root cause as the image directory (issue #915).
       - name: Run QSEoW Docker command (amd64 image)
         run: |
           IMG_DIR="$HOME/bsi-bsi/img"
@@ -807,6 +859,26 @@ jobs:
             --qliksensetag updateSheetThumbnail \
             --prefix "$BSI_PREFIX" \
             --log-level verbose
+
+      - name: Assert the thumbnails are owned by the runner user
+        run: |
+          set -euo pipefail
+          IMG_DIR="$HOME/bsi-bsi/img"
+          EXPECTED_UID=$(id -u)
+
+          if [ -z "$(find "$IMG_DIR" -type f -print -quit)" ]; then
+            echo "::error::no files were written to $IMG_DIR"
+            exit 1
+          fi
+
+          WRONG_OWNER=$(find "$IMG_DIR" -type f ! -uid "$EXPECTED_UID" -print -quit)
+          if [ -n "$WRONG_OWNER" ]; then
+            echo "::error::files under $IMG_DIR are not owned by uid $EXPECTED_UID"
+            find "$IMG_DIR" -type f ! -uid "$EXPECTED_UID" -exec ls -ln {} + | head -5
+            exit 1
+          fi
+
+          echo "Every file under $IMG_DIR is owned by uid $EXPECTED_UID."
 
       - name: Remove local Docker image
         run: docker image rm "$IMAGE_NAME" || true

--- a/docs/docker-testing-commands.md
+++ b/docs/docker-testing-commands.md
@@ -8,6 +8,12 @@ Use these one-liners to exercise the Butler Sheet Icons Docker image the same wa
 
 - Docker Desktop or another Docker runtime that can run Linux containers.
 - Native Docker is assumed to work on both macOS and Windows. On Windows, Docker Desktop with the default Linux VM/WSL2 backend works best (Windows containers are still untested per `README.md`).
+
+> **These commands were written and verified against Docker Desktop**, which ignores file ownership on bind mounts. Docker on Linux does not, and that difference hid issue #915 for a long time: every mounted-`--imagedir` command here failed on a Linux host with `EACCES: permission denied, mkdir './img/...'` while passing on a Mac.
+>
+> The image now inspects the owner of the mounted image directory and runs as that user, so the commands below work unchanged on Linux too — see `src/docker-entrypoint.sh`. Two cases still need the operator's help, and both are worth reproducing when testing on Linux: a mount owned by `root` is deliberately not adopted, and an explicit `--user` is respected as given. Both report what to do rather than a bare permission error.
+>
+> When testing on macOS, remember that a pass here proves nothing about Linux ownership behaviour. The `docker-qscloud-*` and `docker-qseow-amd64` jobs in `ci.yaml` are the ones that exercise it, and they assert that the generated files end up owned by the calling user rather than merely that the command exited 0.
 - Required environment variables (for QS Cloud/QSEoW) must already be exported in the host shell.
   - macOS bash uses `$BSI_*` (for example `$BSI_CLOUD_TENANT_URL`).
   - Windows PowerShell uses `$env:BSI_*`.

--- a/docs/to-doc-site/docker-image-directory-permissions-on-linux.md
+++ b/docs/to-doc-site/docker-image-directory-permissions-on-linux.md
@@ -1,0 +1,86 @@
+# Fixed: the Docker image can now write thumbnails to a mounted folder on Linux
+
+**Applies to:** the Butler Sheet Icons Docker image, on Linux hosts. Any command given a `--imagedir` that points at a mounted folder — in practice `create-sheet-thumbnails` for both Qlik Sense Enterprise on Windows and Qlik Sense Cloud.
+
+::: warning Requires BSI 3.12.0 or later
+In earlier versions, running the Docker image on a Linux host and mounting a folder for the thumbnails failed for **every** app in the run.
+:::
+
+## Summary
+
+The documented way to get thumbnails out of the container is to mount a folder from the host:
+
+```bash
+docker run -it --rm \
+  -v "$HOME/bsi-bsi/img:/nodeapp/img" \
+  ptarmiganlabs/butler-sheet-icons:latest \
+  qseow create-sheet-thumbnails \
+  --imagedir ./img \
+  ...
+```
+
+On a Linux host this did not work. Butler Sheet Icons runs inside the container as a dedicated, unprivileged account, and that account was not the owner of the folder you mounted — your own account was. The container therefore had no permission to create anything in it, and the run failed before a single thumbnail was produced.
+
+The container now looks at who owns the folder you mounted and runs as that user, so it can write there. **Nothing about your command changes.** The examples in this documentation, and any scripts you already have, work as they always should have.
+
+As a bonus, the thumbnails now belong to *you* on the host rather than to an account that exists only inside the container, so you can open, move and delete them without needing elevated rights.
+
+## Why this only affected Linux
+
+Docker Desktop on macOS and Windows quietly ignores file ownership on mounted folders — anything in the container can write to them regardless. Docker on Linux does not, and neither do other Linux container runtimes.
+
+That difference is why the problem went unnoticed for so long: the same command that worked perfectly on a laptop failed on a Linux server, which is exactly where scheduled and automated runs live.
+
+## How to tell if this affected you
+
+The run failed for every app, and the log contained an error like:
+
+```
+error: EACCES: permission denied, mkdir './img/cloud/6ab8a5b7-1f0e-4e9c-8b53-9f42b6c1a0d2'
+error: CLOUD PROCESS APP: Failed to process app 6ab8a5b7-1f0e-4e9c-8b53-9f42b6c1a0d2: Error creating cloud image directory
+```
+
+Search your logs for `EACCES`. On Qlik Sense Enterprise on Windows the wording differs slightly — `QSEOW CREATE THUMBNAILS 1` in place of `CLOUD PROCESS APP`, and `qseow` in place of `cloud` in the folder path — but `EACCES` appears either way.
+
+A **certificate** problem on Qlik Sense Enterprise on Windows had the same underlying cause and is fixed by the same change. If you mounted a folder holding `client.pem` and `client_key.pem` and saw:
+
+```
+error: QSEOW CREATE THUMBNAILS 2: Missing certificate file(s)
+```
+
+even though the files were plainly there, this is why. Certificate files are normally readable only by their owner, and the container was not running as that owner.
+
+If you saw either error, upgrade and re-run. No change to your command is needed.
+
+## If the run still cannot write
+
+Two situations are left where the container cannot adapt on its own. Both now produce an explanation in the log instead of a bare permission error.
+
+**The mounted folder is owned by `root`.** Butler Sheet Icons deliberately does not take on root's identity to get around this — running a web browser and processing untrusted content as root is not a trade worth making. Mount a folder you own instead:
+
+```bash
+mkdir -p "$HOME/bsi-bsi/img"
+```
+
+**You started the container with an explicit `--user`.** That instruction is respected as given, so it is then up to you to make sure the account you named can write to the folder:
+
+```bash
+docker run -it --rm \
+  --user "$(id -u):$(id -g)" \
+  -v "$HOME/bsi-bsi/img:/nodeapp/img" \
+  ...
+```
+
+This form is fully supported and is the right choice where a security policy requires the container's user to be fixed in advance. It also now works correctly for the persistent browser cache, which it did not in earlier versions.
+
+**The folder is mounted read-only.** A mount ending in `:ro` cannot be written to by anyone. Remove the flag for the folder that receives thumbnails.
+
+## What you will see in the log
+
+When the container adapts to the folder's owner, it says so once, before anything else:
+
+```
+butler-sheet-icons: running as uid 1000:1000, adopted from /nodeapp/img, so files written there belong to you
+```
+
+If that line is absent, the container is running as its own built-in account — which is correct and expected when you have not mounted anything, or when the mounted folder already belongs to that account.

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -22,7 +22,10 @@ FROM node:24-alpine
 LABEL maintainer="Göran Sander mountaindude@ptarmiganlabs.com"
 LABEL description="Creates thumbnail images based on sheets in QLik Sense applications."
 
-# Install Puppeteer dependencies for Alpine Linux
+# Install Puppeteer dependencies for Alpine Linux.
+#
+# su-exec is not a Puppeteer dependency: docker-entrypoint.sh uses it to drop privileges to the
+# owner of the mounted image directory. See that file for why (issue #915).
 RUN apk add --no-cache \
     chromium \
     nss \
@@ -30,7 +33,8 @@ RUN apk add --no-cache \
     harfbuzz \
     ca-certificates \
     font-dejavu \
-    tini
+    tini \
+    su-exec
 
 # Create and use non-root user (Alpine syntax) BEFORE copying files
 RUN addgroup -S nodejs && adduser -S -G nodejs nodejs
@@ -52,8 +56,24 @@ COPY --chown=nodejs:nodejs src/globals.js ./src/
 COPY --chown=nodejs:nodejs src/lib/ ./src/lib/
 COPY --chown=nodejs:nodejs package.json ./
 
-USER nodejs
+# Default mount point for --imagedir, created here so it has known ownership when nothing is
+# mounted over it.
+RUN mkdir -p /nodeapp/img && chown nodejs:nodejs /nodeapp/img
+
+COPY src/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# There is deliberately no `USER nodejs` here, and putting one back would reintroduce issue #915.
+#
+# The entrypoint has to start as root so it can drop privileges to whoever owns the bind-mounted
+# image directory - that is the whole fix, and it cannot be done from an unprivileged process. The
+# application itself still never runs as root: every path through docker-entrypoint.sh execs node
+# via su-exec as an unprivileged user, and a root-owned mount is refused rather than adopted.
+#
+# Scanners that judge an image by its final USER will flag this. If that matters in your
+# environment, run with `--user "$(id -u):$(id -g)"`; the entrypoint detects it is not root and
+# hands straight over.
 
 # Use tini as init to properly handle signals (allows Ctrl-C to work)
-ENTRYPOINT ["/sbin/tini", "--", "node", "src/butler-sheet-icons.js"]
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/docker-entrypoint.sh"]
 

--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -1,0 +1,147 @@
+#!/bin/sh
+# Entrypoint for the Butler Sheet Icons container.
+#
+# The problem it solves (issue #915): the image used to run as USER nodejs, which Alpine's
+# `adduser -S` gives uid 100. A directory bind-mounted from a Linux host is owned by the host user -
+# uid 1000 for a normal login, 1001 for a CI runner - so the container could not write to it, and
+# every documented `--imagedir` invocation failed with
+#
+#     EACCES: permission denied, mkdir './img/cloud/<appid>'
+#
+# It worked on macOS and Windows only because Docker Desktop's bind mounts ignore host ownership.
+#
+# The fix is for the image to adapt to the mount rather than the user to the image: look at who owns
+# the directory the run will write to, and become that user. Two alternatives were tried and
+# rejected:
+#
+#   * Telling users to pass `--user "$(id -u):$(id -g)"`. A uid with no /etc/passwd entry gets
+#     HOME=/, so os.homedir() returns "/", the Puppeteer cache under ~/.cache is unwritable, and the
+#     documented /home/nodejs/.cache/puppeteer mount points somewhere the app no longer looks. It
+#     trades one broken case for another, and only after the user knows the incantation.
+#   * `chown -R` on the mount. That is somebody's own directory on their own machine; handing it to
+#     uid 100 would leave them unable to delete their own thumbnails without sudo.
+#
+# Adopting the mount's uid has neither problem: files land owned by the host user, which is what
+# they wanted, and nothing outside the container is modified.
+#
+# The application never runs as root. This script needs root only to drop privileges, and execs
+# node as an unprivileged user in every path.
+
+set -eu
+
+APP_USER="nodejs"
+APP_HOME="/home/nodejs"
+APP_ENTRY="/nodeapp/src/butler-sheet-icons.js"
+DEFAULT_IMAGE_DIR="/nodeapp/img"
+CERT_DIR="/nodeapp/cert"
+
+# To stderr, so it cannot corrupt stdout for `--outputformat table` and friends.
+log() {
+    echo "butler-sheet-icons: $*" >&2
+}
+
+# Walks up to the nearest directory that exists.
+#
+# `--imagedir ./img/sub` is legal and the leaf will not exist on the first run, but its parent is
+# the bind mount whose ownership we actually need.
+nearest_existing_dir() {
+    _dir="$1"
+    while [ ! -d "$_dir" ] && [ "$_dir" != "/" ] && [ -n "$_dir" ]; do
+        _dir=$(dirname "$_dir")
+    done
+    printf '%s' "$_dir"
+}
+
+# Recovers the image directory from the command line, since that is the directory the run writes to.
+#
+# Mirrors the CLI: `--imagedir <path>` and `--imagedir=<path>`, defaulting to ./img, which resolves
+# against the working directory - /nodeapp - exactly as it does inside the app.
+resolve_image_dir() {
+    _image_dir="$DEFAULT_IMAGE_DIR"
+    _prev=""
+
+    for _arg in "$@"; do
+        case "$_arg" in
+            --imagedir=*) _image_dir="${_arg#--imagedir=}" ;;
+        esac
+        if [ "$_prev" = "--imagedir" ]; then
+            _image_dir="$_arg"
+        fi
+        _prev="$_arg"
+    done
+
+    case "$_image_dir" in
+        /*) ;;
+        *) _image_dir="$(pwd)/${_image_dir#./}" ;;
+    esac
+
+    printf '%s' "$_image_dir"
+}
+
+# ------------------------------------------------------------------------------------------------
+# Not root: the operator passed --user, or this is a platform that assigns an arbitrary uid.
+# Their choice wins - just make sure the environment is coherent before handing over.
+# ------------------------------------------------------------------------------------------------
+if [ "$(id -u)" -ne 0 ]; then
+    if [ -z "${HOME:-}" ] || [ "$HOME" = "/" ]; then
+        # What Docker hands a uid with no passwd entry. Left alone, os.homedir() returns "/" and
+        # every write under ~/.cache fails - which is the trap that makes bare --user a bad answer.
+        HOME=/tmp
+        export HOME
+        log "uid $(id -u) has no home directory; using HOME=$HOME so the browser cache is writable"
+    fi
+
+    exec node "$APP_ENTRY" "$@"
+fi
+
+# ------------------------------------------------------------------------------------------------
+# Root: find out who owns what this run will write to, and become them.
+# ------------------------------------------------------------------------------------------------
+APP_UID=$(id -u "$APP_USER")
+
+IMAGE_DIR=$(resolve_image_dir "$@")
+
+TARGET_UID=""
+TARGET_GID=""
+TARGET_SOURCE=""
+
+# The certificate directory is checked as well as the image directory, and not only for symmetry:
+# QSEoW client certificates are mounted mode 0600 owned by the host user, so uid 100 could not read
+# them either. That surfaced as "Missing certificate file(s)" rather than as a permission error,
+# which is why it was not obviously the same bug.
+for candidate in "$IMAGE_DIR" "$CERT_DIR"; do
+    existing=$(nearest_existing_dir "$candidate")
+    [ -d "$existing" ] || continue
+
+    uid=$(stat -c %u "$existing" 2>/dev/null || echo "")
+    gid=$(stat -c %g "$existing" 2>/dev/null || echo "")
+    [ -n "$uid" ] || continue
+
+    # uid 0 is deliberately not adopted: a root-owned mount is not a reason to run the browser and
+    # the whole app as root. That case falls through to nodejs and fails with the advice the app
+    # now prints, which tells the operator what to do about it.
+    if [ "$uid" != "0" ] && [ "$uid" != "$APP_UID" ]; then
+        TARGET_UID="$uid"
+        TARGET_GID="$gid"
+        TARGET_SOURCE="$existing"
+        break
+    fi
+done
+
+if [ -z "$TARGET_UID" ]; then
+    exec su-exec "$APP_USER" node "$APP_ENTRY" "$@"
+fi
+
+# su-exec resolves HOME from /etc/passwd and overwrites whatever was exported before it, so setting
+# HOME here would be silently discarded. Giving the adopted uid a real passwd entry is what makes
+# HOME, whoami and os.homedir() all agree.
+if ! grep -q "^[^:]*:[^:]*:${TARGET_UID}:" /etc/passwd; then
+    echo "bsi:x:${TARGET_UID}:${TARGET_GID}::${APP_HOME}:/bin/sh" >> /etc/passwd
+fi
+
+# Inside the container only. The bind mount is never touched.
+chown -R "${TARGET_UID}:${TARGET_GID}" "$APP_HOME" 2>/dev/null || true
+
+log "running as uid ${TARGET_UID}:${TARGET_GID}, adopted from ${TARGET_SOURCE}, so files written there belong to you"
+
+exec su-exec "${TARGET_UID}:${TARGET_GID}" node "$APP_ENTRY" "$@"

--- a/src/lib/cloud/process-cloud-app.js
+++ b/src/lib/cloud/process-cloud-app.js
@@ -1,4 +1,3 @@
-import fs from 'fs';
 import { setupEnigmaConnection } from './cloud-enigma.js';
 import { logger, sleep } from '../../globals.js';
 import { qscloudUploadToApp } from './cloud-upload.js';
@@ -15,6 +14,7 @@ import {
     SHEET_LIST_FIELDS_WITH_SHOW_CONDITION,
 } from '../util/sheet-list.js';
 import { withEngineSession } from '../util/engine-session.js';
+import { createAppImageDir } from '../util/image-dir.js';
 import { determineSheetExcludeStatus } from './determine-sheet-exclude-status.js';
 
 // Selector paths to elements on login page
@@ -41,19 +41,13 @@ export const processCloudApp = async (appId, saasInstance, options) => {
     let sheetRun;
 
     // Create image directory on disk for this app
-    try {
-        fs.mkdirSync(`${options.imagedir}/cloud/${appId}`, { recursive: true });
-        logger.verbose(`Created cloud image directory '${options.imagedir}/cloud/${appId}'`);
-    } catch (err) {
-        if (err.stack) {
-            logger.error(`CREATE THUMBNAILS 1 (stack): ${err.stack}`);
-        } else if (err.message) {
-            logger.error(`CREATE THUMBNAILS 1 (message): ${err.message}`);
-        } else {
-            logger.error(`CREATE THUMBNAILS 1: Error creating cloud image directory: ${err}`);
-        }
-        throw new Error('Error creating cloud image directory', { cause: err });
-    }
+    createAppImageDir({
+        imagedir: options.imagedir,
+        platform: 'cloud',
+        appId,
+        logPrefix: 'CREATE THUMBNAILS 1',
+        ErrorClass: CloudError,
+    });
     try {
         // Does the app have a thumbnail folder in its media library?
         logger.verbose(

--- a/src/lib/qseow/qseow-process-app.js
+++ b/src/lib/qseow/qseow-process-app.js
@@ -1,4 +1,3 @@
-import fs from 'fs';
 import qrsInteract from 'qrs-interact';
 import { Jimp } from 'jimp';
 
@@ -16,6 +15,7 @@ import {
     SHEET_LIST_FIELDS_WITH_SHOW_CONDITION,
 } from '../util/sheet-list.js';
 import { withEngineSession } from '../util/engine-session.js';
+import { createAppImageDir } from '../util/image-dir.js';
 import { qrsFilterAnyOf, qrsPathWithFilter, toFilterValueList } from './qrs-filter.js';
 
 const selectorLoginPageUserName = '#username-input';
@@ -153,20 +153,13 @@ export const qseowProcessApp = async (appId, options) => {
     // Create image directory for this app
     let blurFailures = 0;
 
-    try {
-        fs.mkdirSync(`${options.imagedir}/qseow/${appId}`, { recursive: true });
-        logger.verbose(`Created image QSEoW directory '${options.imagedir}/qseow/${appId}'`);
-    } catch (err) {
-        logger.error(`QSEOW CREATE THUMBNAILS 1: Error creating QSEoW image directory: ${err}`);
-        if (err.message) {
-            logger.error(`QSEOW CREATE THUMBNAILS 1 (message): ${err.message}`);
-        }
-        if (err.stack) {
-            logger.error(`QSEOW CREATE THUMBNAILS 1 (stack): ${err.stack}`);
-        }
-
-        throw new Error('Error creating QSEoW image directory', { cause: err });
-    }
+    createAppImageDir({
+        imagedir: options.imagedir,
+        platform: 'qseow',
+        appId,
+        logPrefix: 'QSEOW CREATE THUMBNAILS 1',
+        ErrorClass: QseowError,
+    });
 
     try {
         // Get metadata about the app

--- a/src/lib/util/__tests__/image_dir.test.js
+++ b/src/lib/util/__tests__/image_dir.test.js
@@ -1,0 +1,199 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+jest.unstable_mockModule('../../../globals.js', () => ({
+    logger: {
+        info: jest.fn(),
+        verbose: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+    },
+}));
+const { logger } = await import('../../../globals.js');
+
+// existsSync drives the container check, which decides which advice is printed.
+jest.unstable_mockModule('node:fs', () => ({
+    default: { mkdirSync: jest.fn(), existsSync: jest.fn().mockReturnValue(false) },
+}));
+const fs = (await import('node:fs')).default;
+
+const { createAppImageDir } = await import('../image-dir.js');
+const { alreadyReported } = await import('../reported-error.js');
+
+/** Stand-in typed error, matching the (message, { cause }) shape of CloudError/QseowError. */
+class TestError extends Error {
+    /**
+     * Construct a test error carrying an optional cause.
+     *
+     * @param {string} message - Error message.
+     * @param {object} [options] - Error options, including `cause`.
+     */
+    constructor(message, options = {}) {
+        super(message, options);
+        this.name = 'TestError';
+    }
+}
+
+const PARAMS = {
+    imagedir: './img',
+    platform: 'cloud',
+    appId: 'abc123',
+    logPrefix: 'CREATE THUMBNAILS 1',
+    ErrorClass: TestError,
+};
+
+/**
+ * Builds an fs error carrying a syscall code, the way Node reports them.
+ *
+ * @param {string} code - Syscall error code, e.g. `EACCES`.
+ * @param {string} message - Error message.
+ *
+ * @returns {Error} The constructed error.
+ */
+const fsError = (code, message) => Object.assign(new Error(message), { code });
+
+/**
+ * All error lines logged during a test, joined for substring assertions.
+ *
+ * @returns {string} Every `logger.error` argument, newline separated.
+ */
+const errorText = () => logger.error.mock.calls.map((call) => call[0]).join('\n');
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    fs.existsSync.mockReturnValue(false);
+});
+
+describe('createAppImageDir', () => {
+    test('creates the per-app directory and returns its path', () => {
+        const dir = createAppImageDir(PARAMS);
+
+        expect(dir).toBe('./img/cloud/abc123');
+        expect(fs.mkdirSync).toHaveBeenCalledWith('./img/cloud/abc123', { recursive: true });
+    });
+
+    test('builds the path from the platform segment, so the twins stay distinguishable', () => {
+        const dir = createAppImageDir({ ...PARAMS, platform: 'qseow', imagedir: '/data' });
+
+        expect(dir).toBe('/data/qseow/abc123');
+    });
+
+    test('throws the caller-supplied typed error, with the original attached as cause', () => {
+        const cause = fsError('EACCES', 'permission denied');
+        fs.mkdirSync.mockImplementation(() => {
+            throw cause;
+        });
+
+        expect(() => createAppImageDir(PARAMS)).toThrow(TestError);
+
+        try {
+            createAppImageDir(PARAMS);
+        } catch (err) {
+            expect(err.cause).toBe(cause);
+            expect(err.message).toContain('./img/cloud/abc123');
+        }
+    });
+
+    test('marks the failure reported, so outer handlers do not describe it again', () => {
+        fs.mkdirSync.mockImplementation(() => {
+            throw fsError('EACCES', 'permission denied');
+        });
+
+        try {
+            createAppImageDir(PARAMS);
+        } catch (err) {
+            expect(alreadyReported(err)).toBe(true);
+        }
+    });
+
+    // The whole reason this module exists: outside a container the remedy is "check the account",
+    // and there is no reason to talk about Docker at somebody who is not using it.
+    test('advises about the running account when a permission error happens outside a container', () => {
+        fs.mkdirSync.mockImplementation(() => {
+            throw fsError('EACCES', 'permission denied');
+        });
+
+        expect(() => createAppImageDir(PARAMS)).toThrow();
+
+        expect(errorText()).toContain('No permission to create the image directory');
+        expect(errorText()).toContain('can write to it');
+        expect(errorText()).not.toContain('--user');
+    });
+
+    // Inside a container the operator cannot see the uid mismatch from the OS error at all, which
+    // is what made issue #915 take a full investigation to explain.
+    test('explains the host/container ownership mismatch when running in a container', () => {
+        fs.existsSync.mockImplementation((p) => p === '/.dockerenv');
+        fs.mkdirSync.mockImplementation(() => {
+            throw fsError('EACCES', 'permission denied');
+        });
+
+        expect(() => createAppImageDir(PARAMS)).toThrow();
+
+        expect(errorText()).toContain('mounted from the host');
+        expect(errorText()).toContain('--user "$(id -u):$(id -g)"');
+    });
+
+    test('treats EPERM the same as EACCES', () => {
+        fs.mkdirSync.mockImplementation(() => {
+            throw fsError('EPERM', 'operation not permitted');
+        });
+
+        expect(() => createAppImageDir(PARAMS)).toThrow();
+
+        expect(errorText()).toContain('No permission to create the image directory');
+    });
+
+    test('names a read-only filesystem rather than blaming permissions', () => {
+        fs.mkdirSync.mockImplementation(() => {
+            throw fsError('EROFS', 'read-only file system');
+        });
+
+        expect(() => createAppImageDir(PARAMS)).toThrow();
+
+        expect(errorText()).toContain('read-only filesystem');
+        expect(errorText()).toContain(':ro');
+        expect(errorText()).not.toContain('No permission to create');
+    });
+
+    // A read-only Docker mount surfaces as ENOENT, not EROFS - verified by running the image with
+    // `-v vol:/nodeapp/img:ro`. Without this branch the one case the read-only advice was written
+    // for would never reach it.
+    test('covers both readings of ENOENT, including a read-only Docker mount', () => {
+        fs.mkdirSync.mockImplementation(() => {
+            throw fsError('ENOENT', 'no such file or directory');
+        });
+
+        expect(() => createAppImageDir(PARAMS)).toThrow();
+
+        expect(errorText()).toContain('exists and is writable');
+        expect(errorText()).toContain(':ro');
+    });
+
+    test('passes an unrelated failure through with its own message', () => {
+        fs.mkdirSync.mockImplementation(() => {
+            throw fsError('ENOSPC', 'no space left on device');
+        });
+
+        expect(() => createAppImageDir(PARAMS)).toThrow();
+
+        expect(errorText()).toContain('no space left on device');
+        expect(errorText()).not.toContain('No permission to create');
+        expect(errorText()).not.toContain('read-only filesystem');
+    });
+
+    // The stack is diagnostics, not advice - demoting it is what keeps the actionable lines from
+    // being buried, the same argument as logUnusableBrowser in browser-launch.js.
+    test('keeps the stack at debug level', () => {
+        const cause = fsError('EACCES', 'permission denied');
+        cause.stack = 'Error: permission denied\n    at somewhere';
+        fs.mkdirSync.mockImplementation(() => {
+            throw cause;
+        });
+
+        expect(() => createAppImageDir(PARAMS)).toThrow();
+
+        expect(logger.debug).toHaveBeenCalledWith(cause.stack);
+        expect(errorText()).not.toContain('at somewhere');
+    });
+});

--- a/src/lib/util/image-dir.js
+++ b/src/lib/util/image-dir.js
@@ -1,0 +1,126 @@
+import fs from 'node:fs';
+
+import { logger } from '../../globals.js';
+import { markReported } from './reported-error.js';
+
+/**
+ * Creates the per-app image directory, and explains a permission failure rather than leaking it.
+ *
+ * Extracted from `process-cloud-app.js` and `qseow-process-app.js`, which carried the same six
+ * lines with the same purpose and had already drifted apart in log shape - one logged the stack
+ * first, the other the raw error first, and neither marked the failure as reported, so the same
+ * problem was described twice on the way out.
+ *
+ * The reason it is worth a module of its own is the message. In the Docker image this `mkdir` is
+ * the first thing that touches a bind-mounted host directory, and when the container user cannot
+ * write there the operator gets `EACCES: permission denied, mkdir './img/cloud/<id>'` - which
+ * names the syscall and nothing that would help them act (issue #915). The container adapts to the
+ * mount's owner now, so this is the residue: a read-only mount, a root-owned one, or an explicit
+ * `--user` pointed at a directory somebody else owns.
+ *
+ * @param {object} params - Parameters.
+ * @param {string} params.imagedir - Value of `--imagedir`, as given by the user.
+ * @param {string} params.platform - Platform segment of the path, `cloud` or `qseow`.
+ * @param {string} params.appId - App the directory is being created for.
+ * @param {string} params.logPrefix - Log line prefix without a trailing colon, e.g. `'CLOUD APP'`.
+ * @param {Function} params.ErrorClass - Typed error to throw, e.g. `CloudError` or `QseowError`.
+ *
+ * @returns {string} The directory that was created.
+ *
+ * @throws {Error} An instance of `params.ErrorClass`, marked as already reported, with the original
+ * error attached as `cause`.
+ */
+export const createAppImageDir = ({ imagedir, platform, appId, logPrefix, ErrorClass }) => {
+    const dir = `${imagedir}/${platform}/${appId}`;
+
+    try {
+        fs.mkdirSync(dir, { recursive: true });
+        logger.verbose(`Created ${platform} image directory '${dir}'`);
+
+        return dir;
+    } catch (err) {
+        logPermissionAdvice(dir, logPrefix, err);
+
+        throw markReported(
+            new ErrorClass(`Could not create the image directory '${dir}'`, { cause: err })
+        );
+    }
+};
+
+/**
+ * Explains why the image directory could not be created, and what to do about it.
+ *
+ * Message shape follows `logUnusableBrowser` in `browser-launch.js`: what failed, then the thing to
+ * do next, with diagnostics demoted to debug so they do not bury the advice.
+ *
+ * The permission case gets its own text because the remedy is completely different from, say, a
+ * full disk - and because in a container the cause is invisible from the message the OS provides.
+ *
+ * @param {string} dir - Directory that could not be created.
+ * @param {string} logPrefix - Log line prefix, e.g. `'QSEOW'`.
+ * @param {Error|unknown} err - The underlying failure.
+ *
+ * @returns {void}
+ */
+const logPermissionAdvice = (dir, logPrefix, err) => {
+    const code = err?.code;
+
+    if (code === 'EACCES' || code === 'EPERM') {
+        logger.error(`${logPrefix}: No permission to create the image directory '${dir}'.`);
+
+        if (isProbablyContainer()) {
+            // Inside a container this is almost always the host/container user mismatch, and the
+            // operator has no way to see that from the error the OS gave us.
+            logger.error(
+                `${logPrefix}: The directory is mounted from the host and is owned by a user this container cannot write as.`
+            );
+            logger.error(
+                `${logPrefix}: Butler Sheet Icons normally adopts the owner of the mounted directory automatically. That is skipped when the directory is owned by root, or when the container was started with an explicit --user.`
+            );
+            logger.error(
+                `${logPrefix}: Mount a directory you own, or start the container with --user "$(id -u):$(id -g)" and make sure that user can write to it.`
+            );
+        } else {
+            logger.error(
+                `${logPrefix}: Check that the account running Butler Sheet Icons can write to it, or point --imagedir somewhere it can.`
+            );
+        }
+    } else if (code === 'EROFS') {
+        logger.error(`${logPrefix}: The image directory '${dir}' is on a read-only filesystem.`);
+        logger.error(
+            `${logPrefix}: Point --imagedir at a writable location. In Docker, check the mount for a ":ro" flag.`
+        );
+    } else if (code === 'ENOENT') {
+        // A read-only Docker mount arrives here rather than as EROFS: Node's recursive mkdir
+        // reports the missing leaf instead of the read-only parent it could not create. Observed
+        // with `-v vol:/nodeapp/img:ro`, so the advice has to cover both readings of ENOENT.
+        logger.error(`${logPrefix}: Could not create the image directory '${dir}'.`);
+        logger.error(
+            `${logPrefix}: Check that the path given to --imagedir exists and is writable. In Docker, this is also what a read-only mount looks like - check the mount for a ":ro" flag.`
+        );
+    } else {
+        logger.error(
+            `${logPrefix}: Could not create the image directory '${dir}': ${err?.message ?? err}`
+        );
+    }
+
+    logger.debug(err?.stack ?? String(err));
+};
+
+/**
+ * Best-effort guess at whether this process is running inside a container.
+ *
+ * Only used to choose which advice to print, so a wrong answer costs a slightly less relevant
+ * error message and nothing else. `detectDocker` in `browser-launch.js` answers the same question
+ * for a decision that matters more and is correspondingly more thorough; this deliberately stays
+ * synchronous, because it runs inside a `catch`.
+ *
+ * @returns {boolean} `true` when the process looks containerised.
+ */
+const isProbablyContainer = () => {
+    try {
+        return fs.existsSync('/.dockerenv') || fs.existsSync('/run/.containerenv');
+    } catch {
+        return false;
+    }
+};


### PR DESCRIPTION
Fixes #915.

The Docker image ran as `USER nodejs` — uid 100. A directory bind-mounted from a Linux host belongs to the host user, so the container could not write to it and **every** documented `--imagedir` invocation failed:

```
EACCES: permission denied, mkdir './img/cloud/<appid>'
```

Broken since the first commit. It only became *visible* when #877 made the exit code reflect failures, and only surfaced now because the Docker jobs had been skipped in 16 of the last 20 CI runs. It works on macOS and Windows solely because Docker Desktop ignores ownership on bind mounts — which is why it survived development for years.

`docker-qseow-amd64`'s `Missing certificate file(s)` is the same root cause wearing different words: a client certificate written `chmod 600` owned by the runner user, unreadable by uid 100.

**This currently blocks releases.** `release-please` needs both Docker jobs, so it and every `release-*` job are being skipped.

## The fix

The image adapts to the mount rather than the user adapting to the image. `src/docker-entrypoint.sh` reads the owner of the directory the run will write to — falling back to the certificate directory — and becomes that user via `su-exec`. Files land owned by the host user, and the documented `docker run -v …` works with no extra flags.

Two obvious alternatives were tried against a real container and rejected:

- **Documenting `--user "$(id -u):$(id -g)"`.** A uid with no `/etc/passwd` entry gets `HOME=/`, so `os.homedir()` returns `/`, `~/.cache` is unwritable, and the documented `/home/nodejs/.cache/puppeteer` mount points where the app no longer looks. It trades one broken case for another, and only for users who already know the incantation. It stays supported as an escape hatch — and now works properly, because the entrypoint repairs `HOME` on that path too.
- **`chown -R` on the mount.** That is the user's own directory on their own machine. Handing it to uid 100 would leave them unable to delete their own thumbnails without `sudo`.

A root-owned mount is deliberately **not** adopted — running a browser over untrusted content as root is not a trade worth making. That case is explained rather than silently escalated.

`USER nodejs` is gone from the Dockerfile, with a comment where it used to be saying why putting it back reintroduces the bug. The entrypoint needs root only to drop privileges; the application still never runs as root.

The second commit covers what the entrypoint *cannot* fix — root-owned, explicit `--user`, read-only — with advice shaped like `logUnusableBrowser`: what failed, what to do, stack demoted to debug. Both `process-app` twins carried the same six lines and had already drifted, so it is extracted to `src/lib/util/image-dir.js` alongside the other twin extractions.

## Three things running it taught me that reasoning did not

1. **My first test harness was invalid.** Docker rewrites a *named volume's* ownership from the image directory, so `/nodeapp/img` kept coming back as uid 100 and every case looked like it passed. Re-ran on a mount point absent from the image.
2. **`su-exec` overwrites `HOME`** from `/etc/passwd`, so exporting it beforehand is silently discarded. Hence the synthetic passwd entry.
3. **A read-only mount surfaces as `ENOENT`, not `EROFS`** — Node's recursive `mkdir` reports the missing leaf instead of the read-only parent it could not create. Without that branch, the read-only advice would never once have fired for the case it was written for.

## Verification

Against Linux ownership semantics (a Docker volume, not a Docker Desktop bind mount, which hides the bug):

| Mount owner | Ran as | Result | Files owned by |
|---|---|---|---|
| 1001 (Linux host / CI runner) | **adopted 1001** | write OK | 1001 |
| 1002 (a different host user) | **adopted 1002** | write OK | 1002 |
| 100 (image's own user) | 100 | write OK | 100 |
| 1001, explicit `--user 1001` | 1001, `HOME=/tmp` | write OK | 1001 |
| root | 100, not adopted | fails, by design | — |

Also confirmed the entrypoint drives the real binary through both the adopted and default paths, and that `os.homedir()` is writable in every case — the thing bare `--user` broke.

959 unit tests pass (11 new for the helper, 98% coverage), lint and prettier clean, `shellcheck -s sh` clean on the entrypoint, and zizmor reports findings identical to the baseline.

The CI Docker jobs take **no `--user` flag** — them passing unmodified is the regression test. They also now assert that the generated files are owned by the runner user, because checking exit status alone would pass just as happily if the entrypoint had quietly run everything as root.

## Known gap

The new error message could not be integration-tested locally: both `mkdirSync` calls sit behind Qlik authentication, so there is no way to reach them without a live tenant. It is covered by unit tests including the container and read-only branches, but CI is its first real exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
