### PR TITLE
Stop PR titles duplicating every changelog entry

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,6 +33,8 @@ When the user does authorise a commit:
 - **ALWAYS** use Conventional Commits (`type: subject`). This is functional, not cosmetic: release-please derives the changelog and the version bump from the type. `feat` gives a minor bump, `fix` a patch, `feat!` or a `BREAKING CHANGE:` footer a major.
 - Types configured in `release-please-config.json`: `feat`, `fix`, `chore`, `docs`, `build`, `refactor` (hidden from the changelog). Anything else parses but will not appear where you expect.
 - Explain **why** in the body — the diff already shows what changed.
+- **NEVER** give a pull request a Conventional Commits title. Commit subjects use `type: subject`; PR titles are ordinary sentences. PRs land as merge commits, and GitHub copies the PR title into the merge commit _body_. release-please cannot parse the merge subject, falls back to the body, and emits a **duplicate changelog entry** for every such PR — the 4.0.0 release PR listed 154 entries for 128 real changes and had to be cleaned by hand.
+- If a conventional PR title is genuinely needed, strip the merge body instead: `gh pr merge --merge --body ""`. **ALWAYS** prefer the title rule, since it also covers merges done through the GitHub web UI.
 
 ## GitNexus Code Intelligence
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,3 +144,8 @@ The order is: **branch first, implement, verify, stop and report.** Committing, 
 - **MUST use Conventional Commits** — `type: subject`, or `type(scope): subject`. This is functional, not cosmetic: release-please derives both the changelog and the version bump from the type. `feat` produces a minor bump, `fix` a patch, and `feat!` or a `BREAKING CHANGE:` footer a major.
 - The types configured in `release-please-config.json` are `feat`, `fix`, `chore`, `docs`, `build` and `refactor`. `refactor` is deliberately hidden from the changelog. A type outside that list still parses, but will not show up where you expect it to.
 - Explain **why** in the body, not just what — the diff already says what changed.
+- **MUST NOT give a pull request a Conventional Commits title.** Commit subjects use `type: subject`; PR titles must not. Write the PR title as an ordinary sentence — "Ship the Windows binary again, unsigned until a certificate is available", not `fix: ship the Windows binary unsigned`.
+
+  This is not style. PRs land here as merge commits, and GitHub puts the PR title into the **body** of the merge commit. release-please cannot parse the merge commit's subject (`Merge pull request #924 from …`), so it falls back to the body — finds a second conventional commit there — and emits a **duplicate changelog entry** for every such PR. The 4.0.0 release PR had 154 entries for 128 real changes and had to be de-duplicated by hand; 4.0.1 started doing the same.
+
+  If a PR genuinely needs a conventional title for something else, strip the merge commit body instead: `gh pr merge --merge --body ""`. Do not rely on that as the default — it does not help anyone merging through the GitHub web UI, which is why the title rule is the one that holds.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,5 +90,6 @@ When a commit is authorised:
 
 - **MUST group changes by topic** — one commit per logical change, not one commit listing everything. Split a mixed working tree rather than writing a catch-all message.
 - **MUST use Conventional Commits** (`type: subject`). This is functional: release-please derives the changelog and version bump from the type — `feat` minor, `fix` patch, `feat!` or a `BREAKING CHANGE:` footer major. Configured types are `feat`, `fix`, `chore`, `docs`, `build`, `refactor` (hidden from the changelog).
+- **MUST NOT give a pull request a Conventional Commits title** — commit subjects use `type: subject`, PR titles are ordinary sentences. PRs land as merge commits and GitHub copies the PR title into the merge commit *body*; release-please cannot parse the merge subject, falls back to the body, and emits a **duplicate changelog entry**. That is why the 4.0.0 release PR listed 154 entries for 128 real changes. If a conventional PR title is unavoidable, merge with `gh pr merge --merge --body ""` — but the title rule is the one that also covers merges done in the web UI.
 
 See `AGENTS.md` for the full set of repository conventions.


### PR DESCRIPTION
Every entry in the 4.0.0 release changelog appeared **twice** — 154 bullets for 128 real changes — and I de-duplicated it by hand before release. [#926](https://github.com/ptarmiganlabs/butler-sheet-icons/pull/926) (4.0.1) has already started doing the same: 5 bullets, 3 unique. Only the symptom was treated last time; this is the cause.

## Why it happens

Two conventions that are each fine on their own:

- PRs land here as **merge commits**, never squashed.
- Commit subjects use **Conventional Commits**, and so — habitually — do PR titles.

GitHub copies the PR title into the merge commit's **body**:

```
SUBJECT: Merge pull request #924 from ptarmiganlabs/fix/qseow-docker-job-volumes
BODY:    fix: mount the QSEoW Docker job's data through volumes, not host paths
```

release-please cannot parse the merge subject — that is the `commit could not be parsed` logging you see in the release-please job — so it falls back to the body, finds a conventional commit there, and emits a second entry attributed to the merge SHA. One change, two changelog lines.

## The rule

Commit subjects keep `type: subject`. **PR titles are ordinary sentences.** An unparseable merge body yields no duplicate. This PR's own title follows it.

Recorded in all three agent docs — `AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md` — which are kept in sync by hand, each in that file's own voice.

The reasoning travels with the rule on purpose. "PR titles are not conventional commits" reads like arbitrary style, and the next person will helpfully re-align it with the commit convention unless they can see what it costs — which is exactly how the timestamp URL in #944 got broken.

`gh pr merge --merge --body ""` is documented as the escape hatch for a PR that genuinely needs a conventional title, but explicitly not as the default: it does nothing for anyone merging through the GitHub web UI, whereas the title rule holds regardless of who merges or how.

## Note on the pending release PR

[#926](https://github.com/ptarmiganlabs/butler-sheet-icons/pull/926) still carries its two duplicates, and cleaning it now would be wasted — release-please regenerates that branch on every push to `main`, so merging this or #944 will rewrite it. Clean it last, immediately before releasing 4.0.1, if at all.

## Verification

Managed GitNexus blocks end at line 54 in both `AGENTS.md` and `CLAUDE.md`; the edits are at lines 146 and 92, well clear. `.github/copilot-instructions.md` was prettier-clean before and is prettier-clean after. `AGENTS.md` and `CLAUDE.md` are prettier-dirty on `main` already, inside the managed block, and are deliberately left that way rather than sweeping unrelated churn into this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)