### PR TITLE
docs: mark the last three staged drafts as published

### DIFF
--- a/docs/to-doc-site/done/done_docker-image-directory-permissions-on-linux.md
+++ b/docs/to-doc-site/done/done_docker-image-directory-permissions-on-linux.md
@@ -6,6 +6,21 @@
 In earlier versions, running the Docker image on a Linux host and mounting a folder for the thumbnails failed for **every** app in the run.
 :::
 
+<!--
+Correction made while publishing: the version gate is 4.0.0, not 3.12.0. The release-please PR was
+titled 3.12.0 while these drafts were written, then breaking changes recomputed the bump to a major
+and it shipped as 4.0.0. There is no 3.12.0. A version read from an open release PR title is
+provisional - check the merged release commit.
+
+Published 2026-08-09 to the doc site's `next` branch (butler-sheet-icons-docs#51), landing on
+/guide/advanced/docker ("Writing thumbnails to a mounted folder on Linux") and
+/guide/troubleshooting ("Permission denied writing thumbnails from the Docker image", which also
+covers the QSEoW certificate failure sharing this cause). The adoption log line, the deliberate
+refusal to adopt a root-owned mount and the explicit --user behaviour were all verified against
+src/docker-entrypoint.sh rather than taken from this draft; all matched.
+-->
+
+
 ## Summary
 
 The documented way to get thumbnails out of the container is to mount a folder from the host:

--- a/docs/to-doc-site/done/done_log-messages-name-the-right-operation.md
+++ b/docs/to-doc-site/done/done_log-messages-name-the-right-operation.md
@@ -7,6 +7,17 @@ been corrected.
 Nothing about how Butler Sheet Icons behaves has changed — only what it writes to the log. This
 page matters if you search your logs for these lines, or if log monitoring alerts on them.
 
+<!--
+Published 2026-08-09 to the doc site's `next` branch (butler-sheet-icons-docs#51), condensed into a
+single "Log messages changed in BSI 4.0.0" section under a new "Reading the Logs" heading on
+/guide/troubleshooting rather than given a page of its own - it is pure log text with no behaviour
+change, and the audience is specifically operators whose monitoring matches the old strings.
+
+Not published: the note that the same wording was corrected on the QSEoW side "though no command
+exposes it there yet". That is an implementation detail with nothing for an administrator to act
+on. Revisit if a QSEoW remove-sheet-icons command is ever exposed.
+-->
+
 ## Removing sheet icons no longer claims to be updating them
 
 When removing sheet icons, the log said the icons had been updated or generated:

--- a/docs/to-doc-site/done/done_qrs-tag-names-with-special-characters.md
+++ b/docs/to-doc-site/done/done_qrs-tag-names-with-special-characters.md
@@ -13,6 +13,22 @@ This affects `butler-sheet-icons qseow create-sheet-thumbnails` and these option
 | `--exclude-sheet-tag` | `BSI_QSEOW_CST_EXCLUDE_SHEET_TAG` |
 | `--contentlibrary`    | `BSI_QSEOW_CST_CONTENT_LIBRARY`   |
 
+<!--
+Published 2026-08-09 to the doc site's `next` branch (butler-sheet-icons-docs#51). Landed on
+/guide/concepts/sheet-exclusion (danger callout for the several-exclude-tags case, warning callout
+for punctuation), /guide/troubleshooting ("Tag or content library name fails or matches nothing",
+carrying the per-character error table) and /reference/qseow.
+
+Verified against src/lib/qseow/qrs-filter.js rather than taken on trust: qrsFilterAnyOf now emits
+`(tags.name eq 'A' or tags.name eq 'B')` where it previously interpolated the single literal
+'A,B'; qrsFilterValue backslash-escapes before the whole filter is encodeURIComponent-ed; and the
+three options listed above are exactly the ones reaching those helpers. All correct as written.
+
+The silent multi-tag case was given the strongest callout on the site, because an affected reader
+has no signal at all - the run reported success while updating every sheet they had tagged to keep
+out.
+-->
+
 ## What went wrong before
 
 **An ampersand stopped the command.** A tag named `R&D` produced this, and no apps were


### PR DESCRIPTION
Marks the final three drafts as processed, per step 8 of `docs/to-doc-site/README.md`. Moved with `git mv` so history follows each file. **The staging folder is now empty.**

Published together to the doc site's `next` branch in ptarmiganlabs/butler-sheet-icons-docs#51 — grouped because all three land in `/guide/troubleshooting`, so separate branches would have conflicted there.

| Draft | Where it landed |
| --- | --- |
| `qrs-tag-names-with-special-characters.md` | `/guide/concepts/sheet-exclusion`, `/guide/troubleshooting`, `/reference/qseow` |
| `docker-image-directory-permissions-on-linux.md` | `/guide/advanced/docker`, `/guide/troubleshooting` |
| `log-messages-name-the-right-operation.md` | `/guide/troubleshooting` |

## Verification

Both behaviour drafts were checked against the implementation rather than taken on trust, and **both were correct as written** — a first for this batch.

- `qrs-filter.js`: `qrsFilterAnyOf` emits `(tags.name eq 'A' or tags.name eq 'B')` where it previously interpolated the single literal `'A,B'`; `qrsFilterValue` backslash-escapes before the whole filter is `encodeURIComponent`-ed; the three documented options are exactly those reaching the helpers.
- `docker-entrypoint.sh`: the adoption log line is verbatim, a root-owned mount is deliberately not adopted, and an explicit `--user` is respected as given.

## Editorial decisions, recorded inline

**The silent exclude-tag case got the strongest callout on the site.** An affected reader has no signal at all — the run reported success while updating every sheet they had tagged to keep out — so it is a `danger` rather than a `warning`.

**The log-message draft was condensed rather than given its own page.** Pure log text, no behaviour change; the audience is specifically operators whose monitoring matches the old strings. Its note about QSEoW wording that no command exposes yet is left unpublished as an implementation detail, with a comment saying why.

**All three carried the 3.12.0 placeholder.** The real gate is 4.0.0, noted in the Docker draft — the only one of the three that stated it as a version warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)