### PR TITLE
Ship the Windows binary again, unsigned until a certificate is available

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1206,7 +1206,16 @@ jobs:
     env:
       DIST_FILE_NAME: butler-sheet-icons
       GITHUB_TOKEN: ${{ secrets.PAT }}
-      CODESIGN_WIN_THUMBPRINT: ${{ secrets.WIN_CODESIGN_THUMBPRINT}}
+      # Windows code signing is OFF: the certificate expired, and signtool cannot sign with it
+      # whatever else is configured. scripts/release-win.ps1 skips signing when this variable is
+      # empty and ships an unsigned binary instead of failing, which is why 4.0.0 went out with no
+      # Windows binary at all.
+      #
+      # TO RE-ENABLE: uncomment the line below, once WIN_CODESIGN_THUMBPRINT holds the thumbprint
+      # of a valid certificate. Nothing else needs changing here. Note that Certum SimplySign is a
+      # cloud signing service, so the signtool invocation in release-win.ps1 will probably need
+      # reworking for it rather than simply being switched back on - see the comment there.
+      # CODESIGN_WIN_THUMBPRINT: ${{ secrets.WIN_CODESIGN_THUMBPRINT}}
     steps:
       - name: Release tag and upload url from previous job
         shell: powershell

--- a/docs/to-doc-site/windows-binary-temporarily-unsigned.md
+++ b/docs/to-doc-site/windows-binary-temporarily-unsigned.md
@@ -1,0 +1,55 @@
+# The Windows binary is temporarily unsigned
+
+**Applies to:** the Windows download of Butler Sheet Icons. The macOS and Linux downloads, and the Docker image, are unaffected.
+
+::: warning Affects BSI 4.0.0 and later, until further notice
+The Windows executable is not currently digitally signed. Windows will warn you when you run it, and some managed environments will refuse to run it at all.
+:::
+
+## What changed
+
+Butler Sheet Icons' Windows executable used to carry a digital signature identifying Ptarmigan Labs as its publisher. That code signing certificate has expired, and a replacement is being arranged.
+
+Rather than hold Windows releases back until it arrives, the binary now ships unsigned. Everything about how it works is unchanged — this affects only how Windows treats the file, not what Butler Sheet Icons does.
+
+## What you will see
+
+**Downloading.** Some browsers warn that the file "isn't commonly downloaded" and may ask you to confirm before keeping it.
+
+**Running it the first time.** Microsoft Defender SmartScreen shows a blue dialog:
+
+> **Windows protected your PC**
+> Microsoft Defender SmartScreen prevented an unrecognised app from starting.
+
+To continue, choose **More info**, then **Run anyway**. You may need to do this once per new version.
+
+**Unblocking the file.** If Windows keeps treating the download as untrusted, you can clear the download marker in PowerShell:
+
+```powershell
+Unblock-File -Path .\butler-sheet-icons.exe
+```
+
+**Antivirus.** Butler Sheet Icons is a single-file executable built from the Node.js runtime, and that construction is a common source of antivirus false positives. A signature previously helped suppress those. Without it, your antivirus may quarantine the file. If that happens, and you obtained the file from the official release page, you can add an exclusion for it — or use one of the alternatives below.
+
+## If your environment blocks unsigned applications
+
+Many organisations enforce application control through AppLocker or Windows Defender Application Control, often allowing programs by publisher certificate. **An unsigned executable cannot be permitted by a publisher rule and will not run**, and there is no way for you as a user to override that.
+
+If that describes your environment, you have two options that avoid the problem entirely:
+
+- **Use the Docker image.** `ptarmiganlabs/butler-sheet-icons` is unaffected by Windows code signing, and it is the better fit for locked-down and air-gapped servers regardless. It also carries a browser inside the image, so nothing needs downloading at run time.
+- **Ask your Windows administrator for a file hash rule.** Application control policies can permit a specific executable by its hash rather than by publisher. This has to be repeated for each new version, which is why publisher rules are usually preferred — but it works.
+
+## Making sure you have the genuine file
+
+Download only from the official release page:
+
+<https://github.com/ptarmiganlabs/butler-sheet-icons/releases>
+
+Files offered anywhere else are not published by Ptarmigan Labs, and without a signature there is nothing in the file itself that proves where it came from.
+
+## When will signing return
+
+A replacement certificate is being obtained. When it is in place, Windows releases will be signed again and this page will be withdrawn. No change on your side will be needed — simply download the newer release.
+
+The macOS binary continues to be signed and notarized by Apple throughout, and Linux releases are distributed as archives, where code signing is not customary.

--- a/scripts/insider-build-win.ps1
+++ b/scripts/insider-build-win.ps1
@@ -29,14 +29,25 @@ if ($LASTEXITCODE -ne 0) { throw "signtool remove failed with exit code $LASTEXI
 npx postject "${env:DIST_FILE_NAME}.exe" NODE_SEA_BLOB ./build/sea-prep.blob --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2
 
 # -------------------
-# Sign the executable
+# Sign the executable.
+#
+# Disabled, so insider builds ship unsigned. That is a deliberate choice to leave alone here, but it
+# is worth knowing what it costs: because these lines never run, Windows signing is exercised
+# nowhere except an actual release. That is exactly how the timestamp URL below could be switched
+# from http to https in May and not be discovered until the 4.0.0 release failed in August.
+#
+# The URLs are corrected in step with release-win.ps1 so that uncommenting these does not
+# resurrect the same failure. time.certum.pl serves no HTTPS - port 443 refuses the connection -
+# and signtool answers `SignTool Error: Invalid Timestamp URL`. See release-win.ps1 for why plain
+# HTTP is correct here rather than a weakness.
+#
 # 1st signing
-# & $signtool sign /sha1 "$env:CODESIGN_WIN_THUMBPRINT" /tr https://time.certum.pl /td sha256 /fd sha1 /v "./${env:DIST_FILE_NAME}.exe"
+# & $signtool sign /sha1 "$env:CODESIGN_WIN_THUMBPRINT" /tr http://time.certum.pl /td sha256 /fd sha1 /v "./${env:DIST_FILE_NAME}.exe"
 # if ($LASTEXITCODE -ne 0) { throw "signtool sign (sha1) failed with exit code $LASTEXITCODE" }
 
 # -------------------
 # 2nd signing
-# & $signtool sign /sha1 "$env:CODESIGN_WIN_THUMBPRINT" /tr https://time.certum.pl /td sha256 /fd sha256 /v "./${env:DIST_FILE_NAME}.exe"
+# & $signtool sign /sha1 "$env:CODESIGN_WIN_THUMBPRINT" /tr http://time.certum.pl /td sha256 /fd sha256 /v "./${env:DIST_FILE_NAME}.exe"
 # if ($LASTEXITCODE -ne 0) { throw "signtool sign (sha256) failed with exit code $LASTEXITCODE" }
 
 # -------------------

--- a/scripts/release-win.ps1
+++ b/scripts/release-win.ps1
@@ -22,14 +22,24 @@ if ($LASTEXITCODE -ne 0) { throw "signtool remove failed with exit code $LASTEXI
 npx --no-install postject "${env:DIST_FILE_NAME}.exe" NODE_SEA_BLOB ./build/sea-prep.blob --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2
 
 # -------------------
-# Sign the executable
+# Sign the executable.
+#
+# The timestamp URL is http, not https, and has to stay that way: time.certum.pl serves no HTTPS at
+# all - port 443 refuses the connection - so signtool answers `SignTool Error: Invalid Timestamp
+# URL` and the release build fails. That is not a hypothetical; it is what broke the 4.0.0 release.
+#
+# This is not a security weakness, which is why an https "fix" keeps looking tempting. An RFC 3161
+# timestamp token is signed by the timestamping authority, so it is verified on its own signature
+# rather than on the transport, and signtool rejects a token that does not verify. Plain HTTP is
+# what the RFC expects and what essentially every public TSA offers.
+#
 # 1st signing
-& $signtool sign /sha1 "$env:CODESIGN_WIN_THUMBPRINT" /tr https://time.certum.pl /td sha256 /fd sha1 /v "./${env:DIST_FILE_NAME}.exe"
+& $signtool sign /sha1 "$env:CODESIGN_WIN_THUMBPRINT" /tr http://time.certum.pl /td sha256 /fd sha1 /v "./${env:DIST_FILE_NAME}.exe"
 if ($LASTEXITCODE -ne 0) { throw "signtool sign (sha1) failed with exit code $LASTEXITCODE" }
 
 # -------------------
 # 2nd signing
-& $signtool sign /sha1 "$env:CODESIGN_WIN_THUMBPRINT" /tr https://time.certum.pl /td sha256 /fd sha256 /v "./${env:DIST_FILE_NAME}.exe"
+& $signtool sign /sha1 "$env:CODESIGN_WIN_THUMBPRINT" /tr http://time.certum.pl /td sha256 /fd sha256 /v "./${env:DIST_FILE_NAME}.exe"
 if ($LASTEXITCODE -ne 0) { throw "signtool sign (sha256) failed with exit code $LASTEXITCODE" }
 
 # -------------------

--- a/scripts/release-win.ps1
+++ b/scripts/release-win.ps1
@@ -15,32 +15,58 @@ node --experimental-sea-config build-script/sea-config.json
 node -e "require('fs').copyFileSync(process.execPath, '${env:DIST_FILE_NAME}.exe')" 
 
 # -------------------
-# Remove the signature from the executable
+# Remove Node's own signature from the copied executable.
+#
+# This happens whether or not we go on to sign, and it is not optional: postject rewrites the
+# binary below, which invalidates any signature already on it. Shipping a binary carrying a broken
+# signature is worse than shipping an unsigned one - Windows reports it as corrupt or tampered
+# with, which alarms users and antivirus far more than no signature at all.
 & $signtool remove /s "./${env:DIST_FILE_NAME}.exe"
 if ($LASTEXITCODE -ne 0) { throw "signtool remove failed with exit code $LASTEXITCODE" }
 
 npx --no-install postject "${env:DIST_FILE_NAME}.exe" NODE_SEA_BLOB ./build/sea-prep.blob --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2
 
 # -------------------
-# Sign the executable.
+# Sign the executable, if there is a certificate to sign with.
+#
+# Signing is skipped when CODESIGN_WIN_THUMBPRINT is empty, and the release ships unsigned. That is
+# deliberate: the code signing certificate expired, and a release that fails outright is worse than
+# one that ships a working binary with a warning. It is what happened to 4.0.0 - the signing step
+# failed and the release was published with Linux and macOS binaries and no Windows one at all. A
+# user can click through a SmartScreen warning; they cannot click through a missing file.
+#
+# To turn signing back on, set the WIN_CODESIGN_THUMBPRINT secret again. Nothing else needs
+# changing - which is the reason this is a guard rather than deleted code. Note that Certum
+# SimplySign is a cloud signing service, so when that route lands the invocation below will likely
+# need reworking rather than merely re-enabling.
 #
 # The timestamp URL is http, not https, and has to stay that way: time.certum.pl serves no HTTPS at
 # all - port 443 refuses the connection - so signtool answers `SignTool Error: Invalid Timestamp
-# URL` and the release build fails. That is not a hypothetical; it is what broke the 4.0.0 release.
+# URL`. That is not a hypothetical either; it is the bug that broke the 4.0.0 Windows release
+# before the certificate expiry was known about.
 #
 # This is not a security weakness, which is why an https "fix" keeps looking tempting. An RFC 3161
 # timestamp token is signed by the timestamping authority, so it is verified on its own signature
 # rather than on the transport, and signtool rejects a token that does not verify. Plain HTTP is
 # what the RFC expects and what essentially every public TSA offers.
-#
-# 1st signing
-& $signtool sign /sha1 "$env:CODESIGN_WIN_THUMBPRINT" /tr http://time.certum.pl /td sha256 /fd sha1 /v "./${env:DIST_FILE_NAME}.exe"
-if ($LASTEXITCODE -ne 0) { throw "signtool sign (sha1) failed with exit code $LASTEXITCODE" }
+if ([string]::IsNullOrWhiteSpace($env:CODESIGN_WIN_THUMBPRINT)) {
+  Write-Host "::warning title=Unsigned Windows binary::CODESIGN_WIN_THUMBPRINT is not set, so this release ships an UNSIGNED Windows binary. Users will see a Microsoft Defender SmartScreen warning, and environments enforcing AppLocker or WDAC publisher rules will refuse to run it."
+  Write-Host "Skipping Windows code signing - no certificate thumbprint configured."
+}
+else {
+  # 1st signing
+  & $signtool sign /sha1 "$env:CODESIGN_WIN_THUMBPRINT" /tr http://time.certum.pl /td sha256 /fd sha1 /v "./${env:DIST_FILE_NAME}.exe"
+  if ($LASTEXITCODE -ne 0) { throw "signtool sign (sha1) failed with exit code $LASTEXITCODE" }
 
-# -------------------
-# 2nd signing
-& $signtool sign /sha1 "$env:CODESIGN_WIN_THUMBPRINT" /tr http://time.certum.pl /td sha256 /fd sha256 /v "./${env:DIST_FILE_NAME}.exe"
-if ($LASTEXITCODE -ne 0) { throw "signtool sign (sha256) failed with exit code $LASTEXITCODE" }
+  # -------------------
+  # 2nd signing
+  & $signtool sign /sha1 "$env:CODESIGN_WIN_THUMBPRINT" /tr http://time.certum.pl /td sha256 /fd sha256 /v "./${env:DIST_FILE_NAME}.exe"
+  if ($LASTEXITCODE -ne 0) { throw "signtool sign (sha256) failed with exit code $LASTEXITCODE" }
+
+  # Fail loudly rather than shipping something that only looks signed.
+  & $signtool verify /pa /v "./${env:DIST_FILE_NAME}.exe"
+  if ($LASTEXITCODE -ne 0) { throw "signtool verify failed with exit code $LASTEXITCODE - the binary is not correctly signed" }
+}
 
 # -------------------
 # Create release binary zip


### PR DESCRIPTION
4.0.0 shipped with Linux and macOS binaries and **no Windows one**. `release-win64` failed, and a failed job simply produces a release with an asset missing. This makes the Windows binary ship again — unsigned for now.

## Two separate faults, found in that order

**1. The timestamp URL is wrong.** The 4.0.0 failure was:

```
SignTool Error: Invalid Timestamp URL: https://time.certum.pl
```

`time.certum.pl` serves no HTTPS at all. Checked directly rather than assumed: **port 443 refuses the connection; port 80 returns 200 and accepts an RFC 3161 POST.**

It was `http` until `70a2d42` (2026-05-06, *"address all unresolved PR review comments in build scripts"*), which rewrote the signtool invocation and changed the scheme along the way. Nothing caught it for three months, because Windows signing runs in exactly one place — a real release — and the previous one was v3.11.0 in November. The insider build would have been the natural safety net, but its signing lines are commented out.

The comment now explains at the line why `http` is correct rather than a weakness: an RFC 3161 token carries the timestamping authority's own signature and is verified on that, not on the transport, which is why public TSAs are plain HTTP and why signtool rejects a token that does not verify. Without that note the next hardening pass changes it back, as this one did.

**2. The certificate has expired**, which means fixing the URL alone would not have produced a binary either — signtool fails regardless.

## What this does

Signing is **guarded, not deleted**. `CODESIGN_WIN_THUMBPRINT` is commented out in `release-win64`, and `release-win.ps1` skips signing when it is empty: it emits a warning annotation naming both consequences and produces a working executable.

Re-enabling is one uncomment away once a certificate exists, with the steps written at the line. A replacement via Certum SimplySign is being arranged; since that is a *cloud* signing service the invocation will likely need reworking rather than merely switching back on, and the comment says so.

Two details kept deliberately:

- **Node's own signature is still stripped** before postject injects the blob, signing or not. postject rewrites the binary and invalidates any signature on it, and a binary carrying a *broken* signature is worse than an unsigned one — Windows reports it as corrupt rather than merely unknown, which alarms users and antivirus far more.
- **`signtool verify /pa` runs after signing.** It only executes on the signing path, and it means a binary that merely *looks* signed fails the build instead of reaching users.

## Docs

`docs/to-doc-site/windows-binary-temporarily-unsigned.md` is staged for administrators who will meet this without warning: what SmartScreen shows and how to proceed, that antivirus false positives are likelier without a signature on a Node single-file executable, and — for sites enforcing AppLocker or WDAC, where the binary will simply not run and no user override exists — that the Docker image sidesteps Windows signing entirely.

## Verification

- `time.certum.pl:443` refuses connections; `http://time.certum.pl` returns 200 and answers an RFC 3161 POST.
- Both PowerShell scripts parse cleanly under the PowerShell parser.
- The guard was exercised for unset, empty, whitespace-only and populated thumbprints: the first three skip, the last signs.
- `ci.yaml` parses and `release-win64` no longer carries `CODESIGN_WIN_THUMBPRINT`. zizmor drops from 148 findings to 147 — one fewer secret reference — with no new findings.

Not verifiable from here: the actual signtool run on the Windows runner. The next release is its first real exercise, which is the same blind spot that let this sit for three months. A `windows-signing-canary` mirroring `macos-signing-canary.yaml` would close it, and is worth doing when the certificate arrives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
