### PR TITLE
Reach the interactive wizards with -i on the command itself

### DIFF
--- a/.claude/skills/generated/browser/SKILL.md
+++ b/.claude/skills/generated/browser/SKILL.md
@@ -1,86 +1,88 @@
 ---
 name: browser
-description: "Skill for the Browser area of butler-sheet-icons. 41 symbols across 21 files."
+description: 'Skill for the Browser area of butler-sheet-icons. 43 symbols across 23 files.'
 ---
 
 # Browser
 
-41 symbols | 21 files | Cohesion: 86%
+43 symbols | 23 files | Cohesion: 84%
 
 ## When to Use
 
 - Working with code in `src/`
-- Understanding how launchBrowserForApp, resolveBrowserVersion, createAppImageDir work
+- Understanding how launchBrowserForApp, resolveBrowserVersion, assertInteractiveCapable work
 - Modifying browser-related functionality
 
 ## Key Files
 
-| File | Symbols |
-|------|---------|
-| `src/lib/browser/browser-launch.js` | logUnusableBrowser, watchForUnexpectedDisconnect, launchBrowserForApp, detectDocker, buildBrowserArgs (+2) |
-| `src/lib/browser/browser-version.js` | normalizeVersionKeyword, assertExplicitVersionIsWellFormed, markLookupFailure, logVersionLookupFailure, resolveBrowserVersion |
-| `src/lib/browser/browser-list-available.js` | logVersionHistoryFailure, extractVersions, mapPlatformToChrome, browserListAvailable, getMostRecentUsableChromeBuildId |
-| `src/lib/util/image-dir.js` | createAppImageDir, logPermissionAdvice, isProbablyContainer |
-| `src/lib/util/reported-error.js` | markReported, alreadyReported |
-| `src/lib/util/error-categorizer.js` | getErrorCategory, getErrorMetadata |
-| `src/lib/browser/browser-uninstall.js` | browserUninstall, browserUninstallAll |
-| `src/lib/browser/browser-detect.js` | sortNewestFirst, detectAvailableBrowser |
-| `src/lib/browser/browser-install.js` | browserInstall |
-| `src/lib/util/sheet-list.js` | isSessionLevelFailure |
+| File                                        | Symbols                                                                                                                       |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `src/lib/browser/browser-launch.js`         | logUnusableBrowser, watchForUnexpectedDisconnect, launchBrowserForApp, detectDocker, buildBrowserArgs (+2)                    |
+| `src/lib/browser/browser-version.js`        | normalizeVersionKeyword, assertExplicitVersionIsWellFormed, markLookupFailure, logVersionLookupFailure, resolveBrowserVersion |
+| `src/lib/browser/browser-list-available.js` | extractVersions, mapPlatformToChrome, fetchAvailableVersions, browserListAvailable, getMostRecentUsableChromeBuildId          |
+| `src/lib/util/image-dir.js`                 | createAppImageDir, logPermissionAdvice, isProbablyContainer                                                                   |
+| `src/lib/util/reported-error.js`            | markReported, alreadyReported                                                                                                 |
+| `src/globals.js`                            | getLoggingLevel, setLoggingLevel                                                                                              |
+| `src/lib/browser/browser-uninstall.js`      | browserUninstall, browserUninstallAll                                                                                         |
+| `src/lib/browser/browser-detect.js`         | sortNewestFirst, detectAvailableBrowser                                                                                       |
+| `src/lib/interactive/tty.js`                | assertInteractiveCapable                                                                                                      |
+| `src/lib/browser/browser-installed.js`      | browserInstalled                                                                                                              |
 
 ## Entry Points
 
 Start here when exploring this area:
 
-- **`launchBrowserForApp`** (Function) — `src/lib/browser/browser-launch.js:288`
+- **`launchBrowserForApp`** (Function) — `src/lib/browser/browser-launch.js:287`
 - **`resolveBrowserVersion`** (Function) — `src/lib/browser/browser-version.js:354`
+- **`assertInteractiveCapable`** (Function) — `src/lib/interactive/tty.js:121`
 - **`createAppImageDir`** (Function) — `src/lib/util/image-dir.js:32`
 - **`markReported`** (Function) — `src/lib/util/reported-error.js:32`
-- **`browserInstall`** (Function) — `src/lib/browser/browser-install.js:35`
 
 ## Key Symbols
 
-| Symbol | Type | File | Line |
-|--------|------|------|------|
-| `launchBrowserForApp` | Function | `src/lib/browser/browser-launch.js` | 288 |
-| `resolveBrowserVersion` | Function | `src/lib/browser/browser-version.js` | 354 |
-| `createAppImageDir` | Function | `src/lib/util/image-dir.js` | 32 |
-| `markReported` | Function | `src/lib/util/reported-error.js` | 32 |
-| `browserInstall` | Function | `src/lib/browser/browser-install.js` | 35 |
-| `browserListAvailable` | Function | `src/lib/browser/browser-list-available.js` | 137 |
-| `getMostRecentUsableChromeBuildId` | Function | `src/lib/browser/browser-list-available.js` | 300 |
-| `getErrorCategory` | Function | `src/lib/util/error-categorizer.js` | 32 |
-| `getErrorMetadata` | Function | `src/lib/util/error-categorizer.js` | 81 |
-| `alreadyReported` | Function | `src/lib/util/reported-error.js` | 47 |
-| `isSessionLevelFailure` | Function | `src/lib/util/sheet-list.js` | 174 |
-| `browserInstalled` | Function | `src/lib/browser/browser-installed.js` | 16 |
-| `browserUninstall` | Function | `src/lib/browser/browser-uninstall.js` | 24 |
-| `browserUninstallAll` | Function | `src/lib/browser/browser-uninstall.js` | 102 |
-| `qscloudListCollections` | Function | `src/lib/cloud/cloud-collections.js` | 19 |
-| `qscloudCreateThumbnails` | Function | `src/lib/cloud/cloud-create-thumbnails.js` | 30 |
-| `qseowCreateThumbnails` | Function | `src/lib/qseow/qseow-create-thumbnails.js` | 27 |
-| `detectAvailableBrowser` | Function | `src/lib/browser/browser-detect.js` | 62 |
-| `buildBrowserArgs` | Function | `src/lib/browser/browser-launch.js` | 76 |
-| `resolveBrowserExecutablePath` | Function | `src/lib/browser/browser-launch.js` | 153 |
+| Symbol                             | Type     | File                                              | Line |
+| ---------------------------------- | -------- | ------------------------------------------------- | ---- |
+| `launchBrowserForApp`              | Function | `src/lib/browser/browser-launch.js`               | 287  |
+| `resolveBrowserVersion`            | Function | `src/lib/browser/browser-version.js`              | 354  |
+| `assertInteractiveCapable`         | Function | `src/lib/interactive/tty.js`                      | 121  |
+| `createAppImageDir`                | Function | `src/lib/util/image-dir.js`                       | 32   |
+| `markReported`                     | Function | `src/lib/util/reported-error.js`                  | 32   |
+| `browserInstalled`                 | Function | `src/lib/browser/browser-installed.js`            | 17   |
+| `browserUninstall`                 | Function | `src/lib/browser/browser-uninstall.js`            | 24   |
+| `browserUninstallAll`              | Function | `src/lib/browser/browser-uninstall.js`            | 138  |
+| `qscloudListCollections`           | Function | `src/lib/cloud/cloud-collections.js`              | 19   |
+| `qscloudCreateThumbnails`          | Function | `src/lib/cloud/cloud-create-thumbnails.js`        | 33   |
+| `withQuietLogging`                 | Function | `src/lib/interactive/quiet.js`                    | 27   |
+| `qseowCreateThumbnails`            | Function | `src/lib/qseow/qseow-create-thumbnails.js`        | 28   |
+| `buildInteractiveCommand`          | Function | `src/lib/interactive/interactive-command.js`      | 112  |
+| `description`                      | Function | `src/lib/interactive/theme.js`                    | 54   |
+| `fetchAvailableVersions`           | Function | `src/lib/browser/browser-list-available.js`       | 146  |
+| `browserListAvailable`             | Function | `src/lib/browser/browser-list-available.js`       | 197  |
+| `getMostRecentUsableChromeBuildId` | Function | `src/lib/browser/browser-list-available.js`       | 335  |
+| `choices`                          | Function | `src/lib/commands/browser/install.interactive.js` | 51   |
+| `alreadyReported`                  | Function | `src/lib/util/reported-error.js`                  | 47   |
+| `detectAvailableBrowser`           | Function | `src/lib/browser/browser-detect.js`               | 61   |
 
 ## Execution Flows
 
-| Flow | Type | Steps |
-|------|------|-------|
-| `BrowserListAvailable → GetErrorCategory` | intra_community | 3 |
-| `BrowserListAvailable → MarkReported` | cross_community | 3 |
-| `ResolveBrowserVersion → MarkReported` | intra_community | 3 |
-| `ResolveBrowserVersion → GetErrorCategory` | cross_community | 3 |
-| `LaunchBrowserForApp → LogUnusableBrowser` | intra_community | 3 |
-| `CreateAppImageDir → IsProbablyContainer` | intra_community | 3 |
-| `GetMostRecentUsableChromeBuildId → GetErrorCategory` | intra_community | 3 |
-| `GetMostRecentUsableChromeBuildId → MarkReported` | cross_community | 3 |
+| Flow                                                  | Type            | Steps |
+| ----------------------------------------------------- | --------------- | ----- |
+| `EveryLeafCommand → Description`                      | cross_community | 4     |
+| `BrowserListAvailable → GetErrorCategory`             | cross_community | 4     |
+| `BrowserListAvailable → MarkReported`                 | cross_community | 4     |
+| `Choices → GetErrorCategory`                          | cross_community | 4     |
+| `Choices → MarkReported`                              | cross_community | 4     |
+| `GetMostRecentUsableChromeBuildId → GetErrorCategory` | cross_community | 4     |
+| `GetMostRecentUsableChromeBuildId → MarkReported`     | cross_community | 4     |
+| `ResolveBrowserVersion → MarkReported`                | intra_community | 3     |
+| `ResolveBrowserVersion → GetErrorCategory`            | cross_community | 3     |
+| `LaunchBrowserForApp → LogUnusableBrowser`            | intra_community | 3     |
 
 ## Connected Areas
 
 | Area | Connections |
-|------|-------------|
-| Cloud | 1 calls |
+| ---- | ----------- |
+| Util | 2 calls     |
 
 ## How to Explore
 

--- a/.claude/skills/generated/cloud/SKILL.md
+++ b/.claude/skills/generated/cloud/SKILL.md
@@ -1,81 +1,84 @@
 ---
 name: cloud
-description: "Skill for the Cloud area of butler-sheet-icons. 14 symbols across 10 files."
+description: 'Skill for the Cloud area of butler-sheet-icons. 17 symbols across 12 files.'
 ---
 
 # Cloud
 
-14 symbols | 10 files | Cohesion: 78%
+17 symbols | 12 files | Cohesion: 79%
 
 ## When to Use
 
 - Working with code in `src/`
-- Understanding how qscloudRemoveSheetIcons, qscloudUpdateSheetThumbnails, qseowRemoveSheetIcons work
+- Understanding how browserInstall, deleteCloudAppThumbnail, processCloudApp work
 - Modifying cloud-related functionality
 
 ## Key Files
 
-| File | Symbols |
-|------|---------|
-| `src/lib/cloud/cloud-repo-request.js` | bufferToStream, makeRequest, request |
+| File                                        | Symbols                                           |
+| ------------------------------------------- | ------------------------------------------------- |
+| `src/lib/cloud/cloud-repo-request.js`       | bufferToStream, makeRequest, request              |
+| `src/lib/util/socket-keepalive.js`          | attachSocketKeepalive, stop                       |
 | `src/lib/cloud/cloud-remove-sheet-icons.js` | removeSheetIconsCloudApp, qscloudRemoveSheetIcons |
-| `src/lib/qseow/qseow-remove-sheet-icons.js` | removeSheetIconsQSEoWApp, qseowRemoveSheetIcons |
-| `src/lib/cloud/cloud-updatesheets.js` | qscloudUpdateSheetThumbnails |
-| `src/lib/util/sheet-list.js` | assertAllProcessed |
-| `src/globals.js` | sleep |
-| `src/lib/cloud/cloud-delete-thumbnails.js` | deleteCloudAppThumbnail |
-| `src/lib/cloud/process-cloud-app.js` | processCloudApp |
-| `src/lib/cloud/sheet-screenshot.js` | takeSheetScreenshot |
-| `src/lib/cloud/cloud-repo.js` | qlikSaas |
+| `src/lib/qseow/qseow-remove-sheet-icons.js` | removeSheetIconsQSEoWApp, qseowRemoveSheetIcons   |
+| `src/globals.js`                            | sleep                                             |
+| `src/lib/browser/browser-install.js`        | browserInstall                                    |
+| `src/lib/cloud/cloud-delete-thumbnails.js`  | deleteCloudAppThumbnail                           |
+| `src/lib/cloud/process-cloud-app.js`        | processCloudApp                                   |
+| `src/lib/cloud/sheet-screenshot.js`         | takeSheetScreenshot                               |
+| `src/lib/cloud/cloud-updatesheets.js`       | qscloudUpdateSheetThumbnails                      |
 
 ## Entry Points
 
 Start here when exploring this area:
 
-- **`qscloudRemoveSheetIcons`** (Function) — `src/lib/cloud/cloud-remove-sheet-icons.js:168`
-- **`qscloudUpdateSheetThumbnails`** (Function) — `src/lib/cloud/cloud-updatesheets.js:36`
-- **`qseowRemoveSheetIcons`** (Function) — `src/lib/qseow/qseow-remove-sheet-icons.js:138`
-- **`assertAllProcessed`** (Function) — `src/lib/util/sheet-list.js:285`
+- **`browserInstall`** (Function) — `src/lib/browser/browser-install.js:34`
 - **`deleteCloudAppThumbnail`** (Function) — `src/lib/cloud/cloud-delete-thumbnails.js:10`
+- **`processCloudApp`** (Function) — `src/lib/cloud/process-cloud-app.js:33`
+- **`takeSheetScreenshot`** (Function) — `src/lib/cloud/sheet-screenshot.js:19`
+- **`attachSocketKeepalive`** (Function) — `src/lib/util/socket-keepalive.js:38`
 
 ## Key Symbols
 
-| Symbol | Type | File | Line |
-|--------|------|------|------|
-| `qscloudRemoveSheetIcons` | Function | `src/lib/cloud/cloud-remove-sheet-icons.js` | 168 |
-| `qscloudUpdateSheetThumbnails` | Function | `src/lib/cloud/cloud-updatesheets.js` | 36 |
-| `qseowRemoveSheetIcons` | Function | `src/lib/qseow/qseow-remove-sheet-icons.js` | 138 |
-| `assertAllProcessed` | Function | `src/lib/util/sheet-list.js` | 285 |
-| `deleteCloudAppThumbnail` | Function | `src/lib/cloud/cloud-delete-thumbnails.js` | 10 |
-| `processCloudApp` | Function | `src/lib/cloud/process-cloud-app.js` | 33 |
-| `takeSheetScreenshot` | Function | `src/lib/cloud/sheet-screenshot.js` | 18 |
-| `removeSheetIconsCloudApp` | Function | `src/lib/cloud/cloud-remove-sheet-icons.js` | 33 |
-| `removeSheetIconsQSEoWApp` | Function | `src/lib/qseow/qseow-remove-sheet-icons.js` | 34 |
-| `sleep` | Function | `src/globals.js` | 282 |
-| `bufferToStream` | Function | `src/lib/cloud/cloud-repo-request.js` | 59 |
-| `makeRequest` | Function | `src/lib/cloud/cloud-repo-request.js` | 75 |
-| `request` | Function | `src/lib/cloud/cloud-repo-request.js` | 143 |
-| `qlikSaas` | Function | `src/lib/cloud/cloud-repo.js` | 19 |
+| Symbol                         | Type     | File                                        | Line |
+| ------------------------------ | -------- | ------------------------------------------- | ---- |
+| `browserInstall`               | Function | `src/lib/browser/browser-install.js`        | 34   |
+| `deleteCloudAppThumbnail`      | Function | `src/lib/cloud/cloud-delete-thumbnails.js`  | 10   |
+| `processCloudApp`              | Function | `src/lib/cloud/process-cloud-app.js`        | 33   |
+| `takeSheetScreenshot`          | Function | `src/lib/cloud/sheet-screenshot.js`         | 19   |
+| `attachSocketKeepalive`        | Function | `src/lib/util/socket-keepalive.js`          | 38   |
+| `stop`                         | Function | `src/lib/util/socket-keepalive.js`          | 48   |
+| `qscloudRemoveSheetIcons`      | Function | `src/lib/cloud/cloud-remove-sheet-icons.js` | 169  |
+| `qscloudUpdateSheetThumbnails` | Function | `src/lib/cloud/cloud-updatesheets.js`       | 36   |
+| `qseowRemoveSheetIcons`        | Function | `src/lib/qseow/qseow-remove-sheet-icons.js` | 138  |
+| `assertAllProcessed`           | Function | `src/lib/util/sheet-list.js`                | 337  |
+| `sleep`                        | Function | `src/globals.js`                            | 291  |
+| `removeSheetIconsCloudApp`     | Function | `src/lib/cloud/cloud-remove-sheet-icons.js` | 34   |
+| `removeSheetIconsQSEoWApp`     | Function | `src/lib/qseow/qseow-remove-sheet-icons.js` | 34   |
+| `bufferToStream`               | Function | `src/lib/cloud/cloud-repo-request.js`       | 59   |
+| `makeRequest`                  | Function | `src/lib/cloud/cloud-repo-request.js`       | 75   |
+| `request`                      | Function | `src/lib/cloud/cloud-repo-request.js`       | 143  |
+| `qlikSaas`                     | Function | `src/lib/cloud/cloud-repo.js`               | 19   |
 
 ## Execution Flows
 
-| Flow | Type | Steps |
-|------|------|-------|
-| `ProcessCloudApp → Sleep` | intra_community | 3 |
-| `QscloudRemoveSheetIcons → AssertAllProcessed` | intra_community | 3 |
-| `QseowRemoveSheetIcons → AssertAllProcessed` | intra_community | 3 |
-| `QlikSaas → BufferToStream` | intra_community | 3 |
-| `QlikSaas → MakeRequest` | intra_community | 3 |
+| Flow                                           | Type            | Steps |
+| ---------------------------------------------- | --------------- | ----- |
+| `ProcessCloudApp → Sleep`                      | intra_community | 3     |
+| `QscloudRemoveSheetIcons → AssertAllProcessed` | intra_community | 3     |
+| `QseowRemoveSheetIcons → AssertAllProcessed`   | intra_community | 3     |
+| `QlikSaas → BufferToStream`                    | intra_community | 3     |
+| `QlikSaas → MakeRequest`                       | intra_community | 3     |
 
 ## Connected Areas
 
-| Area | Connections |
-|------|-------------|
-| Browser | 2 calls |
-| Util | 1 calls |
+| Area    | Connections |
+| ------- | ----------- |
+| Browser | 4 calls     |
+| Util    | 1 calls     |
 
 ## How to Explore
 
-1. `gitnexus_context({name: "qscloudRemoveSheetIcons"})` — see callers and callees
+1. `gitnexus_context({name: "browserInstall"})` — see callers and callees
 2. `gitnexus_query({query: "cloud"})` — find related execution flows
 3. Read key files listed above for implementation details

--- a/.claude/skills/generated/interactive/SKILL.md
+++ b/.claude/skills/generated/interactive/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: interactive
+description: 'Skill for the Interactive area of butler-sheet-icons. 44 symbols across 10 files.'
+---
+
+# Interactive
+
+44 symbols | 10 files | Cohesion: 98%
+
+## When to Use
+
+- Working with code in `src/`
+- Understanding how askQuestions, runInteractive, runMenu work
+- Modifying interactive-related functionality
+
+## Key Files
+
+| File                                          | Symbols                                                                             |
+| --------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `src/lib/interactive/self-test.js`            | heading, formatCapabilities, renderStaticReport, runPromptGallery, runSelfTest (+6) |
+| `src/lib/interactive/ask-questions.js`        | resolveChoices, configFor, askQuestions, hasDefault, select (+5)                    |
+| `src/lib/interactive/theme.js`                | help, answer, message, defaultAnswer                                                |
+| `src/lib/interactive/to-cli-options.js`       | matchesDeclaredDefault, tokensFor, emissionsFor, notEmitted                         |
+| `src/lib/interactive/prompt-runtime.js`       | loadPrompts, ask, write                                                             |
+| `src/lib/interactive/interactive-command.js`  | runSelfTestUnlessCancelled, runWizardUnlessCancelled, handleInteractive             |
+| `src/lib/interactive/mandatory-relaxation.js` | commandAndAncestors, relaxMandatoryOptionsIfInteractive, relax                      |
+| `src/lib/interactive/option-introspect.js`    | typeForOption, defaultForOption, specFromOption                                     |
+| `src/lib/interactive/index.js`                | review, runInteractive                                                              |
+| `src/lib/interactive/menu.js`                 | runMenu                                                                             |
+
+## Entry Points
+
+Start here when exploring this area:
+
+- **`askQuestions`** (Function) — `src/lib/interactive/ask-questions.js:196`
+- **`runInteractive`** (Function) — `src/lib/interactive/index.js:72`
+- **`runMenu`** (Function) — `src/lib/interactive/menu.js:24`
+- **`formatCapabilities`** (Function) — `src/lib/interactive/self-test.js:152`
+- **`renderStaticReport`** (Function) — `src/lib/interactive/self-test.js:283`
+
+## Key Symbols
+
+| Symbol                               | Type     | File                                          | Line |
+| ------------------------------------ | -------- | --------------------------------------------- | ---- |
+| `askQuestions`                       | Function | `src/lib/interactive/ask-questions.js`        | 196  |
+| `runInteractive`                     | Function | `src/lib/interactive/index.js`                | 72   |
+| `runMenu`                            | Function | `src/lib/interactive/menu.js`                 | 24   |
+| `formatCapabilities`                 | Function | `src/lib/interactive/self-test.js`            | 152  |
+| `renderStaticReport`                 | Function | `src/lib/interactive/self-test.js`            | 283  |
+| `runSelfTest`                        | Function | `src/lib/interactive/self-test.js`            | 364  |
+| `help`                               | Function | `src/lib/interactive/theme.js`                | 48   |
+| `formatPalette`                      | Function | `src/lib/interactive/self-test.js`            | 250  |
+| `answer`                             | Function | `src/lib/interactive/theme.js`                | 44   |
+| `message`                            | Function | `src/lib/interactive/theme.js`                | 45   |
+| `defaultAnswer`                      | Function | `src/lib/interactive/theme.js`                | 47   |
+| `emissionsFor`                       | Function | `src/lib/interactive/to-cli-options.js`       | 105  |
+| `notEmitted`                         | Function | `src/lib/interactive/to-cli-options.js`       | 107  |
+| `relaxMandatoryOptionsIfInteractive` | Function | `src/lib/interactive/mandatory-relaxation.js` | 92   |
+| `relax`                              | Function | `src/lib/interactive/mandatory-relaxation.js` | 100  |
+| `specFromOption`                     | Function | `src/lib/interactive/option-introspect.js`    | 140  |
+| `collectCapabilities`                | Function | `src/lib/interactive/self-test.js`            | 74   |
+| `formatSymbolMatrix`                 | Function | `src/lib/interactive/self-test.js`            | 185  |
+| `frames`                             | Function | `src/lib/interactive/self-test.js`            | 188  |
+| `resolveChoices`                     | Function | `src/lib/interactive/ask-questions.js`        | 53   |
+
+## Execution Flows
+
+| Flow                           | Type            | Steps |
+| ------------------------------ | --------------- | ----- |
+| `RunInteractive → LoadPrompts` | intra_community | 4     |
+| `RunSelfTest → LoadPrompts`    | intra_community | 4     |
+| `AskQuestions → LoadPrompts`   | intra_community | 3     |
+| `RunInteractive → Write`       | intra_community | 3     |
+| `RunMenu → LoadPrompts`        | intra_community | 3     |
+
+## How to Explore
+
+1. `gitnexus_context({name: "askQuestions"})` — see callers and callees
+2. `gitnexus_query({query: "interactive"})` — find related execution flows
+3. Read key files listed above for implementation details

--- a/.claude/skills/generated/qscloud/SKILL.md
+++ b/.claude/skills/generated/qscloud/SKILL.md
@@ -1,50 +1,66 @@
 ---
 name: qscloud
-description: "Skill for the Qscloud area of butler-sheet-icons. 7 symbols across 6 files."
+description: 'Skill for the Qscloud area of butler-sheet-icons. 9 symbols across 7 files.'
 ---
 
 # Qscloud
 
-7 symbols | 6 files | Cohesion: 100%
+9 symbols | 7 files | Cohesion: 81%
 
 ## When to Use
 
 - Working with code in `src/`
-- Understanding how parsePositiveInteger, collectPositiveIntegers, buildCloudCreateSheetThumbnailsCommand work
+- Understanding how everyLeafCommand, walk work
 - Modifying qscloud-related functionality
 
 ## Key Files
 
-| File | Symbols |
-|------|---------|
-| `src/lib/commands/helpers.js` | parsePositiveInteger, collectPositiveIntegers |
-| `src/lib/commands/qscloud/create-sheet-thumbnails.js` | buildCloudCreateSheetThumbnailsCommand |
-| `src/lib/commands/qscloud/index.js` | buildQscloudCommand |
-| `src/lib/commands/qscloud/list-collections.js` | buildCloudListCollectionsCommand |
-| `src/lib/commands/qscloud/remove-sheet-icons.js` | buildCloudRemoveSheetIconsCommand |
-| `src/lib/commands/qseow/index.js` | buildQseowCommand |
+| File                                                  | Symbols                                       |
+| ----------------------------------------------------- | --------------------------------------------- |
+| `src/lib/commands/helpers.js`                         | parsePositiveInteger, collectPositiveIntegers |
+| `src/lib/interactive/command-tree.js`                 | everyLeafCommand, walk                        |
+| `src/lib/commands/qscloud/create-sheet-thumbnails.js` | buildCloudCreateSheetThumbnailsCommand        |
+| `src/lib/commands/qscloud/index.js`                   | buildQscloudCommand                           |
+| `src/lib/commands/qscloud/list-collections.js`        | buildCloudListCollectionsCommand              |
+| `src/lib/commands/qscloud/remove-sheet-icons.js`      | buildCloudRemoveSheetIconsCommand             |
+| `src/lib/commands/qseow/index.js`                     | buildQseowCommand                             |
+
+## Entry Points
+
+Start here when exploring this area:
+
+- **`everyLeafCommand`** (Function) — `src/lib/interactive/command-tree.js:26`
+- **`walk`** (Function) — `src/lib/interactive/command-tree.js:29`
 
 ## Key Symbols
 
-| Symbol | Type | File | Line |
-|--------|------|------|------|
-| `parsePositiveInteger` | Function | `src/lib/commands/helpers.js` | 16 |
-| `collectPositiveIntegers` | Function | `src/lib/commands/helpers.js` | 78 |
-| `buildCloudCreateSheetThumbnailsCommand` | Function | `src/lib/commands/qscloud/create-sheet-thumbnails.js` | 31 |
-| `buildQscloudCommand` | Function | `src/lib/commands/qscloud/index.js` | 10 |
-| `buildCloudListCollectionsCommand` | Function | `src/lib/commands/qscloud/list-collections.js` | 24 |
-| `buildCloudRemoveSheetIconsCommand` | Function | `src/lib/commands/qscloud/remove-sheet-icons.js` | 24 |
-| `buildQseowCommand` | Function | `src/lib/commands/qseow/index.js` | 31 |
+| Symbol                                   | Type     | File                                                  | Line |
+| ---------------------------------------- | -------- | ----------------------------------------------------- | ---- |
+| `everyLeafCommand`                       | Function | `src/lib/interactive/command-tree.js`                 | 26   |
+| `walk`                                   | Function | `src/lib/interactive/command-tree.js`                 | 29   |
+| `parsePositiveInteger`                   | Function | `src/lib/commands/helpers.js`                         | 16   |
+| `collectPositiveIntegers`                | Function | `src/lib/commands/helpers.js`                         | 78   |
+| `buildCloudCreateSheetThumbnailsCommand` | Function | `src/lib/commands/qscloud/create-sheet-thumbnails.js` | 32   |
+| `buildQscloudCommand`                    | Function | `src/lib/commands/qscloud/index.js`                   | 10   |
+| `buildCloudListCollectionsCommand`       | Function | `src/lib/commands/qscloud/list-collections.js`        | 24   |
+| `buildCloudRemoveSheetIconsCommand`      | Function | `src/lib/commands/qscloud/remove-sheet-icons.js`      | 24   |
+| `buildQseowCommand`                      | Function | `src/lib/commands/qseow/index.js`                     | 32   |
 
 ## Execution Flows
 
-| Flow | Type | Steps |
-|------|------|-------|
-| `BuildQscloudCommand → ParsePositiveInteger` | intra_community | 4 |
-| `BuildQseowCommand → ParsePositiveInteger` | intra_community | 3 |
+| Flow                                      | Type            | Steps |
+| ----------------------------------------- | --------------- | ----- |
+| `EveryLeafCommand → ParsePositiveInteger` | intra_community | 5     |
+| `EveryLeafCommand → Description`          | cross_community | 4     |
+
+## Connected Areas
+
+| Area    | Connections |
+| ------- | ----------- |
+| Browser | 5 calls     |
 
 ## How to Explore
 
-1. `gitnexus_context({name: "parsePositiveInteger"})` — see callers and callees
+1. `gitnexus_context({name: "everyLeafCommand"})` — see callers and callees
 2. `gitnexus_query({query: "qscloud"})` — find related execution flows
 3. Read key files listed above for implementation details

--- a/.claude/skills/generated/qseow/SKILL.md
+++ b/.claude/skills/generated/qseow/SKILL.md
@@ -1,61 +1,67 @@
 ---
 name: qseow
-description: "Skill for the Qseow area of butler-sheet-icons. 8 symbols across 6 files."
+description: 'Skill for the Qseow area of butler-sheet-icons. 12 symbols across 8 files.'
 ---
 
 # Qseow
 
-8 symbols | 6 files | Cohesion: 80%
+12 symbols | 8 files | Cohesion: 81%
 
 ## When to Use
 
 - Working with code in `src/`
-- Understanding how qseowProcessApp, qseowUpdateSheetThumbnails, qseowUploadToContentLibrary work
+- Understanding how qrsGetList, qseowProcessApp, qseowUpdateSheetThumbnails work
 - Modifying qseow-related functionality
 
 ## Key Files
 
-| File | Symbols |
-|------|---------|
+| File                                  | Symbols                              |
+| ------------------------------------- | ------------------------------------ |
+| `src/lib/qseow/qseow-process-app.js`  | getSheetsTaggedWith, qseowProcessApp |
+| `src/lib/util/errors.js`              | QseowError, CertError                |
 | `src/lib/qseow/qseow-certificates.js` | exists, qseowVerifyCertificatesExist |
-| `src/lib/qseow/qseow-enigma.js` | readCert, createSocket |
-| `src/lib/qseow/qseow-process-app.js` | qseowProcessApp |
-| `src/lib/qseow/qseow-updatesheets.js` | qseowUpdateSheetThumbnails |
-| `src/lib/qseow/qseow-upload.js` | qseowUploadToContentLibrary |
-| `src/lib/util/errors.js` | QseowError |
+| `src/lib/qseow/qseow-enigma.js`       | readCert, createSocket               |
+| `src/lib/qseow/qrs-response.js`       | qrsGetList                           |
+| `src/lib/qseow/qseow-updatesheets.js` | qseowUpdateSheetThumbnails           |
+| `src/lib/qseow/qseow-upload.js`       | qseowUploadToContentLibrary          |
+| `src/lib/util/cert.js`                | getCertFilePaths                     |
 
 ## Entry Points
 
 Start here when exploring this area:
 
-- **`qseowProcessApp`** (Function) — `src/lib/qseow/qseow-process-app.js:100`
-- **`qseowUpdateSheetThumbnails`** (Function) — `src/lib/qseow/qseow-updatesheets.js:32`
+- **`qrsGetList`** (Function) — `src/lib/qseow/qrs-response.js:28`
+- **`qseowProcessApp`** (Function) — `src/lib/qseow/qseow-process-app.js:162`
+- **`qseowUpdateSheetThumbnails`** (Function) — `src/lib/qseow/qseow-updatesheets.js:33`
 - **`qseowUploadToContentLibrary`** (Function) — `src/lib/qseow/qseow-upload.js:32`
-- **`qseowVerifyCertificatesExist`** (Function) — `src/lib/qseow/qseow-certificates.js:30`
-- **`createSocket`** (Function) — `src/lib/qseow/qseow-enigma.js:71`
+- **`qseowVerifyCertificatesExist`** (Function) — `src/lib/qseow/qseow-certificates.js:49`
 
 ## Key Symbols
 
-| Symbol | Type | File | Line |
-|--------|------|------|------|
-| `QseowError` | Class | `src/lib/util/errors.js` | 91 |
-| `qseowProcessApp` | Function | `src/lib/qseow/qseow-process-app.js` | 100 |
-| `qseowUpdateSheetThumbnails` | Function | `src/lib/qseow/qseow-updatesheets.js` | 32 |
-| `qseowUploadToContentLibrary` | Function | `src/lib/qseow/qseow-upload.js` | 32 |
-| `qseowVerifyCertificatesExist` | Function | `src/lib/qseow/qseow-certificates.js` | 30 |
-| `createSocket` | Function | `src/lib/qseow/qseow-enigma.js` | 71 |
-| `exists` | Function | `src/lib/qseow/qseow-certificates.js` | 12 |
-| `readCert` | Function | `src/lib/qseow/qseow-enigma.js` | 15 |
+| Symbol                         | Type     | File                                  | Line |
+| ------------------------------ | -------- | ------------------------------------- | ---- |
+| `QseowError`                   | Class    | `src/lib/util/errors.js`              | 91   |
+| `CertError`                    | Class    | `src/lib/util/errors.js`              | 43   |
+| `qrsGetList`                   | Function | `src/lib/qseow/qrs-response.js`       | 28   |
+| `qseowProcessApp`              | Function | `src/lib/qseow/qseow-process-app.js`  | 162  |
+| `qseowUpdateSheetThumbnails`   | Function | `src/lib/qseow/qseow-updatesheets.js` | 33   |
+| `qseowUploadToContentLibrary`  | Function | `src/lib/qseow/qseow-upload.js`       | 32   |
+| `qseowVerifyCertificatesExist` | Function | `src/lib/qseow/qseow-certificates.js` | 49   |
+| `getCertFilePaths`             | Function | `src/lib/util/cert.js`                | 18   |
+| `createSocket`                 | Function | `src/lib/qseow/qseow-enigma.js`       | 76   |
+| `getSheetsTaggedWith`          | Function | `src/lib/qseow/qseow-process-app.js`  | 44   |
+| `exists`                       | Function | `src/lib/qseow/qseow-certificates.js` | 21   |
+| `readCert`                     | Function | `src/lib/qseow/qseow-enigma.js`       | 16   |
 
 ## Connected Areas
 
-| Area | Connections |
-|------|-------------|
-| Cloud | 2 calls |
-| Browser | 1 calls |
+| Area    | Connections |
+| ------- | ----------- |
+| Cloud   | 2 calls     |
+| Browser | 1 calls     |
 
 ## How to Explore
 
-1. `gitnexus_context({name: "qseowProcessApp"})` — see callers and callees
+1. `gitnexus_context({name: "qrsGetList"})` — see callers and callees
 2. `gitnexus_query({query: "qseow"})` — find related execution flows
 3. Read key files listed above for implementation details

--- a/.claude/skills/generated/util/SKILL.md
+++ b/.claude/skills/generated/util/SKILL.md
@@ -1,84 +1,91 @@
 ---
 name: util
-description: "Skill for the Util area of butler-sheet-icons. 31 symbols across 10 files."
+description: 'Skill for the Util area of butler-sheet-icons. 47 symbols across 13 files.'
 ---
 
 # Util
 
-31 symbols | 10 files | Cohesion: 92%
+47 symbols | 13 files | Cohesion: 89%
 
 ## When to Use
 
 - Working with code in `src/`
-- Understanding how qscloudTestConnection, qscloudUploadToApp, getCertFilePaths work
+- Understanding how redactValue, redactOptions, redactSensitivePatterns work
 - Modifying util-related functionality
 
 ## Key Files
 
-| File | Symbols |
-|------|---------|
-| `src/lib/util/log-error.js` | logErrorWithLevel, logError, logWarn, logInfo, logVerbose (+1) |
-| `src/lib/util/env-check.js` | isMissing, present, toHex, formatSecret, checkEnv (+1) |
-| `src/lib/util/crash-dump.js` | envBool, buildTimestampForFilename, sanitizeStackTrace, resolveCrashDir, writeCrashDump |
-| `src/lib/util/errors.js` | BsiError, CertError, EnigmaError, CloudError |
-| `src/lib/util/redact-secrets.js` | isSecretKey, redactValue, redactOptions, redactSensitivePatterns |
-| `src/globals.js` | sanitizeLogValue, sanitizeFormat |
-| `src/lib/cloud/cloud-test-connection.js` | qscloudTestConnection |
-| `src/lib/cloud/cloud-upload.js` | qscloudUploadToApp |
-| `src/lib/util/cert.js` | getCertFilePaths |
-| `src/lib/util/enigma-util.js` | getEnigmaSchema |
+| File                                     | Symbols                                                                                     |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `src/lib/util/fatal-handlers.js`         | toError, logFatalLine, exitOnce, armWatchdog, handleFatal (+5)                              |
+| `src/lib/util/crash-dump.js`             | envBool, parseMaxDumps, buildTimestampForFilename, sanitizeStackTrace, resolveCrashDir (+1) |
+| `src/lib/util/log-error.js`              | logErrorWithLevel, logError, logWarn, logInfo, logVerbose (+1)                              |
+| `src/lib/util/env-check.js`              | isMissing, present, toHex, formatSecret, checkEnv (+1)                                      |
+| `src/lib/util/redact-secrets.js`         | isSecretKey, isProseWord, redactValue, redactOptions, redactSensitivePatterns               |
+| `src/lib/util/errors.js`                 | BsiError, EnigmaError, CloudError                                                           |
+| `src/lib/util/sheet-list.js`             | isSessionLevelFailure, describeCloseEvent, runOverSheets                                    |
+| `src/globals.js`                         | sanitizeLogValue, sanitizeFormat                                                            |
+| `src/lib/util/error-categorizer.js`      | getErrorCategory, getErrorMetadata                                                          |
+| `src/lib/cloud/cloud-test-connection.js` | qscloudTestConnection                                                                       |
 
 ## Entry Points
 
 Start here when exploring this area:
 
-- **`qscloudTestConnection`** (Function) — `src/lib/cloud/cloud-test-connection.js:31`
-- **`qscloudUploadToApp`** (Function) — `src/lib/cloud/cloud-upload.js:29`
-- **`getCertFilePaths`** (Function) — `src/lib/util/cert.js:18`
-- **`getEnigmaSchema`** (Function) — `src/lib/util/enigma-util.js:45`
-- **`redactValue`** (Function) — `src/lib/util/redact-secrets.js:89`
+- **`redactValue`** (Function) — `src/lib/util/redact-secrets.js:112`
+- **`redactOptions`** (Function) — `src/lib/util/redact-secrets.js:149`
+- **`redactSensitivePatterns`** (Function) — `src/lib/util/redact-secrets.js:160`
+- **`onUncaughtException`** (Function) — `src/lib/util/fatal-handlers.js:277`
+- **`onUnhandledRejection`** (Function) — `src/lib/util/fatal-handlers.js:291`
 
 ## Key Symbols
 
-| Symbol | Type | File | Line |
-|--------|------|------|------|
-| `BsiError` | Class | `src/lib/util/errors.js` | 26 |
-| `CertError` | Class | `src/lib/util/errors.js` | 43 |
-| `EnigmaError` | Class | `src/lib/util/errors.js` | 59 |
-| `CloudError` | Class | `src/lib/util/errors.js` | 75 |
-| `qscloudTestConnection` | Function | `src/lib/cloud/cloud-test-connection.js` | 31 |
-| `qscloudUploadToApp` | Function | `src/lib/cloud/cloud-upload.js` | 29 |
-| `getCertFilePaths` | Function | `src/lib/util/cert.js` | 18 |
-| `getEnigmaSchema` | Function | `src/lib/util/enigma-util.js` | 45 |
-| `redactValue` | Function | `src/lib/util/redact-secrets.js` | 89 |
-| `redactOptions` | Function | `src/lib/util/redact-secrets.js` | 126 |
-| `redactSensitivePatterns` | Function | `src/lib/util/redact-secrets.js` | 137 |
-| `logError` | Function | `src/lib/util/log-error.js` | 77 |
-| `logWarn` | Function | `src/lib/util/log-error.js` | 88 |
-| `logInfo` | Function | `src/lib/util/log-error.js` | 99 |
-| `logVerbose` | Function | `src/lib/util/log-error.js` | 110 |
-| `logDebug` | Function | `src/lib/util/log-error.js` | 121 |
-| `writeCrashDump` | Function | `src/lib/util/crash-dump.js` | 161 |
-| `present` | Function | `src/lib/util/env-check.js` | 167 |
-| `formatSecret` | Function | `src/lib/util/env-check.js` | 106 |
-| `checkEnv` | Function | `src/lib/util/env-check.js` | 129 |
+| Symbol                    | Type     | File                                     | Line |
+| ------------------------- | -------- | ---------------------------------------- | ---- |
+| `BsiError`                | Class    | `src/lib/util/errors.js`                 | 26   |
+| `EnigmaError`             | Class    | `src/lib/util/errors.js`                 | 59   |
+| `CloudError`              | Class    | `src/lib/util/errors.js`                 | 75   |
+| `redactValue`             | Function | `src/lib/util/redact-secrets.js`         | 112  |
+| `redactOptions`           | Function | `src/lib/util/redact-secrets.js`         | 149  |
+| `redactSensitivePatterns` | Function | `src/lib/util/redact-secrets.js`         | 160  |
+| `onUncaughtException`     | Function | `src/lib/util/fatal-handlers.js`         | 277  |
+| `onUnhandledRejection`    | Function | `src/lib/util/fatal-handlers.js`         | 291  |
+| `qscloudTestConnection`   | Function | `src/lib/cloud/cloud-test-connection.js` | 31   |
+| `qscloudUploadToApp`      | Function | `src/lib/cloud/cloud-upload.js`          | 29   |
+| `getEnigmaSchema`         | Function | `src/lib/util/enigma-util.js`            | 45   |
+| `writeCrashDump`          | Function | `src/lib/util/crash-dump.js`             | 203  |
+| `logError`                | Function | `src/lib/util/log-error.js`              | 77   |
+| `logWarn`                 | Function | `src/lib/util/log-error.js`              | 88   |
+| `logInfo`                 | Function | `src/lib/util/log-error.js`              | 99   |
+| `logVerbose`              | Function | `src/lib/util/log-error.js`              | 110  |
+| `logDebug`                | Function | `src/lib/util/log-error.js`              | 121  |
+| `getErrorCategory`        | Function | `src/lib/util/error-categorizer.js`      | 32   |
+| `getErrorMetadata`        | Function | `src/lib/util/error-categorizer.js`      | 81   |
+| `isSessionLevelFailure`   | Function | `src/lib/util/sheet-list.js`             | 190  |
 
 ## Execution Flows
 
-| Flow | Type | Steps |
-|------|------|-------|
-| `SanitizeFormat → IsSecretKey` | intra_community | 4 |
-| `RedactOptions → IsSecretKey` | intra_community | 3 |
-| `SanitizeFormat → RedactSensitivePatterns` | intra_community | 3 |
+| Flow                                       | Type            | Steps |
+| ------------------------------------------ | --------------- | ----- |
+| `OnUncaughtException → IsProseWord`        | cross_community | 5     |
+| `OnUnhandledRejection → IsProseWord`       | cross_community | 5     |
+| `BrowserListAvailable → GetErrorCategory`  | cross_community | 4     |
+| `BrowserListAvailable → MarkReported`      | cross_community | 4     |
+| `OnUncaughtException → ExitOnce`           | intra_community | 4     |
+| `OnUncaughtException → EnvBool`            | cross_community | 4     |
+| `OnUncaughtException → ParseMaxDumps`      | cross_community | 4     |
+| `OnUncaughtException → SanitizeStackTrace` | cross_community | 4     |
+| `OnUnhandledRejection → ExitOnce`          | intra_community | 4     |
+| `OnUnhandledRejection → EnvBool`           | cross_community | 4     |
 
 ## Connected Areas
 
-| Area | Connections |
-|------|-------------|
-| Browser | 1 calls |
+| Area    | Connections |
+| ------- | ----------- |
+| Browser | 2 calls     |
 
 ## How to Explore
 
-1. `gitnexus_context({name: "qscloudTestConnection"})` — see callers and callees
+1. `gitnexus_context({name: "redactValue"})` — see callers and callees
 2. `gitnexus_query({query: "util"})` — find related execution flows
 3. Read key files listed above for implementation details

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,5 @@
 <!-- gitnexus:start -->
+
 # GitNexus — Code Intelligence
 
 This project is indexed by GitNexus as **butler-sheet-icons**. Use the GitNexus MCP tools to understand code, assess impact, and navigate safely. Read `gitnexus://repo/butler-sheet-icons/context` for live index statistics.
@@ -28,29 +29,30 @@ This project is indexed by GitNexus as **butler-sheet-icons**. Use the GitNexus 
 
 ## Resources
 
-| Resource | Use for |
-|----------|---------|
-| `gitnexus://repo/butler-sheet-icons/context` | Codebase overview, check index freshness |
-| `gitnexus://repo/butler-sheet-icons/clusters` | All functional areas |
-| `gitnexus://repo/butler-sheet-icons/processes` | All execution flows |
-| `gitnexus://repo/butler-sheet-icons/process/{name}` | Step-by-step execution trace |
+| Resource                                            | Use for                                  |
+| --------------------------------------------------- | ---------------------------------------- |
+| `gitnexus://repo/butler-sheet-icons/context`        | Codebase overview, check index freshness |
+| `gitnexus://repo/butler-sheet-icons/clusters`       | All functional areas                     |
+| `gitnexus://repo/butler-sheet-icons/processes`      | All execution flows                      |
+| `gitnexus://repo/butler-sheet-icons/process/{name}` | Step-by-step execution trace             |
 
 ## CLI
 
-| Task | Read this skill file |
-|------|---------------------|
-| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
-| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
-| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
-| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
-| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
-| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
-| Work in the Cloud area | `.claude/skills/generated/cloud/SKILL.md` |
-| Work in the Browser area | `.claude/skills/generated/browser/SKILL.md` |
-| Work in the Qscloud area | `.claude/skills/generated/qscloud/SKILL.md` |
-| Work in the Qseow area | `.claude/skills/generated/qseow/SKILL.md` |
-| Work in the Util area | `.claude/skills/generated/util/SKILL.md` |
-| Work in the Diag area | `.claude/skills/generated/diag/SKILL.md` |
+| Task                                         | Read this skill file                                        |
+| -------------------------------------------- | ----------------------------------------------------------- |
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md`       |
+| Blast radius / "What breaks if I change X?"  | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?"             | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md`       |
+| Rename / extract / split / refactor          | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md`     |
+| Tools, resources, schema reference           | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md`           |
+| Index, status, clean, wiki CLI commands      | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md`             |
+| Work in the Cloud area                       | `.claude/skills/generated/cloud/SKILL.md`                   |
+| Work in the Browser area                     | `.claude/skills/generated/browser/SKILL.md`                 |
+| Work in the Interactive area                 | `.claude/skills/generated/interactive/SKILL.md`             |
+| Work in the Qscloud area                     | `.claude/skills/generated/qscloud/SKILL.md`                 |
+| Work in the Qseow area                       | `.claude/skills/generated/qseow/SKILL.md`                   |
+| Work in the Util area                        | `.claude/skills/generated/util/SKILL.md`                    |
+| Work in the Diag area                        | `.claude/skills/generated/diag/SKILL.md`                    |
 
 <!-- gitnexus:end -->
 
@@ -91,6 +93,6 @@ When a commit is authorised:
 
 - **MUST group changes by topic** — one commit per logical change, not one commit listing everything. Split a mixed working tree rather than writing a catch-all message.
 - **MUST use Conventional Commits** (`type: subject`). This is functional: release-please derives the changelog and version bump from the type — `feat` minor, `fix` patch, `feat!` or a `BREAKING CHANGE:` footer major. Configured types are `feat`, `fix`, `chore`, `docs`, `build`, `refactor` (hidden from the changelog).
-- **MUST NOT give a pull request a Conventional Commits title** — commit subjects use `type: subject`, PR titles are ordinary sentences. PRs land as merge commits and GitHub copies the PR title into the merge commit *body*; release-please cannot parse the merge subject, falls back to the body, and emits a **duplicate changelog entry**. That is why the 4.0.0 release PR listed 154 entries for 128 real changes. If a conventional PR title is unavoidable, merge with `gh pr merge --merge --body ""` — but the title rule is the one that also covers merges done in the web UI.
+- **MUST NOT give a pull request a Conventional Commits title** — commit subjects use `type: subject`, PR titles are ordinary sentences. PRs land as merge commits and GitHub copies the PR title into the merge commit _body_; release-please cannot parse the merge subject, falls back to the body, and emits a **duplicate changelog entry**. That is why the 4.0.0 release PR listed 154 entries for 128 real changes. If a conventional PR title is unavoidable, merge with `gh pr merge --merge --body ""` — but the title rule is the one that also covers merges done in the web UI.
 
 See `AGENTS.md` for the full set of repository conventions.

--- a/docs/to-doc-site/interactive-flag-on-commands.md
+++ b/docs/to-doc-site/interactive-flag-on-commands.md
@@ -1,0 +1,78 @@
+# Interactive mode without leaving the command you were typing
+
+Interactive mode used to be reachable only through its own command:
+
+```bash
+butler-sheet-icons interactive
+```
+
+That is still there and still works. But it meant starting from a menu, even when you already knew which
+command you wanted and had half of it typed.
+
+You can now add `-i` to the command itself:
+
+```bash
+butler-sheet-icons browser uninstall -i
+```
+
+## Anything you already supplied is kept
+
+This is the part worth knowing about. Options you have already given are treated as answers, not asked
+about again. So you can supply the parts you know and let Butler Sheet Icons ask for the rest:
+
+```bash
+butler-sheet-icons browser uninstall --browser chrome -i
+```
+
+```
+Already supplied, so not asked about again: --browser.
+
+? Which browser build should be removed?
+❯ chrome  151.0.7922.108  (mac_arm)
+  chrome  151.0.7922.47   (mac_arm)
+```
+
+This works for `BSI_*` environment variables too. If `BSI_BROWSER_UI_BROWSER` is set in your shell or in
+a `.env` file, the browser question is skipped in exactly the same way.
+
+Values that merely fall back to a **default** are still asked about, with the default offered as the
+pre-filled answer. Only values you actually chose are treated as settled.
+
+## Which commands accept it
+
+`-i` appears on the commands that have something worth asking about:
+
+| Command | `-i` |
+|---|---|
+| `browser install` | yes |
+| `browser uninstall` | yes |
+| `browser list-installed`, `browser list-available`, `browser uninstall-all` | no — they take nothing but a log level |
+| `qseow create-sheet-thumbnails`, and the `qscloud` commands | not yet — planned for the next release |
+
+Running `-i` on a command that does not accept it reports `unknown option '-i'` rather than doing
+something unexpected. The commands still without it are the ones with the longest option lists, and they
+are next.
+
+## Nothing else changes
+
+Worth stating plainly, because this release touches how every command is parsed:
+
+- Without `-i`, every command behaves exactly as it did before — same options, same error messages, same
+  exit codes. This was checked command by command against the previous release.
+- `--help` is unchanged apart from the new `-i` entry on the two commands that have it.
+- Scripts, scheduled tasks and container runs are unaffected. They do not pass `-i`, so none of this
+  applies to them.
+
+## If there is no terminal
+
+Interactive mode needs one. When standard input is not a terminal — piped input, `cron`, `docker run`
+without `-it`, most CI runners — Butler Sheet Icons says so and stops immediately rather than waiting
+forever for an answer that cannot arrive:
+
+```
+Interactive mode needs a terminal. Standard input is not a terminal - this happens with piped
+input, cron, "docker run" without -it, and most CI runners. Re-run with the options on the
+command line, or start the container with "docker run -it".
+```
+
+The exit code is 1, so a scheduler sees a failure rather than a hung job.

--- a/src/butler-sheet-icons.js
+++ b/src/butler-sheet-icons.js
@@ -5,6 +5,7 @@ import { buildQseowCommand } from './lib/commands/qseow/index.js';
 import { buildQscloudCommand } from './lib/commands/qscloud/index.js';
 import { buildBrowserCommand } from './lib/commands/browser/index.js';
 import { buildInteractiveCommand } from './lib/interactive/interactive-command.js';
+import { relaxMandatoryOptionsIfInteractive } from './lib/interactive/mandatory-relaxation.js';
 
 // Process-level safety net: catch any error that escapes all try/catch blocks,
 // write a crash dump, and exit with code 1. Installed before anything else so
@@ -29,6 +30,12 @@ const program = new Command();
     program.addCommand(buildQscloudCommand());
     program.addCommand(buildBrowserCommand());
     program.addCommand(buildInteractiveCommand());
+
+    // Must happen before the parse: Commander rejects a command line missing a
+    // mandatory option before any hook or handler runs, so `-i` would never be
+    // reached. Does nothing at all unless the command line asks for a wizard,
+    // and restores what it changed before any handler runs.
+    relaxMandatoryOptionsIfInteractive(program, process.argv);
 
     await program.parseAsync(process.argv);
 })();

--- a/src/lib/commands/browser/__tests__/browser_wizards.test.js
+++ b/src/lib/commands/browser/__tests__/browser_wizards.test.js
@@ -173,6 +173,65 @@ describe('the uninstall wizard', () => {
     });
 });
 
+describe('options already supplied on the command line', () => {
+    // What makes `-i` compose rather than merely exist:
+    // `bsi browser install --browser firefox -i` should ask which build, not
+    // which browser.
+    test('are not asked about again', async () => {
+        const runtime = scriptedRuntime({ browserVersion: '151.0.7922.47', _review: 'cancel' });
+
+        await runInteractive({
+            path: 'browser install',
+            presetOptions: { browser: 'firefox' },
+            runtime,
+        });
+
+        expect(runtime.asked.map((a) => a.key)).toEqual(['browserVersion', '_review']);
+    });
+
+    test('are still visible to the questions that follow', async () => {
+        // The pre-filled answer has to reach `choices`, or the version list
+        // would be fetched for the wrong browser.
+        const runtime = scriptedRuntime({ browserVersion: '151.0.7922.47', _review: 'cancel' });
+
+        await runInteractive({
+            path: 'browser install',
+            presetOptions: { browser: 'firefox' },
+            runtime,
+        });
+
+        expect(fetchAvailableVersions).toHaveBeenCalledWith(
+            expect.objectContaining({ browser: 'firefox' })
+        );
+    });
+
+    test('and reach the command that finally runs', async () => {
+        const runtime = scriptedRuntime({ browserVersion: '151.0.7922.47', _review: 'run' });
+
+        await runInteractive({
+            path: 'browser install',
+            presetOptions: { browser: 'firefox' },
+            runtime,
+        });
+
+        expect(browserInstall).toHaveBeenCalledWith(
+            expect.objectContaining({ browser: 'firefox', browserVersion: '151.0.7922.47' })
+        );
+    });
+
+    test('are named up front, so it is clear why they were skipped', async () => {
+        const runtime = scriptedRuntime({ browserVersion: '151.0.7922.47', _review: 'cancel' });
+
+        await runInteractive({
+            path: 'browser install',
+            presetOptions: { browser: 'firefox' },
+            runtime,
+        });
+
+        expect(runtime.written.join('')).toContain('--browser');
+    });
+});
+
 describe('the install wizard', () => {
     test('offers published versions without the serial availability check', async () => {
         // browserListAvailable runs one request per version, strictly serially,

--- a/src/lib/commands/browser/install.js
+++ b/src/lib/commands/browser/install.js
@@ -7,6 +7,7 @@ import {
     parseBrowserVersionValue,
 } from '../../browser/browser-version.js';
 import { runCommand } from '../run-command.js';
+import { addInteractiveOption } from '../../interactive/interactive-option.js';
 
 /**
  * Commander action that installs the browser.
@@ -18,6 +19,17 @@ import { runCommand } from '../run-command.js';
  */
 const handleBrowserInstall = async (options = {}, cmd) => {
     logger.info(`App version: ${appVersion}`);
+
+    // Optional chaining, not `options.interactive`: the default parameter only
+    // covers `undefined`, and a null options bag has to keep reaching
+    // runCommand() to be reported as a failure rather than thrown from here.
+    if (options?.interactive) {
+        // Loaded on demand; see the note in uninstall.js for why this import is
+        // not at module scope.
+        const { launchInteractive } = await import('../../interactive/launch.js');
+
+        return launchInteractive('BROWSER MAIN 9', 'browser install', cmd);
+    }
 
     return runCommand('BROWSER MAIN 9', () => browserInstall(options, cmd));
 };
@@ -59,6 +71,10 @@ const buildBrowserInstallCommand = () => {
                 .argParser(parseBrowserVersionValue)
                 .env('BSI_BROWSER_I_BROWSER_VERSION')
         );
+
+    // The version picker is the reason: `--browser-version` accepts hundreds of
+    // build ids that are impossible to recall, and the wizard searches them.
+    addInteractiveOption(command);
 
     return command;
 };

--- a/src/lib/commands/browser/uninstall.js
+++ b/src/lib/commands/browser/uninstall.js
@@ -2,6 +2,7 @@ import { Command, Option } from 'commander';
 import { logger, appVersion } from '../../../globals.js';
 import { browserUninstall } from '../../browser/browser-uninstall.js';
 import { runCommand } from '../run-command.js';
+import { addInteractiveOption } from '../../interactive/interactive-option.js';
 
 /**
  * Commander action that uninstalls a single browser build from the local cache.
@@ -13,6 +14,20 @@ import { runCommand } from '../run-command.js';
  */
 const handleBrowserUninstall = async (options = {}, cmd) => {
     logger.info(`App version: ${appVersion}`);
+
+    // Optional chaining, not `options.interactive`: the default parameter only
+    // covers `undefined`, and a null options bag has to keep reaching
+    // runCommand() to be reported as a failure rather than thrown from here.
+    if (options?.interactive) {
+        // Loaded on demand, and the import specifier is a literal so esbuild
+        // still bundles it for the SEA build. Importing it at module scope
+        // would pull the whole prompt framework into every consumer of this
+        // builder - including `command-tree.js`, which imports the builders and
+        // would close a cycle - to declare one flag.
+        const { launchInteractive } = await import('../../interactive/launch.js');
+
+        return launchInteractive('BROWSER MAIN 7', 'browser uninstall', cmd);
+    }
 
     return runCommand('BROWSER MAIN 7', () => browserUninstall(options, cmd));
 };
@@ -59,6 +74,11 @@ const buildBrowserUninstallCommand = () => {
                 .makeOptionMandatory()
                 .env('BSI_BROWSER_UI_BROWSER_VERSION')
         );
+
+    // Both mandatory options above are exactly why this command is worth doing
+    // interactively: the build to remove has to be named exactly, and today it
+    // is typed from memory. The wizard offers the builds actually installed.
+    addInteractiveOption(command);
 
     return command;
 };

--- a/src/lib/interactive/__tests__/ask-questions.test.js
+++ b/src/lib/interactive/__tests__/ask-questions.test.js
@@ -274,6 +274,30 @@ describe('the needs guard', () => {
         ).toThrow(/needs "a"/);
     });
 
+    test('accepts a dependency that was supplied rather than asked', () => {
+        // `bsi browser install --browser firefox -i` drops the browser question
+        // because it is already answered. The dependency is satisfied by the
+        // answer, so requiring an earlier *question* would reject exactly the
+        // command line that supplied it.
+        expect(() =>
+            assertNeedsAreSatisfiable([spec({ key: 'b', needs: ['a'] })], ['a'])
+        ).not.toThrow();
+    });
+
+    test('and a preset answer is what askQuestions counts as known', async () => {
+        const runtime = scriptedRuntime({ b: '2' });
+
+        await expect(
+            askQuestions(
+                [spec({ key: 'b', needs: ['a'] })],
+                { ...ctx(), answers: { a: '1' } },
+                {
+                    runtime,
+                }
+            )
+        ).resolves.toEqual({ a: '1', b: '2' });
+    });
+
     test('runs before any question is asked', async () => {
         const runtime = scriptedRuntime({ a: '1', b: '2' });
 

--- a/src/lib/interactive/__tests__/launch.test.js
+++ b/src/lib/interactive/__tests__/launch.test.js
@@ -1,0 +1,93 @@
+import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { presetOptionsFrom } from '../launch.js';
+import { addInteractiveOption } from '../interactive-option.js';
+import { buildQseowCommand } from '../../commands/qseow/index.js';
+
+const ENV_SNAPSHOT = { ...process.env };
+
+beforeEach(() => {
+    for (const key of Object.keys(process.env)) {
+        if (/^BS_?I?_/.test(key)) delete process.env[key];
+    }
+});
+
+afterEach(() => {
+    process.env = { ...ENV_SNAPSHOT };
+});
+
+/**
+ * Parse a qseow command line and return the parsed leaf command.
+ *
+ * Mandatory options are cleared first, exactly as the real entry point does when
+ * `-i` is present, so a partial command line parses.
+ *
+ * @param {string[]} tail - Argv after the command path.
+ *
+ * @returns {import('commander').Command} The parsed leaf.
+ */
+const parseQseow = (tail) => {
+    const namespace = buildQseowCommand();
+    const leaf = namespace.commands[0];
+
+    addInteractiveOption(leaf);
+    leaf.exitOverride().configureOutput({ writeOut: () => {}, writeErr: () => {} });
+    leaf._actionHandler = undefined;
+    leaf.action(() => {});
+
+    for (const option of leaf.options) {
+        option.makeOptionMandatory(false);
+    }
+
+    leaf.parse(['node', 'bsi', ...tail]);
+
+    return leaf;
+};
+
+describe('presetOptionsFrom', () => {
+    test('keeps what was given on the command line', () => {
+        const presets = presetOptionsFrom(parseQseow(['--host', 'sense.acme.com', '-i']));
+
+        expect(presets.host).toBe('sense.acme.com');
+    });
+
+    test('keeps what was given through a BSI_* environment variable', () => {
+        process.env.BSI_QSEOW_CST_API_USER_DIR = 'INTERNAL';
+
+        const presets = presetOptionsFrom(parseQseow(['-i']));
+
+        expect(presets.apiuserdir).toBe('INTERNAL');
+    });
+
+    test('leaves defaults out, so they are still asked about', () => {
+        // A default is what the wizard would offer as the pre-filled answer
+        // anyway. Treating it as "already supplied" would silently hide most of
+        // the questions behind values the administrator never chose - the
+        // opposite of the point.
+        const presets = presetOptionsFrom(parseQseow(['-i']));
+
+        expect(presets).not.toHaveProperty('engineport');
+        expect(presets).not.toHaveProperty('contentlibrary');
+    });
+
+    test('leaves unset options out', () => {
+        const presets = presetOptionsFrom(parseQseow(['-i']));
+
+        expect(presets).not.toHaveProperty('logonpwd');
+    });
+
+    test('never carries the interactive flag itself', () => {
+        // It is not an answer to anything, and emitting it into the echoed
+        // command line would make that line re-open the wizard when pasted back.
+        const presets = presetOptionsFrom(parseQseow(['--host', 'h', '-i']));
+
+        expect(presets).not.toHaveProperty('interactive');
+    });
+
+    test('a command line supplying nothing presets nothing', () => {
+        expect(presetOptionsFrom(parseQseow(['-i']))).toEqual({});
+    });
+
+    test('tolerates being handed no command at all', () => {
+        expect(presetOptionsFrom(undefined)).toEqual({});
+    });
+});

--- a/src/lib/interactive/__tests__/mandatory-relaxation.test.js
+++ b/src/lib/interactive/__tests__/mandatory-relaxation.test.js
@@ -1,0 +1,309 @@
+import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { Command } from 'commander';
+import { wantsInteractive, relaxMandatoryOptionsIfInteractive } from '../mandatory-relaxation.js';
+import { addInteractiveOption } from '../interactive-option.js';
+import { specsFromCommand } from '../option-introspect.js';
+import { buildQseowCommand } from '../../commands/qseow/index.js';
+import { buildQscloudCommand } from '../../commands/qscloud/index.js';
+import { buildBrowserCommand } from '../../commands/browser/index.js';
+
+const ENV_SNAPSHOT = { ...process.env };
+
+beforeEach(() => {
+    // Every option in this codebase has an .env() binding, and a stray BSI_*
+    // variable in the developer's shell would satisfy a mandatory option and
+    // make these tests pass for the wrong reason.
+    for (const key of Object.keys(process.env)) {
+        if (/^BS_?I?_/.test(key)) delete process.env[key];
+    }
+});
+
+afterEach(() => {
+    process.env = { ...ENV_SNAPSHOT };
+});
+
+/**
+ * A program shaped like the real one, but silent and non-exiting.
+ *
+ * The real builders are used rather than fixtures: the whole point of the
+ * relaxation is what it does to 18 mandatory options declared across a tree
+ * nobody rebuilds by hand.
+ *
+ * @param {object} [options] - Options.
+ * @param {boolean} [options.withFlag] - Whether leaf commands declare `-i`.
+ *
+ * @returns {import('commander').Command} The program, with `reached` recording the action that ran.
+ */
+const buildProgram = ({ withFlag = true } = {}) => {
+    const program = new Command();
+    const silence = { writeOut: () => {}, writeErr: () => {} };
+
+    program.name('butler-sheet-icons').exitOverride().configureOutput(silence);
+    program.reached = undefined;
+
+    for (const namespace of [buildQseowCommand(), buildQscloudCommand(), buildBrowserCommand()]) {
+        namespace.exitOverride().configureOutput(silence);
+
+        for (const leaf of namespace.commands) {
+            leaf.exitOverride().configureOutput(silence);
+
+            if (withFlag && !leaf.options.some((option) => option.long === '--interactive')) {
+                addInteractiveOption(leaf);
+            }
+
+            // Replace the real action, which would connect to a Qlik server.
+            leaf._actionHandler = undefined;
+            leaf.action((opts, cmd) => {
+                program.reached = { path: cmd.name(), opts, cmd };
+            });
+        }
+
+        program.addCommand(namespace);
+    }
+
+    return program;
+};
+
+/**
+ * Parse a command line, reporting either the action reached or the error code.
+ *
+ * @param {string[]} tail - Argv after the program name.
+ * @param {object} [options] - Options.
+ * @param {boolean} [options.relax] - Whether to apply the relaxation before parsing.
+ * @param {boolean} [options.withFlag] - Whether leaf commands declare `-i`.
+ *
+ * @returns {Promise<object>} `{ reached, error, relaxed, program }`.
+ */
+const run = async (tail, { relax = true, withFlag = true } = {}) => {
+    const program = buildProgram({ withFlag });
+    const argv = ['node', 'bsi', ...tail];
+    const relaxed = relax ? relaxMandatoryOptionsIfInteractive(program, argv) : false;
+
+    try {
+        await program.parseAsync(argv);
+
+        return { reached: program.reached, error: undefined, relaxed, program };
+    } catch (error) {
+        return { reached: program.reached, error, relaxed, program };
+    }
+};
+
+const QSEOW = ['qseow', 'create-sheet-thumbnails'];
+
+describe('wantsInteractive', () => {
+    test.each([
+        [['node', 'bsi', 'browser', 'install', '-i'], true],
+        [['node', 'bsi', 'browser', 'install', '--interactive'], true],
+        [['node', 'bsi', '-i', 'browser', 'install'], true],
+        [['node', 'bsi', 'browser', 'install'], false],
+        [['node', 'bsi'], false],
+    ])('%s -> %s', (argv, expected) => {
+        expect(wantsInteractive(argv)).toBe(expected);
+    });
+
+    test('stops at --, so a word after it is an operand and not a flag', () => {
+        expect(wantsInteractive(['node', 'bsi', 'browser', 'install', '--', '-i'])).toBe(false);
+    });
+
+    test('does not match a flag that merely starts with -i', () => {
+        expect(wantsInteractive(['node', 'bsi', 'browser', 'install', '--imagedir'])).toBe(false);
+    });
+
+    test('tolerates being called with nothing', () => {
+        expect(wantsInteractive()).toBe(false);
+    });
+});
+
+describe('without -i, nothing changes', () => {
+    // The main regression risk in this phase: every existing user is on this
+    // path, and none of them has asked for a wizard.
+    test('the tree is left alone', async () => {
+        const { relaxed } = await run(QSEOW);
+
+        expect(relaxed).toBe(false);
+    });
+
+    test('a missing mandatory option is still rejected, with Commander wording', async () => {
+        const { error, reached } = await run(QSEOW);
+
+        expect(reached).toBeUndefined();
+        expect(error.code).toBe('commander.missingMandatoryOptionValue');
+        expect(error.message).toBe("error: required option '--host <host>' not specified");
+    });
+
+    test('and the error is identical to the one raised before -i existed', async () => {
+        const before = await run(QSEOW, { relax: false, withFlag: false });
+        const after = await run(QSEOW);
+
+        expect(after.error.message).toBe(before.error.message);
+        expect(after.error.code).toBe(before.error.code);
+    });
+
+    test('a complete command line still runs', async () => {
+        const { reached, error } = await run([
+            ...QSEOW,
+            '--host',
+            'sense.acme.com',
+            '--apiuserdir',
+            'INTERNAL',
+            '--apiuserid',
+            'sa_api',
+            '--logonuserdir',
+            'INTERNAL',
+            '--logonuserid',
+            'sa_ui',
+            '--logonpwd',
+            'secret',
+        ]);
+
+        expect(error).toBeUndefined();
+        expect(reached.opts.host).toBe('sense.acme.com');
+    });
+});
+
+describe('with -i, the wizard is reachable', () => {
+    test.each([
+        ['-i', ['-i']],
+        ['--interactive', ['--interactive']],
+        ['-i after another flag', ['--host', 'sense.acme.com', '-i']],
+        ['-i terminating a variadic', ['--exclude-sheet-status', 'private', '-i']],
+    ])('qseow create-sheet-thumbnails %s', async (_label, extra) => {
+        const { reached, error } = await run([...QSEOW, ...extra]);
+
+        expect(error).toBeUndefined();
+        expect(reached.opts.interactive).toBe(true);
+    });
+
+    test.each([
+        ['qscloud create-sheet-thumbnails', ['qscloud', 'create-sheet-thumbnails']],
+        ['qscloud list-collections', ['qscloud', 'list-collections']],
+        ['qscloud remove-sheet-icons', ['qscloud', 'remove-sheet-icons']],
+        ['browser uninstall', ['browser', 'uninstall']],
+    ])('%s -i', async (_label, path) => {
+        const { reached, error } = await run([...path, '-i']);
+
+        expect(error).toBeUndefined();
+        expect(reached.opts.interactive).toBe(true);
+    });
+
+    test('a flag supplied alongside -i still reaches the options bag', async () => {
+        const { reached } = await run([...QSEOW, '--host', 'sense.acme.com', '-i']);
+
+        expect(reached.opts.host).toBe('sense.acme.com');
+    });
+});
+
+describe('the relaxation lasts only as long as the parse', () => {
+    // If it outlived the parse, specsFromCommand() would read the relaxed tree
+    // and decide that none of the wizard's questions are required - a silent
+    // failure with no test of its own to catch it, which is why this one exists.
+    test('every mandatory option is mandatory again once a handler runs', async () => {
+        const { reached } = await run([...QSEOW, '-i']);
+        const stillMandatory = reached.cmd.options.filter((option) => option.mandatory);
+
+        expect(stillMandatory).toHaveLength(18);
+    });
+
+    test('so the wizard still knows which questions are required', async () => {
+        const { reached } = await run([...QSEOW, '-i']);
+        const required = specsFromCommand(reached.cmd, { env: {} })
+            .filter((spec) => spec.required)
+            .map((spec) => spec.key);
+
+        expect(required).toEqual([
+            'host',
+            'apiuserdir',
+            'apiuserid',
+            'logonuserdir',
+            'logonuserid',
+            'logonpwd',
+        ]);
+    });
+});
+
+describe('a literal -i used as an option value does not relax anything', () => {
+    // The argv scan has to run before Commander parses, so it cannot tell a
+    // flag from a value and says yes here. Once the parse is done the truth is
+    // knowable, and the check is re-run rather than skipped.
+    test('the command line is rejected exactly as it is today', async () => {
+        const { reached, error } = await run([...QSEOW, '--qliksensetag', '-i']);
+
+        expect(reached).toBeUndefined();
+        expect(error.code).toBe('commander.missingMandatoryOptionValue');
+        expect(error.message).toBe("error: required option '--host <host>' not specified");
+    });
+
+    test('which is what a run without the relaxation does too', async () => {
+        const argv = [...QSEOW, '--qliksensetag', '-i'];
+        const before = await run(argv, { relax: false, withFlag: false });
+        const after = await run(argv);
+
+        expect(after.error.message).toBe(before.error.message);
+    });
+
+    test('and the value really did land on the option, so this is the case described', async () => {
+        const { program } = await run([
+            ...QSEOW,
+            '--qliksensetag',
+            '-i',
+            '--host',
+            'h',
+            '--apiuserdir',
+            'd',
+            '--apiuserid',
+            'u',
+            '--logonuserdir',
+            'd',
+            '--logonuserid',
+            'u',
+            '--logonpwd',
+            'p',
+        ]);
+
+        expect(program.reached.opts.qliksensetag).toBe('-i');
+        expect(program.reached.opts.interactive).toBeUndefined();
+    });
+});
+
+describe('--help is unaffected', () => {
+    /**
+     * The qseow leaf's help text, taken from a program built the same way twice.
+     *
+     * @param {boolean} relax - Whether to relax the tree first.
+     *
+     * @returns {string} Help output.
+     */
+    const helpFor = (relax) => {
+        const program = buildProgram();
+
+        if (relax) {
+            relaxMandatoryOptionsIfInteractive(program, ['node', 'bsi', '-i']);
+        }
+
+        return program.commands
+            .find((command) => command.name() === 'qseow')
+            .commands[0].helpInformation();
+    };
+
+    test('relaxing the tree does not change a single character of help output', () => {
+        // Both sides declare -i, so the relaxation is the only variable. Nothing
+        // in Commander's help renderer reads `mandatory`, and this is what pins
+        // that: an administrator running --help sees the same page either way.
+        expect(helpFor(true)).toBe(helpFor(false));
+    });
+
+    test('and --help still works on a command line that is missing mandatory options', async () => {
+        const { error } = await run([...QSEOW, '--help']);
+
+        expect(error.code).toBe('commander.helpDisplayed');
+    });
+});
+
+describe('a program with nothing mandatory', () => {
+    test('is reported as relaxed without a hook being needed', () => {
+        const program = new Command();
+        program.command('noop').action(() => {});
+
+        expect(relaxMandatoryOptionsIfInteractive(program, ['node', 'bsi', '-i'])).toBe(true);
+    });
+});

--- a/src/lib/interactive/__tests__/option-introspect.test.js
+++ b/src/lib/interactive/__tests__/option-introspect.test.js
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
 import { everyLeafCommand, leafCommandAt } from '../command-tree.js';
 import { specsFromCommand, specFromOption, splitDescription } from '../option-introspect.js';
+import { isInteractiveOption, INTERACTIVE_OPTION_ATTRIBUTE } from '../interactive-option.js';
 
 const ENV_SNAPSHOT = { ...process.env };
 
@@ -49,12 +50,16 @@ describe('command-tree', () => {
 });
 
 describe('every option yields exactly one question', () => {
+    // Every option except the flag that opens the wizard, which is not one of
+    // the wizard's own questions.
+    const askableOptions = (command) => command.options.filter((o) => !isInteractiveOption(o));
+
     test.each(EVERY_COMMAND)('%s', (_path, command) => {
         const specs = specsFromCommand(command);
 
         // The regression net behind "adding a CLI option gets a prompt for
         // free". If this ever fails, an option has become unaskable.
-        expect(specs).toHaveLength(command.options.length);
+        expect(specs).toHaveLength(askableOptions(command).length);
         expect(specs.every((spec) => spec.message.length > 0)).toBe(true);
     });
 
@@ -62,8 +67,29 @@ describe('every option yields exactly one question', () => {
         const specs = specsFromCommand(command);
 
         expect(specs.map((spec) => spec.key)).toEqual(
-            command.options.map((option) => option.attributeName())
+            askableOptions(command).map((option) => option.attributeName())
         );
+    });
+});
+
+describe('the interactive flag is never a question', () => {
+    // Two things go wrong if it is. The user is asked "Answer questions instead
+    // of assembling a command line?" while already answering questions, and
+    // `--interactive` is emitted into the echoed command line - so the line the
+    // wizard prints as the way to reproduce the run would instead re-open the
+    // wizard when pasted back.
+    test.each(EVERY_COMMAND)('%s', (_path, command) => {
+        expect(specsFromCommand(command).map((spec) => spec.key)).not.toContain(
+            INTERACTIVE_OPTION_ATTRIBUTE
+        );
+    });
+
+    test('and the commands that offer it really do declare it, so this is not vacuous', () => {
+        const withFlag = EVERY_COMMAND.filter(([, command]) =>
+            command.options.some(isInteractiveOption)
+        );
+
+        expect(withFlag.length).toBeGreaterThan(0);
     });
 });
 

--- a/src/lib/interactive/__tests__/registry.test.js
+++ b/src/lib/interactive/__tests__/registry.test.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { everyLeafCommand } from '../command-tree.js';
 import { specsFromCommand } from '../option-introspect.js';
 import { INTERACTIVE_COMMANDS, NOT_INTERACTIVE, loadWizard } from '../registry.js';
+import { isInteractiveOption, INTERACTIVE_OPTION_ATTRIBUTE } from '../interactive-option.js';
 
 const REGISTRY_PATH = join(dirname(fileURLToPath(import.meta.url)), '..', 'registry.js');
 const REGISTERED = Object.keys(INTERACTIVE_COMMANDS);
@@ -36,6 +37,34 @@ describe('every command is accounted for', () => {
         for (const [path, reason] of Object.entries(NOT_INTERACTIVE)) {
             expect(`${path}: ${reason.length > 20}`).toBe(`${path}: true`);
         }
+    });
+});
+
+describe('-i is offered exactly where a wizard exists', () => {
+    // Two failures this rules out, one in each direction. A command advertising
+    // -i with no wizard behind it reaches loadWizard() and throws at the moment
+    // the user asked for help. A command with a wizard but no -i leaves the
+    // wizard reachable only through the `interactive` menu, which is the gap
+    // this phase exists to close.
+    test.each(everyLeafCommand().map(({ path, command }) => [path, command]))(
+        '%s',
+        (path, command) => {
+            const declaresFlag = command.options.some(isInteractiveOption);
+            const registered = path in INTERACTIVE_COMMANDS;
+
+            expect(`${path}: -i=${declaresFlag}`).toBe(`${path}: -i=${registered}`);
+        }
+    );
+
+    test('the flag is a real short option, not a long one in the short slot', () => {
+        // `--log-level, --loglevel` is declared that way and Commander stores
+        // the first long form in `.short`, so "has a short flag" is not by
+        // itself evidence that -i parses as -i.
+        const [{ command }] = everyLeafCommand().filter(({ path }) => path in INTERACTIVE_COMMANDS);
+        const flag = command.options.find(isInteractiveOption);
+
+        expect(flag.short).toBe('-i');
+        expect(flag.attributeName()).toBe(INTERACTIVE_OPTION_ATTRIBUTE);
     });
 });
 

--- a/src/lib/interactive/ask-questions.js
+++ b/src/lib/interactive/ask-questions.js
@@ -15,14 +15,21 @@ import { withQuietLogging } from './quiet.js';
  * five lines that make the property real now, and a graph to sort when phase 2
  * has enough edges to need one.
  *
+ * A need is satisfied by an answer, not by a question. Anything supplied on the
+ * command line or through a BSI_* environment variable is dropped from the
+ * questions but is still an answer, so those keys count as already seen -
+ * otherwise `bsi browser install --browser firefox -i` would fail this check for
+ * having satisfied it.
+ *
  * @param {import('./option-introspect.js').QuestionSpec[]} specs - The questions.
+ * @param {string[]} [known] - Keys already answered before the first question.
  *
  * @returns {void}
  *
  * @throws {Error} If a question needs a key that is not answered before it.
  */
-export const assertNeedsAreSatisfiable = (specs) => {
-    const seen = new Set();
+export const assertNeedsAreSatisfiable = (specs, known = []) => {
+    const seen = new Set(known);
 
     for (const spec of specs) {
         for (const need of spec.needs ?? []) {
@@ -188,11 +195,11 @@ const configFor = (spec, choices, theme) => ({
  * @returns {Promise<object>} Answers, keyed by spec key.
  */
 export const askQuestions = async (specs, ctx = {}, { runtime = defaultRuntime } = {}) => {
-    assertNeedsAreSatisfiable(specs);
-
     const symbols = ctx.symbols ?? getSymbols();
     const theme = ctx.theme ?? buildTheme({ symbols });
     const answers = ctx.answers ?? {};
+
+    assertNeedsAreSatisfiable(specs, Object.keys(answers));
     const context = { ...ctx, answers, symbols, theme, write: runtime.write };
 
     let currentGroup;

--- a/src/lib/interactive/index.js
+++ b/src/lib/interactive/index.js
@@ -84,6 +84,12 @@ export const runInteractive = async ({
     // about without anyone editing the wizard.
     const specs = specsFromCommand(command);
 
+    // Named by flag rather than by storage key, because the flag is what the
+    // user typed. Secrets are named but never shown.
+    const prefilled = specs
+        .filter((spec) => spec.key in presetOptions)
+        .map((spec) => spec.option?.long ?? spec.key);
+
     // Said once, up front. There is no way back to a previous question - the
     // prompt library has no such gesture - so the two things a user can do
     // instead have to be discoverable before they need them, not after.
@@ -91,9 +97,28 @@ export const runInteractive = async ({
         `\n${theme.style.help('Ctrl+C cancels. Nothing is changed until you confirm at the end, where you can also start over.')}\n`
     );
 
+    if (prefilled.length > 0) {
+        runtime.write(
+            `${theme.style.help(`Already supplied, so not asked about again: ${prefilled.join(', ')}.`)}\n`
+        );
+    }
+
     for (;;) {
-        const asked = wizard.refine ? wizard.refine(specs, { answers: presetOptions }) : specs;
-        const raw = await askQuestions(asked, { symbols, theme, answers: {} }, { runtime });
+        const refined = wizard.refine ? wizard.refine(specs, { answers: presetOptions }) : specs;
+
+        // Anything already given on the command line or through a BSI_*
+        // environment variable is an answer, not a question. Dropped here rather
+        // than in `refine`, so every wizard composes with `-i` without having to
+        // remember to.
+        const asked = refined.filter((spec) => !(spec.key in presetOptions));
+
+        const raw = await askQuestions(
+            // Seeded with what is already known, so a later `when` or `choices`
+            // sees the pre-filled answers as well as the typed ones.
+            asked,
+            { symbols, theme, answers: { ...presetOptions } },
+            { runtime }
+        );
         const answers = {
             ...presetOptions,
             ...(wizard.finalize ? wizard.finalize(raw, { specs }) : raw),

--- a/src/lib/interactive/interactive-option.js
+++ b/src/lib/interactive/interactive-option.js
@@ -1,0 +1,53 @@
+import { Option } from 'commander';
+
+/**
+ * The flags the interactive option is declared with.
+ *
+ * `-i` is free across the whole CLI: the only option in `src/` occupying a short
+ * slot is `--log-level, --loglevel`, which is a dual-*long* declaration Commander
+ * happens to store in the short position. Nothing collides.
+ */
+export const INTERACTIVE_OPTION_FLAGS = '-i, --interactive';
+
+/** The long flag, used to recognise the option again once it is on a command. */
+export const INTERACTIVE_OPTION_LONG = '--interactive';
+
+/** The key Commander stores the option under. */
+export const INTERACTIVE_OPTION_ATTRIBUTE = 'interactive';
+
+/**
+ * Whether an option is the interactive flag.
+ *
+ * Matched on the long flag rather than on identity, because the option is
+ * re-created by every call to a command builder and the command tree is rebuilt
+ * several times per process - once for the real parse, and once more each time
+ * `everyLeafCommand()` walks the builders.
+ *
+ * @param {import('commander').Option} option - The option to test.
+ *
+ * @returns {boolean} True for the interactive flag.
+ */
+export const isInteractiveOption = (option) => option?.long === INTERACTIVE_OPTION_LONG;
+
+/**
+ * Add `-i, --interactive` to a command.
+ *
+ * A shared helper rather than a hand-written option on each command, so the
+ * flags, the description and the storage key cannot drift between the commands
+ * that offer it.
+ *
+ * Only commands with a registered wizard get this. `registry.test.js` asserts
+ * the two lists agree, so a command cannot advertise `-i` and then fail to find
+ * a wizard for itself at run time.
+ *
+ * @param {import('commander').Command} command - The command to extend.
+ *
+ * @returns {import('commander').Command} The same command, for chaining.
+ */
+export const addInteractiveOption = (command) =>
+    command.addOption(
+        new Option(
+            INTERACTIVE_OPTION_FLAGS,
+            'Answer questions instead of assembling a command line.\nOptions already supplied - here or through their BSI_* environment variables - are kept and not asked about again.'
+        )
+    );

--- a/src/lib/interactive/launch.js
+++ b/src/lib/interactive/launch.js
@@ -1,0 +1,90 @@
+import { logger } from '../../globals.js';
+import { runCommand } from '../commands/run-command.js';
+import { assertInteractiveCapable } from './tty.js';
+import { isPromptCancellation } from './prompt-runtime.js';
+import { runInteractive } from './index.js';
+import { isInteractiveOption } from './interactive-option.js';
+
+/**
+ * The answers a wizard should start from, taken from what was already supplied.
+ *
+ * This is what makes `-i` compose rather than merely exist:
+ * `bsi qseow create-sheet-thumbnails --host sense.acme.com -i` should ask for
+ * everything *except* the host.
+ *
+ * `getOptionValueSource()` is Commander's own record of where each value came
+ * from, so no guessing is involved. Only `cli` and `env` count as supplied - a
+ * `default` is what the wizard would offer as a pre-filled answer anyway, and
+ * skipping those would hide most of the questions behind values the user never
+ * chose.
+ *
+ * @param {import('commander').Command} command - The parsed command.
+ *
+ * @returns {object} Answers keyed by option attribute name.
+ */
+export const presetOptionsFrom = (command) => {
+    const presets = {};
+
+    for (const option of command?.options ?? []) {
+        // The flag that started the wizard is not an answer to anything, and
+        // must never reach the options bag or the echoed command line - a line
+        // carrying --interactive would re-enter the wizard when pasted back.
+        if (isInteractiveOption(option)) {
+            continue;
+        }
+
+        const key = option.attributeName();
+        const source = command.getOptionValueSource(key);
+
+        if (source === 'cli' || source === 'env') {
+            presets[key] = command.getOptionValue(key);
+        }
+    }
+
+    return presets;
+};
+
+/**
+ * Run a leaf command's wizard instead of the command itself.
+ *
+ * Routed through `runCommand()` so the exit code behaves exactly as it does for
+ * every other command, and so a wizard that cannot run fails fast rather than
+ * blocking on a stdin that will never deliver.
+ *
+ * @param {string} logPrefix - Prefix for error lines, matching the command's own.
+ * @param {string} path - Command path, e.g. `browser uninstall`.
+ * @param {import('commander').Command} command - The parsed command, read for pre-filled answers.
+ *
+ * @returns {Promise<boolean>} `true` on success or cancellation, `false` on failure.
+ */
+export const launchInteractive = async (logPrefix, path, command) =>
+    runCommand(
+        logPrefix,
+        async () => {
+            // A wizard blocking forever inside a scheduled container run is an
+            // outage, not a cosmetic problem, so this is checked before anything
+            // else happens.
+            assertInteractiveCapable();
+
+            try {
+                return await runInteractive({
+                    path,
+                    presetOptions: presetOptionsFrom(command),
+                });
+            } catch (err) {
+                if (isPromptCancellation(err)) {
+                    logger.info('Cancelled. Nothing was changed.');
+
+                    return true;
+                }
+
+                throw err;
+            }
+        },
+        // The guidance from assertInteractiveCapable is already a complete
+        // explanation, so print it alone rather than following it with the
+        // error twice more and a stack trace - the noise issue #785 was about.
+        (err) => {
+            logger.error(err.message);
+        }
+    );

--- a/src/lib/interactive/mandatory-relaxation.js
+++ b/src/lib/interactive/mandatory-relaxation.js
@@ -1,0 +1,152 @@
+import { INTERACTIVE_OPTION_ATTRIBUTE, INTERACTIVE_OPTION_LONG } from './interactive-option.js';
+
+/** Argv words that ask for a wizard. */
+const INTERACTIVE_FLAGS = new Set(['-i', INTERACTIVE_OPTION_LONG]);
+
+/**
+ * Whether the command line asks for interactive mode.
+ *
+ * A plain scan, because it has to run *before* Commander parses anything:
+ * Commander checks for missing mandatory options before `preAction` hooks and
+ * before the action handler, so by the time anything parsed is available the
+ * hard failure has already happened.
+ *
+ * The scan stops at `--`, so words after it are operands and not flags.
+ *
+ * A literal `-i` appearing as an option *value* before `--` therefore looks like
+ * a request for interactive mode when it is not. That false positive is not left
+ * standing: see {@link relaxMandatoryOptionsIfInteractive}, which re-checks once
+ * the real parse can say whether the flag was actually set.
+ *
+ * @param {string[]} [argv] - Full argv, including the node and script entries.
+ *
+ * @returns {boolean} True when `-i` or `--interactive` was asked for.
+ */
+export const wantsInteractive = (argv = []) => {
+    for (const arg of argv.slice(2)) {
+        if (arg === '--') {
+            return false;
+        }
+
+        if (INTERACTIVE_FLAGS.has(arg)) {
+            return true;
+        }
+    }
+
+    return false;
+};
+
+/**
+ * A command and its ancestors, nearest first.
+ *
+ * Mirrors what Commander's own missing-mandatory check walks, so the re-check
+ * below covers exactly the same options in exactly the same order.
+ *
+ * @param {import('commander').Command} command - The command to start from.
+ *
+ * @returns {import('commander').Command[]} The command, then each ancestor.
+ */
+const commandAndAncestors = (command) => {
+    const chain = [];
+
+    for (let cmd = command; cmd; cmd = cmd.parent) {
+        chain.push(cmd);
+    }
+
+    return chain;
+};
+
+/**
+ * Let a wizard past Commander's missing-mandatory check, without changing what
+ * happens to anybody else.
+ *
+ * `qseow create-sheet-thumbnails` declares 18 mandatory options, 6 of which have
+ * no default and so can actually fail the check. Commander runs that check
+ * before `preAction` and before the action handler, so `-i` on a leaf command
+ * would be rejected before a single line of interactive code ran. The options
+ * are therefore cleared for the duration of the parse.
+ *
+ * Two things make that safe rather than merely convenient:
+ *
+ * 1. `makeOptionMandatory(false)` is Commander's own public API for this, and is
+ *    in its typings. Nothing here writes to an undocumented field.
+ * 2. The relaxation lasts only as long as the parse. The `preAction` hook
+ *    restores every option it cleared before any handler runs, so nothing
+ *    downstream ever observes a relaxed command. That matters concretely:
+ *    `specsFromCommand()` reads `option.mandatory` to decide which questions are
+ *    required, and against a still-relaxed command it would quietly decide that
+ *    nothing is.
+ *
+ * The same hook closes the `-i`-as-a-value false positive. Once the parse is
+ * done, whether the flag was really set is knowable, and if it was not the
+ * missing-mandatory check is re-run by hand - reproducing Commander's message
+ * and error code exactly. So for any command line that does not genuinely ask
+ * for a wizard, behaviour is identical to not calling this function at all.
+ *
+ * Called once, on the root program, before `parseAsync`.
+ *
+ * @param {import('commander').Command} program - The root command.
+ * @param {string[]} [argv] - Full argv, including the node and script entries.
+ *
+ * @returns {boolean} True when the tree was relaxed.
+ */
+export const relaxMandatoryOptionsIfInteractive = (program, argv = process.argv) => {
+    if (!wantsInteractive(argv)) {
+        return false;
+    }
+
+    /** @type {Map<import('commander').Command, import('commander').Option[]>} */
+    const cleared = new Map();
+
+    const relax = (command) => {
+        const mandatory = command.options.filter((option) => option.mandatory);
+
+        if (mandatory.length > 0) {
+            cleared.set(command, mandatory);
+
+            for (const option of mandatory) {
+                option.makeOptionMandatory(false);
+            }
+        }
+
+        for (const child of command.commands) {
+            relax(child);
+        }
+    };
+
+    relax(program);
+
+    if (cleared.size === 0) {
+        return true;
+    }
+
+    // One hook on the root covers every command: Commander collects preAction
+    // hooks from the acting command and all of its ancestors.
+    program.hook('preAction', (_hookedCommand, actionCommand) => {
+        // Restore first, and restore everything - not just the branch that ran.
+        // From here on the tree is exactly as its builder declared it.
+        for (const options of cleared.values()) {
+            for (const option of options) {
+                option.makeOptionMandatory(true);
+            }
+        }
+
+        if (actionCommand.opts()[INTERACTIVE_OPTION_ATTRIBUTE]) {
+            return;
+        }
+
+        // The flag was not really set, so this command line was never entitled
+        // to skip the check. Re-run it, reporting exactly what Commander would.
+        for (const command of commandAndAncestors(actionCommand)) {
+            for (const option of cleared.get(command) ?? []) {
+                if (command.getOptionValue(option.attributeName()) === undefined) {
+                    command.error(`error: required option '${option.flags}' not specified`, {
+                        code: 'commander.missingMandatoryOptionValue',
+                    });
+                }
+            }
+        }
+    });
+
+    return true;
+};

--- a/src/lib/interactive/option-introspect.js
+++ b/src/lib/interactive/option-introspect.js
@@ -1,5 +1,6 @@
 import { BSI_SECRET_KEYS } from '../util/redact-secrets.js';
 import { fromOption, validateEntries } from './validators.js';
+import { isInteractiveOption } from './interactive-option.js';
 
 const SECRET_KEYS = new Set(BSI_SECRET_KEYS.map((key) => key.toLowerCase()));
 
@@ -204,7 +205,14 @@ export const specFromOption = (option, { env = process.env } = {}) => {
  * @throws {Error} If two options on the command would store under the same key.
  */
 export const specsFromCommand = (command, { env = process.env } = {}) => {
-    const specs = command.options.map((option) => specFromOption(option, { env }));
+    const specs = command.options
+        // The flag that opened the wizard is not one of the wizard's questions.
+        // Left in, it becomes a confirm reading "Answer questions instead of
+        // assembling a command line?", and - worse - `--interactive` is emitted
+        // into the echoed command line, so the line the wizard tells you to
+        // reuse would re-enter the wizard rather than run the command.
+        .filter((option) => !isInteractiveOption(option))
+        .map((option) => specFromOption(option, { env }));
     const seen = new Set();
 
     for (const spec of specs) {


### PR DESCRIPTION
Phase 2 of #886, first half: interactive mode becomes reachable from the commands themselves rather than only through `bsi interactive`.

```bash
butler-sheet-icons browser uninstall --browser chrome -i
```

Anything already supplied — on the command line or through a `BSI_*` environment variable — is treated as an answer and not asked about again. Values that merely fall back to a default still get asked, with the default pre-filled.

## The mandatory-option problem, and why it costs less than #886 assumed

Commander checks for missing mandatory options **before** `preAction` hooks and before the action handler, so `-i` on a leaf command would be rejected before any interactive code ran. The options are cleared for the duration of the parse and restored before any handler runs.

#886 recorded two costs for this. Both were spiked against the real `commander@15.0.0` and **neither is paid here**:

- **Nothing writes to an undocumented field.** `Option.makeOptionMandatory(false)` is public API and in Commander's typings.
- **The `-i`-as-a-value false positive is closed, not documented.** The argv pre-scan has to run before parsing, so it cannot tell a flag from a value. A `preAction` hook re-runs the missing-mandatory check once the parse can say whether the flag was really set, reproducing Commander's message and error code exactly.

Restoring in that same hook scopes the relaxation to the parse itself, which matters concretely: `specsFromCommand()` reads `option.mandatory` to decide which questions are required, and against a still-relaxed command it would quietly decide that none are.

The blast radius is also smaller than the issue assumed — 6 options can actually fail the check on `qseow create-sheet-thumbnails`, not 18, because the rest carry defaults.

Full spike write-up: https://github.com/ptarmiganlabs/butler-sheet-icons/issues/897#issuecomment-5249861250

## Scope

`-i` is offered exactly where a wizard is registered — `browser install` and `browser uninstall` today — enforced by a guard test, so a command cannot advertise the flag and then fail to find a wizard for itself at run time. The four Qlik commands get it as their wizards land.

## Verification

- 1527 unit tests pass; lint clean.
- Output and exit codes compared **byte-for-byte against the 4.1.0 release** across 17 command lines: every leaf with no options, every `--help`, bare invocations, and the `--qliksensetag -i` edge case. The only diffs are the two intended `-i` help entries.
- Driven through a real pty: `--browser chrome -i` skipped the browser question and listed the actually-installed builds.
- With stdin not a TTY it exits 1 with guidance rather than hanging, and piped output carries no escape codes.

Refs #897, #886

🤖 Generated with [Claude Code](https://claude.com/claude-code)
