### PR TITLE
fix: ship Docker image licence notices, and restore certificate tolerance lost in the Puppeteer v25 upgrade

### DIFF
--- a/docs/to-doc-site/docker-image-third-party-licences.md
+++ b/docs/to-doc-site/docker-image-third-party-licences.md
@@ -1,0 +1,144 @@
+# What is inside the Docker image, and its licensing (doc site update)
+
+Target page: `docs/guide/advanced/docker.md` — **an edit to an existing page, not a new one.**
+
+Two changes there:
+
+1. Replace the single bullet on line 8 that currently reads "Includes an embedded Chromium browser
+   and is designed to work well in air-gapped environments".
+2. Add a new section, **"What is inside the image"**, after the intro bullets and before
+   "Writing thumbnails to a mounted folder on Linux".
+
+Also worth a one-line cross-link from the **"Docker Image Information"** section of
+`docs/examples/docker.md`, pointing at the new section.
+
+::: warning Version gate to fill in at publication time
+Two things below are **new and unreleased**, and both need to sit behind the same version gate:
+
+- the `/nodeapp/licenses/` directory, which did not exist before;
+- the licence files kept in `/nodeapp/node_modules`. Earlier images stripped most of these to save
+  space. On the 4.0.0 image the `find` command in the section below returns **23** results; on an
+  image built after the fix it returns **162**. A reviewer running it against an older image will
+  see a nearly empty list, so the gate has to cover this command too, not just the new directory.
+
+Butler Sheet Icons 4.0.0 shipped on 2026-08-09 and both changes landed after it, as a `fix:` commit,
+so at the time of writing there is no open release-please PR naming the next version. Read the
+version from that PR before publishing rather than assuming a bump —
+`docs/to-doc-site/README.md` §4.
+
+Everything else in this draft — the embedded Chromium, `chrome://credits`, the Alpine package
+database — is true of images already published and needs no gate.
+:::
+
+---
+
+## Replacement for the bullet on line 8
+
+> - Includes an embedded Chromium browser, so it works in air-gapped environments with no internet
+>   access — see [What is inside the image](#what-is-inside-the-image)
+
+## New section
+
+> ## What is inside the image
+>
+> The image is not only Butler Sheet Icons. It also contains a **Chromium browser**, because Butler
+> Sheet Icons works by opening your Qlik Sense sheets in a browser and photographing them.
+>
+> Shipping the browser inside the image is deliberate. It is what allows the container to run in an
+> environment with no internet access — nothing has to be downloaded the first time you use it.
+>
+> Chromium accounts for roughly 260 MB of the image. That is most of the reason the image is as
+> large as it is.
+>
+> ### Chromium is not Google Chrome
+>
+> This distinction matters if someone in your organization has to approve the image, and the two
+> names are used interchangeably almost everywhere else:
+>
+> - **Google Chrome** and **Chrome for Testing** are Google-branded browsers, distributed under
+>   Google's own terms. The Butler Sheet Icons image contains neither of them.
+> - **Chromium** is the open-source project that Chrome is built from. The image uses the Chromium
+>   package published by Alpine Linux, the same one Alpine ships to everybody else. It is recorded
+>   as BSD-3-Clause.
+>
+> When you run Butler Sheet Icons **outside** Docker — as a pre-built binary — it downloads Chrome
+> for Testing onto your own machine the first time it needs a browser. That is a download you
+> perform, not something Butler Sheet Icons redistributes, which is why the two situations are
+> handled differently.
+>
+> ### Where to find the licence information
+>
+> Every licence that applies to the image is inside the image, so a review can be completed without
+> searching the internet for any of it.
+>
+> Start with the notice file, which lists each component and where its licence and source can be
+> found:
+>
+> ```bash
+> docker run --rm --entrypoint sh ptarmiganlabs/butler-sheet-icons:latest \
+>   -c 'cat /nodeapp/licenses/NOTICE.md'
+> ```
+>
+> The same directory holds the full licence text for Butler Sheet Icons itself and for Chromium:
+>
+> ```bash
+> docker run --rm --entrypoint sh ptarmiganlabs/butler-sheet-icons:latest \
+>   -c 'ls /nodeapp/licenses/'
+> ```
+>
+> Three further sources, all inside the image:
+>
+> | What | How to see it |
+> |---|---|
+> | The ~740 components bundled inside Chromium itself, with their licences | The `chrome://credits` page built into the browser |
+> | Licences of the Node.js packages Butler Sheet Icons uses | `find /nodeapp/node_modules -iname "LICENSE*"` |
+> | Licences of every Alpine system package | `grep -E "^(P\|V\|L):" /lib/apk/db/installed` |
+>
+> To check which Chromium version a particular image contains:
+>
+> ```bash
+> docker run --rm --entrypoint /usr/bin/chromium-browser \
+>   ptarmiganlabs/butler-sheet-icons:latest --version
+> ```
+>
+> ::: tip Media codecs
+> The Chromium build in the image can decode the H.264 and AAC media formats. These are covered by
+> patent pools, which is a separate question from the licences above.
+>
+> Butler Sheet Icons never decodes audio or video — it takes still pictures of Qlik Sense sheets —
+> so this capability is present only because it comes as part of the standard Chromium package. It
+> is mentioned here because organizations with strict patent-licensing policies will want to know
+> it is there.
+> :::
+
+---
+
+## Why this matters to administrators
+
+The people who ask this question are usually not the Qlik Sense administrator. They are a security
+reviewer, or someone in procurement, who has been handed a container image and asked what is in it
+and whether the organization is allowed to run it.
+
+Today the doc site tells them only that the image "includes an embedded Chromium browser". There is
+nothing anywhere on the site about licensing, so the reviewer has to either take that on trust or go
+digging. The realistic outcome is a delay, and a question that lands back on the administrator who
+proposed using Butler Sheet Icons in the first place.
+
+The section above is written so the administrator can forward the page as the answer.
+
+## Verify before publishing
+
+- **Read `src/licenses/NOTICE.md` in the main repository and keep this page consistent with it.**
+  That file is what ships to users; this page is a pointer to it. If they disagree, the file wins.
+- **Re-measure the sizes.** The ~260 MB figure was taken from the `latest` image on 2026-08-09
+  (`apk info chromium` reports the installed size; `docker images` gives the total). Both move with
+  every base-image and Chromium bump, and they differ between architectures — the figure above came
+  from the arm64 variant. Keep the wording approximate.
+- **Do not publish a specific Chromium version number.** It changes with every image build, which is
+  why the section gives the command instead.
+- **Confirm `/nodeapp/licenses/` exists in the published image for the version being documented**
+  before the version gate is filled in. The directory is created by `COPY` lines in `src/Dockerfile`;
+  if those are ever reorganized this page becomes wrong in a way no link checker can catch.
+- The `#what-is-inside-the-image` anchor in the replacement bullet must match the generated heading
+  anchor. Check it against the built HTML — `docs/to-doc-site/README.md` §6 explains why anchors are
+  not covered by the link check.

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -10,8 +10,19 @@ COPY package*.json ./
 # Install production dependencies only
 RUN npm ci --omit=dev --ignore-scripts && \
     npm cache clean --force && \
-    # Remove documentation and unnecessary files from node_modules
-    find /build/node_modules -type f \( -name '*.md' -o -name 'LICENSE*' -o -name 'CHANGELOG*' -o -name '*.ts' -o -name '*.map' \) -delete && \
+    # Remove documentation and unnecessary files from node_modules.
+    #
+    # Licence files are deliberately NOT removed. The MIT and BSD licences that cover most of the
+    # dependency tree require their notice to travel with the code, so stripping them to save a few
+    # hundred KB in a 1.3 GB image traded a compliance obligation for nothing. The two exclusions
+    # matter for different reasons: the -iname guards keep LICENSE.md and similar from being caught
+    # by the '*.md' pattern, and 'LICENSE*' is no longer in the delete list at all.
+    #
+    # See src/licenses/NOTICE.md for what the image redistributes.
+    find /build/node_modules -type f \
+        \( -name '*.md' -o -name 'CHANGELOG*' -o -name '*.ts' -o -name '*.map' \) \
+        ! -iname 'licen[cs]e*' ! -iname 'copying*' ! -iname 'notice*' \
+        -delete && \
     # Remove test directories
     find /build/node_modules -type d \( -name test -o -name tests -o -name __tests__ -o -name '.github' \) -exec rm -rf {} + 2>/dev/null || true
 
@@ -55,6 +66,12 @@ COPY --chown=nodejs:nodejs src/butler-sheet-icons.js ./src/
 COPY --chown=nodejs:nodejs src/globals.js ./src/
 COPY --chown=nodejs:nodejs src/lib/ ./src/lib/
 COPY --chown=nodejs:nodejs package.json ./
+
+# Attribution for the third-party software this image redistributes - most importantly Chromium,
+# which is ~263 MB of BSD-3-Clause and assorted other licences. The Alpine package ships no licence
+# text of its own, so without this the image carried a browser with no notice attached to it.
+COPY --chown=nodejs:nodejs LICENSE ./licenses/butler-sheet-icons-LICENSE
+COPY --chown=nodejs:nodejs src/licenses/ ./licenses/
 
 # Default mount point for --imagedir, created here so it has known ownership when nothing is
 # mounted over it.

--- a/src/lib/browser/__tests__/browser_launch.test.js
+++ b/src/lib/browser/__tests__/browser_launch.test.js
@@ -308,7 +308,7 @@ describe('resolveBrowserExecutablePath — invalid version input (issue #878 rev
 });
 
 describe('launchBrowserForApp', () => {
-    test('launches with the v25-compatible option shape', async () => {
+    test('asks Puppeteer to accept insecure certificates, under the name v25 understands', async () => {
         detectAvailableBrowser.mockResolvedValue({
             executablePath: '/cached/chrome',
             source: 'cache',
@@ -325,11 +325,16 @@ describe('launchBrowserForApp', () => {
             expect.objectContaining({
                 executablePath: '/cached/chrome',
                 headless: true,
-                ignoreHTTPSErrors: true,
+                acceptInsecureCerts: true,
             })
         );
+
+        // The old name is a no-op in puppeteer-core v25 - it was removed in v23 and unknown options
+        // are ignored without complaint, so passing it looked like certificate tolerance while
+        // providing none. Asserting its absence is what stops it being reinstated by a future edit
+        // that pattern-matches on older Puppeteer examples.
         expect(puppeteer.launch).not.toHaveBeenCalledWith(
-            expect.objectContaining({ acceptInsecureCerts: expect.anything() })
+            expect.objectContaining({ ignoreHTTPSErrors: expect.anything() })
         );
     });
 

--- a/src/lib/browser/browser-launch.js
+++ b/src/lib/browser/browser-launch.js
@@ -307,9 +307,18 @@ export const launchBrowserForApp = async (options, { appId, logPrefix, appLabel,
     let browser;
     try {
         browser = await puppeteer.launch({
+            // Puppeteer removed `ignoreHTTPSErrors` in v23 and replaced it with
+            // `acceptInsecureCerts`. Butler Sheet Icons kept passing the old name through the v25
+            // upgrade, and because Puppeteer ignores unknown options in silence, the intent behind
+            // that line - tolerate the self-signed certificates that are normal on a QSEoW server -
+            // had quietly stopped being expressed at all. Certificate tolerance was resting
+            // entirely on the --ignore-certificate-errors browser flag in BASE_BROWSER_ARGS.
+            //
+            // The name is not interchangeable: grep the installed puppeteer-core for
+            // `ignoreHTTPSErrors` and there are zero hits, in the code and in the type definitions.
+            acceptInsecureCerts: true,
             executablePath,
             headless,
-            ignoreHTTPSErrors: true,
             args: browserArgs,
         });
     } catch (err) {

--- a/src/lib/cloud/__tests__/process_cloud_app.test.js
+++ b/src/lib/cloud/__tests__/process_cloud_app.test.js
@@ -285,7 +285,7 @@ describe('process-cloud-app.js — puppeteer launch and click options', () => {
         return browser;
     }
 
-    test('launches puppeteer with v25-compatible options (headless: true, no acceptInsecureCerts)', async () => {
+    test('launches puppeteer with v25-compatible options (headless: true, acceptInsecureCerts)', async () => {
         setupHappyPath();
 
         await processCloudApp('test-app-id', defaultSaasInstance, defaultOptions);
@@ -295,11 +295,11 @@ describe('process-cloud-app.js — puppeteer launch and click options', () => {
             expect.objectContaining({
                 executablePath: '/test/browser',
                 headless: true,
-                ignoreHTTPSErrors: true,
+                acceptInsecureCerts: true,
             })
         );
         expect(puppeteer.launch).not.toHaveBeenCalledWith(
-            expect.objectContaining({ acceptInsecureCerts: expect.anything() })
+            expect.objectContaining({ ignoreHTTPSErrors: expect.anything() })
         );
     });
 

--- a/src/lib/qseow/__tests__/qseow_process_app.test.js
+++ b/src/lib/qseow/__tests__/qseow_process_app.test.js
@@ -386,7 +386,7 @@ describe('qseow-process-app.js — puppeteer launch and click options', () => {
         expect(tagQuery).not.toContain("'exclude-thumbnail,R&D'");
     });
 
-    test('launches puppeteer with v25-compatible options (headless: true, no acceptInsecureCerts)', async () => {
+    test('launches puppeteer with v25-compatible options (headless: true, acceptInsecureCerts)', async () => {
         setupHappyPath();
 
         await qseowProcessApp('test-app-id', defaultOptions);
@@ -396,11 +396,15 @@ describe('qseow-process-app.js — puppeteer launch and click options', () => {
             expect.objectContaining({
                 executablePath: '/test/browser',
                 headless: true,
-                ignoreHTTPSErrors: true,
+                acceptInsecureCerts: true,
             })
         );
+
+        // Self-signed certificates are the norm on a QSEoW server, so this is the platform where
+        // getting the option name wrong matters most. `ignoreHTTPSErrors` was removed in Puppeteer
+        // v23 and is silently ignored, which is exactly why it survived the v25 upgrade unnoticed.
         expect(puppeteer.launch).not.toHaveBeenCalledWith(
-            expect.objectContaining({ acceptInsecureCerts: expect.anything() })
+            expect.objectContaining({ ignoreHTTPSErrors: expect.anything() })
         );
     });
 

--- a/src/licenses/NOTICE.md
+++ b/src/licenses/NOTICE.md
@@ -1,0 +1,73 @@
+# Third-party software in the Butler Sheet Icons container image
+
+Butler Sheet Icons itself is MIT licensed - see `LICENSE` in the source repository.
+
+The container image is not only Butler Sheet Icons. It redistributes a browser and a set of
+supporting libraries, and those carry their own licences and their own attribution requirements.
+This file records what is in the image and where the corresponding notices are, so that a security
+or compliance review can answer that question from inside the image rather than from a web search.
+
+## Chromium
+
+The image bundles **Chromium**, installed from the Alpine Linux `community` repository, so that
+Butler Sheet Icons can take screenshots without downloading a browser at run time. This is what
+makes the image usable in air-gapped environments.
+
+Chromium is **not** Google Chrome, and it is not Chrome for Testing. Those are Google-branded builds
+distributed under Google's own terms. Chromium is the open-source project underneath them, and the
+Alpine package is recorded as `BSD-3-Clause`.
+
+| | |
+| --- | --- |
+| Licence of Chromium itself | BSD-3-Clause - full text in `chromium-LICENSE`, next to this file |
+| Licences of Chromium's ~740 bundled components | `chrome://credits`, inside the browser in this image |
+| Source | <https://chromium.googlesource.com/chromium/src/> |
+| Alpine packaging | <https://gitlab.alpinelinux.org/alpine/aports/-/tree/master/community/chromium> |
+| Version in this image | run `chromium-browser --version` |
+
+Chromium incorporates code under a number of other licences besides BSD-3-Clause - including LGPL,
+MPL and MIT. Those components, and their licence texts, are enumerated on the `chrome://credits`
+page built into the browser binary. To read it:
+
+```bash
+docker run --rm --entrypoint /usr/bin/chromium-browser \
+    ptarmiganlabs/butler-sheet-icons:latest \
+    --headless --no-sandbox --remote-debugging-port=9222 about:blank
+```
+
+then open `chrome://credits` against that browser.
+
+### A note on media codecs
+
+The Alpine Chromium build has proprietary codecs enabled, so the binary can decode H.264 and AAC.
+Those formats are covered by patent pools, which is a separate matter from the copyright licences
+above. Butler Sheet Icons does not use video or audio decoding for anything - it screenshots Qlik
+Sense sheets - so the capability is present only because it comes with the distribution package.
+Organisations with strict patent-licensing policies should be aware it is there.
+
+## Node.js and npm dependencies
+
+The base image is the official `node:24-alpine` image. Butler Sheet Icons' own npm dependencies are
+installed under `/nodeapp/node_modules`, and **their licence files are retained there**, next to the
+code they apply to. The image build strips documentation and build artefacts from `node_modules` to
+keep the image small, but it deliberately does not strip `LICENSE`, `LICENCE`, `COPYING` or `NOTICE`
+files - removing those would drop the attribution that the MIT and BSD licences require to travel
+with the code.
+
+To list them:
+
+```bash
+docker run --rm --entrypoint sh ptarmiganlabs/butler-sheet-icons:latest \
+    -c 'find /nodeapp/node_modules -iname "LICENSE*" | head -50'
+```
+
+## Alpine system packages
+
+The image installs `chromium`, `nss`, `freetype`, `harfbuzz`, `ca-certificates`, `font-dejavu`,
+`tini` and `su-exec` from the Alpine repositories. Licence metadata for every installed package is
+in the Alpine package database inside the image:
+
+```bash
+docker run --rm --entrypoint sh ptarmiganlabs/butler-sheet-icons:latest \
+    -c 'grep -E "^(P|V|L):" /lib/apk/db/installed'
+```

--- a/src/licenses/chromium-LICENSE
+++ b/src/licenses/chromium-LICENSE
@@ -1,0 +1,27 @@
+// Copyright 2015 The Chromium Authors
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google LLC nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Two independent fixes, both found while investigating whether bundling Chromium in the Docker image
is defensible from a licensing point of view (background: #809).

## 1. The Docker image shipped a browser with no licence notices

The image redistributes Chromium — 263 MiB of BSD-3-Clause code plus ~740 third-party components
under LGPL, MPL, MIT and others — and carried no licence text for any of it. The only licence files
present were two inherited from the `node` base image, for yarn and libuv.

Two causes:

- The `node_modules` slimming step deleted `LICENSE*` outright, and its `*.md` pattern also caught
  `LICENSE.md`. MIT and BSD both require the notice to travel with the code.
- Nothing shipped for Chromium itself.

`src/licenses/` now carries Chromium's BSD-3-Clause text and a `NOTICE.md` describing what the image
contains and where each component's source and full licence can be found. Both, plus BSI's own MIT
licence, land in `/nodeapp/licenses/`.

**Worth being clear about what was *not* wrong:** this is Chromium from the Alpine package
repository, not Google Chrome or Chrome for Testing. Those are Google-branded builds under Google's
own terms and are not redistributed here. Bundling Chromium is unremarkable — every major distro
ships it. The defect was stripping the attribution, not shipping the browser.

The NOTICE also records that the Alpine build has H.264/AAC decoding enabled. That is a patent
matter rather than a copyright one, so BSD-3-Clause does not speak to it; BSI never decodes media,
so the capability is present only because it comes with the distribution package.

### Verified by building the image

| | Published 4.0.0 | This branch |
|---|---|---|
| Licence files in `node_modules` | 23 | 162 |
| …lost to the `*.md` pattern | 9 | 0 |
| `/nodeapp/licenses/` | absent | 3 files |
| `README.md` still stripped | yes | yes |
| Image size | 1.31 GB | 1.31 GB |

## 2. Certificate tolerance had silently stopped working

`launchBrowserForApp` passed `ignoreHTTPSErrors: true` — an option Puppeteer **removed in v23** and
replaced with `acceptInsecureCerts`. Unknown options are ignored in silence, so the line looked like
certificate tolerance while providing none. Grep the installed puppeteer-core 25.2.0 and there are
zero hits for the old name, in the code and in the type definitions alike.

Tolerance was resting entirely on the `--ignore-certificate-errors` browser flag, which is why it
went unnoticed. It matters most on QSEoW, where self-signed certificates are the norm.

The three tests covering this **asserted the broken shape** — requiring `ignoreHTTPSErrors` and
forbidding `acceptInsecureCerts`, under names claiming v25 compatibility. They came from e28810b,
the v25 upgrade itself, which encoded the rename backwards and so locked the regression in. Each now
asserts the correct option and keeps a negative assertion on the old name, so a future edit copying
an older Puppeteer example reintroduces it as a test failure rather than as silence.

Confirmed red before the fix: three failures, each reporting exactly this substitution.

## Testing

- `npm run lint` — clean
- `npm run test:unit` — 959 passed, 54 suites
- Docker image built and inspected for every row in the table above

## Docs

`docs/to-doc-site/docker-image-third-party-licences.md` stages a draft covering what is inside the
image and its licensing. The doc site currently asserts an "embedded Chromium browser" and has no
licensing content anywhere, which is the first thing a security reviewer asks about. The draft's
version gate is deliberately unfilled — 4.0.0 shipped the same day and there is no open
release-please PR yet to read the next version from.

Follow-up issues filed from the same investigation: #929–#933 (air-gap options A1–A4 and a new A6,
sub-issues of #809) and #936 (documenting air-gapped Docker use, which already works today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
