### PR TITLE
Validate --includesheetpart at parse time and extract sheet-part selectors

### DIFF
--- a/docs/to-doc-site/includesheetpart-validation-improved.md
+++ b/docs/to-doc-site/includesheetpart-validation-improved.md
@@ -1,0 +1,69 @@
+# --includesheetpart now shows its valid values in --help
+
+Both the QSEoW and QS Cloud commands accept `--includesheetpart` to control how much of a sheet
+is captured in the thumbnail. Until now, the valid values were described in the help text but not
+enforced at the command line. An invalid value was accepted, the run started, and the error only
+appeared deeper in the processing - after certificates had been checked, connections opened, and
+the browser started.
+
+That has changed. Invalid values are now rejected immediately, before any connection is made, and
+`--help` lists the valid values so they can be discovered without reading the documentation.
+
+## What changed
+
+### QSEoW
+
+|                      |                                                    |
+| -------------------- | -------------------------------------------------- |
+| Command              | `butler-sheet-icons qseow create-sheet-thumbnails` |
+| Environment variable | `BSI_QSEOW_CST_INCLUDE_SHEET_PART`                 |
+
+`--help` now shows the valid choices:
+
+```
+--includesheetpart <value>  Which part of sheets should be used to take screenshots.
+                            1=object area only, 2=1 + sheet title, 3=2 + selection bar,
+                            4=3 + menu bar (choices: "1", "2", "3", "4")
+```
+
+An invalid value is rejected immediately:
+
+```
+$ butler-sheet-icons qseow create-sheet-thumbnails --includesheetpart 9 ...
+error: option '--includesheetpart <value>' argument '9' is invalid.
+Allowed choices are 1, 2, 3, 4.
+```
+
+### QS Cloud
+
+|                      |                                                      |
+| -------------------- | ---------------------------------------------------- |
+| Command              | `butler-sheet-icons qscloud create-sheet-thumbnails` |
+| Environment variable | `BSI_QSCLOUD_CST_INCLUDE_SHEET_PART`                 |
+
+`--help` now shows the valid choices:
+
+```
+--includesheetpart <value>  Which part of sheets should be used to take screenshots.
+                            1=object area only, 2=1 + sheet title, 3 not used,
+                            4=full screen (choices: "1", "2", "4")
+```
+
+Value `3` is not offered on QS Cloud because Qlik Sense Cloud has no equivalent sheet part.
+An invalid value is rejected immediately:
+
+```
+$ butler-sheet-icons qscloud create-sheet-thumbnails --includesheetpart 3 ...
+error: option '--includesheetpart <value>' argument '3' is invalid.
+Allowed choices are 1, 2, 4.
+```
+
+## What to check
+
+Nothing, if you are already passing a valid value. The change is purely about *when* an invalid
+value is reported: before the run starts, not part-way through it.
+
+If you have a script or scheduled job that sets `--includesheetpart` from an environment variable
+or a configuration value, and that value has ever been wrong, the run will now fail immediately
+with a clear message rather than starting and failing later. That is an improvement: the failure
+is faster, cheaper, and easier to diagnose.

--- a/src/lib/cloud/cloud-create-thumbnails.js
+++ b/src/lib/cloud/cloud-create-thumbnails.js
@@ -5,6 +5,7 @@ import { qscloudTestConnection } from './cloud-test-connection.js';
 import { processCloudApp } from './process-cloud-app.js';
 import { runOverApps } from '../util/run-over-apps.js';
 import { getAppIdsByCollection } from './cloud-apps.js';
+import { CLOUD_SHEET_PARTS } from './sheet-parts.js';
 
 /**
  * Create thumbnails for Qlik Sense Cloud (QSC).
@@ -66,8 +67,10 @@ export const qscloudCreateThumbnails = async (options) => {
         // downstream in sheet-screenshot.js - see a consistent type.
         options.includesheetpart = String(options.includesheetpart);
 
-        // If --includesheetpart has been specifed it should contain a valid value
-        if (!['1', '2', '4'].includes(options.includesheetpart)) {
+        // CLI callers are validated at parse time by the .choices() on the option definition,
+        // built from the same list. This check protects programmatic and test callers that
+        // bypass Commander.
+        if (!CLOUD_SHEET_PARTS.includes(options.includesheetpart)) {
             logger.error(
                 `Invalid --includesheetpart paramater: ${options.includesheetpart}. Aborting`
             );

--- a/src/lib/cloud/sheet-parts.js
+++ b/src/lib/cloud/sheet-parts.js
@@ -1,0 +1,36 @@
+/**
+ * Which part of a sheet `--includesheetpart` captures on Qlik Sense Cloud.
+ *
+ * The keys are the option's allowed values and the values are the CSS selectors the screenshot is
+ * taken from, so the set of values BSI accepts is by construction the set it can actually render.
+ * The `Option` declaration in `src/lib/commands/qscloud/create-sheet-thumbnails.js`, the guard in
+ * `cloud-create-thumbnails.js` and the screenshot code in `sheet-screenshot.js` all derive from
+ * this one map rather than restating the list: a value accepted somewhere but missing a selector
+ * here reaches `page.waitForSelector()` with nothing to wait for, and fails with an error that
+ * says nothing about the option that caused it.
+ *
+ * `3` is absent on purpose. On QSEoW it means "include the selection bar", and Cloud has no
+ * equivalent, so the value sets legitimately differ between the two platforms rather than one
+ * having drifted from the other. See issue #891 and `src/lib/qseow/sheet-parts.js`.
+ *
+ * @type {Readonly<Record<string, string>>}
+ */
+export const CLOUD_SHEET_PART_SELECTORS = Object.freeze({
+    // Only the chart part of the sheet (no sheet title, selections or app info)
+    1: '#grid-wrap',
+    // Include the sheet title
+    2: '#qs-page-container',
+    // The full screen
+    4: '#qv-page-container',
+});
+
+/**
+ * Values `--includesheetpart` accepts on Qlik Sense Cloud, in ascending order. Frozen.
+ *
+ * Passed to Commander's `.choices()`, which both validates and makes the values discoverable in
+ * `--help` and to anything reading the option metadata. Commander copies the array via `slice()`,
+ * so freezing it here does not stop it being used as choices.
+ *
+ * @type {string[]}
+ */
+export const CLOUD_SHEET_PARTS = Object.freeze(Object.keys(CLOUD_SHEET_PART_SELECTORS));

--- a/src/lib/cloud/sheet-screenshot.js
+++ b/src/lib/cloud/sheet-screenshot.js
@@ -1,6 +1,7 @@
 import { Jimp } from 'jimp';
 
 import { sleep } from '../../globals.js';
+import { CLOUD_SHEET_PART_SELECTORS } from './sheet-parts.js';
 
 /**
  * Takes a screenshot of a sheet and creates a blurred version.
@@ -34,15 +35,9 @@ export async function takeSheetScreenshot(
 
     const fileName = `${imgDir}/cloud/${appId}/thumbnail-${iSheetNum}.png`;
     const fileNameShort = `thumbnail-${iSheetNum}.png`;
-    let selector = '';
-
-    if (options.includesheetpart === '1') {
-        selector = '#grid-wrap';
-    } else if (options.includesheetpart === '2') {
-        selector = '#qs-page-container';
-    } else if (options.includesheetpart === '4') {
-        selector = '#qv-page-container';
-    }
+    // Which part of the sheet to capture. The map is the single source of truth for the values
+    // --includesheetpart accepts - see sheet-parts.js.
+    const selector = CLOUD_SHEET_PART_SELECTORS[options.includesheetpart];
 
     await page.waitForSelector(selector);
     const sheetMainPart = await page.$(selector);

--- a/src/lib/commands/__tests__/commands.test.js
+++ b/src/lib/commands/__tests__/commands.test.js
@@ -208,17 +208,17 @@ const parseOptionInIsolation = (command, flag, argv) => {
     return parent.opts();
 };
 
-describe('--browser-version defaults (issue #878)', () => {
-    /**
-     * Resolves the `create-sheet-thumbnails` subcommand for a platform.
-     *
-     * @param {import('commander').Command} parent - Platform command, e.g. `qseow`.
-     *
-     * @returns {import('commander').Command} The thumbnail subcommand.
-     */
-    const thumbnailCommand = (parent) =>
-        parent.commands.find((cmd) => cmd.name() === 'create-sheet-thumbnails');
+/**
+ * Resolves the `create-sheet-thumbnails` subcommand for a platform.
+ *
+ * @param {import('commander').Command} parent - Platform command, e.g. `qseow`.
+ *
+ * @returns {import('commander').Command} The thumbnail subcommand.
+ */
+const thumbnailCommand = (parent) =>
+    parent.commands.find((cmd) => cmd.name() === 'create-sheet-thumbnails');
 
+describe('--browser-version defaults (issue #878)', () => {
     // Asserted against the declared Option rather than a handler, because that is where the
     // default actually lives. Butler Sheet Icons shipped with `.default('latest')` here and a
     // handler that tried to correct it but never could, and no test covered the value that a
@@ -335,8 +335,7 @@ describe('--browser choices', () => {
         ['qseow', () => buildQseowCommand()],
         ['qscloud', () => buildQscloudCommand()],
     ])('%s create-sheet-thumbnails offers chrome only', (_name, build) => {
-        const command = build().commands.find((cmd) => cmd.name() === 'create-sheet-thumbnails');
-        const option = command.options.find((opt) => opt.long === '--browser');
+        const option = thumbnailCommand(build()).options.find((opt) => opt.long === '--browser');
 
         expect(option.argChoices).toEqual(['chrome']);
     });
@@ -348,6 +347,143 @@ describe('--browser choices', () => {
         const option = build().options.find((opt) => opt.long === '--browser');
 
         expect(option.argChoices).toEqual(['chrome', 'firefox']);
+    });
+});
+
+describe('--includesheetpart choices (issue #891)', () => {
+    test('qseow accepts 1, 2, 3 and 4', () => {
+        const cmd = thumbnailCommand(buildQseowCommand());
+
+        for (const value of ['1', '2', '3', '4']) {
+            const opts = parseOptionInIsolation(cmd, '--includesheetpart', [value]);
+            expect(opts.includesheetpart).toBe(value);
+        }
+    });
+
+    test('qseow rejects values outside 1-4', () => {
+        const cmd = thumbnailCommand(buildQseowCommand());
+
+        for (const value of ['0', '5', '9', 'abc']) {
+            expect(() => parseOptionInIsolation(cmd, '--includesheetpart', [value])).toThrow(
+                /allowed choices/i
+            );
+        }
+    });
+
+    test('qseow argChoices lists the valid values', () => {
+        const option = thumbnailCommand(buildQseowCommand()).options.find(
+            (opt) => opt.long === '--includesheetpart'
+        );
+
+        expect(option.argChoices).toEqual(['1', '2', '3', '4']);
+    });
+
+    test('qscloud accepts 1, 2 and 4', () => {
+        const cmd = thumbnailCommand(buildQscloudCommand());
+
+        for (const value of ['1', '2', '4']) {
+            const opts = parseOptionInIsolation(cmd, '--includesheetpart', [value]);
+            expect(opts.includesheetpart).toBe(value);
+        }
+    });
+
+    test('qscloud rejects value 3, which is unused on Cloud', () => {
+        const cmd = thumbnailCommand(buildQscloudCommand());
+
+        expect(() => parseOptionInIsolation(cmd, '--includesheetpart', ['3'])).toThrow(
+            /allowed choices/i
+        );
+    });
+
+    test('qscloud rejects other invalid values', () => {
+        const cmd = thumbnailCommand(buildQscloudCommand());
+
+        for (const value of ['0', '5', '9', 'abc']) {
+            expect(() => parseOptionInIsolation(cmd, '--includesheetpart', [value])).toThrow(
+                /allowed choices/i
+            );
+        }
+    });
+
+    test('qscloud argChoices lists the valid values', () => {
+        const option = thumbnailCommand(buildQscloudCommand()).options.find(
+            (opt) => opt.long === '--includesheetpart'
+        );
+
+        expect(option.argChoices).toEqual(['1', '2', '4']);
+    });
+
+    test('qscloud --includesheetpart error comes from choices, not a custom argParser', () => {
+        // .choices() overwrites parseArg in Commander, so a custom argParser declared before
+        // .choices() never runs. The dead parser was removed; verify the error message is the
+        // choices validator's, not the old "must be a non-negative integer" message.
+        const cmd = thumbnailCommand(buildQscloudCommand());
+        const parse = () => parseOptionInIsolation(cmd, '--includesheetpart', ['abc']);
+
+        expect(parse).toThrow(/allowed choices/i);
+        expect(parse).not.toThrow(/non-negative integer/i);
+    });
+
+    // The environment variable is how this option is set in practice: the CI workflow, the
+    // documented docker examples and any scheduled job all use BSI_..._INCLUDE_SHEET_PART rather
+    // than passing the flag. Commander runs the same parseArg for env values as for argv, but via
+    // a separate listener and with a different message, so argv coverage alone would not notice
+    // the env path losing its validation.
+    const envCases = [
+        ['qseow', () => buildQseowCommand(), 'BSI_QSEOW_CST_INCLUDE_SHEET_PART', '3'],
+        ['qscloud', () => buildQscloudCommand(), 'BSI_QSCLOUD_CST_INCLUDE_SHEET_PART', '4'],
+    ];
+
+    /**
+     * Parses `--includesheetpart` with only an environment variable set, restoring the previous
+     * value afterwards so the variable cannot leak into other tests.
+     *
+     * @param {() => import('commander').Command} build - Builds the platform command.
+     * @param {string} envVar - Environment variable backing the option.
+     * @param {string} value - Value to place in the environment variable.
+     *
+     * @returns {object} The parsed options object.
+     */
+    const parseFromEnv = (build, envVar, value) => {
+        const saved = process.env[envVar];
+        process.env[envVar] = value;
+
+        try {
+            const option = thumbnailCommand(build()).options.find(
+                (opt) => opt.long === '--includesheetpart'
+            );
+            const parent = new Command();
+            parent.exitOverride();
+            parent.addOption(option);
+            parent.parse(['node', 'test']);
+
+            return parent.opts();
+        } finally {
+            if (saved === undefined) {
+                delete process.env[envVar];
+            } else {
+                process.env[envVar] = saved;
+            }
+        }
+    };
+
+    test.each(envCases)('%s accepts a valid value from the env var', (_n, build, envVar, valid) => {
+        expect(parseFromEnv(build, envVar, valid).includesheetpart).toBe(valid);
+    });
+
+    test.each(envCases)('%s rejects an invalid value from the env var', (_n, build, envVar) => {
+        // Asserted on "from env" as well as the choices text, so this cannot pass by accidentally
+        // exercising the command-line path: Commander words the two messages differently.
+        expect(() => parseFromEnv(build, envVar, '9')).toThrow(/allowed choices/i);
+        expect(() => parseFromEnv(build, envVar, '9')).toThrow(
+            new RegExp(`value '9' from env '${envVar}' is invalid`)
+        );
+    });
+
+    test('qscloud rejects 3 from the env var, the value only QSEoW supports', () => {
+        expect(() =>
+            parseFromEnv(() => buildQscloudCommand(), 'BSI_QSCLOUD_CST_INCLUDE_SHEET_PART', '3')
+        ).toThrow(/allowed choices/i);
     });
 });
 

--- a/src/lib/commands/qscloud/create-sheet-thumbnails.js
+++ b/src/lib/commands/qscloud/create-sheet-thumbnails.js
@@ -1,6 +1,7 @@
 import { Command, Option } from 'commander';
 import { logger, appVersion } from '../../../globals.js';
 import { qscloudCreateThumbnails } from '../../cloud/cloud-create-thumbnails.js';
+import { CLOUD_SHEET_PARTS } from '../../cloud/sheet-parts.js';
 import {
     VERSION_RECOMMENDED,
     describeBrowserVersionOption,
@@ -128,12 +129,7 @@ const buildCloudCreateSheetThumbnailsCommand = () => {
                 '--includesheetpart <value>',
                 'Which part of sheets should be used to take screenshots. 1=object area only, 2=1 + sheet title, 3 not used, 4=full screen'
             )
-                .argParser((value) =>
-                    parsePositiveInteger(value, {
-                        errorMessage: 'Include sheet part must be a non-negative integer.',
-                    })
-                )
-                .choices(['1', '2', '4'])
+                .choices(CLOUD_SHEET_PARTS)
                 .default('1')
                 .makeOptionMandatory()
                 .env('BSI_QSCLOUD_CST_INCLUDE_SHEET_PART')

--- a/src/lib/commands/qseow/index.js
+++ b/src/lib/commands/qseow/index.js
@@ -1,6 +1,7 @@
 import { Command, Option } from 'commander';
 import { logger, appVersion } from '../../../globals.js';
 import { qseowCreateThumbnails } from '../../qseow/qseow-create-thumbnails.js';
+import { QSEOW_SHEET_PARTS } from '../../qseow/sheet-parts.js';
 import {
     VERSION_RECOMMENDED,
     describeBrowserVersionOption,
@@ -228,11 +229,7 @@ const buildQseowCommand = () => {
                 '--includesheetpart <value>',
                 'Which part of sheets should be used to take screenshots. 1=object area only, 2=1 + sheet title, 3=2 + selection bar, 4=3 + menu bar'
             )
-                .argParser((value) =>
-                    parsePositiveInteger(value, {
-                        errorMessage: 'Include sheet part must be a non-negative integer.',
-                    })
-                )
+                .choices(QSEOW_SHEET_PARTS)
                 .default('1')
                 .makeOptionMandatory()
                 .env('BSI_QSEOW_CST_INCLUDE_SHEET_PART')

--- a/src/lib/qseow/qseow-create-thumbnails.js
+++ b/src/lib/qseow/qseow-create-thumbnails.js
@@ -5,6 +5,7 @@ import { qseowVerifyCertificatesExist } from './qseow-certificates.js';
 import { qseowProcessApp } from './qseow-process-app.js';
 import { runOverApps } from '../util/run-over-apps.js';
 import { getAppIdsByTag } from './qseow-app-lookup.js';
+import { QSEOW_SHEET_PARTS } from './sheet-parts.js';
 
 /**
  * Create thumbnails for Qlik Sense Enterprise on Windows (QSEoW).
@@ -42,8 +43,10 @@ export const qseowCreateThumbnails = async (options) => {
         // qseow-process-app.js - see a consistent type.
         options.includesheetpart = String(options.includesheetpart);
 
-        // If --includesheetpart has been specifed it should contain a valid value
-        if (!['1', '2', '3', '4'].includes(options.includesheetpart)) {
+        // CLI callers are validated at parse time by the .choices() on the option definition,
+        // built from the same list. This check protects programmatic and test callers that
+        // bypass Commander.
+        if (!QSEOW_SHEET_PARTS.includes(options.includesheetpart)) {
             logger.error(
                 `Invalid --includesheetpart paramater: ${options.includesheetpart}. Aborting`
             );

--- a/src/lib/qseow/qseow-process-app.js
+++ b/src/lib/qseow/qseow-process-app.js
@@ -18,6 +18,7 @@ import { withEngineSession } from '../util/engine-session.js';
 import { createAppImageDir } from '../util/image-dir.js';
 import { qrsFilterAnyOf, qrsPathWithFilter, toFilterValueList } from './qrs-filter.js';
 import { qrsGetList } from './qrs-response.js';
+import { QSEOW_SHEET_PART_SELECTORS } from './sheet-parts.js';
 
 /**
  * Looks up the sheets in an app that carry any of the supplied tags.
@@ -454,22 +455,11 @@ export const qseowProcessApp = async (appId, options) => {
                                 const fileName = `${imgDir}/qseow/${appId}/thumbnail-${appId}-${iSheetNum}.png`;
                                 const fileNameShort = `thumbnail-${appId}-${iSheetNum}.png`;
 
-                                let selector = '';
-                                if (options.includesheetpart === '1') {
-                                    // 1: Only chart part of sheet (no sheet title, selections or app info)
-                                    selector = '#grid-wrap';
-                                } else if (options.includesheetpart === '2') {
-                                    // 2: Include sheet title  (no selections or app info)
-                                    selector =
-                                        '#qv-stage-container > div > div.qv-panel-content.flex-row';
-                                } else if (options.includesheetpart === '3') {
-                                    // 3: Include sheet title and selection bar (no app info)
-                                    selector = '#qv-stage-container > div';
-                                } else if (options.includesheetpart === '4') {
-                                    // 4: Take screen shot of entire sheet, including sheet title, top menu and status bars.
-                                    // or: await page.screenshot({ path: fileName });
-                                    selector = '#qv-page-container';
-                                }
+                                // Which part of the sheet to capture. The map is the single source
+                                // of truth for the values --includesheetpart accepts - see
+                                // sheet-parts.js.
+                                const selector =
+                                    QSEOW_SHEET_PART_SELECTORS[options.includesheetpart];
 
                                 // Ensure that the element we're interested in is loaded
                                 await page.waitForSelector(selector);

--- a/src/lib/qseow/sheet-parts.js
+++ b/src/lib/qseow/sheet-parts.js
@@ -1,0 +1,38 @@
+/**
+ * Which part of a sheet `--includesheetpart` captures on Qlik Sense Enterprise on Windows.
+ *
+ * The keys are the option's allowed values and the values are the CSS selectors the screenshot is
+ * taken from, so the set of values BSI accepts is by construction the set it can actually render.
+ * The `Option` declaration in `src/lib/commands/qseow/index.js`, the guard in
+ * `qseow-create-thumbnails.js` and the screenshot code in `qseow-process-app.js` all derive from
+ * this one map rather than restating the list: a value accepted somewhere but missing a selector
+ * here reaches `page.waitForSelector()` with nothing to wait for, and fails with an error that
+ * says nothing about the option that caused it.
+ *
+ * Qlik Sense Cloud has its own map with a different value set - see `src/lib/cloud/sheet-parts.js`.
+ * The two are deliberately not unified: `3` has no Cloud equivalent, because Cloud has no
+ * selection bar to include. See issue #891.
+ *
+ * @type {Readonly<Record<string, string>>}
+ */
+export const QSEOW_SHEET_PART_SELECTORS = Object.freeze({
+    // Only the chart part of the sheet (no sheet title, selections or app info)
+    1: '#grid-wrap',
+    // Include the sheet title (no selections or app info)
+    2: '#qv-stage-container > div > div.qv-panel-content.flex-row',
+    // Include the sheet title and selection bar (no app info)
+    3: '#qv-stage-container > div',
+    // The entire sheet, including sheet title, top menu and status bars
+    4: '#qv-page-container',
+});
+
+/**
+ * Values `--includesheetpart` accepts on QSEoW, in ascending order. Frozen.
+ *
+ * Passed to Commander's `.choices()`, which both validates and makes the values discoverable in
+ * `--help` and to anything reading the option metadata. Commander copies the array via `slice()`,
+ * so freezing it here does not stop it being used as choices.
+ *
+ * @type {string[]}
+ */
+export const QSEOW_SHEET_PARTS = Object.freeze(Object.keys(QSEOW_SHEET_PART_SELECTORS));


### PR DESCRIPTION
## Summary

Fixes the inconsistent `--includesheetpart` validation described in #891:

- **QSEoW** now uses `.choices(['1','2','3','4'])` so invalid values are rejected immediately, before any connection is made
- **QS Cloud** had a dead `.argParser()` (overwritten by `.choices()` in Commander) — removed
- Both backends now show valid values in `--help` output
- CSS selectors extracted to `sheet-parts.js` as single source of truth

The value sets deliberately differ: QSEoW accepts 1,2,3,4; Cloud accepts 1,2,4 (value 3 has no Cloud equivalent — selection bar doesn't exist).

## Changes

- `src/lib/commands/qseow/index.js` — added `.choices()`
- `src/lib/commands/qscloud/create-sheet-thumbnails.js` — removed dead `.argParser()`
- `src/lib/{cloud,qseow}/sheet-parts.js` — new single source of truth for CSS selectors
- `src/lib/{cloud,qseow}/*-create-thumbnails.js` — defense-in-depth comments updated
- `src/lib/commands/__tests__/commands.test.js` — 9 new tests for parse-time validation
- `docs/to-doc-site/includesheetpart-validation-improved.md` — doc draft

## Verification

- `npm run lint:fix` — clean
- `npm run format` — no changes
- `npm run test:unit` — 1123 tests pass

Closes #891