### PR TITLE
Stop the log sanitiser removing the word that explained the error

### DIFF
--- a/docs/to-doc-site/options-and-messages-that-told-you-the-wrong-thing.md
+++ b/docs/to-doc-site/options-and-messages-that-told-you-the-wrong-thing.md
@@ -1,8 +1,9 @@
 # Options and error messages that told you the wrong thing
 
-Four fixes in this release share a theme: Butler Sheet Icons accepted something, or reported
-something, that did not match what it actually did. Two options were silently ignored, and two
-checks blamed the wrong cause when they failed.
+Five fixes in this release share a theme: Butler Sheet Icons accepted something, or reported
+something, that did not match what it actually did. Two options were silently ignored, two
+checks blamed the wrong cause when they failed, and one message removed the word that would
+have explained it.
 
 Nothing about a run that already works changes. Read the section matching anything you recognise.
 
@@ -142,3 +143,48 @@ Icons and QRS — a reverse proxy or load balancer — is answering instead of Q
 
 The same protection applies to the app lookup behind `--qliksensetag`, which previously failed
 with an internal error naming nothing useful.
+
+## A message that hid the one word you needed
+
+Butler Sheet Icons strips secrets out of everything it writes — log lines, error messages, crash
+dumps. Passwords, API keys and the `Authorization` header sent to Qlik Sense are replaced with
+`[REDACTED]` before anything reaches disk or screen.
+
+That stripping was too eager. It removed whatever word happened to follow `token`, `bearer` or
+`basic`, whether or not the word was a secret — and ordinary English sentences contain those
+words too.
+
+The message you get when the Qlik Sense Cloud API key is empty was one of them.
+
+**Before:**
+
+```
+CLOUD CREATE THUMBNAILS 2 (stack): Error: API token [REDACTED] is required
+```
+
+That reads as though Butler Sheet Icons found a token and hid it from you. It had not. The word
+it removed was `parameter`, which was the part telling you what was actually wrong.
+
+**Now:**
+
+```
+CLOUD CREATE THUMBNAILS 2 (stack): Error: API token parameter is required
+```
+
+Any message could be affected, not just this one. Phrases such as "no token available for
+tenant" or "Basic authentication is required" lost a word the same way.
+
+**Secrets are still removed.** An `Authorization` header is still redacted whatever follows it,
+and so is anything that looks like a credential — a Qlik Sense Cloud API key, which is a long
+mixed-case string with dots in it, is untouched by this change. What is now left alone is plain
+lowercase text of the kind that only ever appears in a sentence. Passwords, API keys and
+credentials in URLs are handled by separate rules that did not change at all.
+
+**What to check.** Nothing, before or after upgrading. If you have ever seen `[REDACTED]` in the
+middle of a sentence and wondered which secret of yours was in that log line, the answer is that
+there was none — it was this.
+
+**Where this message comes from.** The Qlik Sense Cloud commands accept the API key as
+`--apikey` or as the environment variable `BSI_QSCLOUD_CST_APIKEY`. An environment variable that
+is set but empty — a typo in a name, a secret store that returned nothing — passes the
+"was it supplied?" check and fails this one instead. That is the common route to this message.

--- a/src/lib/util/__tests__/redact-secrets.test.js
+++ b/src/lib/util/__tests__/redact-secrets.test.js
@@ -130,11 +130,57 @@ describe('redactSensitivePatterns', () => {
     test('redacts Bearer / Basic / Token headers', () => {
         const a = 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.fake.sig';
         const b = 'Authorization: Basic dXNlcjpwYXNz';
-        const c = 'Token abcdefghijklmnop';
+        const c = 'Authorization: Token abcdefghijklmnop';
 
         expect(redactSensitivePatterns(a)).toMatch(/Bearer\s+\[REDACTED\]/);
         expect(redactSensitivePatterns(b)).toMatch(/Basic\s+\[REDACTED\]/);
         expect(redactSensitivePatterns(c)).toMatch(/Token\s+\[REDACTED\]/);
+    });
+
+    test('redacts an Authorization header however it is spelled or quoted', () => {
+        // The stringified-config form: what reaches the log when a caller does
+        // JSON.stringify(err) on an axios error.
+        expect(
+            redactSensitivePatterns('{"Authorization":"Bearer eyJhbGciOiJIUzI1NiJ9.fake.sig"}')
+        ).toBe('{"Authorization":"Bearer [REDACTED]"}');
+        expect(redactSensitivePatterns('proxy-authorization: Basic dXNlcjpwYXNz')).toBe(
+            'proxy-authorization: Basic [REDACTED]'
+        );
+    });
+
+    test('redacts a bare scheme when what follows is credential-shaped', () => {
+        // No Authorization header name in front, as in a stack trace or a server
+        // error. Mixed case, digits, dots and long lowercase runs are credentials.
+        expect(redactSensitivePatterns('Basic dXNlcjpwYXNz')).toBe('Basic [REDACTED]');
+        expect(redactSensitivePatterns('bearer eyJhbGciOi.payload.sig')).toBe('bearer [REDACTED]');
+        expect(redactSensitivePatterns('Token abcdefghijklmnopqrstuvwxyz')).toBe(
+            'Token [REDACTED]'
+        );
+    });
+
+    test('leaves prose that merely contains a scheme keyword alone', () => {
+        // Issue #949: the rule used to eat the word after `token`, so the message
+        // an operator gets for a missing --apikey read "API token [REDACTED] is
+        // required" - as though a token value had been found and hidden.
+        for (const text of [
+            'API token parameter is required',
+            'the token parameter',
+            'Basic authentication is required',
+            'no token available for tenant',
+            'token successfully refreshed',
+            'Token retrieval failed',
+        ]) {
+            expect(redactSensitivePatterns(text)).toBe(text);
+        }
+    });
+
+    test('does not redact a bare scheme followed by a plain lowercase word', () => {
+        // The deliberate cost of the fix above (issue #949): an all-lowercase
+        // credential of 8-23 characters, with no Authorization header name and no
+        // `token=` delimiter, is indistinguishable from an English word and is
+        // left alone. Qlik Cloud API keys are JWTs, so they stay covered by the
+        // cases above. Change this test only alongside that trade-off.
+        expect(redactSensitivePatterns('Token abcdefghijklmnop')).toBe('Token abcdefghijklmnop');
     });
 
     test('redacts common key=value secret patterns', () => {

--- a/src/lib/util/redact-secrets.js
+++ b/src/lib/util/redact-secrets.js
@@ -14,6 +14,12 @@
  *     credentials, `Authorization: Bearer …` headers, and key=value
  *     patterns such as `password=…` or `api_key=…` in any string.
  *
+ * The free-text layer has to tell a credential apart from a sentence that
+ * happens to contain the word `token`. It does so by context: after an
+ * `Authorization:` header name anything goes, while a bare `Bearer`/`Basic`/
+ * `Token` only redacts what follows if it does not look like an English word.
+ * See `isProseWord()` and issue #949.
+ *
  * Both layers are best-effort: a determined attacker could craft values
  * that evade either, but normal Qlik Sense / Qlik Cloud / Qlik config
  * shapes are covered.
@@ -71,6 +77,23 @@ const REDACTED = '***redacted***';
 function isSecretKey(name) {
     if (typeof name !== 'string') return false;
     return SECRET_KEY_SET.has(name.toLowerCase());
+}
+
+/**
+ * Tests whether the text following a bare auth scheme keyword reads as ordinary
+ * prose rather than as a credential.
+ *
+ * Credentials are base64, hex, JWTs or UUIDs: mixed case, digits, dots or
+ * dashes. A run of plain lowercase letters short enough to be a word
+ * (`parameter`, `authentication`, `available`) is prose. The 24-letter ceiling
+ * keeps longer lowercase runs — too long to be an English word — on the
+ * redacted side.
+ *
+ * @param {string} value - The text following an auth scheme keyword.
+ * @returns {boolean} `true` when the value looks like prose rather than a credential.
+ */
+function isProseWord(value) {
+    return /^[a-z]{1,23}$/.test(value);
 }
 
 /**
@@ -142,8 +165,33 @@ export function redactSensitivePatterns(text) {
     // 1. URLs with embedded credentials: protocol://user:pass@host
     result = result.replace(/([\w+.-]+:\/\/)[^@\s]+@/g, '$1[REDACTED]@');
 
-    // 2. Bearer / Basic / Token authorization headers
-    result = result.replace(/\b(Bearer|Basic|Token)\s+[A-Za-z0-9+/=._-]{8,}/gi, '$1 [REDACTED]');
+    // 2a. Authorization headers. The header name in front of the scheme settles
+    //     the question: whatever follows is a credential, whatever it looks like.
+    //     The optional quotes cover the stringified-config form
+    //     (`"Authorization": "Bearer …"`) that reaches the log when a caller does
+    //     `JSON.stringify(err)` - see the note in cloud-repo-request.js.
+    result = result.replace(
+        /\b((?:proxy-)?authorization["']?\s*[:=]\s*["']?)(bearer|basic|token)(\s+)[A-Za-z0-9+/=._~-]+/gi,
+        '$1$2$3[REDACTED]'
+    );
+
+    // 2b. A bare scheme word, as it appears in a stack trace or a server error.
+    //     With no header name there is nothing to say the next word is a
+    //     credential rather than prose: `Token` also matches the English word
+    //     `token`, which turned "API token parameter is required" into
+    //     "API token [REDACTED] is required" - the message an operator gets when
+    //     --apikey (or BSI_QSCLOUD_CST_APIKEY) is empty, with the one useful word
+    //     removed (issue #949).
+    //
+    //     The prose test has to live in a callback. This regex is
+    //     case-insensitive, so an inline `(?![a-z]+\b)` lookahead would fold to
+    //     any case and match base64 such as `dXNlcjpwYXNz`, silently disabling
+    //     the rule for real credentials.
+    result = result.replace(
+        /\b(Bearer|Basic|Token)(\s+)([A-Za-z0-9+/=._-]{8,})/gi,
+        (match, scheme, space, value) =>
+            isProseWord(value) ? match : `${scheme}${space}[REDACTED]`
+    );
 
     // 3. Common key=value secret patterns (query strings, connection strings, etc.)
     //    Matches: password=, passwd=, pwd=, logonpwd=, secret=, token=, api_key=,


### PR DESCRIPTION
Fixes #949.

## The problem

Run a Qlik Sense Cloud command with an empty API key and the log reads:

```
CLOUD CREATE THUMBNAILS 2 (stack): Error: API token [REDACTED] is required
```

That reads as though a token value was found and hidden. Nothing was hidden — the word removed was `parameter`, which was the part that explained the problem. This is the message a first-time user meets when the key is missing.

## Correction to the issue's diagnosis

The issue blames the key=value rule and recommends requiring a delimiter before redacting. **That rule already requires `[=:]`**, so the recommended fix was already in place and would have changed nothing.

The real culprit is the auth-header rule: `/\b(Bearer|Basic|Token)\s+[A-Za-z0-9+/=._-]{8,}/gi`. The `i` flag makes `Token` match the English word `token`, and the next 8+ character word is eaten. A Bearer credential legitimately follows a *space*, not a delimiter, so "require a delimiter" cannot be applied to this rule at all.

Two false positives beyond the reported one, found by running the function:

```
"Basic authentication is required" -> "Basic [REDACTED] is required"
"no token available for tenant"    -> "no token [REDACTED] for tenant"
```

## The fix

The rule is split in two:

- **After an `Authorization:` / `proxy-authorization:` header name** — redact whatever follows, whatever it looks like. Covers the quoted `{"Authorization":"Bearer …"}` form that reaches the log when a caller does `JSON.stringify(err)`.
- **A bare scheme word** — skip the match when what follows is plain lowercase text of fewer than 24 letters, i.e. English prose.

The prose test lives in a replace callback, not a lookahead. The regex is case-insensitive, so an inline `(?![a-z]+\b)` folds to any case and matches mixed-case base64 such as `dXNlcjpwYXNz` — which would silently disable the rule for real credentials. That was caught by running a first draft, not by reading it.

Rules 1, 3 and 4 (URL credentials, key=value, JSON-style) are untouched.

## What this gives up

A bare all-lowercase credential of 8–23 characters, with no `Authorization` header name and no `token=` delimiter, is no longer redacted. Qlik Cloud API keys are JWTs — dots, digits, mixed case — so they stay covered, as does `Basic dXNlcjpwYXNz`. The 24-letter ceiling keeps longer lowercase runs on the redacted side.

This is a real loosening of a security control, so there is a test asserting it explicitly, with a comment pointing here. It costs one existing fixture (`Token abcdefghijklmnop`).

## Verification

- 1021 unit tests pass across 55 suites; `redact-secrets.js` at 100% statement coverage. Lint and prettier clean.
- The exact line from the issue, run for real: `Error: API token parameter is required`.
- Redaction confirmed still firing through the real winston pipeline — a JWT-shaped key in a bearer header and in a stringified config never reaches the output.
- Not tested against a live Qlik Cloud tenant; the "a real key never leaks" check rests on the fake-JWT pipeline test.

## Known gap, not fixed here

`Authorization: <value>` with no scheme word is redacted by no rule, because rule 3's `auth` alternative needs `[=:]` immediately after `auth`. Fixing it interacts with the new header rule, so it needs its own change. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)