### PR TITLE
Stop a failing run filling the disk with crash dumps

### DIFF
--- a/docs/to-doc-site/one-crash-dump-per-run.md
+++ b/docs/to-doc-site/one-crash-dump-per-run.md
@@ -1,0 +1,94 @@
+# One crash dump per run, and a cap on how many can ever be written
+
+Butler Sheet Icons writes a *crash dump* when it stops because of an unrecoverable error. This draft covers a change to how many of those files a single run can produce, and to whether the run reliably ends at all.
+
+It updates the existing crash dump material — the page describing where dumps are written, what they contain, and the `BSI_CRASH_DUMP_*` environment variables.
+
+## What changed
+
+**A run now writes at most one crash dump.**
+
+Previously, a run that failed with several errors at once wrote a separate crash dump for each of them. In the worst case the errors kept arriving faster than Butler Sheet Icons could shut down, and the run produced crash dump files continuously without ever exiting. One report described a single run leaving **479,178 files** in its `crash_dumps` folder over about fifteen minutes, every one of them empty, while the run itself never finished.
+
+Three things are different now:
+
+1. **Only the first error produces a crash dump.** Once Butler Sheet Icons has begun writing a dump, any further errors in the same run are ignored rather than starting dumps of their own. The first error is the one worth having — the ones that follow are usually consequences of it.
+2. **The run always ends.** Butler Sheet Icons now exits with code `1` even when the crash dump cannot be written, and even when writing it hangs. Previously a failure while writing the dump could leave the run stuck indefinitely, so a scheduled task would sit there rather than reporting a failure.
+3. **There is a hard limit on crash dump files per run**, as a safety net. See below.
+
+## What you may notice
+
+- **One `.json` and one `.txt` file per failed run**, instead of a pair per error. This is the normal case and needs no configuration.
+- **One `FATAL:` line in the log** describing the first error, instead of one per error. Log output from a failing run is correspondingly shorter and easier to read.
+- **Scheduled tasks now fail properly.** A run that hits a fatal error returns exit code `1` promptly. If you previously had scheduled Butler Sheet Icons tasks that occasionally hung and had to be killed, this is a likely cause.
+
+## If you have a folder full of empty crash dumps
+
+If you find a `crash_dumps` folder containing a very large number of zero-byte files that all share the same process ID in their names, they are the symptom described above. **They are safe to delete** — a zero-byte dump contains nothing.
+
+Because there can be a great many of them, a plain wildcard delete may fail with an "argument list too long" error. Delete them in batches instead.
+
+### macOS / Linux
+
+```bash
+# Count them first
+find crash_dumps -type f -size 0 | wc -l
+
+# Then delete
+find crash_dumps -type f -size 0 -delete
+```
+
+### Windows PowerShell
+
+```powershell
+# Count them first
+(Get-ChildItem crash_dumps -File | Where-Object Length -eq 0).Count
+
+# Then delete
+Get-ChildItem crash_dumps -File | Where-Object Length -eq 0 | Remove-Item
+```
+
+## New environment variable: `BSI_CRASH_DUMP_MAX_PER_PROCESS`
+
+This is the safety net behind the change: a hard ceiling on how many crash dumps a single run may write, no matter what goes wrong.
+
+| Environment variable | Default | What it controls |
+|---|---|---|
+| `BSI_CRASH_DUMP_MAX_PER_PROCESS` | `10` | Maximum crash dumps a single run may write. Set to `0` for no limit. |
+
+It belongs with the crash dump variables already documented — `BSI_CRASH_DUMP_ENABLE`, `BSI_CRASH_DUMP_DIR`, `BSI_CRASH_DUMP_CREATE_JSON`, and `BSI_CRASH_DUMP_CREATE_TEXT`.
+
+Because a run now writes one dump, **you should never reach this limit in normal operation**, and there is no reason to change it. It exists so that a future defect cannot fill a disk. If you do see the limit reached, Butler Sheet Icons says so once in the log:
+
+```
+CRASH DUMP: Limit of 10 dumps per process reached, no further dumps will be written. Set BSI_CRASH_DUMP_MAX_PER_PROCESS to raise or remove the limit.
+```
+
+Seeing that line means something is repeatedly failing inside a single run, and is worth reporting as a bug along with the dumps that *were* written.
+
+A value that is not a whole number of zero or more — a typo such as `ten` or `-1` — is ignored and the default of `10` is used instead, so that a mistake in configuration cannot quietly remove the ceiling.
+
+### Setting it
+
+```bash
+# macOS / Linux
+BSI_CRASH_DUMP_MAX_PER_PROCESS=25 butler-sheet-icons qseow create-sheet-thumbnails ...
+```
+
+```powershell
+# Windows PowerShell
+$env:BSI_CRASH_DUMP_MAX_PER_PROCESS = "25"
+butler-sheet-icons.exe qseow create-sheet-thumbnails ...
+```
+
+## Correction to existing content
+
+The crash dump page currently answers the question "Can I keep just the last few dumps and discard the rest?" by explaining that Butler Sheet Icons does not clean up old dumps and suggesting a scheduled job to remove files older than 30 days.
+
+That advice is still correct — dumps accumulate across runs and nothing removes them — but the answer was written when a single run could produce many files. It is worth adding that **each run contributes at most one dump**, so the folder grows by one dump per failed run, not by an unpredictable number. That makes a simple age-based cleanup far more predictable than it used to be.
+
+## Notes for the publishing pass
+
+- The behaviour described here is **not released yet** at the time of writing. Gate it with a `::: warning Requires BSI X.Y.Z or later` callout using the version from the open release-please pull request.
+- Prefer **editing the existing crash dump page** over adding a new one: the environment variable table, the FAQ entry noted above, and a short section on the one-dump-per-run guarantee.
+- The troubleshooting page is the natural home for the "folder full of empty crash dumps" symptom, cross-linked to the crash dump page.

--- a/src/__tests__/butler-sheet-icons.test.js
+++ b/src/__tests__/butler-sheet-icons.test.js
@@ -7,7 +7,7 @@ import childProcess from 'child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 // Mock all the imported modules that are used in the main file
 jest.mock('../globals.js', () => ({
@@ -147,6 +147,9 @@ describe('butler-sheet-icons CLI', () => {
     });
 });
 
+/** Printed by the child once the handlers are installed, to prove it got that far. */
+const HANDLERS_READY = '__bsi_fatal_handlers_installed__';
+
 describe('fatal error safety net, end to end (issue #946)', () => {
     // No mocks here: a real child process, the real handlers, the real crash
     // dump writer, and a real directory on disk. Measured against the handlers
@@ -172,13 +175,18 @@ describe('fatal error safety net, end to end (issue #946)', () => {
     const runFatalBurst = (rejectionCount) => {
         const __dirname = path.dirname(fileURLToPath(import.meta.url));
         const handlersPath = path.resolve(__dirname, '../lib/util/fatal-handlers.js');
+        // A bare Windows path is not a valid ESM specifier — `import 'C:\...'`
+        // fails with ERR_UNSUPPORTED_ESM_URL_SCHEME. Feed the loader a file URL
+        // on every platform.
+        const handlersUrl = pathToFileURL(handlersPath).href;
         const source = [
-            `import { installFatalHandlers } from ${JSON.stringify(handlersPath)};`,
+            `import { installFatalHandlers } from ${JSON.stringify(handlersUrl)};`,
             'installFatalHandlers();',
+            `console.log(${JSON.stringify(HANDLERS_READY)});`,
             `for (let i = 0; i < ${rejectionCount}; i += 1) Promise.reject(new Error('boom ' + i));`,
         ].join('\n');
 
-        return childProcess.spawnSync('node', ['--input-type=module', '-e', source], {
+        const result = childProcess.spawnSync('node', ['--input-type=module', '-e', source], {
             encoding: 'utf-8',
             timeout: 30000,
             env: {
@@ -189,6 +197,22 @@ describe('fatal error safety net, end to end (issue #946)', () => {
                 BSI_CRASH_DUMP_CREATE_TEXT: '1',
             },
         });
+
+        // A child that never got as far as installing the handlers would fail
+        // every assertion below as "no crash dumps written", which points at
+        // the wrong thing entirely. Fail here instead, quoting the child.
+        if (!result.stdout?.includes(HANDLERS_READY)) {
+            throw new Error(
+                [
+                    'The child process did not reach installFatalHandlers().',
+                    `status: ${result.status}, signal: ${result.signal}`,
+                    `stdout: ${result.stdout}`,
+                    `stderr: ${result.stderr}`,
+                ].join('\n')
+            );
+        }
+
+        return result;
     };
 
     test('a burst of 200 unhandled rejections writes exactly one crash dump', () => {

--- a/src/__tests__/butler-sheet-icons.test.js
+++ b/src/__tests__/butler-sheet-icons.test.js
@@ -1,9 +1,11 @@
 // filepath: /Users/goran/code/butler-sheet-icons/src/__tests__/butler-sheet-icons.test.js
-import { test, expect, describe, jest, beforeEach } from '@jest/globals';
+import { test, expect, describe, jest, beforeEach, afterEach } from '@jest/globals';
 import 'dotenv/config';
 import {} from 'commander';
 import {} from '../globals.js';
 import childProcess from 'child_process';
+import fs from 'node:fs';
+import os from 'node:os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -142,5 +144,88 @@ describe('butler-sheet-icons CLI', () => {
         const result = execCLI(['browser', '--help']);
         expect(result.status).toBe(0);
         expect(result.stdout).toContain('list-available');
+    });
+});
+
+describe('fatal error safety net, end to end (issue #946)', () => {
+    // No mocks here: a real child process, the real handlers, the real crash
+    // dump writer, and a real directory on disk. Measured against the handlers
+    // as they were before the fix, this burst wrote 400 files.
+    let dumpDir;
+
+    beforeEach(() => {
+        dumpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bsi-fatal-e2e-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(dumpDir, { recursive: true, force: true });
+    });
+
+    /**
+     * Runs a child process that installs the real fatal handlers and then
+     * emits a burst of unhandled rejections.
+     *
+     * @param {number} rejectionCount - How many rejections the child should produce.
+     *
+     * @returns {import('child_process').SpawnSyncReturns<string>} The `spawnSync` result.
+     */
+    const runFatalBurst = (rejectionCount) => {
+        const __dirname = path.dirname(fileURLToPath(import.meta.url));
+        const handlersPath = path.resolve(__dirname, '../lib/util/fatal-handlers.js');
+        const source = [
+            `import { installFatalHandlers } from ${JSON.stringify(handlersPath)};`,
+            'installFatalHandlers();',
+            `for (let i = 0; i < ${rejectionCount}; i += 1) Promise.reject(new Error('boom ' + i));`,
+        ].join('\n');
+
+        return childProcess.spawnSync('node', ['--input-type=module', '-e', source], {
+            encoding: 'utf-8',
+            timeout: 30000,
+            env: {
+                ...process.env,
+                BSI_CRASH_DUMP_DIR: dumpDir,
+                BSI_CRASH_DUMP_ENABLE: '1',
+                BSI_CRASH_DUMP_CREATE_JSON: '1',
+                BSI_CRASH_DUMP_CREATE_TEXT: '1',
+            },
+        });
+    };
+
+    test('a burst of 200 unhandled rejections writes exactly one crash dump', () => {
+        const result = runFatalBurst(200);
+
+        const files = fs.readdirSync(dumpDir);
+        expect(files.filter((f) => f.endsWith('.json'))).toHaveLength(1);
+        expect(files.filter((f) => f.endsWith('.txt'))).toHaveLength(1);
+        expect(files).toHaveLength(2);
+
+        // Zero-byte dumps were the visible symptom in the issue. Both files
+        // must have actually been written, not merely created.
+        for (const file of files) {
+            expect(fs.statSync(path.join(dumpDir, file)).size).toBeGreaterThan(0);
+        }
+
+        expect(result.status).toBe(1);
+    });
+
+    test('the process exits with code 1 rather than hanging', () => {
+        const result = runFatalBurst(1);
+
+        // `spawnSync` reports a timeout kill via `signal`, so a null signal is
+        // the assertion that the process ended on its own.
+        expect(result.signal).toBeNull();
+        expect(result.status).toBe(1);
+    });
+
+    test('a single FATAL line is logged, naming the first failure only', () => {
+        const result = runFatalBurst(200);
+
+        // The winston console transport writes every level to stdout.
+        const fatalLines = result.stdout
+            .split('\n')
+            .filter((line) => line.includes('FATAL: Unhandled promise rejection'));
+
+        expect(fatalLines).toHaveLength(1);
+        expect(fatalLines[0]).toContain('boom 0');
     });
 });

--- a/src/butler-sheet-icons.js
+++ b/src/butler-sheet-icons.js
@@ -1,65 +1,14 @@
 import { Command } from 'commander';
-import { appVersion, logger } from './globals.js';
-import { writeCrashDump } from './lib/util/crash-dump.js';
+import { appVersion } from './globals.js';
+import { installFatalHandlers } from './lib/util/fatal-handlers.js';
 import { buildQseowCommand } from './lib/commands/qseow/index.js';
 import { buildQscloudCommand } from './lib/commands/qscloud/index.js';
 import { buildBrowserCommand } from './lib/commands/browser/index.js';
 
-// ---------------------------------------------------------------------------
-// Process-level safety net: catch any error that escapes all try/catch blocks
-// ---------------------------------------------------------------------------
-
-/**
- * Handler for synchronous uncaught exceptions.
- * Writes a crash dump and exits with code 1.
- *
- * @param {Error} err - The uncaught error.
- *
- * @returns {void}
- */
-process.on('uncaughtException', (err) => {
-    try {
-        const message = `FATAL: Uncaught exception: ${err?.message ?? err}`;
-        try {
-            logger.error(message);
-        } catch {
-            console.error(message);
-        }
-    } finally {
-        // Fire-and-forget the crash dump write, then exit. writeCrashDump has
-        // its own 5s timeout so it can never block process exit indefinitely.
-        writeCrashDump(err, 'uncaughtException').finally(() => {
-            process.exit(1);
-        });
-    }
-});
-
-/**
- * Handler for unhandled promise rejections.
- * Logs the error and writes a crash dump, then exits with code 1. We treat
- * unhandled rejections the same as uncaught exceptions because BSI runs
- * short-lived batch commands — there is no "recovery" mode worth returning
- * to, and silently continuing can leave half-completed work in Qlik Sense.
- *
- * @param {Error|unknown} reason - The rejection reason (usually an Error).
- *
- * @returns {void}
- */
-process.on('unhandledRejection', (reason) => {
-    const err = reason instanceof Error ? reason : new Error(String(reason));
-    try {
-        const message = `FATAL: Unhandled promise rejection: ${err?.message ?? err}`;
-        try {
-            logger.error(message);
-        } catch {
-            console.error(message);
-        }
-    } finally {
-        writeCrashDump(err, 'unhandledRejection').finally(() => {
-            process.exit(1);
-        });
-    }
-});
+// Process-level safety net: catch any error that escapes all try/catch blocks,
+// write a crash dump, and exit with code 1. Installed before anything else so
+// the net is in place before there is anything to fall out of it.
+installFatalHandlers();
 
 const program = new Command();
 

--- a/src/lib/util/__tests__/crash-dump.test.js
+++ b/src/lib/util/__tests__/crash-dump.test.js
@@ -14,13 +14,16 @@ jest.unstable_mockModule('../../../globals.js', () => ({
     isSea: false,
 }));
 
-const { writeCrashDump } = await import('../crash-dump.js');
+const { writeCrashDump, resetCrashDumpLimit } = await import('../crash-dump.js');
 const { logger } = await import('../../../globals.js');
 
 let tmpDir;
 
 beforeEach(async () => {
     jest.clearAllMocks();
+    // The dump cap is per-process, so the allowance has to be restored for each
+    // case or a suite this size trips the limit partway through.
+    resetCrashDumpLimit();
     tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'bsi-crash-'));
     process.env.BSI_CRASH_DUMP_DIR = tmpDir;
     process.env.BSI_CRASH_DUMP_ENABLE = '1';
@@ -34,6 +37,7 @@ afterEach(async () => {
     delete process.env.BSI_CRASH_DUMP_ENABLE;
     delete process.env.BSI_CRASH_DUMP_CREATE_JSON;
     delete process.env.BSI_CRASH_DUMP_CREATE_TEXT;
+    delete process.env.BSI_CRASH_DUMP_MAX_PER_PROCESS;
 });
 
 /**
@@ -188,6 +192,23 @@ describe('writeCrashDump', () => {
         expect(writtenCalls.length).toBeGreaterThan(0);
     });
 
+    test('never rejects, even when every filesystem call fails', async () => {
+        // The fatal handlers lean on this: a crash dump that rejected would
+        // feed the handler that asked for it (issue #946). The property was
+        // true but untested, so it was one refactor away from being lost.
+        const mkdirSync = jest.spyOn(fs, 'mkdirSync').mockImplementation(() => {
+            throw new Error('ENOSPC: no space left on device');
+        });
+        const writeFile = jest
+            .spyOn(fs.promises, 'writeFile')
+            .mockRejectedValue(new Error('ENOSPC: no space left on device'));
+
+        await expect(writeCrashDump(new Error('boom'), 'manual')).resolves.toBeUndefined();
+
+        mkdirSync.mockRestore();
+        writeFile.mockRestore();
+    });
+
     test('does not throw on a totally broken error input', async () => {
         // Pass a value whose constructor access itself throws.
         const hostile = Object.create(null);
@@ -202,5 +223,106 @@ describe('writeCrashDump', () => {
         });
 
         await expect(writeCrashDump(hostile, 'manual')).resolves.toBeUndefined();
+    });
+});
+
+describe('per-process dump cap (issue #946)', () => {
+    /**
+     * Counts the JSON dumps written to the temp dir so far.
+     *
+     * @returns {Promise<number>} Number of `.json` dump files.
+     */
+    const countJsonDumps = async () =>
+        (await listDumps()).filter((f) => f.endsWith('.json')).length;
+
+    test('stops writing once the limit is reached', async () => {
+        process.env.BSI_CRASH_DUMP_MAX_PER_PROCESS = '3';
+
+        for (let i = 0; i < 50; i += 1) {
+            await writeCrashDump(new Error(`boom ${i}`), 'manual');
+        }
+
+        expect(await countJsonDumps()).toBe(3);
+    });
+
+    test('the dumps written before the limit are complete, not truncated', async () => {
+        process.env.BSI_CRASH_DUMP_MAX_PER_PROCESS = '2';
+
+        await writeCrashDump(new Error('first'), 'manual');
+        await writeCrashDump(new Error('second'), 'manual');
+        await writeCrashDump(new Error('third, over the limit'), 'manual');
+
+        const files = (await listDumps()).filter((f) => f.endsWith('.json'));
+        expect(files).toHaveLength(2);
+
+        const messages = await Promise.all(
+            files.map(
+                async (f) =>
+                    JSON.parse(await fs.promises.readFile(path.join(tmpDir, f), 'utf8')).error
+                        .message
+            )
+        );
+        expect(messages.sort()).toEqual(['first', 'second']);
+    });
+
+    test('logs once when the limit is reached, not once per refused dump', async () => {
+        process.env.BSI_CRASH_DUMP_MAX_PER_PROCESS = '1';
+
+        for (let i = 0; i < 20; i += 1) {
+            await writeCrashDump(new Error(`boom ${i}`), 'manual');
+        }
+
+        const limitLines = logger.error.mock.calls.filter((c) =>
+            String(c[0] ?? '').includes('Limit of 1 dumps per process reached')
+        );
+        expect(limitLines).toHaveLength(1);
+    });
+
+    test('0 means no limit', async () => {
+        process.env.BSI_CRASH_DUMP_MAX_PER_PROCESS = '0';
+
+        for (let i = 0; i < 15; i += 1) {
+            await writeCrashDump(new Error(`boom ${i}`), 'manual');
+        }
+
+        expect(await countJsonDumps()).toBe(15);
+    });
+
+    test('defaults to 10 when the variable is unset', async () => {
+        delete process.env.BSI_CRASH_DUMP_MAX_PER_PROCESS;
+
+        for (let i = 0; i < 25; i += 1) {
+            await writeCrashDump(new Error(`boom ${i}`), 'manual');
+        }
+
+        expect(await countJsonDumps()).toBe(10);
+    });
+
+    test.each([['not-a-number'], ['-1'], ['2.5'], ['']])(
+        'falls back to the default for the invalid value %p',
+        async (value) => {
+            // A typo in an env var must not silently remove the backstop.
+            process.env.BSI_CRASH_DUMP_MAX_PER_PROCESS = value;
+
+            for (let i = 0; i < 25; i += 1) {
+                await writeCrashDump(new Error(`boom ${i}`), 'manual');
+            }
+
+            expect(await countJsonDumps()).toBe(10);
+        }
+    );
+
+    test('resetCrashDumpLimit allows writing again', async () => {
+        process.env.BSI_CRASH_DUMP_MAX_PER_PROCESS = '2';
+
+        await writeCrashDump(new Error('a'), 'manual');
+        await writeCrashDump(new Error('b'), 'manual');
+        await writeCrashDump(new Error('refused'), 'manual');
+        expect(await countJsonDumps()).toBe(2);
+
+        resetCrashDumpLimit();
+        await writeCrashDump(new Error('c'), 'manual');
+
+        expect(await countJsonDumps()).toBe(3);
     });
 });

--- a/src/lib/util/__tests__/fatal-handlers.test.js
+++ b/src/lib/util/__tests__/fatal-handlers.test.js
@@ -1,0 +1,381 @@
+import { jest, describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { EventEmitter } from 'node:events';
+
+import {
+    installFatalHandlers,
+    resetFatalHandlerState,
+    FATAL_EXIT_WATCHDOG_MS,
+} from '../fatal-handlers.js';
+
+/**
+ * Every test installs the handlers onto a throwaway emitter with an injected
+ * `exit` spy, so nothing here can register a listener on the real `process` or
+ * take the Jest worker down with it.
+ */
+let target;
+let exit;
+let logger;
+
+beforeEach(() => {
+    resetFatalHandlerState();
+    target = new EventEmitter();
+    exit = jest.fn();
+    logger = { error: jest.fn() };
+});
+
+afterEach(() => {
+    resetFatalHandlerState();
+    jest.useRealTimers();
+});
+
+/**
+ * Installs the handlers with the shared test doubles, overriding as needed.
+ *
+ * @param {object} [overrides] - Dependency overrides passed to `installFatalHandlers`.
+ *
+ * @returns {void}
+ */
+const install = (overrides = {}) => installFatalHandlers({ logger, exit, target, ...overrides });
+
+/**
+ * Yields to the microtask queue so the promise chain inside the handler can
+ * settle before assertions run.
+ *
+ * @returns {Promise<void>} Resolves on the next macrotask tick.
+ */
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+describe('installFatalHandlers', () => {
+    test('registers exactly one listener per fatal event', () => {
+        install();
+
+        expect(target.listenerCount('uncaughtException')).toBe(1);
+        expect(target.listenerCount('unhandledRejection')).toBe(1);
+    });
+
+    test('is idempotent: installing twice does not double up listeners or dumps', async () => {
+        const writeCrashDump = jest.fn().mockResolvedValue(undefined);
+        install({ writeCrashDump });
+        install({ writeCrashDump });
+
+        expect(target.listenerCount('uncaughtException')).toBe(1);
+        expect(target.listenerCount('unhandledRejection')).toBe(1);
+
+        target.emit('uncaughtException', new Error('boom'));
+        await flush();
+
+        expect(writeCrashDump).toHaveBeenCalledTimes(1);
+        expect(exit).toHaveBeenCalledTimes(1);
+    });
+
+    test('resetFatalHandlerState removes the listeners', () => {
+        install();
+        resetFatalHandlerState();
+
+        expect(target.listenerCount('uncaughtException')).toBe(0);
+        expect(target.listenerCount('unhandledRejection')).toBe(0);
+    });
+});
+
+describe('happy path', () => {
+    test.each([
+        ['uncaughtException', 'uncaughtException'],
+        ['unhandledRejection', 'unhandledRejection'],
+    ])('%s writes one dump and exits once with code 1', async (event, source) => {
+        const writeCrashDump = jest.fn().mockResolvedValue(undefined);
+        install({ writeCrashDump });
+
+        const err = new Error('boom');
+        target.emit(event, err);
+        await flush();
+
+        expect(writeCrashDump).toHaveBeenCalledTimes(1);
+        expect(writeCrashDump).toHaveBeenCalledWith(err, source);
+        expect(exit).toHaveBeenCalledTimes(1);
+        expect(exit).toHaveBeenCalledWith(1);
+    });
+
+    test('logs a single FATAL line naming the kind of failure', async () => {
+        install({ writeCrashDump: jest.fn().mockResolvedValue(undefined) });
+
+        target.emit('unhandledRejection', new Error('the reason'));
+        await flush();
+
+        expect(logger.error).toHaveBeenCalledTimes(1);
+        expect(logger.error).toHaveBeenCalledWith('FATAL: Unhandled promise rejection: the reason');
+    });
+});
+
+describe('a failing crash dump cannot re-enter the handler (issue #946)', () => {
+    test('a rejecting writeCrashDump still exits exactly once', async () => {
+        const writeCrashDump = jest.fn().mockRejectedValue(new Error('dump write failed'));
+        install({ writeCrashDump });
+
+        target.emit('unhandledRejection', new Error('seed'));
+        await flush();
+
+        expect(writeCrashDump).toHaveBeenCalledTimes(1);
+        expect(exit).toHaveBeenCalledTimes(1);
+        expect(exit).toHaveBeenCalledWith(1);
+    });
+
+    test('the rejection does not escape as a new unhandled rejection', async () => {
+        // The old code ended in `.finally(...)`, whose derived promise rejects
+        // and is reported by Node as a fresh unhandledRejection — feeding the
+        // handler that produced it. Watch the real process for that escape.
+        const escaped = [];
+        /**
+         * Records any unhandled rejection Node reports during this test.
+         *
+         * @param {unknown} reason - The rejection reason.
+         *
+         * @returns {void}
+         */
+        const spy = (reason) => escaped.push(reason);
+        process.on('unhandledRejection', spy);
+
+        try {
+            install({ writeCrashDump: jest.fn().mockRejectedValue(new Error('dump failed')) });
+            target.emit('unhandledRejection', new Error('seed'));
+            await flush();
+            await flush();
+        } finally {
+            process.removeListener('unhandledRejection', spy);
+        }
+
+        expect(escaped).toEqual([]);
+    });
+
+    test('a writeCrashDump that throws synchronously still exits once', async () => {
+        const writeCrashDump = jest.fn(() => {
+            throw new Error('not even a promise');
+        });
+        install({ writeCrashDump });
+
+        target.emit('uncaughtException', new Error('seed'));
+        await flush();
+
+        expect(exit).toHaveBeenCalledTimes(1);
+        expect(exit).toHaveBeenCalledWith(1);
+    });
+
+    test('a writeCrashDump that returns a non-promise still exits once', async () => {
+        install({ writeCrashDump: jest.fn(() => undefined) });
+
+        target.emit('uncaughtException', new Error('seed'));
+        await flush();
+
+        expect(exit).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('re-entry guard', () => {
+    test('a burst of 200 rejections produces one dump and one exit', async () => {
+        // Measured against the pre-fix handlers, this burst wrote 400 files.
+        const writeCrashDump = jest.fn().mockResolvedValue(undefined);
+        install({ writeCrashDump });
+
+        for (let i = 0; i < 200; i += 1) {
+            target.emit('unhandledRejection', new Error(`boom ${i}`));
+        }
+        await flush();
+
+        expect(writeCrashDump).toHaveBeenCalledTimes(1);
+        expect(writeCrashDump).toHaveBeenCalledWith(expect.any(Error), 'unhandledRejection');
+        expect(exit).toHaveBeenCalledTimes(1);
+        expect(logger.error).toHaveBeenCalledTimes(1);
+    });
+
+    test('the guard is shared across both handlers', async () => {
+        // The two handlers are twins. A guard held per-handler would let an
+        // uncaught exception raised while handling a rejection start a second
+        // dump, which is the hole the issue is about.
+        const writeCrashDump = jest.fn().mockResolvedValue(undefined);
+        install({ writeCrashDump });
+
+        target.emit('uncaughtException', new Error('first'));
+        target.emit('unhandledRejection', new Error('second'));
+        await flush();
+
+        expect(writeCrashDump).toHaveBeenCalledTimes(1);
+        expect(writeCrashDump).toHaveBeenCalledWith(expect.any(Error), 'uncaughtException');
+        expect(exit).toHaveBeenCalledTimes(1);
+    });
+
+    test('a fatal event arriving while the dump is in flight is dropped, not exited on', async () => {
+        // The dropped event must not shortcut to exit: that would truncate the
+        // one dump the operator needs and leave a zero-byte file.
+        let releaseDump;
+        const dumpPromise = new Promise((resolve) => {
+            releaseDump = resolve;
+        });
+        const writeCrashDump = jest.fn(() => dumpPromise);
+        install({ writeCrashDump });
+
+        target.emit('unhandledRejection', new Error('first'));
+        await flush();
+
+        target.emit('unhandledRejection', new Error('while writing'));
+        await flush();
+
+        expect(writeCrashDump).toHaveBeenCalledTimes(1);
+        expect(exit).not.toHaveBeenCalled();
+
+        releaseDump();
+        await flush();
+
+        expect(exit).toHaveBeenCalledTimes(1);
+        expect(exit).toHaveBeenCalledWith(1);
+    });
+});
+
+describe('exit watchdog', () => {
+    test('exits when the crash dump promise never settles', async () => {
+        jest.useFakeTimers();
+        // A dump that never settles: a hung network filesystem, say. Without
+        // the watchdog the process hangs and a scheduled job never returns.
+        install({ writeCrashDump: jest.fn(() => new Promise(() => {})) });
+
+        target.emit('uncaughtException', new Error('boom'));
+        expect(exit).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(FATAL_EXIT_WATCHDOG_MS + 1);
+
+        expect(exit).toHaveBeenCalledTimes(1);
+        expect(exit).toHaveBeenCalledWith(1);
+    });
+
+    test('honours an injected watchdog delay', () => {
+        jest.useFakeTimers();
+        install({ writeCrashDump: jest.fn(() => new Promise(() => {})), watchdogMs: 250 });
+
+        target.emit('uncaughtException', new Error('boom'));
+
+        jest.advanceTimersByTime(249);
+        expect(exit).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(2);
+        expect(exit).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not exit a second time after the dump has already exited', async () => {
+        jest.useFakeTimers();
+        install({ writeCrashDump: jest.fn().mockResolvedValue(undefined), watchdogMs: 250 });
+
+        target.emit('uncaughtException', new Error('boom'));
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(exit).toHaveBeenCalledTimes(1);
+
+        jest.advanceTimersByTime(10_000);
+        expect(exit).toHaveBeenCalledTimes(1);
+    });
+
+    test('the watchdog timer is unref’d so it cannot hold a process open', () => {
+        jest.useFakeTimers();
+        const unref = jest.spyOn(global, 'setTimeout');
+        install({ writeCrashDump: jest.fn(() => new Promise(() => {})) });
+
+        target.emit('uncaughtException', new Error('boom'));
+
+        const timer = unref.mock.results[unref.mock.results.length - 1].value;
+        expect(typeof timer.unref).toBe('function');
+        unref.mockRestore();
+    });
+});
+
+describe('rejection reasons that are not Errors', () => {
+    test('a string reason is coerced to an Error carrying that text', async () => {
+        const writeCrashDump = jest.fn().mockResolvedValue(undefined);
+        install({ writeCrashDump });
+
+        target.emit('unhandledRejection', 'just a string');
+        await flush();
+
+        const [err, source] = writeCrashDump.mock.calls[0];
+        expect(err).toBeInstanceOf(Error);
+        expect(err.message).toBe('just a string');
+        expect(source).toBe('unhandledRejection');
+    });
+
+    test('a reason whose toString throws does not take the handler down', async () => {
+        const writeCrashDump = jest.fn().mockResolvedValue(undefined);
+        install({ writeCrashDump });
+
+        const hostile = {
+            /**
+             * Throwing `toString`, so `String(reason)` cannot be trusted.
+             *
+             * @returns {never} Never returns; always throws.
+             */
+            toString() {
+                throw new Error('cannot stringify');
+            },
+        };
+        target.emit('unhandledRejection', hostile);
+        await flush();
+
+        const [err] = writeCrashDump.mock.calls[0];
+        expect(err).toBeInstanceOf(Error);
+        expect(err.message).toBe('Unhandled promise rejection with an uncoercible reason');
+        expect(exit).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('a broken logger', () => {
+    test('falls back to console.error and still writes the dump and exits', async () => {
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const writeCrashDump = jest.fn().mockResolvedValue(undefined);
+        install({
+            writeCrashDump,
+            logger: {
+                /**
+                 * Logger whose `error` method is itself broken.
+                 *
+                 * @returns {never} Never returns; always throws.
+                 */
+                error() {
+                    throw new Error('logger is broken');
+                },
+            },
+        });
+
+        target.emit('uncaughtException', new Error('boom'));
+        await flush();
+
+        expect(consoleError).toHaveBeenCalledWith('FATAL: Uncaught exception: boom');
+        expect(writeCrashDump).toHaveBeenCalledTimes(1);
+        expect(exit).toHaveBeenCalledTimes(1);
+
+        consoleError.mockRestore();
+    });
+
+    test('a logger that cannot log at all still writes the dump and exits', async () => {
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {
+            throw new Error('console is broken too');
+        });
+        const writeCrashDump = jest.fn().mockResolvedValue(undefined);
+        install({
+            writeCrashDump,
+            logger: {
+                /**
+                 * Logger whose `error` method is itself broken.
+                 *
+                 * @returns {never} Never returns; always throws.
+                 */
+                error() {
+                    throw new Error('logger is broken');
+                },
+            },
+        });
+
+        target.emit('uncaughtException', new Error('boom'));
+        await flush();
+
+        expect(writeCrashDump).toHaveBeenCalledTimes(1);
+        expect(exit).toHaveBeenCalledTimes(1);
+
+        consoleError.mockRestore();
+    });
+});

--- a/src/lib/util/crash-dump.js
+++ b/src/lib/util/crash-dump.js
@@ -24,6 +24,7 @@
  * - `BSI_CRASH_DUMP_DIR`               (default: `crash_dumps`) — output dir
  * - `BSI_CRASH_DUMP_CREATE_JSON`       (default: `1`) — emit JSON file
  * - `BSI_CRASH_DUMP_CREATE_TEXT`       (default: `1`) — emit plain text file
+ * - `BSI_CRASH_DUMP_MAX_PER_PROCESS`   (default: `10`) — `0` for no limit
  */
 
 import fs from 'node:fs';
@@ -44,10 +45,31 @@ import { redactSensitivePatterns } from './redact-secrets.js';
 const CRASH_DUMP_WRITE_TIMEOUT_MS = 5000;
 
 /**
+ * Default cap on how many crash dumps a single process may write.
+ *
+ * A backstop against a runaway caller, not a feature: issue #946 saw one process
+ * write 479,178 dump files because nothing counted them. The fatal handlers in
+ * `fatal-handlers.js` already guarantee one dump per run, so reaching this limit
+ * means some other caller is looping, and refusing to write is the right answer.
+ * Ten leaves ample room for deliberate `manual` dumps while still being a cap.
+ */
+const DEFAULT_MAX_DUMPS_PER_PROCESS = 10;
+
+/**
  * Per-process counter to ensure filename uniqueness when multiple crashes occur
  * within the same millisecond (e.g. multiple fatal handlers firing simultaneously).
+ *
+ * Strictly monotonic for the life of the process, and deliberately separate from
+ * the cap below: filenames are only unique if this never goes backwards, whereas
+ * the cap accounting has to be resettable for tests.
  */
 let crashDumpCounter = 0;
+
+/** How many dumps have been written against the current cap allowance. */
+let dumpsAgainstLimit = 0;
+
+/** True once the "limit reached" message has been logged, so it is logged once. */
+let limitReachedLogged = false;
 
 /**
  * List of environment variable names that trigger crash-dump functionality.
@@ -57,6 +79,7 @@ const ENV_ENABLE = 'BSI_CRASH_DUMP_ENABLE';
 const ENV_DIR = 'BSI_CRASH_DUMP_DIR';
 const ENV_CREATE_JSON = 'BSI_CRASH_DUMP_CREATE_JSON';
 const ENV_CREATE_TEXT = 'BSI_CRASH_DUMP_CREATE_TEXT';
+const ENV_MAX_PER_PROCESS = 'BSI_CRASH_DUMP_MAX_PER_PROCESS';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -73,6 +96,25 @@ function envBool(value) {
     if (typeof value !== 'string') return false;
     const v = value.trim().toLowerCase();
     return v === '1' || v === 'true' || v === 'yes';
+}
+
+/**
+ * Parse the per-process dump limit from its env var.
+ *
+ * Anything that is not a non-negative integer falls back to the default, on the
+ * principle that a typo in an env var should not silently remove the backstop.
+ *
+ * @param {string|undefined} value - Raw env-var value.
+ *
+ * @returns {number} The limit, where `0` means no limit.
+ */
+function parseMaxDumps(value) {
+    if (typeof value !== 'string' || value.trim() === '') return DEFAULT_MAX_DUMPS_PER_PROCESS;
+
+    const parsed = Number(value.trim());
+    if (!Number.isInteger(parsed) || parsed < 0) return DEFAULT_MAX_DUMPS_PER_PROCESS;
+
+    return parsed;
 }
 
 /**
@@ -179,6 +221,27 @@ export async function writeCrashDump(error, source) {
 
         if (!enable) return;
         if (!createJson && !createText) return;
+
+        // Backstop against a caller that loops. Checked before anything is
+        // built or written, so a runaway costs nothing but a function call.
+        const maxDumps = parseMaxDumps(process.env[ENV_MAX_PER_PROCESS]);
+        if (maxDumps > 0 && dumpsAgainstLimit >= maxDumps) {
+            if (!limitReachedLogged) {
+                limitReachedLogged = true;
+                const message = `CRASH DUMP: Limit of ${maxDumps} dumps per process reached, no further dumps will be written. Set ${ENV_MAX_PER_PROCESS} to raise or remove the limit.`;
+                try {
+                    if (logger) {
+                        logger.error(message);
+                    } else {
+                        console.error(message);
+                    }
+                } catch {
+                    console.error(message);
+                }
+            }
+            return;
+        }
+        dumpsAgainstLimit += 1;
 
         // ----------------------------------------------------------------
         // Build the crash dump payload
@@ -347,4 +410,22 @@ export async function writeCrashDump(error, source) {
     } catch {
         // writeCrashDump must never throw
     }
+}
+
+/**
+ * Restores the full per-process dump allowance and the "limit reached" log latch.
+ *
+ * Exists for tests, which share module state across the cases in a file and
+ * would otherwise trip the cap partway through a suite. Production code never
+ * calls this: the cap is meant to last a process.
+ *
+ * Deliberately does not touch the filename counter. Winding that back would let
+ * a later dump reuse an earlier dump's name, and since the files are written
+ * with the exclusive-create `wx` flag the later dump would be silently dropped.
+ *
+ * @returns {void}
+ */
+export function resetCrashDumpLimit() {
+    dumpsAgainstLimit = 0;
+    limitReachedLogged = false;
 }

--- a/src/lib/util/errors.js
+++ b/src/lib/util/errors.js
@@ -3,8 +3,8 @@
  *
  * Library code throws these instead of calling `process.exit(1)` so that:
  *
- *   1. The top-level `process.on('uncaughtException')` handler in
- *      `src/butler-sheet-icons.js` is the single source of process exit
+ *   1. The `uncaughtException` handler installed by
+ *      `src/lib/util/fatal-handlers.js` is the single source of process exit
  *      logic. Crash dumps, log lines, and exit codes live in one place.
  *   2. Test code can `await expect(promise).rejects.toThrow(<ErrorClass>)`
  *      instead of monkey-patching `process.exit` (which never worked

--- a/src/lib/util/fatal-handlers.js
+++ b/src/lib/util/fatal-handlers.js
@@ -1,0 +1,327 @@
+/**
+ * Process-level fatal error handlers for Butler Sheet Icons.
+ *
+ * These are the safety net of last resort: the `uncaughtException` and
+ * `unhandledRejection` listeners that catch anything escaping every try/catch
+ * in the application, write a crash dump, and exit with a non-zero code.
+ *
+ * They live here rather than in `src/butler-sheet-icons.js` for two reasons:
+ * importing the entry point runs the CLI as a side effect, so the handlers
+ * could not be unit-tested where they were; and the two handlers are twins, so
+ * keeping them in one place stops a fix being applied to one and not the other.
+ *
+ * ## Why the shape of this module matters
+ *
+ * Issue #946 reported a single process producing 479,178 crash dump files and
+ * never exiting. Two properties of the old handlers combined to allow that:
+ *
+ *   1. They were re-entrant. Every fatal event started its own crash dump, so a
+ *      failing run that produced a burst of rejections produced a burst of
+ *      dumps. Measured before this module existed: 200 unhandled rejections in
+ *      one process wrote 400 files.
+ *   2. They ended with `writeCrashDump(...).finally(() => process.exit(1))`.
+ *      `.finally()` does not handle a rejection — it passes it through, and the
+ *      promise it returns then rejects with nobody listening, which Node reports
+ *      as a fresh `unhandledRejection`. A failing crash dump could therefore
+ *      re-trigger the handler that asked for it.
+ *
+ * Four independent guards now close that off, so that no single mistake can
+ * bring the runaway back:
+ *
+ *   - A re-entry guard. The first fatal event owns the exit; later ones are
+ *     dropped. This is what makes the loop structurally impossible.
+ *   - A `.catch()` before the `.finally()`, so a rejected crash dump can never
+ *     become a new fatal event.
+ *   - A watchdog timer, so the process still exits if the crash dump write
+ *     never settles (a hung network filesystem, say).
+ *   - A per-process cap inside `writeCrashDump()` itself, which covers any
+ *     future caller rather than just these two handlers.
+ *
+ * A second fatal error arriving while the first crash dump is still being
+ * written is dropped rather than exiting immediately. Exiting there would
+ * truncate the one dump the operator actually needs, leaving the zero-byte file
+ * that #946 is about; the watchdog bounds how long the wait can be instead.
+ */
+
+import { logger as defaultLogger } from '../../globals.js';
+import { writeCrashDump as defaultWriteCrashDump } from './crash-dump.js';
+
+// ---------------------------------------------------------------------------
+// Module-level constants and state
+// ---------------------------------------------------------------------------
+
+/**
+ * Maximum time (ms) to wait for the crash dump write to settle before exiting
+ * anyway. Twice `CRASH_DUMP_WRITE_TIMEOUT_MS` in `crash-dump.js`, so under
+ * normal conditions the dump's own timeout always fires first and this is never
+ * reached. It exists for the case where the dump promise never settles at all.
+ */
+export const FATAL_EXIT_WATCHDOG_MS = 10000;
+
+/** True once a fatal event is being handled. Later fatal events are dropped. */
+let handlingFatal = false;
+
+/** True once `exit` has been called, so it can never be called twice. */
+let exited = false;
+
+/** Handle for the watchdog timer, cleared when the process exits. */
+let watchdogTimer = null;
+
+/**
+ * The listeners currently registered, so a re-install can remove them first.
+ * `null` when nothing is installed.
+ *
+ * @type {{target: import('node:events').EventEmitter, listeners: Array<[string, Function]>}|null}
+ */
+let installation = null;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Coerces an unhandled rejection reason into an `Error`.
+ *
+ * Rejection reasons are arbitrary values, and `String(reason)` can itself throw
+ * when the reason is an object with a hostile `toString`. Throwing here would
+ * turn an unhandled rejection into an uncaught exception before the re-entry
+ * guard is set, so the coercion is guarded.
+ *
+ * @param {Error|unknown} reason - The rejection reason.
+ *
+ * @returns {Error} The reason itself when it is already an `Error`, otherwise a
+ *   new `Error` describing it.
+ */
+function toError(reason) {
+    if (reason instanceof Error) return reason;
+    try {
+        return new Error(String(reason));
+    } catch {
+        return new Error('Unhandled promise rejection with an uncoercible reason');
+    }
+}
+
+/**
+ * Writes the single `FATAL:` log line for a fatal event.
+ *
+ * Never throws: falls back to `console.error` if the logger is broken, and
+ * gives up silently if that fails too. A failure to log must not stop the crash
+ * dump from being written.
+ *
+ * @param {Error} err - The error that caused the crash.
+ * @param {string} source - Where the crash originated (`uncaughtException` | `unhandledRejection`).
+ * @param {object} logger - Logger with an `error` method.
+ *
+ * @returns {void}
+ */
+function logFatalLine(err, source, logger) {
+    const label =
+        source === 'uncaughtException' ? 'Uncaught exception' : 'Unhandled promise rejection';
+    const message = `FATAL: ${label}: ${err?.message ?? err}`;
+
+    try {
+        logger.error(message);
+    } catch {
+        try {
+            console.error(message);
+        } catch {
+            // Nothing left to log with. Carry on to the crash dump.
+        }
+    }
+}
+
+/**
+ * Exits the process, at most once per process lifetime.
+ *
+ * Both the crash dump completing and the watchdog firing lead here, so this
+ * collapses them into a single exit.
+ *
+ * @param {number} code - Exit code to pass to the injected exit function.
+ * @param {Function} exit - The exit function (`process.exit` in production).
+ *
+ * @returns {void}
+ */
+function exitOnce(code, exit) {
+    if (exited) return;
+    exited = true;
+
+    if (watchdogTimer !== null) {
+        clearTimeout(watchdogTimer);
+        watchdogTimer = null;
+    }
+
+    exit(code);
+}
+
+/**
+ * Arms the watchdog that force-exits if the crash dump write never settles.
+ *
+ * The timer is `unref`'d so it can never by itself keep an otherwise healthy
+ * process alive.
+ *
+ * @param {object} deps - Resolved dependencies for this installation.
+ *
+ * @returns {void}
+ */
+function armWatchdog(deps) {
+    try {
+        watchdogTimer = setTimeout(() => exitOnce(1, deps.exit), deps.watchdogMs);
+        if (typeof watchdogTimer.unref === 'function') watchdogTimer.unref();
+    } catch {
+        // If the timer cannot be created we still have the crash dump's own
+        // timeout as a path to exit.
+    }
+}
+
+/**
+ * Handles one fatal event: log it, write a crash dump, exit.
+ *
+ * The first fatal event to arrive wins; every later one returns immediately
+ * without logging, writing, or exiting.
+ *
+ * @param {Error} err - The error that caused the crash.
+ * @param {string} source - Where the crash originated (`uncaughtException` | `unhandledRejection`).
+ * @param {object} deps - Resolved dependencies for this installation.
+ *
+ * @returns {void}
+ */
+function handleFatal(err, source, deps) {
+    // A fatal error raised while already handling a fatal error is dropped.
+    if (handlingFatal) return;
+    handlingFatal = true;
+
+    armWatchdog(deps);
+    logFatalLine(err, source, deps.logger);
+
+    try {
+        // `Promise.resolve` so that a `writeCrashDump` which returns a
+        // non-promise cannot throw here, and `.catch` so that a failed dump can
+        // never become a new fatal event.
+        Promise.resolve(deps.writeCrashDump(err, source))
+            .catch(() => {})
+            .finally(() => exitOnce(1, deps.exit));
+    } catch {
+        // `writeCrashDump` threw synchronously. Exit anyway — that is the one
+        // thing this handler must always do.
+        exitOnce(1, deps.exit);
+    }
+}
+
+/**
+ * Removes the listeners registered by a previous `installFatalHandlers()` call.
+ *
+ * @returns {void}
+ */
+function removeInstalledListeners() {
+    if (installation === null) return;
+
+    for (const [event, listener] of installation.listeners) {
+        try {
+            installation.target.removeListener(event, listener);
+        } catch {
+            // Best effort: a target that cannot remove listeners is replaced
+            // wholesale by the new installation anyway.
+        }
+    }
+    installation = null;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Installs the `uncaughtException` and `unhandledRejection` safety net.
+ *
+ * Call this before any other work in the entry point, so the net is in place
+ * before anything can fail. Calling it more than once is safe: the previous
+ * listeners are removed first, so there is never more than one listener per
+ * event.
+ *
+ * Every dependency is injectable so the handlers can be unit-tested without
+ * killing the test process.
+ *
+ * @param {object} [options] - Dependency overrides. All are optional.
+ * @param {object} [options.logger] - Logger with an `error` method. Defaults to the global logger.
+ * @param {Function} [options.writeCrashDump] - Crash dump writer. Defaults to the real one.
+ * @param {Function} [options.exit] - Exit function. Defaults to `process.exit`.
+ * @param {import('node:events').EventEmitter} [options.target] - Emitter to listen on. Defaults to `process`.
+ * @param {number} [options.watchdogMs] - Watchdog delay in ms. Defaults to {@link FATAL_EXIT_WATCHDOG_MS}.
+ *
+ * @returns {void}
+ */
+export function installFatalHandlers({
+    logger = defaultLogger,
+    writeCrashDump = defaultWriteCrashDump,
+    /**
+     * Default exit function: terminate the process with the given code.
+     *
+     * @param {number} code - Process exit code.
+     *
+     * @returns {void}
+     */
+    exit = (code) => process.exit(code),
+    target = process,
+    watchdogMs = FATAL_EXIT_WATCHDOG_MS,
+} = {}) {
+    removeInstalledListeners();
+
+    const deps = { logger, writeCrashDump, exit, watchdogMs };
+
+    /**
+     * Listener for synchronous uncaught exceptions.
+     *
+     * @param {Error} err - The uncaught error.
+     *
+     * @returns {void}
+     */
+    const onUncaughtException = (err) => handleFatal(toError(err), 'uncaughtException', deps);
+
+    /**
+     * Listener for unhandled promise rejections.
+     *
+     * BSI runs short-lived batch commands, so an unhandled rejection is treated
+     * exactly like an uncaught exception: there is no "recovery" mode worth
+     * returning to, and silently continuing can leave half-completed work in
+     * Qlik Sense.
+     *
+     * @param {Error|unknown} reason - The rejection reason (usually an `Error`).
+     *
+     * @returns {void}
+     */
+    const onUnhandledRejection = (reason) =>
+        handleFatal(toError(reason), 'unhandledRejection', deps);
+
+    target.on('uncaughtException', onUncaughtException);
+    target.on('unhandledRejection', onUnhandledRejection);
+
+    installation = {
+        target,
+        listeners: [
+            ['uncaughtException', onUncaughtException],
+            ['unhandledRejection', onUnhandledRejection],
+        ],
+    };
+}
+
+/**
+ * Removes the installed listeners and clears the re-entry, exit, and watchdog
+ * state.
+ *
+ * Exists for tests, which need a clean slate between cases. Production code
+ * installs the handlers once and never resets them — by the time either guard
+ * has been set, the process is on its way out.
+ *
+ * @returns {void}
+ */
+export function resetFatalHandlerState() {
+    removeInstalledListeners();
+
+    handlingFatal = false;
+    exited = false;
+
+    if (watchdogTimer !== null) {
+        clearTimeout(watchdogTimer);
+        watchdogTimer = null;
+    }
+}


### PR DESCRIPTION
Fixes #946.

A run that hit several fatal errors wrote a crash dump for each one. In the reported case that reached **479,178 files** from a single process, all zero bytes, and the run never exited — so a scheduled job hung instead of returning a non-zero code.

## One correction to the issue

The issue says `process.exit(1)` "never runs on the failing path" because it sits inside `.finally()`. It does run — `.finally(cb)` invokes `cb` on rejection too. Verified before planning.

The rest of the diagnosis holds. `.finally()`'s derived promise **does** reject unhandled and re-enter the handler; with `process.exit` stubbed out, the handler re-entered 51 times and kept going.

Worth noting: today's `writeCrashDump` cannot reject at all — its whole body sits in `try/catch` with a per-write `.catch()`. Checked against the real module with a `Proxy` whose every property access throws; it still resolved. So the loop as described needed the transient refactor state the issue mentions.

But there is a **live** defect that needs none of that: the handlers were re-entrant. Measured against the real module before any change — a burst of 200 unhandled rejections wrote **400 dump files** from one process. Same mechanism, 1/1200th the scale.

## The fix

Four layers, each of which stops the runaway on its own. The redundancy is deliberate: a single unguarded `.finally()` was all that stood between a failed write and a full disk.

| Layer | Where |
|---|---|
| Re-entry guard — the first fatal event owns the exit, later ones are dropped | `src/lib/util/fatal-handlers.js` |
| `.catch()` before `.finally()` — a failed dump cannot become a new fatal event | same |
| Unref'd watchdog — exits even if the dump write never settles | same |
| `BSI_CRASH_DUMP_MAX_PER_PROCESS`, default 10 | `src/lib/util/crash-dump.js` |

A second fatal arriving mid-dump is **dropped**, not exited on. Exiting there would truncate the one dump the operator needs and leave exactly the zero-byte file this issue is about; the watchdog bounds the wait instead.

Both handlers moved out of `src/butler-sheet-icons.js` into their own module. They could not be unit-tested where they were — importing the entry point runs the CLI as a side effect — so extraction is what makes the test the issue asks for writable at all. The entry point is 63 lines shorter.

## Verification

**400 → 2 files, exit code 1, both non-empty**, on the same 200-rejection burst against the real crash dump writer.

Every new test was checked against a mutated build with the guards removed. 8 unit tests and 2 end-to-end tests go red without them — and the mutation incidentally demonstrated the cap working alone: **10 files instead of 400** with the re-entry guard gone.

- `npm run test:unit` — 1052 passed, 56 suites
- `npm run lint` — clean
- `fatal-handlers.js` — 98% statements; the uncovered lines are defensive `catch` blocks

The end-to-end test is a real child process, real filesystem, no mocks: it fires 200 rejections and asserts exactly two non-empty files plus exit code 1.

One test caught a flaw in the first cut of this change — resetting the dump counter reintroduced filename collisions under the `wx` flag. The counter was doing two jobs; uniqueness is now monotonic for the life of the process and separate from the resettable cap accounting.

## Still open

**The original trigger is unexplained.** This stops the runaway and guarantees the exit; it does not explain what made the first write fail in the reported run, and there is no clean reproduction. Worth tracking separately rather than treating as covered here.

## Docs

`docs/to-doc-site/one-crash-dump-per-run.md` is staged for the next publishing pass — the new environment variable, the one-dump-per-run guarantee, batch deletes for a folder holding hundreds of thousands of zero-byte files, and a correction to the FAQ answer that assumed dumps accumulate unpredictably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)