### PR TITLE
docs: scope a publishing pass to the file that was actually named

### DIFF
--- a/docs/to-doc-site/README.md
+++ b/docs/to-doc-site/README.md
@@ -66,11 +66,18 @@ This is the standing instruction for "update the doc site from `docs/to-doc-site
 
 **This is not a bulk pass.** Every file is approved individually before anything is written — see step 1.
 
-### 1. Inventory the pending drafts and get approval
+### 1. Establish scope, then get approval
 
-Before reading deeply, before editing anything, list what is there and get a decision on each file.
+Before reading deeply, before editing anything, work out which files are in scope and get a decision on each one.
 
-Work through steps 2–4 far enough to form a recommendation, then present a table covering **every** unprefixed file:
+**Scope comes from how the request was phrased:**
+
+| Request | Files in scope |
+|---|---|
+| "Process `<filename>.md`" — a named file | **That file only.** Do not inventory the rest. Name the other pending drafts in one line at the end so nothing is forgotten, and leave them alone. |
+| "Update the doc site from `docs/to-doc-site`" — no file named | **Every** unprefixed file in this folder. |
+
+Work through steps 2–4 far enough to form a recommendation, then present a table covering the files in scope:
 
 | Draft | Recommendation | Target page(s) | Why |
 |---|---|---|---|


### PR DESCRIPTION
Step 1 of the publishing workflow told the agent to inventory **every** unprefixed file in `docs/to-doc-site/`, regardless of what was asked.

That wording assumes the bulk entry point — *"update the doc site from `docs/to-doc-site`"*. It is wrong for the far more common case of naming a single draft, where it produces analysis of five files nobody asked about, and dilutes the per-file approval gate by putting four unrequested decisions in front of the one that matters.

## What changed

Scope is now derived from how the request was phrased:

| Request | Files in scope |
|---|---|
| "Process `<filename>.md>`" — a named file | That file only; the others get a one-line mention so nothing is forgotten |
| "Update the doc site from `docs/to-doc-site`" — no file named | Every unprefixed file |

The per-file approval gate is unchanged in both cases, as is everything downstream.

## Why now

A test run surfaced it by doing the sensible thing rather than the documented thing. Asked to process one named draft, it scoped to that file and listed the remaining three in a closing line — better behaviour than the instruction called for.

Encoding it means that is no longer left to the model's judgement.

Section renamed from "Inventory the pending drafts and get approval" to "Establish scope, then get approval". The three cross-references elsewhere in the file refer to "step 1" by number, so they still resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)