### PR TITLE
build: let release-please see the whole backlog, and record Docker mount ownership

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -555,6 +555,17 @@ jobs:
       - name: Load Docker image
         run: docker load --input "$IMAGE_TAR"
 
+      # Which user the container runs as is decided by who owns the mounted directory (issue #915),
+      # so that ownership is the first thing worth knowing when one of these jobs misbehaves. It
+      # was not recorded anywhere, which is how #915 came to assert that docker-qseow-amd64 shared
+      # the same root cause on the strength of an inference rather than a measurement.
+      - name: Report mounted directory ownership
+        run: |
+          IMG_DIR="$RUNNER_TEMP/bsi-img"
+          mkdir -p "$IMG_DIR"
+          echo "runner user : $(id)"
+          ls -lnd "$IMG_DIR"
+
       - name: Run QS Cloud commands (arm64 image)
         run: |
           IMG_DIR="$RUNNER_TEMP/bsi-img"
@@ -632,6 +643,14 @@ jobs:
 
       - name: Load Docker image
         run: docker load --input "$IMAGE_TAR"
+
+      # See the same step in docker-qscloud-arm64.
+      - name: Report mounted directory ownership
+        run: |
+          IMG_DIR="$RUNNER_TEMP/bsi-img"
+          mkdir -p "$IMG_DIR"
+          echo "runner user : $(id)"
+          ls -lnd "$IMG_DIR"
 
       - name: Run QS Cloud commands (amd64 image)
         run: |
@@ -827,10 +846,33 @@ jobs:
           printf '%s\n' "$QS_CLIENT_KEY_PEM" > "$CERT_DIR/client_key.pem"
           chmod 600 "$CERT_DIR"/client*.pem
 
-      # See the assertion step below, and the same one in docker-qscloud-arm64. This job is the one
-      # that used to fail with "Missing certificate file(s)" rather than a permission error: the
-      # client certificate is written chmod 600 owned by the runner user, and the container user
-      # could not read it. Same root cause as the image directory (issue #915).
+      # This job has never passed. It fails with "Missing certificate file(s)" even though the
+      # files are plainly there, which points at the container user being unable to read them - the
+      # certificate is written mode 0600 above, so only its owner can.
+      #
+      # #915 asserted this was the same root cause as the image directory and would be fixed by the
+      # same change. It was not: the entrypoint shipped, the two QS Cloud jobs went green, and this
+      # one failed identically. That claim was an inference from the chmod, never a measurement, so
+      # the step below measures it instead of guessing again - on the host and from inside the
+      # image, as the unprivileged user the container actually runs as.
+      - name: Report mounted directory ownership and certificate readability
+        run: |
+          IMG_DIR="$HOME/bsi-bsi/img"
+          CERT_DIR="$HOME/bsi-bsi/cert"
+
+          echo "runner user : $(id)"
+          echo "HOME        : $HOME"
+          echo "--- host side ---"
+          ls -lnd "$IMG_DIR" "$CERT_DIR"
+          ls -ln "$CERT_DIR"
+
+          echo "--- inside the image, as the user it runs as by default ---"
+          docker run --rm \
+            -v "$IMG_DIR:/nodeapp/img" \
+            -v "$CERT_DIR:/nodeapp/cert" \
+            --entrypoint /bin/sh \
+            "$IMAGE_NAME" -c 'echo "image dir : $(stat -c "%u:%g %a" /nodeapp/img)"; echo "cert dir  : $(stat -c "%u:%g %a" /nodeapp/cert)"; ls -ln /nodeapp/cert; su-exec nodejs test -r /nodeapp/cert/client.pem && echo "nodejs CAN read client.pem" || echo "nodejs CANNOT read client.pem"; su-exec nodejs test -w /nodeapp/img && echo "nodejs CAN write the image dir" || echo "nodejs CANNOT write the image dir"'
+
       - name: Run QSEoW Docker command (amd64 image)
         run: |
           IMG_DIR="$HOME/bsi-bsi/img"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,7 @@
   "prerelease": false,
   "draft": true,
   "release-search-depth": 10,
-  "commit-search-depth": 200,
+  "commit-search-depth": 1000,
   "changelog-sections": [
     {
       "type": "feat",


### PR DESCRIPTION
Two independent things, both found while working out why the release pipeline has been shut for eight months. Neither changes product behaviour.

## 1. release-please could not see back as far as the last release

`release-please-config.json` set `commit-search-depth` to **200**. The `butler-sheet-icons-v3.11.0` tag sits at **position 235** in the history of `main` — 234 commits back — so the previous release has been beyond release-please's horizon since roughly **2026-05-06**.

That is not cosmetic. release-please walks back from HEAD looking for the previous release to establish a baseline; when it never reaches one, the notes it can generate only describe the newest 200 commits. The pending 3.12.0 release PR (#774) covers 234 commits, 48 of them `feat`/`fix` — so the oldest three months of changes would have been silently missing from the changelog even once CI went green.

Raised to **1000**. The upstream default is 500, and 200 was a deliberate narrowing that has been outgrown; 1000 leaves headroom for this backlog to ship and the next to accumulate without anyone needing to think about the setting again.

## 2. The Docker jobs now record who owns what they mount

Which user the container runs as is decided by who owns the mounted directory (#915). That ownership was recorded nowhere, so when `docker-qseow-amd64` failed there was nothing in the log to reason from — and #915 duly asserted it shared the image directory's root cause, on the strength of an inference from the `chmod 600` in the workflow rather than a measurement.

**That inference was wrong.** The entrypoint shipped in #920, both QS Cloud jobs went green on the strength of it, and `docker-qseow-amd64` failed identically to before. The comment in that job claiming the shared root cause is replaced here with what is actually known, which is less.

Each Linux Docker job now prints the runner's identity and the ownership of what it mounts. `docker-qseow-amd64` — the one still failing — additionally probes from inside the image, as the unprivileged user the container really runs as, whether it can read the client certificate and write the image directory. Those two answers are what distinguish "the mount is root-owned, so the entrypoint declined to adopt it" from anything else, and neither is obtainable from outside the container.

The probe was verified against a container reproducing the suspected arrangement — a root-owned, mode 0600 certificate — where it correctly reports that the container user cannot read it.

**Diagnostics only.** `docker-qseow-amd64` stays red until its cause is known; tracked in #922, which carries the full analysis and the design question that follows.

## Verification

- `release-please-config.json` parses; the one-line diff is the value only. The file is prettier-dirty on `main` already and is deliberately left that way rather than sweeping unrelated reformatting into this diff.
- `ci.yaml` parses, and the new steps land in the intended jobs in the intended order.
- zizmor reports findings **identical to `main`** (148, of which 0 low/medium/high).

Related: #922, #915, #920

🤖 Generated with [Claude Code](https://claude.com/claude-code)
