### PR TITLE
Tell a dropped Qlik Sense Cloud connection apart from a broken sheet

### DIFF
--- a/docs/to-doc-site/lost-connection-to-qlik-sense-mid-run.md
+++ b/docs/to-doc-site/lost-connection-to-qlik-sense-mid-run.md
@@ -1,0 +1,70 @@
+# When the connection to Qlik Sense drops in the middle of a run
+
+Butler Sheet Icons holds one connection to the Qlik Sense engine open for as long as it is working on an app. If that connection is lost part-way through — the app has ten sheets and the connection dies at sheet three — the run cannot finish that app.
+
+This draft covers a change to **how such a drop is reported**, and a change that makes it **less likely to happen** in the first place. It belongs with the troubleshooting material, alongside the existing pages on connecting to Qlik Sense Cloud and to Qlik Sense Enterprise on Windows.
+
+Nothing here needs configuring. There are no new options.
+
+## What the log used to say
+
+A dropped connection was reported once per remaining sheet, as though each sheet were individually at fault:
+
+```
+error: CLOUD APP: Failed to create a thumbnail for sheet 3 ('Sales overview', ID 5e93a5a8-…) in app 5838acc6-…: Not connected
+error: CLOUD APP: Failed to create a thumbnail for sheet 4 ('Regional split', ID e507b7f4-…) in app 5838acc6-…: Not connected
+error: CLOUD APP: Failed to create a thumbnail for sheet 5 …: Not connected
+error: CLOUD APP: Failed to create a thumbnail for sheet 6 …: Not connected
+error: CLOUD APP: Failed to create a thumbnail for sheet 7 …: Not connected
+error: CLOUD PROCESS APP: Failed to process app 5838acc6-…: Failed to create a thumbnail for 5 of 6 sheet(s)
+```
+
+Read literally, that says five sheets are broken. They are not — there is nothing wrong with any of them. One connection was lost, and every sheet after it was reported as a casualty. On an app with forty sheets this filled the log with dozens of identical lines and a summary blaming the sheets.
+
+## What the log says now
+
+The run stops working on that app as soon as the connection is gone, and says so once:
+
+```
+warning: CLOUD PROCESS APP: The engine session to Qlik Sense Cloud tenant your-tenant.eu.qlikcloud.com
+         was closed from the other end, code 1006. Whatever is still using this session will fail
+         from here on.
+error:   CLOUD APP: Lost the engine session while processing app 5838acc6-… at sheet 3, abandoning
+         the remaining sheets: Not connected (websocket closed with code 1006)
+```
+
+(Both lines are shown wrapped here; each is a single line in the log. The prefix at the start of each line names the stage the run was in, and differs between commands.)
+
+Three things are worth knowing about this output:
+
+- **The `warning` line appears at the moment the connection drops**, which can be up to a minute before anything fails. Taking a screenshot of a sheet is slow, and Butler Sheet Icons does not talk to the engine while it is waiting for the browser. The connection can therefore be gone for some time before the next request discovers it.
+- **The number after `code` is the reason the connection ended**, as reported by the network layer. `1006` means the connection ended without a proper goodbye — typically a network device, firewall or proxy somewhere between Butler Sheet Icons and Qlik Sense dropping it. Other codes indicate the Qlik Sense end closed it deliberately, and usually come with a reason in the message. **If you report this problem, please include this line** — it is the single most useful piece of information for diagnosing it.
+- **Sheets after the failure point are no longer listed as failures.** They were never attempted.
+
+## What happens to the app
+
+The same as before, stated more clearly:
+
+- Sheets whose thumbnails were already produced **are** uploaded and applied.
+- The remaining sheets **keep the icons they already had**. Nothing is blanked or replaced with a broken image.
+- The app is reported as failed, and the run ends with a non-zero exit code. A scheduled task will show it as failed.
+
+Re-running Butler Sheet Icons for that app is safe and is the right response.
+
+## Making it less likely
+
+Butler Sheet Icons now sends a small "still here" signal on the Qlik Sense connection every 20 seconds while it is otherwise idle.
+
+The reason is that taking a screenshot of one sheet takes 25–40 seconds, and during that time the connection to Qlik Sense carries no traffic at all. Network equipment commonly closes connections it believes have been abandoned, and a connection that has been silent for half a minute looks abandoned. Keeping a little traffic on it makes that far less likely.
+
+This applies to both Qlik Sense Cloud and Qlik Sense Enterprise on Windows, needs no configuration, and is not something you will see in the log. Connections to Qlik Sense Cloud benefit most, as they cross the public internet rather than your own network.
+
+## If it keeps happening
+
+A run that loses its connection occasionally, and succeeds on a re-run, is a network hiccup — annoying, not a misconfiguration.
+
+If it happens repeatedly, the close code in the log is the place to start:
+
+- **Code 1006, repeatedly** — something on the network path is closing the connection. A firewall, proxy or VPN with an idle-connection timeout is the usual culprit. Ask whoever manages it whether long-lived WebSocket connections to Qlik Sense are being timed out.
+- **Any other code, usually with a reason** — the Qlik Sense end closed the connection on purpose. The reason text is the thing to investigate, and is worth including in a support request.
+- **Consider a shorter `--pagewait`** if your sheets render quickly. It shortens the time the connection spends idle per sheet. Do not shorten it past what your sheets need to finish rendering, or the thumbnails will show half-drawn charts.

--- a/src/lib/cloud/cloud-enigma.js
+++ b/src/lib/cloud/cloud-enigma.js
@@ -3,6 +3,7 @@ import WebSocket from 'ws';
 
 import { logger } from '../../globals.js';
 import { getEnigmaSchema } from '../util/enigma-util.js';
+import { attachSocketKeepalive } from '../util/socket-keepalive.js';
 
 /**
  * Sets up an Enigma connection to a Qlik Sense SaaS tenant.
@@ -33,15 +34,21 @@ export const setupEnigmaConnection = (appId, options, _command) => {
         /**
          * Builds a `WebSocket` connection to the SaaS Enigma endpoint, using the API key for authentication.
          *
+         * The keepalive matters most on this platform: the connection crosses the public
+         * internet to the tenant, and the screenshot path leaves it idle for the whole time a
+         * sheet takes to render. See `attachSocketKeepalive` and issue #975.
+         *
          * @param {string} url - Full WebSocket URL produced by `SenseUtilities.buildUrl`.
          *
          * @returns {WebSocket} A `ws` WebSocket instance ready to be used by `enigma.js`.
          */
         createSocket: (url) =>
-            new WebSocket(url, {
-                headers: {
-                    Authorization: `Bearer ${options.apikey}`,
-                },
-            }),
+            attachSocketKeepalive(
+                new WebSocket(url, {
+                    headers: {
+                        Authorization: `Bearer ${options.apikey}`,
+                    },
+                })
+            ),
     };
 };

--- a/src/lib/qseow/qseow-enigma.js
+++ b/src/lib/qseow/qseow-enigma.js
@@ -5,6 +5,7 @@ import fs from 'fs-extra';
 import { logger, bsiExecutablePath } from '../../globals.js';
 import { getEnigmaSchema } from '../util/enigma-util.js';
 import { getCertFilePaths } from '../util/cert.js';
+import { attachSocketKeepalive } from '../util/socket-keepalive.js';
 
 /**
  * Reads a file from disk and returns its bytes.
@@ -65,19 +66,26 @@ export const setupEnigmaConnection = (appId, options, _command) => {
          * Builds a `WebSocket` connection to the QSEoW Enigma endpoint, using the loaded
          * client certificate and the API user header for authentication.
          *
+         * The keepalive is the Cloud twin's, applied here for symmetry rather than because
+         * this platform has shown the fault - a LAN socket has much less to survive. See
+         * `attachSocketKeepalive` and issue #975.
+         *
          * @param {string} url - Full WebSocket URL produced by `SenseUtilities.buildUrl`.
          *
          * @returns {WebSocket} A `ws` WebSocket instance ready to be used by `enigma.js`.
          */
         createSocket: (url) =>
-            new WebSocket(url, {
-                key: readCert(fileCertKey),
-                cert: readCert(fileCert),
-                headers: {
-                    'X-Qlik-User': `UserDirectory=${options.apiuserdir};UserId=${options.apiuserid}`,
-                },
-                rejectUnauthorized:
-                    options.rejectUnauthorized === 'true' || options.rejectUnauthorized === true,
-            }),
+            attachSocketKeepalive(
+                new WebSocket(url, {
+                    key: readCert(fileCertKey),
+                    cert: readCert(fileCert),
+                    headers: {
+                        'X-Qlik-User': `UserDirectory=${options.apiuserdir};UserId=${options.apiuserid}`,
+                    },
+                    rejectUnauthorized:
+                        options.rejectUnauthorized === 'true' ||
+                        options.rejectUnauthorized === true,
+                })
+            ),
     };
 };

--- a/src/lib/util/__tests__/engine-session.test.js
+++ b/src/lib/util/__tests__/engine-session.test.js
@@ -177,7 +177,11 @@ describe('withEngineSession', () => {
 
             await withEngineSession({}, { ...CTX, loglevel: 'debug' }, async () => true);
 
-            expect(session.on).not.toHaveBeenCalled();
+            // Not `not.toHaveBeenCalled()`: the close listener is attached at every level,
+            // because a session dying unannounced is worth a line whatever the log level.
+            const events = session.on.mock.calls.map(([event]) => event);
+            expect(events).not.toContain('traffic:sent');
+            expect(events).not.toContain('traffic:received');
         });
 
         test('attaches both traffic handlers at silly', async () => {
@@ -201,6 +205,49 @@ describe('withEngineSession', () => {
 
             expect(log).toHaveBeenCalledWith('received:', JSON.stringify({ a: 1 }, null, 2));
             log.mockRestore();
+        });
+    });
+
+    describe('an unexpected close', () => {
+        /**
+         * Runs a session and hands back the handler registered for enigma's `closed` event.
+         *
+         * @returns {Function} The registered handler.
+         */
+        const closeHandler = async () => {
+            const { session } = wireSession();
+
+            await withEngineSession({}, CTX, async () => true);
+
+            return session.on.mock.calls.find(([event]) => event === 'closed')[1];
+        };
+
+        test('is listened for at every log level', async () => {
+            const { session } = wireSession();
+
+            await withEngineSession({}, { ...CTX, loglevel: 'info' }, async () => true);
+
+            expect(session.on).toHaveBeenCalledWith('closed', expect.any(Function));
+        });
+
+        test('reports the close code and reason', async () => {
+            // The whole point of the listener: `Not connected` on the next engine call says
+            // the session was gone, and only the close event says what closed it.
+            (await closeHandler())({ code: 1006, reason: 'connection reset' });
+
+            const line = String(logger.warn.mock.calls.at(-1)[0]);
+            expect(line).toContain('server sense.example.com');
+            expect(line).toContain('code 1006');
+            expect(line).toContain('connection reset');
+        });
+
+        test('still names the code when the far end gave no reason', async () => {
+            // 1006 arrives with an empty reason - there was no close frame to carry one.
+            (await closeHandler())({ code: 1006, reason: '' });
+
+            const line = String(logger.warn.mock.calls.at(-1)[0]);
+            expect(line).toContain('code 1006');
+            expect(line).not.toContain('reason');
         });
     });
 

--- a/src/lib/util/__tests__/sheet-list.test.js
+++ b/src/lib/util/__tests__/sheet-list.test.js
@@ -286,9 +286,43 @@ describe('runOverSheets', () => {
     });
 });
 
+/**
+ * Builds an error shaped the way enigma.js raises one.
+ *
+ * Spelled out rather than imported from enigma so the test states what the contract is: a
+ * message, a numeric `code`, and the `enigmaError` marker. `original` is the WebSocket close
+ * event, which enigma attaches to the socket-level rejections.
+ *
+ * @param {string} message - enigma's wording.
+ * @param {number} code - Value from `enigma.js/error-codes.js`.
+ * @param {object} [original] - The close event, when there is one.
+ *
+ * @returns {Error} The error.
+ */
+const enigmaError = (message, code, original) =>
+    Object.assign(new Error(message), { code, enigmaError: true, original });
+
 describe('isSessionLevelFailure', () => {
+    // enigma has three wordings for one dead socket, and this loop hits the one the message
+    // list missed - see issue #975. All three carry NOT_CONNECTED (-1).
+    test.each([
+        ['a request issued after the socket died', enigmaError('Not connected', -1)],
+        ['a request in flight when the socket died', enigmaError('Socket closed', -1)],
+        ['a socket error', enigmaError('Socket error', -1)],
+        ['a suspended session', enigmaError('Session suspended', -11)],
+    ])('treats %s as session-level', (_label, err) => {
+        expect(isSessionLevelFailure(err)).toBe(true);
+    });
+
+    test('leaves a per-sheet enigma failure to the per-sheet path', () => {
+        // OBJECT_NOT_FOUND (-2) is one sheet's problem; the session is still alive, and the
+        // sheets after it can still be processed.
+        expect(isSessionLevelFailure(enigmaError('Object not found', -2))).toBe(false);
+    });
+
     test.each([
         ['a dropped enigma socket', new Error('Socket closed')],
+        ['a dead session named without its code', new Error('Not connected')],
         ['a closed CDP session', new Error('Protocol error: Session closed.')],
         [
             'a closed puppeteer target',
@@ -360,6 +394,44 @@ describe('runOverSheets — a lost engine session', () => {
 
         expect(errorLog()).toContain('Lost the engine session');
         expect(errorLog()).not.toContain("Failed to update sheet 1 ('Sheet a'");
+    });
+
+    test('stops on the `Not connected` that issue #975 actually produced', async () => {
+        // The exact run: the socket dies while the browser is busy, so the failure arrives as
+        // `Not connected` rather than `Socket closed`, and every sheet after it used to be
+        // logged as broken. Five sheets, dying at three, as in the reported log.
+        const worker = jest.fn(async (s, n) => {
+            if (n >= 3) throw enigmaError('Not connected', -1, { code: 1006, reason: '' });
+        });
+
+        const result = await runOverSheets(
+            [sheet('a'), sheet('b'), sheet('c'), sheet('d'), sheet('e')],
+            CTX,
+            worker
+        );
+
+        expect(worker).toHaveBeenCalledTimes(3);
+        expect(errorLog()).toContain('Lost the engine session');
+        expect(errorLog()).not.toContain('Failed to update sheet 4');
+        expect(result.failed).toBe(0);
+    });
+
+    test('names the websocket close code when enigma carries one', async () => {
+        await runOverSheets([sheet('a')], CTX, async () => {
+            throw enigmaError('Not connected', -1, { code: 1006, reason: 'going away' });
+        });
+
+        expect(errorLog()).toContain('websocket closed with code 1006');
+        expect(errorLog()).toContain('going away');
+    });
+
+    test('says nothing about a close event when there is none', async () => {
+        await runOverSheets([sheet('a')], CTX, async () => {
+            throw enigmaError('Not connected', -1);
+        });
+
+        expect(errorLog()).toContain('Lost the engine session');
+        expect(errorLog()).not.toContain('websocket closed');
     });
 });
 

--- a/src/lib/util/__tests__/socket-keepalive.test.js
+++ b/src/lib/util/__tests__/socket-keepalive.test.js
@@ -1,0 +1,137 @@
+import { jest, describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { EventEmitter } from 'events';
+
+jest.unstable_mockModule('../../../globals.js', () => ({
+    logger: {
+        info: jest.fn(),
+        error: jest.fn(),
+        verbose: jest.fn(),
+        debug: jest.fn(),
+        warn: jest.fn(),
+    },
+}));
+
+const { logger } = await import('../../../globals.js');
+const { attachSocketKeepalive } = await import('../socket-keepalive.js');
+
+/**
+ * Builds a stand-in for a `ws` WebSocket: an event emitter that records its pings.
+ *
+ * @param {object} [overrides] - Properties to merge onto the socket, e.g. a throwing `ping`.
+ *
+ * @returns {object} The fake socket, with `ping` as a jest mock.
+ */
+const fakeSocket = (overrides = {}) =>
+    Object.assign(new EventEmitter(), { ping: jest.fn() }, overrides);
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+});
+
+afterEach(() => {
+    jest.useRealTimers();
+});
+
+describe('attachSocketKeepalive', () => {
+    test('returns the socket, so createSocket can wrap its constructor call', () => {
+        const socket = fakeSocket();
+
+        expect(attachSocketKeepalive(socket)).toBe(socket);
+    });
+
+    test('sends nothing before the socket is open', () => {
+        const socket = fakeSocket();
+        attachSocketKeepalive(socket, { intervalMs: 1000 });
+
+        jest.advanceTimersByTime(10000);
+
+        expect(socket.ping).not.toHaveBeenCalled();
+    });
+
+    test('pings on every interval once open', () => {
+        const socket = fakeSocket();
+        attachSocketKeepalive(socket, { intervalMs: 1000 });
+
+        socket.emit('open');
+        jest.advanceTimersByTime(3000);
+
+        expect(socket.ping).toHaveBeenCalledTimes(3);
+    });
+
+    test('covers the gap a sheet screenshot leaves', () => {
+        // The default has to fire inside the 25-40 s the browser spends per sheet, which is
+        // the window issue #975's sockets died in. A default longer than that gap would leave
+        // the connection idle for exactly as long as before.
+        const socket = fakeSocket();
+        attachSocketKeepalive(socket);
+
+        socket.emit('open');
+        jest.advanceTimersByTime(25000);
+
+        expect(socket.ping).toHaveBeenCalled();
+    });
+
+    test('stops when the socket closes', () => {
+        const socket = fakeSocket();
+        attachSocketKeepalive(socket, { intervalMs: 1000 });
+
+        socket.emit('open');
+        jest.advanceTimersByTime(2000);
+        socket.emit('close');
+        jest.advanceTimersByTime(10000);
+
+        expect(socket.ping).toHaveBeenCalledTimes(2);
+    });
+
+    test('stops on a socket error', () => {
+        const socket = fakeSocket();
+        attachSocketKeepalive(socket, { intervalMs: 1000 });
+
+        socket.emit('open');
+        jest.advanceTimersByTime(1000);
+        // An emitter with no `error` listener throws on emit; the keepalive registers one, so
+        // this also asserts the socket is not left to take the process down over a dead ping.
+        socket.emit('error', new Error('boom'));
+        jest.advanceTimersByTime(10000);
+
+        expect(socket.ping).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not hold the process open', () => {
+        // An interval alone keeps Node running. A finished run with an unclosed socket would
+        // hang on exit instead of ending.
+        const socket = fakeSocket();
+        const unref = jest.spyOn(global, 'setInterval');
+        attachSocketKeepalive(socket, { intervalMs: 1000 });
+
+        socket.emit('open');
+
+        expect(unref.mock.results.at(-1).value.hasRef()).toBe(false);
+        unref.mockRestore();
+    });
+
+    test('gives up quietly when a ping throws on a dying socket', () => {
+        const socket = fakeSocket({
+            ping: jest.fn(() => {
+                throw new Error('WebSocket is not open');
+            }),
+        });
+        attachSocketKeepalive(socket, { intervalMs: 1000 });
+
+        socket.emit('open');
+        jest.advanceTimersByTime(5000);
+
+        // Tried once, then stood down - the engine call that follows reports the real problem.
+        expect(socket.ping).toHaveBeenCalledTimes(1);
+        expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('keepalive'));
+    });
+
+    test('leaves a socket with no ping support alone', () => {
+        // A browser WebSocket has no ping method, and neither do some test doubles.
+        const socket = Object.assign(new EventEmitter(), {});
+
+        expect(() => attachSocketKeepalive(socket)).not.toThrow();
+        expect(() => socket.emit('open')).not.toThrow();
+    });
+});

--- a/src/lib/util/engine-session.js
+++ b/src/lib/util/engine-session.js
@@ -75,6 +75,20 @@ export const withEngineSession = async (configEnigma, ctx, fn) => {
             );
         }
 
+        // enigma emits this only for a close nobody here asked for: it returns early on a
+        // normal close and on a manual suspend, so a healthy run never logs this line.
+        //
+        // It is worth a line of its own because it fires when the socket dies, whereas the
+        // error surfaces later - up to 40 s later in the screenshot paths, which use the
+        // engine once per sheet and spend the rest of the time in the browser. Issue #975 is
+        // that gap: the log showed sheets failing with `Not connected` long after the event,
+        // and nothing recorded the close code that would say what closed the connection.
+        session.on('closed', (evt) =>
+            logger.warn(
+                `${logPrefix}: The engine session to ${connectionLabel} was closed from the other end, code ${evt?.code}${evt?.reason ? `, reason "${evt.reason}"` : ''}. Whatever is still using this session will fail from here on.`
+            )
+        );
+
         const global = await session.open();
 
         const engineVersion = await global.engineVersion();

--- a/src/lib/util/sheet-list.js
+++ b/src/lib/util/sheet-list.js
@@ -3,6 +3,8 @@
  * session object, shared by the Qlik Sense Cloud and QSEoW code paths.
  */
 
+import errorCodes from 'enigma.js/error-codes.js';
+
 import { logger } from '../../globals.js';
 import { getErrorCategory } from './error-categorizer.js';
 
@@ -161,11 +163,25 @@ export const SHEET_SKIPPED = Symbol('sheet skipped');
  * sheet then fails for the same reason, and the run reports "38 of 40 sheets failed" when
  * what actually happened is one dropped websocket.
  *
+ * enigma.js is asked by error code rather than by message, because it has three wordings for
+ * one dead socket and this loop reliably hits the one that used to be missed. `Socket closed`
+ * and `Socket error` reject the requests that were *in flight* when the socket died; `Not
+ * connected` is what every request issued afterwards gets. The engine sits idle here for the
+ * 25-40 s each screenshot takes, so the socket almost always dies with nothing outstanding -
+ * making `Not connected` the message that actually arrives, and the message list, which named
+ * only `Socket closed`, silently inapplicable. All three carry `NOT_CONNECTED`, so the code
+ * covers what no amount of guessing at wording did. See issue #975.
+ *
+ * `SESSION_SUSPENDED` is included so this stays correct if `suspendOnClose` is ever turned on:
+ * the session then rejects with that instead, and it means the same thing here - the socket is
+ * gone and nothing further will succeed on it.
+ *
  * Net-level classification is delegated to `getErrorCategory`, which already knows about
- * refused connections, timeouts and resets. The message checks cover enigma.js and the
- * Chrome DevTools Protocol, whose session deaths carry no `code`. They are deliberately
- * whole phrases: matching a bare `websocket` also caught per-sheet engine errors that merely
- * mention the transport, aborting the loop on a session that was still alive.
+ * refused connections, timeouts and resets. The message checks cover the Chrome DevTools
+ * Protocol, whose session deaths carry no `code`, and act as a fallback for an enigma error
+ * that lost its code crossing a boundary. They are deliberately whole phrases: matching a bare
+ * `websocket` also caught per-sheet engine errors that merely mention the transport, aborting
+ * the loop on a session that was still alive.
  *
  * @param {Error|unknown} err - Error thrown by a per-sheet worker.
  *
@@ -173,6 +189,15 @@ export const SHEET_SKIPPED = Symbol('sheet skipped');
  *     to the next sheet would only repeat it.
  */
 export const isSessionLevelFailure = (err) => {
+    // Only the socket-level rejections carry these codes - enigma raises a per-sheet failure
+    // such as `Object not found` under its own code, and is left to the per-sheet path.
+    if (
+        err?.enigmaError === true &&
+        (err.code === errorCodes.NOT_CONNECTED || err.code === errorCodes.SESSION_SUSPENDED)
+    ) {
+        return true;
+    }
+
     if (
         ['timeout', 'connection_refused', 'host_not_found', 'connection_reset'].includes(
             getErrorCategory(err)
@@ -185,12 +210,39 @@ export const isSessionLevelFailure = (err) => {
 
     return (
         message.includes('socket closed') ||
+        message.includes('not connected') ||
         message.includes('session closed') ||
         message.includes('connection closed') ||
         message.includes('target closed') ||
         message.includes('websocket connection') ||
         message.includes('websocket is not open')
     );
+};
+
+/**
+ * Renders the WebSocket close event enigma.js attaches to a socket-level rejection.
+ *
+ * `Not connected` on its own says the session was gone, not why it went. enigma carries the
+ * close event through as `original`, and its `code` is the one field that separates a network
+ * drop (1006, no clean close frame) from a deliberate close by the far end (1000-1001, or a
+ * Qlik-specific 4xxx with a reason). Without it a dropped session cannot be told from one the
+ * tenant closed on purpose, which is what left issue #975 undiagnosable from its own logs.
+ *
+ * @param {Error|unknown} err - Error thrown by a per-sheet worker.
+ *
+ * @returns {string} A sentence to append to the log line, or an empty string when the error
+ *     carries no close event - the errors that reach here through other paths have none.
+ */
+const describeCloseEvent = (err) => {
+    const code = err?.original?.code;
+
+    if (code === undefined || code === null) {
+        return '';
+    }
+
+    const reason = err.original.reason;
+
+    return ` (websocket closed with code ${code}${reason ? `, reason "${reason}"` : ''})`;
 };
 
 /**
@@ -264,7 +316,7 @@ export const runOverSheets = async (sheets, ctx, processSheet) => {
                 // Not this sheet's fault, and every sheet after it would fail identically.
                 sessionFailure = err;
                 logger.error(
-                    `${logPrefix}: Lost the engine session while processing app ${appId} at sheet ${iSheetNum}, abandoning the remaining sheets: ${err?.message ?? err}`
+                    `${logPrefix}: Lost the engine session while processing app ${appId} at sheet ${iSheetNum}, abandoning the remaining sheets: ${err?.message ?? err}${describeCloseEvent(err)}`
                 );
                 break;
             }

--- a/src/lib/util/socket-keepalive.js
+++ b/src/lib/util/socket-keepalive.js
@@ -1,0 +1,79 @@
+import { logger } from '../../globals.js';
+
+/**
+ * How often to ping an otherwise idle engine socket, in milliseconds.
+ *
+ * Chosen against what the screenshot paths do rather than against any documented limit: they
+ * call the engine once per sheet and then hand over to the browser for 25-40 s, so the socket
+ * goes quiet for that long every sheet. 20 s puts at least one frame in every such gap, which
+ * is the point - a connection that is never idle for a full gap cannot be reaped for being
+ * idle. Shorter buys nothing; longer leaves gaps unprotected.
+ */
+const DEFAULT_KEEPALIVE_INTERVAL_MS = 20000;
+
+/**
+ * Keeps an engine WebSocket from going silent while the caller is busy elsewhere.
+ *
+ * enigma.js never sends anything on its own, so between two engine calls the socket carries no
+ * traffic at all. Anything on the path - a load balancer, a NAT table, a corporate firewall -
+ * is then free to drop the connection as idle without telling either end, and the drop is only
+ * discovered by the next request, which fails with `Not connected`. That is the shape of issue
+ * #975: sessions dropped mid-app while the browser was taking a screenshot, and sessions four
+ * times older survived in the same run, so it was never a lifetime limit.
+ *
+ * A ping frame is the standard answer and costs a few bytes per interval. It does not make a
+ * dropped session recoverable - nothing here retries - it makes the drop less likely to happen
+ * in the first place.
+ *
+ * Applied to both platforms even though only Qlik Sense Cloud has shown the fault. QSEoW
+ * reaches its server over the LAN, where an idle socket has far less to survive, but the two
+ * connection modules are twins and a divergence here would be one more thing to remember.
+ *
+ * @param {object} socket - A `ws` WebSocket. Anything without a `ping` method is left alone, so
+ *     a browser `WebSocket` or a test double needs no special casing at the call site.
+ * @param {object} [ctx] - Options.
+ * @param {number} [ctx.intervalMs] - Ping interval. Defaults to 20 s; see above.
+ *
+ * @returns {object} The same socket, so `createSocket` can return the call directly.
+ */
+export const attachSocketKeepalive = (
+    socket,
+    { intervalMs = DEFAULT_KEEPALIVE_INTERVAL_MS } = {}
+) => {
+    if (typeof socket?.ping !== 'function' || typeof socket.on !== 'function') {
+        return socket;
+    }
+
+    let timer;
+
+    const stop = () => {
+        if (timer) {
+            clearInterval(timer);
+            timer = undefined;
+        }
+    };
+
+    socket.on('open', () => {
+        timer = setInterval(() => {
+            try {
+                socket.ping();
+            } catch (err) {
+                // A socket that has died between the interval firing and the ping being sent
+                // throws here. It is not this module's business to report that - the engine
+                // call that follows will, with far more context - but an uncaught throw from a
+                // timer callback would take the process down.
+                logger.debug(`Engine socket keepalive ping failed: ${err?.message ?? err}`);
+                stop();
+            }
+        }, intervalMs);
+
+        // An interval alone is enough to keep Node alive. Without this, a run that finished
+        // its work but left a socket unclosed would hang instead of exiting.
+        timer.unref?.();
+    });
+
+    socket.on('close', stop);
+    socket.on('error', stop);
+
+    return socket;
+};


### PR DESCRIPTION
Investigates #975 and fixes the part of it that is ours.

## What the logs actually show

The two failing CI jobs, reconstructed from their timestamps:

| | session opened | died during | session age at death |
|---|---|---|---|
| macOS attempt 1, app `5838acc6` | 19:57:16 | sheet 2's ~25 s screenshot | **55 s** |
| Windows attempt 2, first app | 20:23:50 | sheet 1's ~38 s screenshot | **116 s** |
| macOS, app that passed in the same job | 19:54:53 | — | 141 s, same idle gaps |
| Windows, app that passed in the same job | 20:25:51 | — | **247 s**, same idle gaps |

Sessions four times older survived alongside the ones that died, with the same gaps between engine calls. So it is neither a session-lifetime limit nor a fixed idle timeout, and the issue's "long-running session" framing is backwards — the sessions that died were the younger ones. The drop is transient and environmental. What the code contributed was leaving the socket silent for 25–40 s at a stretch with no ping and no reconnect, which is the shape an intermediary drops.

## The part that was broken

`isSessionLevelFailure` exists for exactly this scenario, and never fired:

```
"Not connected"  -> false     <-- what actually happens
"Socket closed"  -> true      <-- the only wording it matched
"Socket error"   -> false
```

enigma raises `Socket closed` only for requests already in flight. These loops are idle while the browser works, so the socket dies with nothing outstanding and the first failure is always `Not connected`. The classifier matched the rarer wording, and the unit tests froze the guess in place. All three wordings carry `NOT_CONNECTED`, so the code is now asked instead of the text.

## Changes

- `sheet-list.js` — classify by enigma's error code; the "Lost the engine session" line carries the websocket close code and reason.
- `engine-session.js` — a `closed` listener logs the close code when the socket dies, not up to 40 s later. Fires only on an unrequested close, so healthy runs stay quiet. All six session-opening modules get it.
- `socket-keepalive.js` — 20 s ping, wired into both platforms' `createSocket`.
- A staged doc page, since the log output an administrator sees has changed.

## Verification

- 1465 unit tests, 74 suites, lint clean; the standalone SEA bundle still builds with the new import.
- Mutation-tested: dropping the code check fails 2 tests; dropping the message fallback as well fails 7, including a loop test built from the reported log.
- The keepalive is verified against a real `ws` server — 5 pings received while idle, 0 after close — not only against the fake socket in its unit test.
- The drop itself could not be reproduced; it is 2-in-5 against a live tenant. What proves the diagnosis is the next failure, which will now name a close code.

## What this does not do

It does not reconnect. A session lost mid-app still costs that app, reported honestly rather than as a list of blameless sheets. Reconnect-and-continue changes `withEngineSession`'s contract for six callers and needs per-sheet retry semantics — worth building against a measured cause rather than a guessed one, which is why #975 stays open until a close code arrives.

Also found in passing and filed as #976, not fixed here: the QSEoW thumbnail path is the one sheet loop that never adopted `runOverSheets`, so none of this classification reaches it. It fails differently rather than wrongly, and that issue argues it may not be worth fixing.
