### PR TITLE
chore: keep the GitNexus index fresh with git hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,23 @@
 # versions into a clear "upgrade pre-commit" message.
 minimum_pre_commit_version: '3.2.0'
 
+# `pre-commit install` wires up the pre-commit hook and nothing else by default, which
+# would leave the four post-* hooks below installed in config but never fired. Naming
+# the types here means a plain `pre-commit install` sets up all five.
+default_install_hook_types:
+    - pre-commit
+    - post-commit
+    - post-merge
+    - post-rewrite
+    - post-checkout
+
+# A hook that names no stages runs at *every* installed stage. Before the post-* hooks
+# below existed that was harmless, because only pre-commit was installed; now it means
+# every commit, merge, checkout and rebase prints a "Skipped (no files to check)" line
+# for each file-based hook. Default them to pre-commit; the one hook that belongs
+# elsewhere names its own stages and is unaffected.
+default_stages: [pre-commit]
+
 repos:
     - repo: https://github.com/gitguardian/ggshield
       rev: v1.53.0
@@ -26,6 +43,23 @@ repos:
                     sea-prep.blob|
                     build.cjs
                 )$
+
+          # Keeps the GitNexus index current instead of relying on an agent to notice
+          # it has gone stale. Inert until `npm run gitnexus:install` has been run in
+          # the clone, and never blocks a git operation — see the script's header and
+          # docs/README.gitnexus.md.
+          #
+          # always_run/pass_filenames are both required: the post-* stages hand a hook
+          # no file list, so the default behaviour would be to skip it entirely.
+          - id: gitnexus-reindex
+            name: gitnexus re-index
+            entry: scripts/gitnexus-reindex.sh
+            language: script
+            stages: [post-commit, post-merge, post-rewrite, post-checkout]
+            always_run: true
+            pass_filenames: false
+            verbose: true
+
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v6.0.0 # Use the ref you want to point at
       hooks:

--- a/docs/README.gitnexus.md
+++ b/docs/README.gitnexus.md
@@ -2,7 +2,7 @@
 
 How GitNexus is run in this repository, and the one command you must not use.
 
-This mirrors the setup in [butler-sos](https://github.com/ptarmiganlabs/butler-sos); keep the two in step when changing either.
+This mirrors the setup in [butler-sos](https://github.com/ptarmiganlabs/butler-sos); keep the two in step when changing either — with one deliberate divergence, the hook mechanism, explained under [Automatic re-indexing](#automatic-re-indexing).
 
 ## Never run a bare `npx gitnexus analyze`
 
@@ -24,6 +24,14 @@ npm run gitnexus:install
 
 This is the only command allowed to download the package. Everything else runs under `npx --no-install`, which executes an already-present copy and never fetches one.
 
+Then install the git hooks, which is what keeps the index current afterwards:
+
+```bash
+pre-commit install
+```
+
+Both are per-clone. Until the first is run the hooks are inert by design; until the second is run nothing fires at all — including this repo's ggshield secret scan, which is installed by the same command.
+
 ## Commands
 
 | Command | What it does |
@@ -35,7 +43,7 @@ This is the only command allowed to download the package. Everything else runs u
 
 Extra arguments are forwarded, so `npm run gitnexus:index -- --embeddings` works.
 
-There is also an internal `check` subcommand that reports through its exit code and prints nothing. Nothing calls it yet — it is the interface the git hooks in issue #829 will use.
+There is also an internal `check` subcommand that reports through its exit code and prints nothing. `scripts/gitnexus-reindex.sh` uses it to tell "GitNexus is not installed in this clone" apart from "the re-index failed".
 
 ## Everything routes through `scripts/gitnexus.js`
 
@@ -83,12 +91,30 @@ It is also worktree-aware. A linked worktree under `.claude/worktrees/` never ca
 
 ## Version pinning
 
-The version is pinned deliberately. An unpinned `npx gitnexus` executes whatever the registry serves at that moment — a new major, or a compromised release — with no repository change and no review. That matters more once re-indexing runs from a git hook (issue #829).
+The version is pinned deliberately. An unpinned `npx gitnexus` executes whatever the registry serves at that moment — a new major, or a compromised release — with no repository change and no review. That matters more now that re-indexing runs from a git hook.
 
 Bump `GITNEXUS_VERSION` in `scripts/gitnexus.js`, and bump butler-sos to match.
 
 ## Automatic re-indexing
 
-Not set up here yet. butler-sos keeps its index current with husky-installed `post-commit`, `post-merge`, `post-rewrite` and `post-checkout` hooks. Adopting the same is tracked in issue #829.
+Four git hooks — `post-commit`, `post-merge`, `post-rewrite` and `post-checkout` — run `scripts/gitnexus-reindex.sh`, which re-indexes incrementally. Between them they cover every routine way the working tree changes. They are declared in `.pre-commit-config.yaml` and installed by `pre-commit install`.
 
-Until then, run `npm run gitnexus:index` when a GitNexus tool reports the index is stale.
+The script never blocks a git operation: every failure path exits 0.
+
+### Why pre-commit and not husky
+
+butler-sos does this with husky, and porting that here would have been a mistake. husky works by pointing `core.hooksPath` at `.husky/_`, which takes `.git/hooks` out of the picture entirely — and that is where this repo's ggshield secret scan lives. The result would have been auto-reindexing bought at the price of a silently disabled secret scan, with nothing to announce the trade.
+
+That is not hypothetical. In butler-sos `core.hooksPath` is `.husky/_`, `.git/hooks` holds no non-sample hooks, and there is no `.husky/pre-commit`, so nothing runs at commit time. It cost that repo nothing only because its `.pre-commit-config.yaml` had been dead since 2022. Ours is current.
+
+The pre-commit framework supports the same four hook types natively, so this needed no new dependency, no `prepare` script and no devDependency — just a `repo: local` entry.
+
+### What the script decides, and why
+
+- **Inert until `npm run gitnexus:install`.** A hook that downloaded and executed a package after every commit would be a supply-chain surface. The download stays opt-in per clone; `node scripts/gitnexus.js check` probes for an already-present copy without fetching one.
+- **A missing index is left alone.** A full build is far too slow for a hook, so an absent `.gitnexus/` gets one line of advice rather than a blocked commit.
+- **A lost lock race is retried once.** The MCP server holds the KuzuDB index open during an agent session, and a write from the hook can lose that race. Silently accepting a stale index would defeat the point.
+- **Linked worktrees are skipped.** Worktrees share `.git`, so git fires these hooks there too — but a worktree has no `.gitnexus/` of its own. The index lives in, and describes, the canonical checkout, which a commit made in a worktree does not touch; re-indexing from there would be a no-op that still costs a write and can lose the lock race. The work reaches the index when the branch is merged in the canonical checkout, where `post-merge` fires.
+- **Only branch checkouts count.** `post-checkout` also fires for `git checkout -- <file>`, which changes nothing worth re-indexing.
+
+One thing does not port verbatim from butler-sos: git hands `post-checkout` three positional arguments, whereas pre-commit passes them as `PRE_COMMIT_CHECKOUT_TYPE`, `PRE_COMMIT_FROM_REF` and `PRE_COMMIT_TO_REF`. A copied `[ "$3" = "1" ]` test would read an unset variable and re-index on every file checkout.

--- a/scripts/gitnexus-reindex.sh
+++ b/scripts/gitnexus-reindex.sh
@@ -1,0 +1,112 @@
+#!/bin/sh
+#
+# Refresh the GitNexus knowledge-graph index after git changes the working tree.
+#
+# Why a hook rather than documentation: CLAUDE.md already tells agents to re-index
+# when the index goes stale, and it still goes stale — the index sat three commits
+# behind `main` while this was being written. An instruction is a backstop; the hook
+# is the mechanism.
+#
+# Wired up through .pre-commit-config.yaml rather than husky. butler-sos uses husky
+# for the same job, but husky works by pointing core.hooksPath at .husky/_, which
+# takes .git/hooks out of the picture entirely — and that is where this repo's
+# ggshield secret scan lives. Porting husky here would have traded a working secret
+# scan for auto-reindexing without anyone noticing. The pre-commit framework already
+# in use supports the same four hook types natively, so it costs no new dependency.
+#
+# This runs SYNCHRONOUSLY because an incremental index is fast. Running it in the
+# background would buy little and risks concurrent writers corrupting KuzuDB.
+#
+# It never blocks a git operation: every failure path exits 0.
+
+set -u
+
+# --- post-checkout: only branch checkouts are worth re-indexing --------------
+#
+# git passes post-checkout three positional arguments; pre-commit forwards them as
+# environment variables instead, so butler-sos's `[ "${3:-0}" = "1" ]` test does not
+# port across unchanged. PRE_COMMIT_CHECKOUT_TYPE is "1" for a branch checkout and
+# "0" for a file checkout, and re-indexing on every `git checkout -- <file>` would be
+# pure noise. Only post-checkout sets the variable, so the guard is inert elsewhere.
+if [ -n "${PRE_COMMIT_CHECKOUT_TYPE:-}" ]; then
+    [ "$PRE_COMMIT_CHECKOUT_TYPE" = "1" ] || exit 0
+
+    # Same commit on both sides (e.g. `git checkout -b` from HEAD) changes nothing.
+    [ "${PRE_COMMIT_FROM_REF:-}" != "${PRE_COMMIT_TO_REF:-}" ] || exit 0
+fi
+
+# --- act only in the checkout that owns the index ----------------------------
+#
+# Linked worktrees share .git, and git resolves hooks through the shared .git/hooks,
+# so these hooks fire from worktrees too. A linked worktree never carries its own
+# .gitnexus/: the index lives in the canonical checkout and describes *that*
+# checkout's files, which a commit made in a worktree does not touch. Re-indexing
+# from here would be a no-op that still costs a KuzuDB write and can lose the lock
+# race against a running MCP server. The work reaches the index when the branch is
+# merged in the canonical checkout, where post-merge fires.
+#
+# In the canonical checkout --git-dir and --git-common-dir resolve to the same path;
+# in a linked worktree the former is .git/worktrees/<name>. Directory containment
+# cannot substitute for this test — worktrees created under .claude/worktrees/ live
+# *inside* the canonical root.
+git_dir=$(git rev-parse --path-format=absolute --git-dir 2>/dev/null) || exit 0
+common_dir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || exit 0
+[ -n "$common_dir" ] || exit 0
+[ "$git_dir" = "$common_dir" ] || exit 0
+
+# Hooks already run from the top of the working tree; every path below depends on
+# that, so make it explicit rather than inherited.
+cd "$(dirname "$common_dir")" || exit 0
+
+# A missing index means a FULL build, which is far too slow to run inside a hook.
+# Leave it to the developer and say so once.
+if [ ! -d ".gitnexus" ]; then
+    echo "gitnexus: no index in this checkout — run 'npm run gitnexus:refresh' to build one." >&2
+    exit 0
+fi
+
+# node runs the wrapper, npx runs GitNexus itself. Both are checked, and both exit
+# silently: an environment without them cannot act on any advice we could print.
+command -v node >/dev/null 2>&1 || exit 0
+command -v npx >/dev/null 2>&1 || exit 0
+
+# The pinned version, the analyze flags and the npx invocation all live in
+# scripts/gitnexus.js — one definition shared by this hook and the gitnexus:* npm
+# scripts, so there is no second copy to keep in sync.
+#
+# The wrapper is absent from every commit made before it was introduced, and
+# post-checkout fires on exactly those. That is not the same as GitNexus being
+# missing, so it does not get the same message: `npm run gitnexus:install` would not
+# fix it, and telling someone to run it wastes their time.
+if [ ! -f scripts/gitnexus.js ]; then
+    echo "gitnexus: scripts/gitnexus.js not in this checkout — skipping re-index." >&2
+    exit 0
+fi
+
+# `check` probes for an already-installed copy without fetching one. Nothing on this
+# path may download: a hook that installed and executed a package after every commit
+# would be a supply-chain surface (SonarCloud shell:S6505, and a fair point). GitNexus
+# is not a devDependency either — ~40 MB unpacked with native tree-sitter builds is a
+# lot to add to every CI install for a local developer convenience — so it is fetched
+# once, deliberately, by `npm run gitnexus:install`.
+if ! node scripts/gitnexus.js check >/dev/null 2>&1; then
+    echo "gitnexus: not installed — run 'npm run gitnexus:install' to enable auto-reindexing." >&2
+    exit 0
+fi
+
+# Retried once: the KuzuDB index is held open by the GitNexus MCP server when an
+# agent session is running, and a write from here can lose that lock race. A silent
+# stale index defeats the whole point, so give it a second chance before giving up.
+reindex() {
+    node scripts/gitnexus.js index >/dev/null 2>&1
+}
+
+if ! reindex; then
+    sleep 2
+    if ! reindex; then
+        echo "gitnexus: index refresh failed twice; run 'npm run gitnexus:index' manually." >&2
+        exit 0
+    fi
+fi
+
+exit 0


### PR DESCRIPTION
Closes #829 — but deliberately **not** with husky, which is what that issue proposed.

## Why not husky

husky works by pointing `core.hooksPath` at `.husky/_`, which takes `.git/hooks` out of the picture entirely. That is where this repo's ggshield secret scan lives, via the `pre-commit` framework and `.pre-commit-config.yaml`. Adopting husky would have bought auto-reindexing at the price of a silently disabled secret scan, with nothing to announce the trade.

Not hypothetical: in butler-sos today `core.hooksPath` is `.husky/_`, `.git/hooks` holds no non-sample hooks, and there is no `.husky/pre-commit` — nothing runs at commit time there. It cost butler-sos nothing only because its `.pre-commit-config.yaml` had been dead since 2022-07-10. Ours is current, upgraded as recently as #819.

## What this does instead

The `pre-commit` framework already in use supports the same four hook types natively, so this needs **no new dependency, no `prepare` script and no devDependency** — just a `repo: local` entry plus `scripts/gitnexus-reindex.sh`.

All three design points from #829 carry over intact: inert before `npm run gitnexus:install` (nothing on the hook path may download), advice rather than a blocked commit when there is no index to update, and one retry when the MCP server wins the KuzuDB lock race. Every failure path exits 0.

Two things did not port verbatim from butler-sos, and would have been silent bugs:

- git hands `post-checkout` three positional arguments; pre-commit passes `PRE_COMMIT_CHECKOUT_TYPE` / `FROM_REF` / `TO_REF`. A copied `[ "$3" = "1" ]` test reads an unset variable and re-indexes on every `git checkout -- <file>`.
- Linked worktrees share `.git`, so git fires these hooks there too — but a worktree carries no `.gitnexus/`, and the index describes the canonical checkout, which a worktree commit does not touch. butler-sos's script would print "no index in this checkout" after every worktree commit; ours skips silently. The work reaches the index when the branch is merged in the canonical checkout, where `post-merge` fires.

`default_stages: [pre-commit]` preserves existing behaviour rather than reducing it. Those hooks were only ever installed at the pre-commit stage, so their unset `stages` never mattered; installing four more types is what would have changed it, adding five `Skipped (no files to check)` lines to every commit, merge, checkout and rebase.

## Verified

- 11 guard-path tests against a purpose-built fake repo: worktree skip, both post-checkout guards, not-installed, no-index, missing wrapper, retry-then-give-up, cwd independence.
- All four stages firing from real git operations — `post-commit` and `post-rewrite` via a commit and an amend, `post-checkout` via a real branch checkout, `post-merge` via an explicit stage run.
- A real end-to-end re-index in a standalone clone: 4.5s, index written, `meta.json` `lastCommit` matching `HEAD`.
- The existing checks still block bad commits under the final config: a deliberately broken JSON file was rejected by `check-json`, and prettier reformatted an unformatted JS file.

## Note for reviewers

`pre-commit` was not installed in the maintainer's clone — `.git/hooks` held only samples — so none of the existing checks, including the ggshield secret scan, had been running locally. `pre-commit install` now wires all five hook types in one go via `default_install_hook_types`. It remains a per-clone step, documented in `docs/README.gitnexus.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)