### PR TITLE
Extract duplicated collection-resolution logic into a shared helper

### DIFF
--- a/src/lib/cloud/__tests__/cloud_apps.test.js
+++ b/src/lib/cloud/__tests__/cloud_apps.test.js
@@ -1,0 +1,213 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+jest.unstable_mockModule('../../../globals.js', () => ({
+    logger: {
+        info: jest.fn(),
+        verbose: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+    },
+    setLoggingLevel: jest.fn(),
+    bsiExecutablePath: '/test/path',
+    isSea: false,
+}));
+
+const Get = jest.fn();
+const saasInstance = { Get };
+
+const { logger } = await import('../../../globals.js');
+const { getAppIdsByCollection } = await import('../cloud-apps.js');
+
+const COLLECTION_ID = 'collection-1';
+
+/**
+ * Points the mocked `Get` at a tenant with one collection holding the given items.
+ *
+ * @param {Array<object>} items - Items the collection should report.
+ *
+ * @returns {void}
+ */
+const withCollectionItems = (items) => {
+    Get.mockImplementation(async (path) => {
+        if (path === 'collections') return [{ id: COLLECTION_ID }];
+        if (path === `collections/${COLLECTION_ID}/items`) return items;
+        return [];
+    });
+};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('getAppIdsByCollection', () => {
+    describe('happy path', () => {
+        test('returns id and name for every app in the collection', async () => {
+            withCollectionItems([
+                {
+                    id: 'item-a',
+                    resourceType: 'app',
+                    resourceAttributes: { id: 'app-a', name: 'Alpha' },
+                },
+                {
+                    id: 'item-b',
+                    resourceType: 'app',
+                    resourceAttributes: { id: 'app-b', name: 'Beta' },
+                },
+            ]);
+
+            const apps = await getAppIdsByCollection(saasInstance, COLLECTION_ID);
+
+            expect(apps).toEqual([
+                { id: 'app-a', name: 'Alpha' },
+                { id: 'app-b', name: 'Beta' },
+            ]);
+        });
+
+        test('fetches collections and then collection items, in that order', async () => {
+            withCollectionItems([]);
+
+            await getAppIdsByCollection(saasInstance, COLLECTION_ID);
+
+            expect(Get).toHaveBeenCalledTimes(2);
+            expect(Get.mock.calls[0][0]).toBe('collections');
+            expect(Get.mock.calls[1][0]).toBe(`collections/${COLLECTION_ID}/items`);
+        });
+
+        test('returns an empty array for a collection with no apps', async () => {
+            withCollectionItems([]);
+
+            const apps = await getAppIdsByCollection(saasInstance, COLLECTION_ID);
+
+            expect(apps).toEqual([]);
+        });
+    });
+
+    describe('non-app items', () => {
+        test('skips collection items that are not apps', async () => {
+            withCollectionItems([
+                {
+                    id: 'item-a',
+                    resourceType: 'app',
+                    resourceAttributes: { id: 'app-a', name: 'Alpha' },
+                },
+                { id: 'item-ds', resourceType: 'dataset' },
+                {
+                    id: 'item-b',
+                    resourceType: 'app',
+                    resourceAttributes: { id: 'app-b', name: 'Beta' },
+                },
+            ]);
+
+            const apps = await getAppIdsByCollection(saasInstance, COLLECTION_ID);
+
+            expect(apps).toEqual([
+                { id: 'app-a', name: 'Alpha' },
+                { id: 'app-b', name: 'Beta' },
+            ]);
+        });
+
+        test('logs a verbose line for each skipped non-app item', async () => {
+            withCollectionItems([{ id: 'item-ds', resourceType: 'dataset' }]);
+
+            await getAppIdsByCollection(saasInstance, COLLECTION_ID);
+
+            const verbose = logger.verbose.mock.calls.map((c) => String(c[0])).join('\n');
+            expect(verbose).toContain('item-ds');
+            expect(verbose).toContain('dataset');
+        });
+
+        test('a collection with only non-app items returns an empty array', async () => {
+            withCollectionItems([
+                { id: 'ds-1', resourceType: 'dataset' },
+                { id: 'ds-2', resourceType: 'dataset' },
+            ]);
+
+            const apps = await getAppIdsByCollection(saasInstance, COLLECTION_ID);
+
+            expect(apps).toEqual([]);
+        });
+    });
+
+    describe('name fallback', () => {
+        test('falls back to id when resourceAttributes.name is absent', async () => {
+            withCollectionItems([
+                { id: 'item-a', resourceType: 'app', resourceAttributes: { id: 'app-a' } },
+            ]);
+
+            const apps = await getAppIdsByCollection(saasInstance, COLLECTION_ID);
+
+            expect(apps).toEqual([{ id: 'app-a', name: 'app-a' }]);
+        });
+
+        test('falls back to id when resourceAttributes.name is null', async () => {
+            withCollectionItems([
+                {
+                    id: 'item-a',
+                    resourceType: 'app',
+                    resourceAttributes: { id: 'app-a', name: null },
+                },
+            ]);
+
+            const apps = await getAppIdsByCollection(saasInstance, COLLECTION_ID);
+
+            expect(apps).toEqual([{ id: 'app-a', name: 'app-a' }]);
+        });
+    });
+
+    describe('collection not found', () => {
+        test('throws when the collection does not exist on the tenant', async () => {
+            Get.mockResolvedValue([{ id: 'some-other-collection' }]);
+
+            await expect(getAppIdsByCollection(saasInstance, COLLECTION_ID)).rejects.toThrow(
+                /does not exist/
+            );
+        });
+
+        test('the error message names the requested collection', async () => {
+            Get.mockResolvedValue([{ id: 'some-other-collection' }]);
+
+            await expect(getAppIdsByCollection(saasInstance, COLLECTION_ID)).rejects.toThrow(
+                COLLECTION_ID
+            );
+        });
+
+        test('does not fetch items when the collection is missing', async () => {
+            Get.mockResolvedValue([{ id: 'some-other-collection' }]);
+
+            await expect(getAppIdsByCollection(saasInstance, COLLECTION_ID)).rejects.toThrow();
+
+            expect(Get).toHaveBeenCalledTimes(1);
+            expect(Get).toHaveBeenCalledWith('collections');
+        });
+
+        test('throws when the tenant has no collections at all', async () => {
+            Get.mockResolvedValue([]);
+
+            await expect(getAppIdsByCollection(saasInstance, COLLECTION_ID)).rejects.toThrow(
+                /does not exist/
+            );
+        });
+    });
+
+    describe('error propagation', () => {
+        test('propagates errors from the collections call', async () => {
+            Get.mockRejectedValue(new Error('401 Unauthorized'));
+
+            await expect(getAppIdsByCollection(saasInstance, COLLECTION_ID)).rejects.toThrow(
+                '401 Unauthorized'
+            );
+        });
+
+        test('propagates errors from the items call', async () => {
+            Get.mockImplementation(async (path) => {
+                if (path === 'collections') return [{ id: COLLECTION_ID }];
+                throw new Error('500 Internal Server Error');
+            });
+
+            await expect(getAppIdsByCollection(saasInstance, COLLECTION_ID)).rejects.toThrow(
+                '500 Internal Server Error'
+            );
+        });
+    });
+});

--- a/src/lib/cloud/__tests__/cloud_create_thumbnails_app_loop.test.js
+++ b/src/lib/cloud/__tests__/cloud_create_thumbnails_app_loop.test.js
@@ -21,7 +21,11 @@ jest.unstable_mockModule('../cloud-test-connection.js', () => ({
     qscloudTestConnection: jest.fn().mockResolvedValue(true),
 }));
 
-jest.unstable_mockModule('../cloud-repo.js', () => ({ default: jest.fn() }));
+const Get = jest.fn();
+const QlikSaas = jest.fn(function QlikSaasMock() {
+    this.Get = Get;
+});
+jest.unstable_mockModule('../cloud-repo.js', () => ({ default: QlikSaas }));
 
 jest.unstable_mockModule('../process-cloud-app.js', () => ({
     processCloudApp: jest.fn().mockResolvedValue(true),
@@ -98,5 +102,103 @@ describe('qscloudCreateThumbnails app loop', () => {
         await expect(qscloudCreateThumbnails({ ...OPTIONS })).resolves.toBe(false);
 
         expect(errorLog()).toContain('CLOUD CREATE THUMBNAILS 2');
+    });
+
+    describe('multiple apps via --collectionid', () => {
+        /**
+         * Points the mocked `Get` at a tenant with one collection holding the given items.
+         *
+         * @param {Array<object>} items - Items the collection should report.
+         *
+         * @returns {void}
+         */
+        const withCollectionItems = (items) => {
+            Get.mockImplementation(async (path) => {
+                if (path === 'collections') return [{ id: 'collection-1' }];
+                if (path === 'collections/collection-1/items') return items;
+                return [];
+            });
+        };
+
+        beforeEach(() => {
+            Get.mockReset();
+        });
+
+        test('passes every app in the collection to the loop', async () => {
+            runOverApps.mockResolvedValue(true);
+            withCollectionItems([
+                { resourceType: 'app', resourceAttributes: { id: 'app-a', name: 'Alpha' } },
+                { resourceType: 'app', resourceAttributes: { id: 'app-b', name: 'Beta' } },
+            ]);
+
+            await qscloudCreateThumbnails({
+                ...OPTIONS,
+                appid: '',
+                collectionid: 'collection-1',
+            });
+
+            expect(runOverApps.mock.calls[0][0]).toEqual(['app-a', 'app-b']);
+        });
+
+        test('skips collection items that are not apps', async () => {
+            runOverApps.mockResolvedValue(true);
+            withCollectionItems([
+                { resourceType: 'app', resourceAttributes: { id: 'app-a', name: 'Alpha' } },
+                { id: 'item-ds', resourceType: 'dataset' },
+            ]);
+
+            await qscloudCreateThumbnails({
+                ...OPTIONS,
+                appid: '',
+                collectionid: 'collection-1',
+            });
+
+            expect(runOverApps.mock.calls[0][0]).toEqual(['app-a']);
+        });
+
+        test('returns false when the collection does not exist', async () => {
+            runOverApps.mockResolvedValue(true);
+            Get.mockResolvedValue([{ id: 'some-other-collection' }]);
+
+            await expect(
+                qscloudCreateThumbnails({
+                    ...OPTIONS,
+                    appid: '',
+                    collectionid: 'collection-1',
+                })
+            ).resolves.toBe(false);
+
+            expect(errorLog()).toContain('collection-1');
+        });
+
+        test('reports failure when the collection resolves to no apps at all', async () => {
+            runOverApps.mockResolvedValue(false);
+            withCollectionItems([]);
+
+            await expect(
+                qscloudCreateThumbnails({
+                    ...OPTIONS,
+                    appid: '',
+                    collectionid: 'collection-1',
+                })
+            ).resolves.toBe(false);
+
+            expect(runOverApps).toHaveBeenCalledWith([], expect.any(Object), expect.any(Function));
+        });
+
+        test('an explicitly named --appid still runs when the collection is empty', async () => {
+            runOverApps.mockResolvedValue(true);
+            withCollectionItems([]);
+
+            await expect(
+                qscloudCreateThumbnails({
+                    ...OPTIONS,
+                    appid: 'test-app-id',
+                    collectionid: 'collection-1',
+                })
+            ).resolves.toBe(true);
+
+            expect(runOverApps.mock.calls[0][0]).toEqual(['test-app-id']);
+        });
     });
 });

--- a/src/lib/cloud/cloud-apps.js
+++ b/src/lib/cloud/cloud-apps.js
@@ -1,0 +1,48 @@
+import { logger } from '../../globals.js';
+
+/**
+ * Returns the apps in a Qlik Sense Cloud collection.
+ *
+ * The two commands that accept `--collectionid` previously held byte-identical copies of this
+ * block — fetch collections, check the requested one exists, fetch its items, keep only apps.
+ * Fixing a bug in one copy without the other was the repo's dominant defect pattern; a single
+ * helper is the fix.
+ *
+ * @param {object} saasInstance - Configured QlikSaas client.
+ * @param {string} collectionId - ID of the collection to query.
+ *
+ * @returns {Promise<Array<{id: string, name: string}>>} Apps in the collection. Each object
+ *     carries at least `{ id, name }` so callers can display something more useful than a
+ *     GUID. `name` falls back to `id` when the API does not supply one.
+ *
+ * @throws {Error} If the collection does not exist on the tenant. The message includes the
+ *     requested collection ID so the caller can report it without re-extracting it.
+ */
+export const getAppIdsByCollection = async (saasInstance, collectionId) => {
+    const allCollections = await saasInstance.Get('collections');
+    logger.debug(`Collections:\n${JSON.stringify(allCollections, null, 2)}`);
+
+    const index = allCollections.map((e) => e.id).indexOf(collectionId);
+
+    if (index === -1) {
+        throw new Error(`Collection '${collectionId}' does not exist`);
+    }
+
+    const collectionItems = await saasInstance.Get(`collections/${collectionId}/items`);
+
+    const apps = [];
+    for (const item of collectionItems) {
+        if (item.resourceType === 'app') {
+            apps.push({
+                id: item.resourceAttributes.id,
+                name: item.resourceAttributes.name ?? item.resourceAttributes.id,
+            });
+        } else {
+            logger.verbose(
+                `Skipping collection item ${item.id} as it is not an app: ${item.resourceType}`
+            );
+        }
+    }
+
+    return apps;
+};

--- a/src/lib/cloud/cloud-create-thumbnails.js
+++ b/src/lib/cloud/cloud-create-thumbnails.js
@@ -4,6 +4,7 @@ import QlikSaas from './cloud-repo.js';
 import { qscloudTestConnection } from './cloud-test-connection.js';
 import { processCloudApp } from './process-cloud-app.js';
 import { runOverApps } from '../util/run-over-apps.js';
+import { getAppIdsByCollection } from './cloud-apps.js';
 
 /**
  * Create thumbnails for Qlik Sense Cloud (QSC).
@@ -112,37 +113,9 @@ export const qscloudCreateThumbnails = async (options) => {
         // If --collection exists we should loop over all matching apps.
         // If --collection does not exist the app specified by --appid should be processed.
         if (options.collectionid && options.collectionid.length > 0) {
-            // Get index of specified collection among the existin ones.
-            const allCollections = await saasInstance.Get('collections');
-            logger.debug(`Collections:\n${JSON.stringify(allCollections, null, 2)}`);
-
-            const index = allCollections.map((e) => e.id).indexOf(options.collectionid);
-
-            if (index === -1) {
-                // Collection not found
-                logger.error(`Collection '${options.collectionid}' does not exist - aborting`);
-                throw Error('Collection does not exist');
-            } else {
-                // Collection found
-                logger.verbose(`Collection '${options.collectionid}' exists`);
-
-                // Get all items within collection
-                const collectionItems = await saasInstance.Get(
-                    `collections/${options.collectionid}/items`
-                );
-
-                // Process all apps in this collection
-                for (const item of collectionItems) {
-                    // Is item an app?
-                    if (item.resourceType === 'app') {
-                        appIdsToProcess.push(item.resourceAttributes.id);
-                    } else {
-                        logger.verbose(
-                            `Skipping collection item ${item.id} as it is not an app: ${item.resourceType}`
-                        );
-                    }
-                }
-            }
+            const apps = await getAppIdsByCollection(saasInstance, options.collectionid);
+            logger.verbose(`Collection '${options.collectionid}' exists`);
+            appIdsToProcess.push(...apps.map((app) => app.id));
         }
 
         return await runOverApps(

--- a/src/lib/cloud/cloud-remove-sheet-icons.js
+++ b/src/lib/cloud/cloud-remove-sheet-icons.js
@@ -13,6 +13,7 @@ import {
     SHEET_LIST_FIELDS_EXTENDED,
 } from '../util/sheet-list.js';
 import { withEngineSession } from '../util/engine-session.js';
+import { getAppIdsByCollection } from './cloud-apps.js';
 
 /**
  * Removes all sheet icons from a Qlik Sense Cloud app.
@@ -214,38 +215,9 @@ export const qscloudRemoveSheetIcons = async (options) => {
         // If --collection exists we should loop over all matching apps.
         // If --collection does not exist the app specified by --appid should be processed.
         if (options.collectionid && options.collectionid.length > 0) {
-            // Get index of specified collection among the existin ones.
-            const allCollections = await saasInstance.Get('collections');
-            logger.debug(`Collections:\n${JSON.stringify(allCollections, null, 2)}`);
-
-            const index = allCollections.map((e) => e.id).indexOf(options.collectionid);
-
-            if (index === -1) {
-                // Collection not found
-                logger.error(`Collection '${options.collectionid}' does not exist - aborting`);
-                throw Error('Collection does not exist');
-            } else {
-                // Collection found
-                logger.verbose(`Collection '${options.collectionid}' exists`);
-
-                // Get all items within collection
-                const collectionItems = await saasInstance.Get(
-                    `collections/${options.collectionid}/items`
-                );
-
-                // Process all apps in this collection
-
-                for (const item of collectionItems) {
-                    // Is item an app?
-                    if (item.resourceType === 'app') {
-                        appIdsToProcess.push(item.resourceAttributes.id);
-                    } else {
-                        logger.verbose(
-                            `Skipping collection item ${item.id} as it is not an app: ${item.resourceType}`
-                        );
-                    }
-                }
-            }
+            const apps = await getAppIdsByCollection(saasInstance, options.collectionid);
+            logger.verbose(`Collection '${options.collectionid}' exists`);
+            appIdsToProcess.push(...apps.map((app) => app.id));
         }
 
         return await runOverApps(


### PR DESCRIPTION
## What

Both `cloud-create-thumbnails.js` and `cloud-remove-sheet-icons.js` held byte-identical blocks that:

1. Fetch all collections
2. Verify the requested one exists
3. Fetch its items
4. Keep only apps

A new helper `getAppIdsByCollection(saasInstance, collectionId)` in `cloud-apps.js` replaces both copies.

## Why

Fixing a bug in one copy without the other was the repo's dominant defect pattern. The QSEoW twin of this pattern was already extracted in `qseow-app-lookup.js`; this completes the Cloud side of #889.

The helper returns `{id, name}[]` so callers can eventually display something more useful than a GUID — prerequisite for the interactive app picker (#886).

## Changes

| File | Change |
|---|---|
| `src/lib/cloud/cloud-apps.js` | **New** — `getAppIdsByCollection` helper |
| `src/lib/cloud/cloud-create-thumbnails.js` | 30-line inline block → 3-line call to helper |
| `src/lib/cloud/cloud-remove-sheet-icons.js` | 30-line inline block → 3-line call to helper |
| `src/lib/cloud/__tests__/cloud_apps.test.js` | **New** — 11 unit tests |
| `src/lib/cloud/__tests__/cloud_create_thumbnails_app_loop.test.js` | +5 collection-based tests |

## Deferred

`listCollections(saas)` and `listApps(saas)` from the original #889 proposal have no caller yet. Tracked in #960.
