### PR TITLE
docs: mark the four Docker drafts as published

### DIFF
--- a/docs/to-doc-site/done/done_docker-air-gapped-environments.md
+++ b/docs/to-doc-site/done/done_docker-air-gapped-environments.md
@@ -1,0 +1,461 @@
+# Running the Docker image in an air-gapped environment
+
+<!--
+PUBLISHED 2026-08-09.
+
+Doc site PR ptarmiganlabs/butler-sheet-icons-docs#57 (into next), published to production by #58.
+Landed on /guide/advanced/docker as the "Air-gapped environments" section, with cross-links added
+from /examples/docker and /guide/concepts/browser-detection-and-environment-variables.
+
+Changed at publication:
+  * The link to "What is inside the image" was dropped and replaced with plain text. That section
+    does not exist on the doc site - its draft still lives only on the unmerged branch
+    claude/docker-chromium-licensing-50d429 - and the site build does not catch dead #anchors.
+    Restore the link if that draft is ever published.
+
+Still open, and NOT a documentation problem:
+  * --port is accepted by the CLI but never read anywhere in the codebase, so the web UI is always
+    reached on 443/80. reference/qseow.md still documents it as "Web port" with the example
+    --port 8443. The published ports table avoids the question rather than repeating the error.
+-->
+
+Closes [#936](https://github.com/ptarmiganlabs/butler-sheet-icons/issues/936).
+
+Target page: `docs/guide/advanced/docker.md` — **an edit to an existing page, not a new one.**
+
+Two changes there:
+
+1. Replace the single bullet on line 8, which today is the entire coverage of air-gapped support.
+2. Add a new section, **"Air-gapped environments"**, after "Writing thumbnails to a mounted folder
+   on Linux".
+
+Also worth a one-line cross-link from `docs/examples/docker.md` (line 5 already claims air-gapped
+support without explaining it) and from
+`docs/guide/concepts/browser-detection-and-environment-variables.md` ("Docker image (embedded
+browser)" section).
+
+::: tip No version gate needed
+Everything below is true of the published **4.0.0** image and of earlier images — the embedded
+browser and the two environment variables that point at it have been in the image for a long time.
+4.0.0 is the current release (published 2026-08-09) and there is no open release-please PR, so
+nothing here is unreleased.
+
+The one exception is the `--user` / mounted-folder-ownership behaviour referenced from the worked
+example, which the doc site already gates at 4.0.0 on the same page.
+:::
+
+::: warning Depends on a neighbouring draft
+The proposed text links to a **"What is inside the image"** section that does not exist on the site
+yet. It comes from `docs/to-doc-site/docker-image-third-party-licences.md`, which currently lives
+only on the unmerged branch `claude/docker-chromium-licensing-50d429` and is **not** in
+`docs/to-doc-site/` on `main`.
+
+If that draft is published first, keep the link. If not, replace
+`[What is inside the image](#what-is-inside-the-image)` with a plain sentence — the site build fails
+on dead links, but an anchor within the same page is **not** checked by the build, so a stale anchor
+would ship silently.
+:::
+
+---
+
+## Replacement for the bullet on line 8
+
+> - Includes an embedded Chromium browser, so it needs no internet access at all — see
+>   [Air-gapped environments](#air-gapped-environments)
+
+---
+
+## New section
+
+> ## Air-gapped environments
+>
+> The Docker image is the easiest way to run Butler Sheet Icons on a server that has no internet
+> access. Everything it needs to open your Qlik Sense sheets and photograph them — including the
+> browser — is already inside the image. Nothing is downloaded at run time.
+>
+> ### "Air-gapped" does not mean "no network"
+>
+> This is the one thing to get right before anything else.
+>
+> The container needs **no internet access**. That is what the embedded browser buys you: on a
+> machine with internet, Butler Sheet Icons would download a browser the first time it needed one,
+> and inside this image it never has to.
+>
+> The container still needs **network access to your Qlik Sense server**. That is not internet
+> access — it is a route to a server on your own network — but it is a network requirement, and a
+> container with no networking at all cannot do the job.
+>
+> If you take away the container's network entirely, the run fails as soon as it tries to talk to
+> Qlik Sense:
+>
+> ```
+> error: QSEOW CONTENT LIBRARY 1 (stack): Error: QRS request error:Error: getaddrinfo EAI_AGAIN qlik-server.company.com
+> ```
+>
+> ::: warning `--network none` is a test, not a deployment mode
+> You will see `--network none` used further down this page. It is there to **prove** that the
+> browser inside the image works with no internet whatsoever. A real run started that way cannot
+> reach Qlik Sense and will always fail. Do not carry it over into your scheduled job.
+> :::
+>
+> ### What the container needs to reach
+>
+> For **Qlik Sense Enterprise on Windows**, all three of these are on your own Sense server:
+>
+> | Destination | Port | Used for | Option that changes it |
+> |---|---|---|---|
+> | Qlik Sense proxy (the web UI) | 443 for `https`, 80 for `http` | The browser opens each sheet here, the same way a user would | — |
+> | Qlik Sense Engine Service | 4747 | Reading which sheets an app contains | `--engineport` |
+> | Qlik Sense Repository Service (QRS) | 4242 | Looking up apps and tags, and uploading the finished thumbnails to the content library | `--qrsport` |
+>
+> Ports 4747 and 4242 are certificate-authenticated, which is why the QSEoW examples mount a
+> certificate directory.
+>
+> **Outbound internet access is not needed for any of this**, provided you leave `--browser-version`
+> alone — see [Browser versions on an air-gapped host](#browser-versions-on-an-air-gapped-host)
+> below.
+>
+> ::: tip Qlik Sense Cloud is a different story
+> Qlik Sense Cloud lives on the public internet, so a genuinely air-gapped host cannot use the
+> `qscloud` commands at all. Everything on this page is about **QSEoW**.
+> :::
+>
+> ### Why the image is the easiest option
+>
+> The image already contains a Chromium browser — around 260 MB of the image, and the reason it is
+> as large as it is. See [What is inside the image](#what-is-inside-the-image) for the full
+> inventory.
+>
+> Two environment variables are set inside the image and point Butler Sheet Icons at that browser:
+>
+> ```
+> PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+> PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+> ```
+>
+> You do not need to set these yourself, and in normal use you should not change them. They are what
+> makes the container decide which browser to use **without asking the internet first**.
+>
+> ### Getting the image across the gap
+>
+> The image itself has to get onto the air-gapped host somehow. There are two usual routes; pick
+> whichever matches how your organization already moves software.
+>
+> #### Decide which version you are approving
+>
+> Before either route, decide what you are transferring. `:latest` moves whenever a new release
+> ships, which is usually not what a change-controlled environment wants. These tags are published:
+>
+> | Tag | Points at |
+> |---|---|
+> | `latest` | The newest release. Changes over time. |
+> | `4` | The newest 4.x release. |
+> | `4.0` | The newest 4.0.x release. |
+> | `4.0.0` | Exactly that release. Does not move. |
+>
+> Even a version tag can in principle be re-pushed. For an audit trail that cannot move at all, pin
+> by digest:
+>
+> ```bash
+> docker pull ptarmiganlabs/butler-sheet-icons@sha256:20f3621e937f0b9763dac6a69a53a8979a04debca2ac2666b53785a89cd1f617
+> ```
+>
+> That digest is the 4.0.0 image. Find the digest of any image you already have with:
+>
+> ```bash
+> docker image inspect ptarmiganlabs/butler-sheet-icons:4.0.0 --format '{{index .RepoDigests 0}}'
+> ```
+>
+> #### Route 1: transfer the image as a file
+>
+> On a machine that **does** have internet access:
+>
+> ```bash
+> docker pull --platform linux/amd64 ptarmiganlabs/butler-sheet-icons:4.0.0
+> docker save ptarmiganlabs/butler-sheet-icons:4.0.0 -o butler-sheet-icons-4.0.0.tar
+> ```
+>
+> Move `butler-sheet-icons-4.0.0.tar` across the gap by whatever means your organization allows, then
+> on the air-gapped host:
+>
+> ```bash
+> docker load -i butler-sheet-icons-4.0.0.tar
+> ```
+>
+> which reports:
+>
+> ```
+> Loaded image: ptarmiganlabs/butler-sheet-icons:4.0.0
+> ```
+>
+> ::: warning `--platform` is not optional if the two machines differ
+> `docker save` only packs the processor architecture the staging machine actually pulled. Pull on an
+> Apple Silicon Mac and you get an ARM64-only archive, which will not run on an x64 Linux server —
+> even though the tag itself covers both architectures.
+>
+> Almost every Qlik Sense server is x64, so `--platform linux/amd64` is the right choice for nearly
+> everyone. If you prefer, the per-architecture tags `4.0.0-amd64` and `4.0.0-arm64` do the same job
+> and are harder to get wrong.
+> :::
+>
+> The archive is about **355 MB**. Compressing it is not worth the effort — the layers inside are
+> already compressed, so gzip saves well under 1%.
+>
+> #### Route 2: publish to an internal registry
+>
+> If you run an internal registry — Artifactory, Harbor, ECR, or similar — mirror the image into it
+> once, and the air-gapped hosts pull from there like any other internal image:
+>
+> ```bash
+> # On a machine with internet access
+> docker pull --platform linux/amd64 ptarmiganlabs/butler-sheet-icons:4.0.0
+> docker tag ptarmiganlabs/butler-sheet-icons:4.0.0 registry.internal.company.com/qlik/butler-sheet-icons:4.0.0
+> docker push registry.internal.company.com/qlik/butler-sheet-icons:4.0.0
+> ```
+>
+> ```bash
+> # On the air-gapped host
+> docker pull registry.internal.company.com/qlik/butler-sheet-icons:4.0.0
+> ```
+>
+> This is the better route if more than one host needs the image, or if you already scan images
+> centrally before they are allowed in.
+>
+> ### Verify it before going near production
+>
+> These checks need nothing except the image itself. Run them on the air-gapped host after loading
+> the image, before you point anything at a production Qlik Sense server.
+>
+> `--network none` gives the container no networking at all, which is exactly the point: whatever
+> succeeds under it cannot possibly have used the internet.
+>
+> **1. Butler Sheet Icons starts with no network:**
+>
+> ```bash
+> docker run --rm --network none ptarmiganlabs/butler-sheet-icons:4.0.0 --version
+> ```
+>
+> ```
+> 4.0.0
+> ```
+>
+> **2. The embedded browser is present and runs:**
+>
+> ```bash
+> docker run --rm --network none \
+>   --entrypoint /usr/bin/chromium-browser \
+>   ptarmiganlabs/butler-sheet-icons:4.0.0 --version
+> ```
+>
+> ```
+> Chromium 150.0.7871.181 Alpine Linux
+> ```
+>
+> The exact build depends on which Chromium version Alpine Linux was publishing when the image was
+> built, so a different image may print a different number. What matters is that a version prints at
+> all — that means the browser is there and can start.
+>
+> **3. The browser can actually render a page with no network:**
+>
+> ```bash
+> docker run --rm --network none \
+>   --entrypoint /usr/bin/chromium-browser \
+>   ptarmiganlabs/butler-sheet-icons:4.0.0 \
+>   --headless --no-sandbox --disable-gpu --dump-dom about:blank 2>/dev/null
+> ```
+>
+> ```
+> <html><head></head><body></body></html>
+> ```
+>
+> ::: tip The `2>/dev/null` is deliberate
+> Without it this command prints around 130 lines of Chromium diagnostics — complaints about D-Bus,
+> Vulkan and the GPU, all marked `ERROR`. They are normal for a browser running headless in a
+> container with no desktop and no graphics card, and they do not mean the check failed. The
+> `2>/dev/null` hides them so you can see the one line that matters.
+>
+> Judge this check on the `<html>` line, not on the absence of error text.
+>
+> The commands on this page are written for a Linux shell, since that is where an air-gapped Docker
+> host almost always is. In PowerShell the equivalent is `2>$null`.
+> :::
+>
+> **4. A real run says which browser it chose.** Once you point the container at Qlik Sense, a
+> healthy air-gapped run logs this sequence. It is worth searching your logs for, because it is the
+> proof that Butler Sheet Icons never went looking for a browser on the internet:
+>
+> ```
+> info: Browser version "recommended" resolved to chrome build 150.0.7871.24 (the build this version of Butler Sheet Icons is tested with)
+> info: Checking for available browsers...
+> info: Found system browser at: /usr/bin/chromium-browser
+> info: Using system browser (PUPPETEER_EXECUTABLE_PATH is set)
+> info: Browser ready from system: chrome system-installed
+> ```
+>
+> ::: tip Two different version numbers, and that is fine
+> The first line names the build Butler Sheet Icons was tested against. The browser that actually
+> runs is the one in the image, which is a different build — the last line says `system-installed`
+> rather than a version number for exactly that reason.
+>
+> The two numbers are not supposed to match, and a mismatch is not something to fix.
+> :::
+>
+> ### A complete QSEoW example
+>
+> On the air-gapped host, with the image already loaded:
+>
+> ```bash
+> mkdir -p "$HOME/bsi/img"
+> # $HOME/bsi/cert holds client.pem and client_key.pem, exported from the QMC
+>
+> docker run -it --rm \
+>   --name butler-sheet-icons \
+>   -v "$HOME/bsi/img:/nodeapp/img" \
+>   -v "$HOME/bsi/cert:/nodeapp/cert" \
+>   ptarmiganlabs/butler-sheet-icons:4.0.0 \
+>   qseow create-sheet-thumbnails \
+>   --host qlik-server.company.com \
+>   --appid a3e0f5d2-000a-464f-998d-33d333b175d7 \
+>   --apiuserdir Internal \
+>   --apiuserid sa_api \
+>   --logonuserdir Internal \
+>   --logonuserid your-username \
+>   --logonpwd your-password \
+>   --contentlibrary "Butler sheet thumbnails" \
+>   --sense-version 2025-Nov \
+>   --imagedir ./img
+> ```
+>
+> Notice what is **not** in that command: nothing about browsers. That is the whole point — on an
+> air-gapped host the browser question is already answered by the image.
+>
+> Two details that matter more here than elsewhere:
+>
+> - **Mount a folder you own** for the images. On a Linux host the container adopts the owner of the
+>   mounted image directory so the thumbnails belong to you — see
+>   [Writing thumbnails to a mounted folder on Linux](#writing-thumbnails-to-a-mounted-folder-on-linux).
+>   That directory has to be writable; a `:ro` mount there stops the run.
+> - **The certificate directory is only ever read**, so mounting it `:ro` is fine and is a reasonable
+>   precaution for files that authenticate you to Qlik Sense.
+>
+> ### Browser versions on an air-gapped host
+>
+> Leave `--browser-version` alone. The default, `recommended`, is the only value that never needs the
+> internet.
+>
+> This surprises people, because the image contains a browser and it seems like the version question
+> is settled. It is not quite: Butler Sheet Icons works out which browser build was asked for
+> **before** it looks at which browsers are available, and some values can only be answered by asking
+> the browser vendor's version service — a service that does not exist on your network.
+>
+> | `--browser-version` | On an air-gapped host |
+> |---|---|
+> | `recommended` (the default) | **Works.** No lookup — the answer is built into Butler Sheet Icons. |
+> | `stable`, `latest`, a channel such as `beta` | **Works, but slowly and noisily.** The lookup fails, two warnings are logged, and the run continues with the embedded browser. Costs several seconds per run, waiting for a name lookup that cannot succeed. |
+> | A milestone or build prefix, e.g. `151` or `151.0.7922` | **Fails the whole run.** The lookup fails and Butler Sheet Icons stops rather than quietly running a build you did not ask for. |
+> | A full build id, e.g. `151.0.7922.77` | **Works, but is ignored.** No lookup is needed, and the embedded browser is used regardless. Butler Sheet Icons warns that your pin was overridden. |
+>
+> In the failing case, the reported error names the host that could not be reached:
+>
+> ```
+> getaddrinfo EAI_AGAIN googlechromelabs.github.io
+> ```
+>
+> That host is Google's index of Chrome builds. It is on the public internet, so an air-gapped host
+> will never reach it — which is the whole reason to leave `--browser-version` at `recommended`.
+>
+> The two warnings in the second case are:
+>
+> ```
+> warn: Could not resolve --browser-version "stable": getaddrinfo EAI_AGAIN googlechromelabs.github.io
+> warn: Falling back to the newest browser already in the local cache.
+> ```
+>
+> The second warning mentions a local cache. Inside the Docker image that cache is empty, and the
+> run does not need it — the embedded browser is found first, and the next line will be
+> `Found system browser at: /usr/bin/chromium-browser`. There is no cache to go and populate.
+>
+> The bottom line: **inside the Docker image, `--browser-version` cannot change which browser runs.**
+> All it can do is decide whether your run needs the internet. See
+> [Browser detection and environment variables](/guide/concepts/browser-detection-and-environment-variables)
+> for the full picture.
+>
+> ### If you do not want the embedded browser
+>
+> Some organizations require a centrally approved browser build rather than the one in the image.
+> Set `PUPPETEER_EXECUTABLE_PATH` to an empty string and mount a browser cache from the host, and
+> Butler Sheet Icons will use that instead. This needs no internet either, as long as the cache is
+> populated before the machine goes offline.
+>
+> That is described on
+> [Browser detection and environment variables](/guide/concepts/browser-detection-and-environment-variables#docker-image-with-external-browser)
+> and is not repeated here.
+>
+> ### Running Butler Sheet Icons air-gapped without Docker
+>
+> The pre-built binaries contain no browser, so an air-gapped host running them has to be given one
+> up front. See
+> [Strategy 3: use a pre-cached browser](/guide/concepts/browser-detection-and-environment-variables#strategy-3-use-a-pre-cached-browser-semi-offline).
+
+---
+
+## How this was verified
+
+All of it was executed on 2026-08-09 against the published image
+`ptarmiganlabs/butler-sheet-icons@sha256:20f3621e937f0b9763dac6a69a53a8979a04debca2ac2666b53785a89cd1f617`,
+which is what `ptarmiganlabs/butler-sheet-icons:latest`, `:4`, `:4.0` and `:4.0.0` all resolved to at
+the time. Re-run before publishing rather than trusting these numbers.
+
+| Claim | How it was checked | Result |
+|---|---|---|
+| Chromium runs with no network at all | `docker run --rm --network none --entrypoint /usr/bin/chromium-browser … --dump-dom about:blank` | `<html><head></head><body></body></html>`, exit 0 |
+| …and prints ~130 lines of stderr while doing so | Same command, `2>&1 >/dev/null \| wc -l` | 130 |
+| Chromium version | `--entrypoint /usr/bin/chromium-browser … --version` | `Chromium 150.0.7871.181 Alpine Linux` |
+| Chromium size | `apk info -s chromium` inside the container | 263 MiB installed |
+| Butler Sheet Icons starts offline | `docker run --rm --network none … --version` | `4.0.0` |
+| The two environment variables | `docker image inspect … --format '{{json .Config.Env}}'` | Both present, values as quoted |
+| Browser detection resolves offline | `detectAvailableBrowser({browser:'chrome'})` run inside the container under `--network none` | `{"executablePath":"/usr/bin/chromium-browser","source":"system","browser":"chrome","buildId":"system-installed"}` |
+| The healthy-run log sequence | `resolveBrowserExecutablePath()` under `--network none` | Exactly as quoted, including the `resolved to chrome build 150.0.7871.24` line |
+| `--browser-version` behaviour | `resolveBrowserExecutablePath()` under `--network none` with `recommended`, `stable`, `151`, `151.0.7922.77` | Works / warns and continues / throws / works but overridden. Elapsed: 0 s, ~6 s, ~5 s, 0 s |
+| Losing the network fails at Qlik Sense | Full `qseow create-sheet-thumbnails` under `--network none` with a self-signed certificate pair | `QRS request error:Error: getaddrinfo EAI_AGAIN qlik-server.company.com`, after about 5 s |
+| A read-only certificate mount is fine | Same run with `-v …/cert:/nodeapp/cert:ro` | Reached the Qlik Sense connection, so the certificates were read successfully |
+| Published tags | Docker Hub API, `/v2/repositories/ptarmiganlabs/butler-sheet-icons/tags/` | `latest`, `4`, `4.0`, `4.0.0` all share one multi-arch digest; `…-amd64` and `…-arm64` variants are single-architecture |
+| The multi-arch manifest, from the registry | `docker buildx imagetools inspect ptarmiganlabs/butler-sheet-icons:latest` | `linux/amd64` (`ae7892c8…`) and `linux/arm64` (`1a39c8ed…`), each with an attestation manifest |
+| `4.0.0-amd64` really is amd64 | `docker buildx imagetools inspect ptarmiganlabs/butler-sheet-icons:4.0.0-amd64` | One `linux/amd64` manifest, `ae7892c8…` — the same one the multi-arch tag carries |
+| Pinning by digest works | `docker pull ptarmiganlabs/butler-sheet-icons@sha256:20f3621e…` | `Status: Image is up to date for …@sha256:20f3621e…` |
+| `docker save` is single-architecture | Unpacked the archive and compared the manifests it references against the blobs it contains | Index lists `linux/amd64` and `linux/arm64`; only the `linux/arm64` manifest blob (`1a39c8ed…`) is present — the `linux/amd64` one (`ae7892c8…`) is not |
+| Archive size | `docker save` then `gzip -c` | 355 MB, gzip 354 MB |
+| `docker load` round trip | `docker load -i` | `Loaded image: ptarmiganlabs/butler-sheet-icons:latest` |
+| Ports | `src/lib/qseow/qseow-enigma.js`, `qseow-qrs.js`, `qseow-process-app.js` | Engine `--engineport` 4747, QRS `--qrsport` 4242, browser URL built with no port so 443/80 |
+
+### Two things deliberately **not** claimed as end-to-end verified
+
+**The `--browser-version 151` failure was verified one level down, not through a full run.** A
+complete `qseow create-sheet-thumbnails` under `--network none` never reaches the browser at all —
+it fails earlier, at the content library check, because Qlik Sense is unreachable too. On a real
+air-gapped host, where Qlik Sense *is* reachable, that earlier check succeeds and the run proceeds
+to the browser, which is the point at which the pin fails. The behaviour was therefore confirmed by
+calling `resolveBrowserExecutablePath()` directly inside the container.
+
+**The image was *run* on `linux/arm64` only.** The `linux/amd64` manifest was confirmed to exist and
+to be what `4.0.0-amd64` points at, and it is built from the same `src/Dockerfile` in the same
+workflow run — but no command was executed inside it. The Chromium build number quoted above
+therefore comes from the ARM64 image, which is why the text tells readers to judge that check on "a
+version prints" rather than on matching the string.
+
+## Notes for the doc pass
+
+**`--port` does nothing, and `reference/qseow.md` says otherwise.** The option is defined
+(`BSI_QSEOW_CST_PORT`, described as "Qlik Sense http/https port") but its value is never read
+anywhere in the codebase. The browser URL is built as `https://<host>[/<prefix>]/sense/app/<id>`
+with no port, so the web UI is always reached on 443, or 80 when `--secure false` is used. The
+reference page currently documents it as "Web port" with the example `--port 8443`, which will not
+work.
+
+This is a **code** defect rather than a documentation one, and the ports table above is written to
+be correct either way — it simply does not offer `--port` as the thing that changes the web port.
+Worth raising as its own issue rather than papering over on the doc site.
+
+**When #809 lands**, the native/Windows air-gapped page and this section should link to each other.
+This section deliberately says only one sentence about binaries, so there is nothing to keep in
+sync.

--- a/docs/to-doc-site/done/done_docker-air-gapped-environments.md
+++ b/docs/to-doc-site/done/done_docker-air-gapped-environments.md
@@ -9,9 +9,12 @@ from /examples/docker and /guide/concepts/browser-detection-and-environment-vari
 
 Changed at publication:
   * The link to "What is inside the image" was dropped and replaced with plain text. That section
-    does not exist on the doc site - its draft still lives only on the unmerged branch
-    claude/docker-chromium-licensing-50d429 - and the site build does not catch dead #anchors.
-    Restore the link if that draft is ever published.
+    does not exist on the doc site yet, and the site build does not catch dead #anchors.
+
+    Its draft is docs/to-doc-site/docker-image-third-party-licences.md, which IS on main and is
+    still pending publication - the code half of that work merged as PR #937 and ships in 4.0.1.
+    Restore the link when that draft is published. (An earlier version of this note said the draft
+    was on an unmerged branch; that was read from a stale worktree predating the #937 merge.)
 
 Still open, and NOT a documentation problem:
   * --port is accepted by the CLI but never read anywhere in the codebase, so the web UI is always

--- a/docs/to-doc-site/done/done_docker-browser-management-section-is-wrong.md
+++ b/docs/to-doc-site/done/done_docker-browser-management-section-is-wrong.md
@@ -1,0 +1,247 @@
+# The "Docker usage" section of the Browser Management examples is wrong
+
+<!--
+PUBLISHED 2026-08-09.
+
+Doc site PR ptarmiganlabs/butler-sheet-icons-docs#61 (into next), published to production by #62.
+Landed on /examples/browser-management, replacing the "Docker usage" section. Published together
+with docker-external-browser-cache-example-cannot-work.md, since the two cross-link.
+
+Not verified before publication:
+  * The `browser install` command in the published text was never executed - it needs internet
+    access to Google's browser download service. Its mechanism was confirmed from the code and by
+    mounting a hand-prepared cache folder. The build id 151.0.7922.77 is an example and was not
+    checked against Google's current index.
+
+Not done, deliberately:
+  * 121.0.6167.85 (a Chrome 121 build from early 2024) still appears 12 times elsewhere on that
+    page. Normalising it is cosmetic and would have buried the corrections in an unrelated diff.
+-->
+
+
+Target page: `docs/examples/browser-management.md` — **replace the "Docker usage" section**
+(currently lines 226–276). Nothing else on that page needs to change.
+
+This is a correction, not new material. The section as published tells administrators to do three
+things in a row, and **none of the three does what the page says it does**. Someone following it
+will conclude that browser management in Docker is broken, when in fact there is simply nothing to
+manage.
+
+::: tip No version gate needed
+This has always been how the image behaves. It is not a change in 4.0.0 — the published text was
+never right.
+:::
+
+::: warning Publish after `docker-air-gapped-environments.md`, or adjust two links
+The replacement text links to `/guide/advanced/docker#air-gapped-environments` and
+`/guide/advanced/docker#browser-versions-on-an-air-gapped-host`. Both anchors are created by the
+`docker-air-gapped-environments.md` draft in this folder.
+
+The site build catches a dead **page** link but not a dead `#anchor`, so publishing this one first
+would leave two links that quietly go nowhere. Either publish that draft first, or point both links
+at `/guide/advanced/docker` without the fragment.
+:::
+
+---
+
+## What the page says today
+
+> ## Docker usage
+>
+> Browsers in Docker are downloaded inside the container.
+>
+> ```bash
+> # List browsers in container
+> docker run -it --rm ptarmiganlabs/butler-sheet-icons:latest browser list-installed
+>
+> # Install a specific Chrome build in container
+> docker run -it --rm ptarmiganlabs/butler-sheet-icons:latest browser install --browser chrome --browser-version 121.0.6167.85
+>
+> # Use that build for sheet icons
+> docker run -it --rm \
+>   -v $(pwd)/images:/nodeapp/img \
+>   ptarmiganlabs/butler-sheet-icons:latest \
+>   qscloud create-sheet-icons \
+>   … \
+>   --browser chrome \
+>   --browser-version 121.0.6167.85 \
+>   --headless true
+> ```
+
+## Why each part is wrong
+
+**"Browsers in Docker are downloaded inside the container."** No download happens. The image ships
+with a Chromium browser already installed at `/usr/bin/chromium-browser`, and
+`PUPPETEER_EXECUTABLE_PATH` inside the image points Butler Sheet Icons straight at it. That is the
+whole reason the image works without internet access.
+
+**`browser list-installed`** reports nothing, which reads like a fault but is correct:
+
+```
+info: No browsers installed
+```
+
+That command lists the *managed browser cache* — browsers Butler Sheet Icons downloaded itself. The
+embedded Chromium is a system package, not a cache entry, so it is not listed. Nothing is wrong.
+
+**`browser install` in a `--rm` container** downloads into a container that is deleted the moment
+the command finishes, so the download is thrown away. It also needs internet access, which defeats
+the main reason to choose the image in the first place.
+
+**The third command does not use the build the second one installed.** Each `docker run` is a
+separate container, so nothing carries over — but even within one container it would make no
+difference, because the embedded browser wins. Butler Sheet Icons says so explicitly:
+
+```
+warn: PUPPETEER_EXECUTABLE_PATH overrides --browser-version "121.0.6167.85": the browser at /usr/bin/chromium-browser will be used instead. Unset PUPPETEER_EXECUTABLE_PATH to use the requested build.
+```
+
+## Proposed replacement
+
+> ## Docker usage
+>
+> **The Docker image already contains a browser, and the `browser` commands are not how you manage
+> it.**
+>
+> Chromium is installed inside the image, and the image is configured to use it. This is deliberate:
+> it is what lets the container run on a server with no internet access. See
+> [Air-gapped environments](/guide/advanced/docker#air-gapped-environments).
+>
+> ### What to expect
+>
+> `browser list-installed` reports nothing when run against the image:
+>
+> ```bash
+> docker run --rm ptarmiganlabs/butler-sheet-icons:latest browser list-installed
+> ```
+>
+> ```
+> info: No browsers installed
+> ```
+>
+> **This is correct, not a fault.** That command lists browsers Butler Sheet Icons downloaded and
+> cached for itself. The browser in the image is a system package installed when the image was
+> built, so it does not appear there.
+>
+> To see which browser the container will actually use:
+>
+> ```bash
+> docker run --rm --entrypoint /usr/bin/chromium-browser \
+>   ptarmiganlabs/butler-sheet-icons:latest --version
+> ```
+>
+> ```
+> Chromium 150.0.7871.181 Alpine Linux
+> ```
+>
+> ### `--browser-version` has no effect inside the image
+>
+> Passing `--browser-version` to a thumbnail command in the container does not change which browser
+> runs. Butler Sheet Icons uses the embedded one and tells you it has done so:
+>
+> ```
+> warn: PUPPETEER_EXECUTABLE_PATH overrides --browser-version "121.0.6167.85": the browser at /usr/bin/chromium-browser will be used instead. Unset PUPPETEER_EXECUTABLE_PATH to use the requested build.
+> ```
+>
+> Worse, on a machine without internet access, some values of `--browser-version` will make the run
+> **fail** while still not changing the browser — because the version has to be resolved before the
+> browser is chosen. Leave it at its default, `recommended`, when running in Docker. The reasoning is
+> in [Browser versions on an air-gapped host](/guide/advanced/docker#browser-versions-on-an-air-gapped-host).
+>
+> ### If you need a different browser build
+>
+> `browser install` on its own achieves nothing here: in a `--rm` container the download lands
+> somewhere that is deleted seconds later. Using a browser other than the embedded one takes three
+> things together, and leaving out any one of them breaks the run.
+>
+> **1. Put a browser in a folder on the host that the container can see.** Mount the folder and run
+> `browser install` *inside the container*, so the browser that gets downloaded is a Linux build —
+> which is what a Linux container can run. This step needs internet access:
+>
+> ```bash
+> mkdir -p "$HOME/bsi/browser-cache"
+>
+> docker run --rm \
+>   -v "$HOME/bsi/browser-cache:/home/nodejs/.cache/puppeteer" \
+>   ptarmiganlabs/butler-sheet-icons:latest \
+>   browser install --browser chrome --browser-version 151.0.7922.77
+> ```
+>
+> **2. Mount that folder on every later run, and empty `PUPPETEER_EXECUTABLE_PATH`** so the embedded
+> browser stops winning.
+>
+> **3. Ask for the same build you installed.** Butler Sheet Icons looks for the exact build id that
+> `--browser-version` resolves to, so the two have to agree:
+>
+> ```bash
+> docker run --rm \
+>   -v "$HOME/bsi/browser-cache:/home/nodejs/.cache/puppeteer" \
+>   -v "$HOME/bsi/img:/nodeapp/img" \
+>   -e PUPPETEER_EXECUTABLE_PATH="" \
+>   ptarmiganlabs/butler-sheet-icons:latest \
+>   qscloud create-sheet-thumbnails \
+>   --browser-version 151.0.7922.77 \
+>   --tenanturl mytenant.eu.qlikcloud.com \
+>   --apikey "$BSI_API_KEY" \
+>   --logonuserid user@company.com \
+>   --logonpwd "$BSI_PASSWORD" \
+>   --appid 12345678-1234-1234-1234-123456789012 \
+>   --imagedir ./img
+> ```
+>
+> A successful run says which one it picked:
+>
+> ```
+> info: Using cached browser: chrome 151.0.7922.77
+> info: Browser ready from cache: chrome 151.0.7922.77
+> ```
+>
+> ::: warning Do not mount a browser folder built on Windows or macOS
+> The folder has to contain a **Linux** browser. A cache filled by running Butler Sheet Icons on a
+> Windows desktop contains Windows builds, and mounting it into the container does not fail cleanly —
+> Butler Sheet Icons accepts the entry and then tries to start a `.exe` inside a Linux container.
+>
+> Filling the folder with the command in step 1 avoids this, because the download then happens inside
+> the container. See
+> [Docker image with external browser](/guide/concepts/browser-detection-and-environment-variables#docker-image-with-external-browser).
+> :::
+>
+> ::: warning Clearing `PUPPETEER_EXECUTABLE_PATH` without providing a browser breaks the run
+> With the variable emptied and no usable cache mounted, the container has no browser and tries to
+> download one. On a host with no internet access that ends the run:
+>
+> ```
+> info: No local browser found. Downloading and installing browser...
+> error: Error installing browser: Browser "chrome" version "recommended" cannot be downloaded. Please use the "list-available" command to check available versions
+> ```
+>
+> Mount the folder, or leave the embedded browser alone.
+> :::
+
+---
+
+## How this was verified
+
+Executed on 2026-08-09 against
+`ptarmiganlabs/butler-sheet-icons@sha256:20f3621e937f0b9763dac6a69a53a8979a04debca2ac2666b53785a89cd1f617`
+(the image `:latest` and `:4.0.0` both resolved to).
+
+| Claim | How it was checked | Result |
+|---|---|---|
+| The image contains a browser and points at it | `docker image inspect … --format '{{json .Config.Env}}'` | `PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser`, `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true` |
+| `browser list-installed` reports nothing | `docker run --rm --network none … browser list-installed` | `info: No browsers installed` |
+| Chromium version | `--entrypoint /usr/bin/chromium-browser … --version` | `Chromium 150.0.7871.181 Alpine Linux` |
+| `--browser-version` is overridden | `resolveBrowserExecutablePath({browser:'chrome',browserVersion:'151.0.7922.77'})` inside the container | Warning quoted above; `source: "system"` returned |
+| Emptying the variable with no cache fails offline | Same call with `-e PUPPETEER_EXECUTABLE_PATH=""` under `--network none` | Two log lines quoted above |
+| A mounted cache is used, and the build ids must match | Same call with a cache mounted at `/home/nodejs/.cache/puppeteer` containing build `151.0.7922.77` | `Using cached browser: chrome 151.0.7922.77`, `source: "cache"` |
+| A Windows build in that cache is accepted, not rejected | Same, with the cache entry named `chrome/win64-151.0.7922.77` | Returned `…/chrome-win64/chrome.exe` as the browser to run |
+| `browser install` writes to the mounted folder | `src/lib/browser/browser-install.js` | Installs into `homedir()/.cache/puppeteer`, which is `/home/nodejs/.cache/puppeteer` in the container |
+
+The override warning is emitted from `src/lib/browser/browser-detect.js`; the ordering that makes
+version resolution happen before browser detection is in `src/lib/browser/browser-launch.js`.
+
+## Note for the doc pass
+
+The version `121.0.6167.85` used throughout the current page is a Chrome 121 build from early 2024.
+Everything else on the site now uses 151-series examples. Worth normalising while the page is open,
+including in the sections above the Docker one — but that is cosmetic, unlike the corrections here.

--- a/docs/to-doc-site/done/done_docker-external-browser-cache-example-cannot-work.md
+++ b/docs/to-doc-site/done/done_docker-external-browser-cache-example-cannot-work.md
@@ -1,0 +1,247 @@
+# The "Docker image with external browser" example cannot work as written
+
+<!--
+PUBLISHED 2026-08-09.
+
+Doc site PR ptarmiganlabs/butler-sheet-icons-docs#61 (into next), published to production by #62.
+Landed on /guide/concepts/browser-detection-and-environment-variables, replacing the
+"Docker image with external browser" section. Published together with
+docker-browser-management-section-is-wrong.md, since the two cross-link.
+
+Not verified before publication:
+  * The `browser install` command in the published text was never executed - it needs internet
+    access. See the note in the neighbouring draft.
+
+Still open, and NOT a documentation problem:
+  * detectAvailableBrowser() in src/lib/browser/browser-detect.js filters cached browsers by type
+    and build id but not by platform, which is why a win64 build mounted into a Linux container is
+    accepted and returned as a .exe to run. Refusing it, or at least logging the mismatch, would
+    turn a confusing browser-launch failure into an obvious one.
+  * Unverified on Linux: when the container adopts the owner of the mounted image directory, the
+    entrypoint runs chown -R on /home/nodejs, which contains the mounted browser cache. Harmless
+    when both belong to the same person; not reproducible on macOS, where bind mounts appear
+    root-owned and adoption never triggers.
+-->
+
+
+Target page: `docs/guide/concepts/browser-detection-and-environment-variables.md` — **replace the
+"Docker image with external browser" section** (currently lines 325–357).
+
+This is a correction. The published example mounts a **Windows** browser folder into a **Linux**
+container, and omits the one option that decides whether the mounted browser is accepted at all.
+Following it produces a failure that does not explain itself.
+
+::: tip No version gate needed
+Both faults are in how the example was written, not in a behaviour that changed. The cache matching
+described here is the 4.0.0 behaviour the same page already documents under "Cached browser
+(medium priority)".
+:::
+
+::: warning One link depends on another draft
+The closing paragraph links to `/guide/advanced/docker#air-gapped-environments`, an anchor created by
+the `docker-air-gapped-environments.md` draft in this folder. The site build does not check
+`#anchor` fragments, so publish that draft first or drop the fragment.
+:::
+
+---
+
+## What is wrong with the published example
+
+The example tells a Windows administrator to mount `%USERPROFILE%\.cache\puppeteer` into the
+container and empty `PUPPETEER_EXECUTABLE_PATH`. Two separate things go wrong.
+
+**1. A browser downloaded on Windows cannot run in a Linux container.** Butler Sheet Icons stores
+each browser under a folder named for the operating system it was downloaded for — `win64-…` on
+Windows, `linux…` on Linux. Mounting a Windows folder into the container does not fail cleanly:
+Butler Sheet Icons accepts the entry and hands back a path ending in `chrome.exe`, which the
+container then tries to start. The run fails at the browser, with an error about the browser rather
+than about the mount.
+
+**2. The example passes no `--browser-version`, so nothing in the folder will match.** Butler Sheet
+Icons works out one exact build id first, then looks for that build and no other. The default,
+`recommended`, means the build Butler Sheet Icons itself was tested with — which is almost certainly
+not the build the administrator installed on their desktop.
+
+The result is a pair of log lines that look like a contradiction:
+
+```
+info: Found 1 cached browser(s)
+info: No local browser found. Downloading and installing browser...
+```
+
+Both lines are correct. A browser was found; it was not the requested build; so it was not used. On
+a machine with internet access the run then downloads the right build and carries on, and the
+mounted folder was pointless. On a machine without internet access the run fails:
+
+```
+error: Error installing browser: Browser "chrome" version "recommended" cannot be downloaded. Please use the "list-available" command to check available versions
+```
+
+## Proposed replacement
+
+> ### Docker image with external browser
+>
+> Sometimes you want the container to use a specific browser build rather than the Chromium that
+> comes with the image — usually because your organization approves browser versions centrally.
+>
+> This takes three things, and leaving out any one of them breaks the run:
+>
+> 1. A folder on the host holding a **Linux** browser build, mounted at
+>    `/home/nodejs/.cache/puppeteer` in the container.
+> 2. `PUPPETEER_EXECUTABLE_PATH` set to an empty string, so the embedded browser stops taking
+>    priority.
+> 3. `--browser-version` set to **the same build** that is in the folder.
+>
+> #### Fill the folder from inside a container
+>
+> The browser has to be a Linux build, because the container is Linux. The reliable way to get one
+> is to let the container download it — then it cannot be the wrong kind. This step needs internet
+> access, and is done once:
+>
+> ::: code-group
+>
+> ```bash [macOS/Linux]
+> mkdir -p "$HOME/bsi/browser-cache"
+>
+> docker run --rm \
+>   -v "$HOME/bsi/browser-cache:/home/nodejs/.cache/puppeteer" \
+>   ptarmiganlabs/butler-sheet-icons:latest \
+>   browser install --browser chrome --browser-version 151.0.7922.77
+> ```
+>
+> ```powershell [Windows PowerShell]
+> $cachePath = 'C:\bsi-browser-cache'
+> New-Item -ItemType Directory -Path $cachePath -Force | Out-Null
+>
+> docker run --rm `
+>   -v "${cachePath}:/home/nodejs/.cache/puppeteer" `
+>   ptarmiganlabs/butler-sheet-icons:latest `
+>   browser install --browser chrome --browser-version 151.0.7922.77
+> ```
+>
+> :::
+>
+> ::: danger Do not mount your own desktop's browser folder
+> On Windows, `%USERPROFILE%\.cache\puppeteer` holds browsers downloaded **for Windows**. Mounting it
+> into the container does not produce a clear error — Butler Sheet Icons accepts the entry and then
+> tries to run a `.exe` inside a Linux container. The same applies to a macOS cache.
+>
+> Use the command above instead, which downloads a Linux build into a folder you nominate.
+> :::
+>
+> #### Use it
+>
+> ::: code-group
+>
+> ```bash [macOS/Linux]
+> docker run --rm \
+>   -v "$HOME/bsi/browser-cache:/home/nodejs/.cache/puppeteer" \
+>   -v "$HOME/bsi/img:/nodeapp/img" \
+>   -e PUPPETEER_EXECUTABLE_PATH="" \
+>   ptarmiganlabs/butler-sheet-icons:latest \
+>   qscloud create-sheet-thumbnails \
+>   --browser-version 151.0.7922.77 \
+>   --tenanturl "$BSI_CLOUD_TENANT_URL" \
+>   --apikey "$BSI_CLOUD_API_KEY" \
+>   --appid "$BSI_CLOUD_APP_ID" \
+>   --imagedir ./img
+> ```
+>
+> ```powershell [Windows PowerShell]
+> $cachePath = 'C:\bsi-browser-cache'
+> $imgPath = 'C:\bsi-img'
+> New-Item -ItemType Directory -Path $imgPath -Force | Out-Null
+>
+> docker run --rm `
+>   -v "${cachePath}:/home/nodejs/.cache/puppeteer" `
+>   -v "${imgPath}:/nodeapp/img" `
+>   -e PUPPETEER_EXECUTABLE_PATH="" `
+>   ptarmiganlabs/butler-sheet-icons:latest `
+>   qscloud create-sheet-thumbnails `
+>   --browser-version 151.0.7922.77 `
+>   --tenanturl $env:BSI_CLOUD_TENANT_URL `
+>   --apikey $env:BSI_CLOUD_API_KEY `
+>   --appid $env:BSI_CLOUD_APP_ID `
+>   --imagedir ./img
+> ```
+>
+> :::
+>
+> A run that picked up the mounted browser says so:
+>
+> ```
+> info: Found 1 cached browser(s)
+> info: Using cached browser: chrome 151.0.7922.77
+> info: Browser ready from cache: chrome 151.0.7922.77
+> ```
+>
+> ::: warning "Found 1 cached browser(s)" followed by "No local browser found"
+> These two lines together mean the folder was read, but the browser in it is not the build that was
+> asked for — so it was skipped. Both lines are accurate; it is the pair that is confusing.
+>
+> The fix is to make `--browser-version` name the build that is actually in the folder. Run
+> `browser list-installed` with the folder mounted to see what that is:
+>
+> ```bash
+> docker run --rm \
+>   -v "$HOME/bsi/browser-cache:/home/nodejs/.cache/puppeteer" \
+>   ptarmiganlabs/butler-sheet-icons:latest \
+>   browser list-installed
+> ```
+> :::
+>
+> #### The simpler alternative
+>
+> If a specific build is not actually a requirement, do nothing: the browser inside the image is
+> already there, already Linux, and needs no internet access. See
+> [Air-gapped environments](/guide/advanced/docker#air-gapped-environments).
+
+---
+
+## How this was verified
+
+Executed on 2026-08-09 against
+`ptarmiganlabs/butler-sheet-icons@sha256:20f3621e937f0b9763dac6a69a53a8979a04debca2ac2666b53785a89cd1f617`
+(linux/arm64). Each check ran `resolveBrowserExecutablePath()` inside the container under
+`--network none`, with a prepared folder mounted at `/home/nodejs/.cache/puppeteer`.
+
+| Claim | Folder contained | Result |
+|---|---|---|
+| A matching build is used | `chrome/linux_arm-151.0.7922.77` | `Using cached browser: chrome 151.0.7922.77`, `source: "cache"` |
+| A Windows build is accepted rather than rejected | `chrome/win64-151.0.7922.77` | Returned `…/chrome-win64/chrome.exe` as the browser to run |
+| A non-matching build is skipped, with the confusing log pair | `chrome/linux_arm-151.0.7922.77`, asked for `recommended` | `Found 1 cached browser(s)` then `No local browser found. Downloading and installing browser...`, then the download failure quoted above |
+| `recommended` resolves to a fixed build | Same run | `Browser version "recommended" resolved to chrome build 150.0.7871.24` |
+| The cache folder path in the container | `os.homedir()` inside the container | `/home/nodejs`, so `/home/nodejs/.cache/puppeteer` — the mount point the page already uses is correct |
+| `browser install` writes there too | `src/lib/browser/browser-install.js` | Installs into `homedir()/.cache/puppeteer` |
+
+Exact-build matching is implemented in `src/lib/browser/browser-detect.js`; the platform of a cached
+entry is **not** part of that match, which is what lets the Windows build through.
+
+## Notes for the doc pass
+
+**The `browser install` command in the proposed text was not executed**, because it needs internet
+access to Google's browser download service, which was not available while this was written. The
+mechanism it relies on — that `browser install` writes into `homedir()/.cache/puppeteer`, and that
+detection reads the same folder — was verified from the code and by mounting a folder that was
+prepared by hand. Run it once before publishing.
+
+**The build id `151.0.7922.77` is an example.** Confirm it still exists, or pick a current one, when
+the page is written.
+
+**`$env:PUPPETEER_EXECUTABLE_PATH = ''` in the published example does nothing** and is dropped in the
+replacement. It sets the variable in the administrator's own PowerShell session; the `-e` flag on
+`docker run` is what reaches the container.
+
+**One thing to check on a Linux host before publishing.** When the container adopts the owner of the
+mounted image directory, its entrypoint runs `chown -R` on `/home/nodejs` so the adopted account has
+a usable home. A browser folder mounted at `/home/nodejs/.cache/puppeteer` sits inside that path. In
+the normal case the folder and the image directory belong to the same person, so the ownership does
+not change — but this was not reproducible on macOS, where Docker Desktop presents bind mounts as
+root-owned and the adoption never triggers. Worth confirming on Linux, especially if anyone mounts a
+shared browser folder.
+
+**This may be worth a code issue rather than only a doc fix.** A cached browser whose platform does
+not match the machine is silently treated as usable. Refusing it — or at least logging that a
+`win64` build was found on Linux — would turn a confusing browser-launch failure into an obvious
+one. That is a change to `detectAvailableBrowser` in `src/lib/browser/browser-detect.js`, which
+already filters by browser type and build id and could filter by platform in the same place.

--- a/docs/to-doc-site/done/done_docker-kubernetes-examples-do-not-run.md
+++ b/docs/to-doc-site/done/done_docker-kubernetes-examples-do-not-run.md
@@ -1,0 +1,216 @@
+# The Kubernetes examples in the Docker examples page do not run
+
+<!--
+PUBLISHED 2026-08-09.
+
+Doc site PR ptarmiganlabs/butler-sheet-icons-docs#59 (into next), published to production by #60.
+Landed on /examples/docker, replacing the Job and CronJob manifests.
+
+Added at publication, beyond what this draft proposed:
+  * A note that Docker Compose's command:, used correctly further up the same page, means what
+    Kubernetes calls args:. Without it the new "use args:, never command:" callout reads as
+    contradicting the Compose examples above it.
+-->
+
+
+Target page: `docs/examples/docker.md` — **fix the "Kubernetes Deployment" section** (the `Job` and
+`CronJob` manifests, currently lines 403–492). The rest of the page is fine.
+
+Both manifests fail immediately if anyone copies them. This is a correction, not new material.
+
+::: tip No version gate needed
+The manifests have never worked. This is not a change in behaviour.
+:::
+
+::: warning One link depends on another draft
+"Other changes to make in the same edit" links to
+`/guide/advanced/docker#decide-which-version-you-are-approving`, an anchor created by the
+`docker-air-gapped-environments.md` draft in this folder. The site build does not check `#anchor`
+fragments, so publish that draft first or drop the fragment. The other link on this page,
+`#writing-thumbnails-to-a-mounted-folder-on-linux`, already exists on the site.
+:::
+
+---
+
+## The problem
+
+Both manifests start the container like this:
+
+```yaml
+command:
+  - "node"
+  - "butler-sheet-icons.js"
+  - "qscloud"
+  - "create-sheet-icons"
+```
+
+There are two independent faults, either of which is enough to break the job.
+
+**The path is wrong.** Inside the image the application lives at `/nodeapp/src/butler-sheet-icons.js`,
+and the working directory is `/nodeapp`. The container exits at once:
+
+```
+Error: Cannot find module '/nodeapp/butler-sheet-icons.js'
+```
+
+**`command:` replaces the image's entrypoint.** In Kubernetes, `command:` overrides the image's
+`ENTRYPOINT` and `args:` overrides its `CMD`. The Butler Sheet Icons image does real work in its
+entrypoint: it decides which user the application should run as, based on who owns the directory the
+thumbnails are written to, and it makes sure that user has a usable home directory. Replacing
+`command:` skips all of it. Even with the path corrected, the pod would run as whatever user
+Kubernetes picked, without the adjustment the image makes for you — the same class of problem
+described under
+[Writing thumbnails to a mounted folder on Linux](/guide/advanced/docker#writing-thumbnails-to-a-mounted-folder-on-linux).
+
+**The fix for both is the same: use `args:`, and pass exactly what you would pass to
+`docker run`.**
+
+## Proposed replacement
+
+> ### Job Example
+>
+> Pass the Butler Sheet Icons command in `args:`, never in `command:`. `args:` supplies the
+> arguments and leaves the image's own entrypoint in place; `command:` replaces the entrypoint and
+> stops the container from setting itself up correctly.
+>
+> ```yaml
+> apiVersion: batch/v1
+> kind: Job
+> metadata:
+>   name: butler-sheet-icons-job
+> spec:
+>   template:
+>     spec:
+>       containers:
+>         - name: butler-sheet-icons
+>           image: ptarmiganlabs/butler-sheet-icons:4.0.0
+>           args:
+>             - "qscloud"
+>             - "create-sheet-thumbnails"
+>             - "--imagedir"
+>             - "./img"
+>           env:
+>             - name: BSI_QSCLOUD_CST_TENANTURL
+>               valueFrom:
+>                 secretKeyRef:
+>                   name: qlik-credentials
+>                   key: tenant-url
+>             - name: BSI_QSCLOUD_CST_APIKEY
+>               valueFrom:
+>                 secretKeyRef:
+>                   name: qlik-credentials
+>                   key: api-key
+>             - name: BSI_QSCLOUD_CST_LOGON_USER_ID
+>               valueFrom:
+>                 secretKeyRef:
+>                   name: qlik-credentials
+>                   key: user-id
+>             - name: BSI_QSCLOUD_CST_LOGON_PWD
+>               valueFrom:
+>                 secretKeyRef:
+>                   name: qlik-credentials
+>                   key: password
+>             - name: BSI_QSCLOUD_CST_COLLECTION_ID
+>               valueFrom:
+>                 configMapKeyRef:
+>                   name: qlik-config
+>                   key: collection-id
+>           volumeMounts:
+>             - name: images-volume
+>               mountPath: /nodeapp/img
+>       volumes:
+>         - name: images-volume
+>           emptyDir: {}
+>       restartPolicy: Never
+>   backoffLimit: 3
+> ```
+>
+> ::: tip The thumbnails do not need to survive the pod
+> `emptyDir` is thrown away when the pod ends, which is fine here. Butler Sheet Icons uploads each
+> thumbnail to Qlik Sense as it goes — the files on disk are working copies, not the result. Mount
+> something durable only if you also want to keep the images yourself.
+> :::
+>
+> ### CronJob Example
+>
+> ```yaml
+> apiVersion: batch/v1
+> kind: CronJob
+> metadata:
+>   name: butler-sheet-icons-cronjob
+> spec:
+>   schedule: "0 2 * * *" # Daily at 2 AM
+>   jobTemplate:
+>     spec:
+>       template:
+>         spec:
+>           containers:
+>             - name: butler-sheet-icons
+>               image: ptarmiganlabs/butler-sheet-icons:4.0.0
+>               args:
+>                 - "qscloud"
+>                 - "create-sheet-thumbnails"
+>                 - "--imagedir"
+>                 - "./img"
+>               env:
+>                 - name: BSI_QSCLOUD_CST_TENANTURL
+>                   valueFrom:
+>                     secretKeyRef:
+>                       name: qlik-credentials
+>                       key: tenant-url
+>                 # ... other environment variables
+>               volumeMounts:
+>                 - name: images-volume
+>                   mountPath: /nodeapp/img
+>           volumes:
+>             - name: images-volume
+>               emptyDir: {}
+>           restartPolicy: OnFailure
+> ```
+>
+> ::: warning If a security policy forces a fixed user
+> Where `securityContext.runAsUser` is mandatory, the image detects that it was not started as root
+> and hands straight over to the user you named. That is supported, but the container can then no
+> longer adapt to the volume for you — it is up to you to make sure the account can write to the
+> directory given by `--imagedir`.
+> :::
+
+## Other changes to make in the same edit
+
+- **`--imagedir /app/images` → `--imagedir ./img`, and the mount path to `/nodeapp/img`.** `/app` is
+  not a path the image knows about; `/nodeapp/img` is created when the image is built, with
+  ownership already set, and is what every other example on the site uses. Whether `/app/images`
+  would also have worked was not tested — there is no reason to keep it either way.
+- **`create-sheet-icons` → `create-sheet-thumbnails`.** Both are accepted — `create-sheet-icons` is a
+  documented alias — so this is a consistency fix rather than a correction.
+- **Pin the image.** `:4.0.0` rather than `:latest` for anything running on a schedule, so an
+  unattended nightly job does not change version underneath you. See
+  [Air-gapped environments](/guide/advanced/docker#decide-which-version-you-are-approving) for the
+  full list of published tags.
+
+---
+
+## How this was verified
+
+Executed on 2026-08-09 against
+`ptarmiganlabs/butler-sheet-icons@sha256:20f3621e937f0b9763dac6a69a53a8979a04debca2ac2666b53785a89cd1f617`.
+
+| Claim | How it was checked | Result |
+|---|---|---|
+| The path in the published manifests is wrong | `docker run --rm --entrypoint node <image> butler-sheet-icons.js --version` | `Error: Cannot find module '/nodeapp/butler-sheet-icons.js'` |
+| The correct path is `src/butler-sheet-icons.js` | `docker run --rm --entrypoint node <image> src/butler-sheet-icons.js --version` | `4.0.0` |
+| Passing arguments only — the `args:` form — works | `docker run --rm <image> qscloud create-sheet-thumbnails --help` | Full help text |
+| The image does work in its entrypoint | `docker image inspect … --format '{{json .Config.Entrypoint}}'` | `["/sbin/tini","--","/usr/local/bin/docker-entrypoint.sh"]` |
+| The entrypoint hands over when not started as root | `src/docker-entrypoint.sh` | `if [ "$(id -u)" -ne 0 ]` branch execs `node` directly |
+| `create-sheet-icons` is a valid alias | `docker run --rm <image> qscloud --help` | `create-sheet-thumbnails\|create-sheet-icons` |
+| Environment variable names in the manifests | `docker run --rm <image> qscloud create-sheet-thumbnails --help` | All five are correct as published |
+
+The Kubernetes semantics — `command:` overriding `ENTRYPOINT` and `args:` overriding `CMD` — are from
+the Kubernetes container specification and were **not** exercised against a live cluster. The
+consequence of overriding the entrypoint was verified at the Docker level instead, by running the
+image both ways.
+
+## Note for the doc pass
+
+`docs/guide/advanced/ci-cd.md` mentions "Kubernetes-based runners" but contains no manifests, so it
+needs no change. The broken manifests exist only on `docs/examples/docker.md`.


### PR DESCRIPTION
Closes #936.

Staging cleanup only — no source or site content in this repo changes. The four Docker drafts written for #936 have all been published to the doc site and are live on production, so they move into `docs/to-doc-site/done/` with the `done_` prefix per that folder's README.

| Draft | Landed on | Doc site PRs |
| --- | --- | --- |
| `docker-air-gapped-environments` | `/guide/advanced/docker` — new "Air-gapped environments" section | ptarmiganlabs/butler-sheet-icons-docs#57 → #58 |
| `docker-kubernetes-examples-do-not-run` | `/examples/docker` — `Job` and `CronJob` manifests | ptarmiganlabs/butler-sheet-icons-docs#59 → #60 |
| `docker-browser-management-section-is-wrong` | `/examples/browser-management` — "Docker usage" | ptarmiganlabs/butler-sheet-icons-docs#61 → #62 |
| `docker-external-browser-cache-example-cannot-work` | `/guide/concepts/browser-detection-and-environment-variables` — "Docker image with external browser" | ptarmiganlabs/butler-sheet-icons-docs#61 → #62 |

**One draft remains pending in `docs/to-doc-site/`** — `docker-image-third-party-licences.md`, the documentation half of #937. It is untouched by this PR.

## Each file records what happened to it

Per the staging README, a processed draft carries a note when reality differed from the draft. Added as HTML comments at the top of each:

- **Air-gapped** — the proposed link to a "What is inside the image" section was dropped, because that section is not on the doc site yet; its draft is the pending one named above.
- **Kubernetes** — a note about Compose's `command:` was added beyond the draft, so the new "use `args:`" callout does not read as contradicting the Compose examples on the same page.
- **Both browser drafts** — the `browser install` command in the published text was never executed; it needs internet access to Google's download service.

## Two code findings, recorded but not fixed

Neither is a documentation problem, and neither is addressed here:

1. **`--port` is a dead option.** Defined with `BSI_QSEOW_CST_PORT` and never read anywhere in the codebase, so the QSEoW web UI is always reached on 443/80. `reference/qseow.md` on the doc site still documents it as "Web port" with the example `--port 8443`.
2. **Cached-browser matching ignores platform.** `detectAvailableBrowser()` filters by browser type and build id but not by platform, so a `win64` build mounted into a Linux container is accepted and returned as a `.exe` to run. Verified by mounting a prepared cache folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)