### PR TITLE
Stop the per-app QRS lookups failing as internal errors

### DIFF
--- a/docs/to-doc-site/options-and-messages-that-told-you-the-wrong-thing.md
+++ b/docs/to-doc-site/options-and-messages-that-told-you-the-wrong-thing.md
@@ -78,10 +78,10 @@ a bare host name for the engine connection and the repository API, each of which
 separately from `--engineport` and `--qrsport`. A `--host` containing `:8443` breaks both of those
 connections. `--port` is the only correct place for the web port.
 
-## Two failures that named the wrong cause
+## Three failures that named the wrong cause
 
-Separately from the options above, two checks reported the wrong reason when they went wrong,
-and both sent you looking in the wrong place. Nothing about a working run changes.
+Separately from the options above, three checks reported the wrong reason when they went wrong,
+and each sent you looking in the wrong place. Nothing about a working run changes.
 
 ### An unreadable certificate is no longer called a missing one
 
@@ -143,6 +143,45 @@ Icons and QRS — a reverse proxy or load balancer — is answering instead of Q
 
 The same protection applies to the app lookup behind `--qliksensetag`, which previously failed
 with an internal error naming nothing useful.
+
+### Per-app lookups no longer fail as internal errors
+
+Client-managed Qlik Sense only. Before generating thumbnails for an app, Butler Sheet Icons asks
+QRS three questions: what the app is called, which of its sheets carry the tags named by
+`--exclude-sheet-tag` and `--blur-sheet-tag`, and how the sheet ids in the repository map to the
+ones the engine uses. All three assumed the answer would be a list.
+
+When the answer was something else — an error object from QRS, or a reply from something other
+than Qlik Sense sitting in front of it — each failed in its own unhelpful way:
+
+| Lookup             | What you were told                                                                     |
+| ------------------ | -------------------------------------------------------------------------------------- |
+| Sheet id mapping   | `TypeError: mapRepoEngineSheetIdTmp1.forEach is not a function`                          |
+| App name           | The run reported `App name: "undefined"` and **carried on**, generating thumbnails anyway |
+| Tagged sheets      | A sheet count that was never real, then a failure part-way through the sheets            |
+
+The middle one is the one worth knowing about: the run looked like it was working.
+
+**Now** all three report the response as the problem, naming the request, and the app stops before
+a browser is started or a Qlik Sense session is opened:
+
+```
+QRS returned an unusable response for "app?filter=id%20eq%20<app id>": expected a list, got string
+```
+
+Other apps in the same run are unaffected — the run continues to the next one and reports how many
+failed, as it does for any other per-app failure.
+
+**What to check.** Same as above: whether the account named by `--apiuserid` and `--apiuserdir`
+may read apps and app objects, and whether something between Butler Sheet Icons and QRS is
+answering instead of Qlik Sense.
+
+An app that genuinely cannot be found is now named as that, rather than failing later inside the
+Qlik Sense session:
+
+```
+QSEoW app <app id> was not found in the Qlik Sense repository. Check --appid, and that the account named by --apiuserdir/--apiuserid may read the app.
+```
 
 ## A message that hid the one word you needed
 

--- a/src/lib/cloud/cloud-create-thumbnails.js
+++ b/src/lib/cloud/cloud-create-thumbnails.js
@@ -21,8 +21,10 @@ import { runOverApps } from '../util/run-over-apps.js';
  * @param {string} options.schemaversion - Version of the QS schema.
  * @param {string} options.browser - Name of browser to use for rendering thumbnails.
  * @param {string} options.browserVersion - Version of browser to use for rendering thumbnails.
- * @param {string} options.blurSheetStatus - Which sheet statuses should be blurred.
+ * @param {Array<string>} options.blurSheetStatus - Sheet statuses to blur. Variadic, and defaulted to `[]` by Commander.
  * @param {Array<string>} options.blurSheetNumber - Sheet numbers (1=first sheet) to blur.
+ * @param {string|string[]} options.excludeSheetTag - Tags for sheets to exclude. Read only to warn: Qlik Sense Cloud cannot tag individual sheets, so the option is accepted and ignored.
+ * @param {string|string[]} options.blurSheetTag - Tags for sheets whose thumbnail should be blurred. Read only to warn, for the same reason.
  * @param {string} options.blurFactor - Blur factor.
  *
  * @returns {Promise<boolean>} Resolves to `true` if thumbnails were created successfully, `false` otherwise.

--- a/src/lib/qseow/__tests__/qseow_process_app.test.js
+++ b/src/lib/qseow/__tests__/qseow_process_app.test.js
@@ -1117,3 +1117,153 @@ describe('qseow-process-app.js — a blurred thumbnail that cannot be created', 
         );
     });
 });
+
+describe('qseow-process-app.js — a QRS reply that is not a list', () => {
+    // The three per-app lookups used to read `.body` straight off the qrs-interact result. A
+    // reply that parsed as JSON but was not an array then flowed on: the sheet-id map blew up as
+    // `TypeError: ... .forEach is not a function`, the app-metadata read reported
+    // `App name: "undefined"` and carried on, and the tag lookup reported a fabricated sheet
+    // count. Reading through qrsGetList makes the response itself the reported problem.
+    //
+    // Only the 200-with-wrong-shape case is reachable: qrs-interact rejects every other status,
+    // and its unguarded JSON.parse throws on a non-JSON body before the promise resolves.
+    const options = {
+        senseVersion: '2023-Nov',
+        browser: 'chrome',
+        browserVersion: 'recommended',
+        imagedir: './img',
+        host: 'test-server.example.com',
+        logonuserdir: 'INTERNAL',
+        logonuserid: 'sa_api',
+        logonpwd: 'password',
+        excludeSheetNumber: [],
+        excludeSheetTitle: [],
+        excludeSheetStatus: [],
+        includesheetpart: '1',
+        pagewait: 0,
+        secure: true,
+        prefix: '',
+        headless: true,
+        blurFactor: 5,
+        loglevel: 'info',
+    };
+
+    const APP_METADATA = [{ id: 'test-app-id', name: 'Test App', published: true }];
+    const SHEET_ROWS = [{ id: 'sheet-id-1', engineObjectId: 'engine-sheet-id-1' }];
+
+    /**
+     * Wires the mock stack with one QRS lookup answering a caller-supplied body.
+     *
+     * Everything is re-established here rather than shared with the blocks above, because this
+     * file does not reset between describes and earlier tests leave mocks in a failure state.
+     *
+     * @param {'appMetadata'|'tagLookup'|'sheetMap'} target - Which lookup should misbehave.
+     * @param {object|Array<object>|string|number|null} body - The body that lookup should answer
+     *     with. Anything but an array is what the assertions are about.
+     *
+     * @returns {void}
+     */
+    function wireBadBody(target, body) {
+        jest.clearAllMocks();
+
+        detectAvailableBrowser.mockResolvedValue({
+            executablePath: '/test/browser',
+            source: 'system',
+            browser: 'chrome',
+            buildId: 'system-installed',
+        });
+        qseowUploadToContentLibrary.mockResolvedValue(true);
+        qseowUpdateSheetThumbnails.mockResolvedValue(true);
+
+        const mockGet = jest.fn().mockImplementation((encodedPath) => {
+            const path = decodeURIComponent(encodedPath);
+
+            if (path.includes('app?filter=id eq')) {
+                return Promise.resolve({
+                    statusCode: 200,
+                    body: target === 'appMetadata' ? body : APP_METADATA,
+                });
+            }
+            if (path.includes('tags.name eq')) {
+                return Promise.resolve({
+                    statusCode: 200,
+                    body: target === 'tagLookup' ? body : [],
+                });
+            }
+            if (path.includes('app/object/full?filter=objectType eq')) {
+                return Promise.resolve({
+                    statusCode: 200,
+                    body: target === 'sheetMap' ? body : SHEET_ROWS,
+                });
+            }
+            return Promise.resolve({ statusCode: 200, body: [] });
+        });
+
+        qrsInteract.mockImplementation(() => ({ Get: mockGet }));
+    }
+
+    const badBodies = [
+        ['an error object', { error: 'proxy failure' }],
+        ['null', null],
+        ['a quoted JSON string', 'Unauthorized'],
+        ['a number', 42],
+    ];
+
+    describe.each(badBodies)('%s from the sheet-id map lookup', (_label, body) => {
+        test('fails the app naming QRS, before any engine session or browser', async () => {
+            wireBadBody('sheetMap', body);
+
+            await expect(qseowProcessApp('test-app-id', options)).rejects.toThrow(
+                /unusable response/
+            );
+
+            // The point of failing here rather than downstream: nothing has been spent yet.
+            expect(enigma.create).not.toHaveBeenCalled();
+            expect(puppeteer.launch).not.toHaveBeenCalled();
+        });
+    });
+
+    test('names the endpoint that answered badly, not the symptom', async () => {
+        wireBadBody('sheetMap', { error: 'proxy failure' });
+
+        await expect(qseowProcessApp('test-app-id', options)).rejects.toThrow(
+            /app%2Fobject%2Ffull|app\/object\/full/
+        );
+    });
+
+    test('app metadata: fails instead of reporting the app name as undefined', async () => {
+        // This was the genuine silent wrong answer. A quoted string made appMetadata[0] the
+        // first character, so `.name` was undefined and the run continued to completion -
+        // taking screenshots and repointing sheet icons for an app it could not describe.
+        wireBadBody('appMetadata', 'Unauthorized');
+
+        await expect(qseowProcessApp('test-app-id', options)).rejects.toThrow(/unusable response/);
+
+        const infos = logger.info.mock.calls.map((call) => String(call[0])).join('\n');
+        expect(infos).not.toContain('App name: "undefined"');
+        expect(enigma.create).not.toHaveBeenCalled();
+    });
+
+    test('app metadata: an empty list names the app and --appid', async () => {
+        wireBadBody('appMetadata', []);
+
+        await expect(qseowProcessApp('test-app-id', options)).rejects.toThrow(
+            /test-app-id[\s\S]*--appid/
+        );
+
+        expect(enigma.create).not.toHaveBeenCalled();
+    });
+
+    test('tag lookup: refuses to report a fabricated sheet count', async () => {
+        // A quoted string has a .length, so the count line added to expose a mistyped tag
+        // would have reported its character count as though that many sheets carried the tag.
+        wireBadBody('tagLookup', 'Unauthorized');
+
+        await expect(
+            qseowProcessApp('test-app-id', { ...options, excludeSheetTag: ['exclude-me'] })
+        ).rejects.toThrow(/unusable response/);
+
+        const infos = logger.info.mock.calls.map((call) => String(call[0])).join('\n');
+        expect(infos).not.toContain('Sheets carrying a tag named by');
+    });
+});

--- a/src/lib/qseow/qseow-process-app.js
+++ b/src/lib/qseow/qseow-process-app.js
@@ -17,6 +17,7 @@ import {
 import { withEngineSession } from '../util/engine-session.js';
 import { createAppImageDir } from '../util/image-dir.js';
 import { qrsFilterAnyOf, qrsPathWithFilter, toFilterValueList } from './qrs-filter.js';
+import { qrsGetList } from './qrs-response.js';
 
 /**
  * Looks up the sheets in an app that carry any of the supplied tags.
@@ -37,6 +38,8 @@ import { qrsFilterAnyOf, qrsPathWithFilter, toFilterValueList } from './qrs-filt
  *
  * @returns {Promise<Array<object>>} Sheet metadata objects exposing `engineObjectId`, empty when
  *     no tags were supplied.
+ *
+ * @throws {QseowError} When QRS answers with something that is not a list.
  */
 const getSheetsTaggedWith = async (qrsInteractInstance, appSheetsFilter, tagOption, optionName) => {
     // Variadic options arrive as arrays, so the tag term has to be an `or` group over every tag
@@ -51,8 +54,13 @@ const getSheetsTaggedWith = async (qrsInteractInstance, appSheetsFilter, tagOpti
     const tagFilter = `${appSheetsFilter} and ${qrsFilterAnyOf('tags.name', tags)}`;
     logger.debug(`GET sheets tagged for ${optionName}: app/object/full?filter=${tagFilter}`);
 
-    const response = await qrsInteractInstance.Get(qrsPathWithFilter('app/object/full', tagFilter));
-    const taggedSheets = response.body;
+    // Through qrsGetList: the count logged below is taken with `.length`, and a reply that is not
+    // a list answers that with a plausible number rather than failing - a quoted JSON string would
+    // report its character count as though that many sheets carried the tag.
+    const taggedSheets = await qrsGetList(
+        qrsInteractInstance,
+        qrsPathWithFilter('app/object/full', tagFilter)
+    );
 
     // Report the count at the default log level whenever the option was used. A misspelled tag
     // otherwise produces a run byte-identical to one where the option was never passed - the
@@ -224,8 +232,18 @@ export const qseowProcessApp = async (appId, options) => {
         // Get app top level metadata
         const appMetadataPath = qrsPathWithFilter('app', `id eq ${appId}`);
         logger.debug(`GET app top level metadata: ${appMetadataPath}`);
-        let appMetadata = await qrsInteractInstance.Get(appMetadataPath);
-        appMetadata = appMetadata.body;
+        const appMetadata = await qrsGetList(qrsInteractInstance, appMetadataPath);
+
+        // An empty list is a real answer - the filter matched no app - but the two reads of
+        // appMetadata[0] further down sit inside the engine session, so leaving it unchecked
+        // spends a session and an openDoc before failing with `Cannot read properties of
+        // undefined`. In practice the engine refuses first, since the QRS lookup and the session
+        // use the same service identity; this is here so the invariant holds for the next reader.
+        if (appMetadata.length === 0) {
+            throw new QseowError(
+                `QSEoW app ${appId} was not found in the Qlik Sense repository. Check --appid, and that the account named by --apiuserdir/--apiuserid may read the app.`
+            );
+        }
 
         const appSheetsFilter = `objectType eq 'sheet' and app.id eq ${appId}`;
 
@@ -248,15 +266,15 @@ export const qseowProcessApp = async (appId, options) => {
         );
 
         // Create mapping between repo db sheet id and engine sheet id
-        let mapRepoEngineSheetIdTmp1 = await qrsInteractInstance.Get(
+        const repoSheets = await qrsGetList(
+            qrsInteractInstance,
             qrsPathWithFilter('app/object/full', appSheetsFilter)
         );
-        mapRepoEngineSheetIdTmp1 = mapRepoEngineSheetIdTmp1.body;
 
-        // mapRepoEngineSheetIdTmp1 is an array of sheet objects, each object has properties called 'id' and 'engineObjectId'
+        // repoSheets is an array of sheet objects, each object has properties called 'id' and 'engineObjectId'
         // Create a new bidirectional map between repo db sheet id and engine sheet id
         const mapRepoEngineSheetId = new Map();
-        mapRepoEngineSheetIdTmp1.forEach((element) => {
+        repoSheets.forEach((element) => {
             mapRepoEngineSheetId.set(element.id, element.engineObjectId);
             mapRepoEngineSheetId.set(element.engineObjectId, element.id);
         });
@@ -388,7 +406,7 @@ export const qseowProcessApp = async (appId, options) => {
 
                         // Loop over all sheets in app, processing each one unless excluded
                         for (const sheet of sheets) {
-                            // Get repository db sheet id from mapRepoEngineSheetIdTmp1, using sheet.qInfo.qId as key
+                            // Get repository db sheet id from mapRepoEngineSheetId, using sheet.qInfo.qId as key
                             const repoDbSheetId = mapRepoEngineSheetId.get(sheet.qInfo.qId);
                             const engineSheetId = sheet.qInfo.qId;
 


### PR DESCRIPTION
Follow-up to #956, from the code review of that PR. Refs #840.

## What this fixes

`src/lib/qseow/qrs-response.js` exists as the single place that interprets a `qrs-interact` response body, because call sites reaching into `.body` directly each guessed differently about what a non-list meant. `qseow-process-app.js` was still guessing, at three sites — including `getSheetsTaggedWith`, which #956 added and which should have adopted the helper then.

When QRS answered with something that parsed as JSON but was not a list, each failed in its own unhelpful way:

| Lookup | What the operator saw |
|---|---|
| Sheet id mapping | `TypeError: mapRepoEngineSheetIdTmp1.forEach is not a function` |
| App name | `App name: "undefined"`, and **the run carried on** generating thumbnails |
| Tagged sheets | A sheet count that was never real, then a failure part-way through |

The middle one is why this is `fix:` and not `refactor:` — that run looked like it was working. All three now name the response and the request, and fail before any browser or engine session, so nothing is spent. Other apps in the run are unaffected: `runOverApps` counts the app as failed and continues.

## One thing worth knowing, because it narrows the claim

I read `node_modules/qrs-interact/qrsInteract.js:99-118`. `Get` **rejects** on any status other than 200, and on 200 runs `JSON.parse` unguarded — so an HTML error page throws before the promise resolves. Two consequences:

- `qrsGetList`'s status guard is effectively dead on this path; the "403 is reported honestly" benefit already comes from qrs-interact's own rejection.
- The HTML-error-page scenario in `qrs-response.js`'s own docstring **cannot reach this code by this route**.

So the honest claim is narrower than that docstring implies: what this catches is a reply that parses as JSON but is not a list — an error object, `null`, a quoted string, a number. The doc page says that, not the HTML story. That docstring overstating its own case is worth a separate look; I have not touched it here.

## Also included

- **An empty-list guard on the app metadata.** Labelled honestly in the commit: readability and message quality, not a crash fix. The QRS lookup and the engine session use the same service identity, so an app QRS won't list is an app `openDoc` won't open — and `openDoc` runs first. No reachable trigger was found. It is there so the "guaranteed array" invariant holds for the next reader.
- **Cloud JSDoc.** The commit that added the "not supported on Cloud" warning removed `@param options.blurSheetTag` in the same change that started reading it, and `options.excludeSheetTag` was never documented. Both restored, typed to match the QSEoW twin. `blurSheetStatus` corrected from `{string}` to `{Array<string>}`.

## Verification

1090 unit tests across 56 suites, lint clean. Eight new tests.

Mutation-checked, since passing tests prove nothing on their own here — reverting **any one** of the three sites to a raw `.body` read fails a test that passes today:

| Mutation | Tests failed |
|---|---|
| Sheet-id map back to raw `.body` | 5 |
| App metadata back to raw `.body`, guard removed | 2 |
| Tag lookup back to raw `.body` | 1 |

`gitnexus_detect_changes` reports 9 symbols across 4 files, LOW risk, no affected processes.

## Not done

No live QSEoW run. All three sites are unconditional per-app critical path, so a smoke run against a real server before the next release is cheap insurance that unit tests cannot substitute for.

## Deliberately not included

`docs/README-legacy.md` — my review flagged it as documenting a stale option arity. That finding was **invalid**: the file is an explicitly archived snapshot ("reflects the final full README before the doc-site migration"), single commit, never modified. Those lines were accurate on 2025-11-27; the #956 merge is what made them stale. Correcting them would falsify the archive, and the live reference lives in the separate docs repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)