### PR TITLE
Allow naming several apps in one run

### DIFF
--- a/docs/to-doc-site/several-apps-in-one-run.md
+++ b/docs/to-doc-site/several-apps-in-one-run.md
@@ -1,0 +1,65 @@
+# Naming several apps in one run
+
+`--appid` used to accept exactly one app. If you wanted thumbnails for three named apps you had to
+run Butler Sheet Icons three times, or put a tag on all three in Qlik Sense first.
+
+It now accepts as many as you like:
+
+```bash
+butler-sheet-icons qseow create-sheet-thumbnails \
+  --appid a1b2c3d4-1111-2222-3333-444455556666 \
+  9f8e7d6c-aaaa-bbbb-cccc-ddddeeeeffff \
+  --host sense.acme.com \
+  ...
+```
+
+Commas work too, which is usually easier to read and easier to paste:
+
+```bash
+--appid a1b2c3d4-1111-2222-3333-444455556666,9f8e7d6c-aaaa-bbbb-cccc-ddddeeeeffff
+```
+
+Both forms are accepted everywhere, including in the environment variable:
+
+```bash
+export BSI_QSEOW_CST_APP_ID=a1b2c3d4-1111-2222-3333-444455556666,9f8e7d6c-aaaa-bbbb-cccc-ddddeeeeffff
+```
+
+This applies to `qseow create-sheet-thumbnails`, `qscloud create-sheet-thumbnails` and
+`qscloud remove-sheet-icons`.
+
+## Combining with tags and collections
+
+`--appid` and `--qliksensetag` (or `--collectionid` on Qlik Sense Cloud) are **added together**,
+not chosen between. This is how Butler Sheet Icons has always behaved, but the built-in help
+previously suggested otherwise.
+
+So this processes every app carrying the `Butler Sheet Icons` tag, **plus** the one named
+explicitly:
+
+```bash
+butler-sheet-icons qseow create-sheet-thumbnails \
+  --qliksensetag "Butler Sheet Icons" \
+  --appid a1b2c3d4-1111-2222-3333-444455556666 \
+  ...
+```
+
+An app that is both named by `--appid` and carries the tag is still processed **once**. You can
+see exactly which apps were selected by running with `--loglevel debug`, which lists them before
+any work starts:
+
+```
+debug: Will process these app IDs:
+debug: a1b2c3d4-1111-2222-3333-444455556666
+debug: 9f8e7d6c-aaaa-bbbb-cccc-ddddeeeeffff
+```
+
+## Nothing changes for existing commands
+
+A single `--appid <id>` behaves exactly as it always has, so existing scripts, scheduled tasks
+and container runs need no changes. Every other option and message is unchanged; the only visible
+difference is the `--appid` entry in `--help`.
+
+One detail worth knowing if you drive Butler Sheet Icons from a systemd unit file or a Docker
+environment file: a variable that is *set but empty* — a bare `BSI_QSEOW_CST_APP_ID=` line —
+counts as no app being named, rather than as one app with a blank id.

--- a/src/lib/cloud/__tests__/cloud_create_thumbnails_app_loop.test.js
+++ b/src/lib/cloud/__tests__/cloud_create_thumbnails_app_loop.test.js
@@ -44,7 +44,7 @@ const { qscloudCreateThumbnails } = await import('../cloud-create-thumbnails.js'
 const OPTIONS = {
     tenanturl: 'tenant.eu.qlikcloud.com',
     apikey: 'api-key',
-    appid: 'test-app-id',
+    appid: ['test-app-id'],
     includesheetpart: '1',
     loglevel: 'info',
 };
@@ -104,6 +104,25 @@ describe('qscloudCreateThumbnails app loop', () => {
         expect(errorLog()).toContain('CLOUD CREATE THUMBNAILS 2');
     });
 
+    test('hands every app id to the loop when several are named (issue #895)', async () => {
+        runOverApps.mockResolvedValue(true);
+
+        await qscloudCreateThumbnails({ ...OPTIONS, appid: ['app-1', 'app-2', 'app-3'] });
+
+        expect(runOverApps.mock.calls[0][0]).toEqual(['app-1', 'app-2', 'app-3']);
+    });
+
+    test('never explodes a bare string into one app per character', async () => {
+        // A string is iterable, so a plain spread would push eleven
+        // single-character app ids. Nothing the CLI produces is a string any
+        // more, but a hand-built options bag can still be.
+        runOverApps.mockResolvedValue(true);
+
+        await qscloudCreateThumbnails({ ...OPTIONS, appid: 'test-app-id' });
+
+        expect(runOverApps.mock.calls[0][0]).toEqual(['test-app-id']);
+    });
+
     describe('multiple apps via --collectionid', () => {
         /**
          * Points the mocked `Get` at a tenant with one collection holding the given items.
@@ -138,6 +157,27 @@ describe('qscloudCreateThumbnails app loop', () => {
             });
 
             expect(runOverApps.mock.calls[0][0]).toEqual(['app-a', 'app-b']);
+        });
+
+        test('unions --appid with --collectionid rather than choosing between them', async () => {
+            // The two are additive. Several comments used to claim the collection
+            // was only consulted when no app id was given, which the code never did.
+            runOverApps.mockResolvedValue(true);
+            withCollectionItems([
+                { resourceType: 'app', resourceAttributes: { id: 'app-a', name: 'Alpha' } },
+                { resourceType: 'app', resourceAttributes: { id: 'app-b', name: 'Beta' } },
+            ]);
+
+            await qscloudCreateThumbnails({
+                ...OPTIONS,
+                appid: ['app-b', 'named-directly'],
+                collectionid: 'collection-1',
+            });
+
+            // runOverApps dedupes, so app-b - named both ways - is processed once.
+            const selected = runOverApps.mock.calls[0][0];
+            expect(selected).toEqual(['app-b', 'named-directly', 'app-a', 'app-b']);
+            expect([...new Set(selected)]).toEqual(['app-b', 'named-directly', 'app-a']);
         });
 
         test('skips collection items that are not apps', async () => {
@@ -193,7 +233,7 @@ describe('qscloudCreateThumbnails app loop', () => {
             await expect(
                 qscloudCreateThumbnails({
                     ...OPTIONS,
-                    appid: 'test-app-id',
+                    appid: ['test-app-id'],
                     collectionid: 'collection-1',
                 })
             ).resolves.toBe(true);

--- a/src/lib/cloud/__tests__/cloud_remove_sheet_icons.test.js
+++ b/src/lib/cloud/__tests__/cloud_remove_sheet_icons.test.js
@@ -46,7 +46,7 @@ const { qscloudRemoveSheetIcons } = await import('../cloud-remove-sheet-icons.js
 const BASE_OPTIONS = {
     tenanturl: 'tenant.eu.qlikcloud.com',
     apikey: 'api-key',
-    appid: 'test-app-id',
+    appid: ['test-app-id'],
     loglevel: 'info',
 };
 
@@ -531,7 +531,7 @@ describe('qscloudRemoveSheetIcons', () => {
             await expect(
                 qscloudRemoveSheetIcons({
                     ...BASE_OPTIONS,
-                    appid: 'test-app-id',
+                    appid: ['test-app-id'],
                     collectionid: 'collection-1',
                 })
             ).resolves.toBe(true);

--- a/src/lib/cloud/__tests__/qscloudCreateThumbnails_fail.integration.test.js
+++ b/src/lib/cloud/__tests__/qscloudCreateThumbnails_fail.integration.test.js
@@ -61,7 +61,7 @@ describe('qs cloud create sheet thumbnails - failure paths', () => {
             const result = await qscloudCreateThumbnails(
                 buildOptions({
                     apikey: 'not-a-valid-api-key',
-                    appid: process.env.BSI_CLOUD_APP_ID,
+                    appid: [process.env.BSI_CLOUD_APP_ID],
                 })
             );
 
@@ -79,7 +79,7 @@ describe('qs cloud create sheet thumbnails - failure paths', () => {
             const result = await qscloudCreateThumbnails(
                 buildOptions({
                     tenanturl: 'no-such-tenant.invalid',
-                    appid: process.env.BSI_CLOUD_APP_ID,
+                    appid: [process.env.BSI_CLOUD_APP_ID],
                 })
             );
 
@@ -98,7 +98,7 @@ describe('qs cloud create sheet thumbnails - failure paths', () => {
         'a non-existent app id fails the run',
         async () => {
             const result = await qscloudCreateThumbnails(
-                buildOptions({ appid: '00000000-0000-0000-0000-000000000000' })
+                buildOptions({ appid: ['00000000-0000-0000-0000-000000000000'] })
             );
 
             expect(result).toBe(false);
@@ -131,7 +131,7 @@ describe('qs cloud create sheet thumbnails - failure paths', () => {
         async () => {
             const result = await qscloudCreateThumbnails(
                 buildOptions({
-                    appid: process.env.BSI_CLOUD_APP_ID,
+                    appid: [process.env.BSI_CLOUD_APP_ID],
                     browserVersion: '99.0.1234.56',
                 })
             );

--- a/src/lib/cloud/__tests__/qscloudCreateThumbnails_success.integration.test.js
+++ b/src/lib/cloud/__tests__/qscloudCreateThumbnails_success.integration.test.js
@@ -19,7 +19,7 @@ const options = {
     pagewait: process.env.BSI_PAGE_WAIT || '10',
     imagedir: process.env.BSI_IMAGE_DIR || 'img',
     schemaversion: process.env.BSI_CLOUD_SCHEMA_VERSION || '12.612.0',
-    appid: process.env.BSI_CLOUD_APP_ID,
+    appid: [process.env.BSI_CLOUD_APP_ID],
     includesheetpart: process.env.BSI_INCLUDE_SHEET_PART || '1',
     browser: process.env.BSI_BROWSER || 'chrome',
     // These options bypass Commander, so the CLI default is not applied for them - the fallback

--- a/src/lib/cloud/cloud-create-thumbnails.js
+++ b/src/lib/cloud/cloud-create-thumbnails.js
@@ -5,6 +5,7 @@ import { qscloudTestConnection } from './cloud-test-connection.js';
 import { processCloudApp } from './process-cloud-app.js';
 import { runOverApps } from '../util/run-over-apps.js';
 import { getAppIdsByCollection } from './cloud-apps.js';
+import { toAppIdList } from '../util/app-ids.js';
 import { CLOUD_SHEET_PARTS } from './sheet-parts.js';
 
 /**
@@ -17,7 +18,8 @@ import { CLOUD_SHEET_PARTS } from './sheet-parts.js';
  * @param {string} options.logonuserid - User ID for Qlik Sense Cloud tenant.
  * @param {string} options.logonpwd - Password for Qlik Sense Cloud tenant.
  * @param {string} options.collectionid - ID of collection in Qlik Sense Cloud tenant.
- * @param {string} options.appid - ID of app in Qlik Sense Cloud tenant.
+ * @param {string[]} options.appid - IDs of apps in Qlik Sense Cloud tenant. Added to whatever
+ *     `collectionid` matches rather than replacing it.
  * @param {string} options.imagedir - Directory where images will be stored.
  * @param {string} options.includesheetpart - Optional parameter to include sheet parts in the thumbnails. Values: 1, 2, 4. Normalised to a string on entry, so a number is also accepted.
  * @param {string} options.schemaversion - Version of the QS schema.
@@ -108,13 +110,12 @@ export const qscloudCreateThumbnails = async (options) => {
             return false;
         }
 
-        // Is there a specific app ID specified?
-        if (options.appid) {
-            appIdsToProcess.push(options.appid);
-        }
+        // Apps named directly. --appid is variadic, so this is a list.
+        appIdsToProcess.push(...toAppIdList(options.appid));
 
-        // If --collection exists we should loop over all matching apps.
-        // If --collection does not exist the app specified by --appid should be processed.
+        // --appid and --collectionid are additive, not alternatives: apps named either
+        // way are all processed. runOverApps() dedupes, so an app that is both named by
+        // --appid and in the collection is still processed once.
         if (options.collectionid && options.collectionid.length > 0) {
             const apps = await getAppIdsByCollection(saasInstance, options.collectionid);
             logger.verbose(`Collection '${options.collectionid}' exists`);

--- a/src/lib/cloud/cloud-remove-sheet-icons.js
+++ b/src/lib/cloud/cloud-remove-sheet-icons.js
@@ -14,6 +14,7 @@ import {
 } from '../util/sheet-list.js';
 import { withEngineSession } from '../util/engine-session.js';
 import { getAppIdsByCollection } from './cloud-apps.js';
+import { toAppIdList } from '../util/app-ids.js';
 
 /**
  * Removes all sheet icons from a Qlik Sense Cloud app.
@@ -161,7 +162,8 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
  * @param {object} options - Configuration options for the command.
  * @param {string} options.tenanturl - URL or host of Qlik Sense cloud tenant. Example: `https://tenant.eu.qlikcloud.com` or `tenant.eu.qlikcloud.com`.
  * @param {string} options.apikey - API key used to access the Sense APIs.
- * @param {string} options.appid - The ID of the Qlik Sense Cloud application to process.
+ * @param {string[]} options.appid - IDs of the Qlik Sense Cloud applications to process. Added to
+ *     whatever `collectionid` matches rather than replacing it.
  * @param {string} options.collectionid - The ID of the collection containing apps to process.
  * @param {string} options.loglevel - The level of logging to output. Valid values are 'error', 'warn', 'info', 'verbose', 'debug', 'silly'.
  *
@@ -207,13 +209,12 @@ export const qscloudRemoveSheetIcons = async (options) => {
             return false;
         }
 
-        // Is there a specific app ID specified?
-        if (options.appid) {
-            appIdsToProcess.push(options.appid);
-        }
+        // Apps named directly. --appid is variadic, so this is a list.
+        appIdsToProcess.push(...toAppIdList(options.appid));
 
-        // If --collection exists we should loop over all matching apps.
-        // If --collection does not exist the app specified by --appid should be processed.
+        // --appid and --collectionid are additive, not alternatives: apps named either
+        // way are all processed. runOverApps() dedupes, so an app that is both named by
+        // --appid and in the collection is still processed once.
         if (options.collectionid && options.collectionid.length > 0) {
             const apps = await getAppIdsByCollection(saasInstance, options.collectionid);
             logger.verbose(`Collection '${options.collectionid}' exists`);

--- a/src/lib/commands/__tests__/commands.test.js
+++ b/src/lib/commands/__tests__/commands.test.js
@@ -88,6 +88,7 @@ let browserUninstallAll;
 let browserListAvailable;
 let parsePositiveInteger;
 let collectPositiveIntegers;
+let collectAppIds;
 let buildQseowCommand;
 let handleQseowCreateSheetThumbnails;
 let handleCloudCreateSheetThumbnails;
@@ -125,7 +126,8 @@ beforeAll(async () => {
     ({ browserUninstall, browserUninstallAll } =
         await import('../../browser/browser-uninstall.js'));
     ({ browserListAvailable } = await import('../../browser/browser-list-available.js'));
-    ({ parsePositiveInteger, collectPositiveIntegers } = await import('../helpers.js'));
+    ({ parsePositiveInteger, collectPositiveIntegers, collectAppIds } =
+        await import('../helpers.js'));
     ({ buildQseowCommand, handleQseowCreateSheetThumbnails } = await import('../qseow/index.js'));
     ({ handleCloudCreateSheetThumbnails } = await import('../qscloud/create-sheet-thumbnails.js'));
     ({ handleCloudListCollections } = await import('../qscloud/list-collections.js'));
@@ -181,6 +183,31 @@ describe('collectPositiveIntegers', () => {
         const parser = collectPositiveIntegers({ errorMessage: 'nope' });
         expect(() => parser('abc')).toThrow(InvalidArgumentError);
         expect(() => parser('abc')).toThrow('nope');
+    });
+});
+
+describe('collectAppIds', () => {
+    test('accumulates onto the previous value instead of replacing it', () => {
+        // Same trap as collectPositiveIntegers: a variadic option with a parser
+        // that ignores the accumulator keeps only the last value.
+        expect(collectAppIds('a')).toEqual(['a']);
+        expect(collectAppIds('b', ['a'])).toEqual(['a', 'b']);
+    });
+
+    test('does not mutate the accumulator it is given', () => {
+        const previous = ['a'];
+        collectAppIds('b', previous);
+        expect(previous).toEqual(['a']);
+    });
+
+    test('splits on commas and trims, so both separators behave the same', () => {
+        expect(collectAppIds('a,b , c')).toEqual(['a', 'b', 'c']);
+    });
+
+    test('drops empty entries, so a set-but-empty value means nothing supplied', () => {
+        expect(collectAppIds('')).toEqual([]);
+        expect(collectAppIds('   ')).toEqual([]);
+        expect(collectAppIds('a,,b')).toEqual(['a', 'b']);
     });
 });
 
@@ -530,6 +557,94 @@ describe('variadic sheet-number options collect into arrays', () => {
             expect(() => parseOptionInIsolation(subcommand(), flag, ['abc'])).toThrow(
                 /must be a non-negative integer/i
             );
+        });
+    });
+});
+
+describe('--appid accepts several apps (issue #895)', () => {
+    // Processing several named apps in one run was not expressible, even though
+    // everything downstream is already list-shaped: the workers build an array and
+    // runOverApps() dedupes it. The limitation was purely in the option declaration.
+    const cases = [
+        ['qseow', () => buildQseowCommand(), 'create-sheet-thumbnails', 'BSI_QSEOW_CST_APP_ID'],
+        [
+            'qscloud',
+            () => buildQscloudCommand(),
+            'create-sheet-thumbnails',
+            'BSI_QSCLOUD_CST_APP_ID',
+        ],
+        ['qscloud', () => buildQscloudCommand(), 'remove-sheet-icons', 'BSI_QSCLOUD_RSI_APPID'],
+    ];
+
+    describe.each(cases)('%s %s', (platform, build, leaf, envVar) => {
+        /**
+         * Resolves the subcommand under test.
+         *
+         * @returns {import('commander').Command} The subcommand carrying --appid.
+         */
+        const subcommand = () => build().commands.find((cmd) => cmd.name() === leaf);
+
+        /**
+         * Parses with no `--appid` on the command line, so the env var is the only source.
+         *
+         * `parseOptionInIsolation` always prepends the flag, which for a variadic option
+         * with nothing after it is `argument missing` rather than "not supplied".
+         *
+         * @returns {object} The parsed options object.
+         */
+        const parseEnvOnly = () => {
+            const parent = new Command();
+            parent.exitOverride();
+            parent.addOption(subcommand().options.find((opt) => opt.long === '--appid'));
+            parent.parse(['node', 'test']);
+
+            return parent.opts();
+        };
+
+        afterEach(() => {
+            delete process.env[envVar];
+        });
+
+        test('keeps every id when several are supplied', () => {
+            const opts = parseOptionInIsolation(subcommand(), '--appid', ['a', 'b', 'c']);
+            expect(opts.appid).toEqual(['a', 'b', 'c']);
+        });
+
+        test('yields a one-element array for a single id, as before', () => {
+            const opts = parseOptionInIsolation(subcommand(), '--appid', ['a']);
+            expect(opts.appid).toEqual(['a']);
+        });
+
+        test('splits a comma-separated value', () => {
+            const opts = parseOptionInIsolation(subcommand(), '--appid', ['a,b,c']);
+            expect(opts.appid).toEqual(['a', 'b', 'c']);
+        });
+
+        test('tolerates spaces around the commas', () => {
+            const opts = parseOptionInIsolation(subcommand(), '--appid', ['a, b , c']);
+            expect(opts.appid).toEqual(['a', 'b', 'c']);
+        });
+
+        test('splits a comma-separated environment variable', () => {
+            // Commander wraps an env-var value in a one-element array without
+            // splitting it, so without the parser this is one app whose id
+            // contains commas. Every option here has an .env() binding, so this
+            // path is first-class.
+            process.env[envVar] = 'a,b,c';
+            expect(parseEnvOnly().appid).toEqual(['a', 'b', 'c']);
+        });
+
+        test('treats a set-but-empty environment variable as nothing supplied', () => {
+            // This repo has been bitten by set-but-empty before: Commander lets a
+            // bare `BSI_..._APP_ID=` line in a unit file beat .default().
+            process.env[envVar] = '';
+            expect(parseEnvOnly().appid).toEqual([]);
+        });
+
+        test('lets the command line win over the environment variable', () => {
+            process.env[envVar] = 'from-env';
+            const opts = parseOptionInIsolation(subcommand(), '--appid', ['from-cli']);
+            expect(opts.appid).toEqual(['from-cli']);
         });
     });
 });

--- a/src/lib/commands/helpers.js
+++ b/src/lib/commands/helpers.js
@@ -80,4 +80,38 @@ const collectPositiveIntegers =
     (parseOptions = {}) =>
     (value, previous = []) => [...previous, parsePositiveInteger(value, parseOptions)];
 
-export { parsePositiveInteger, collectPositiveIntegers };
+/**
+ * Commander `argParser` for a **variadic** app-id option (`<id...>`).
+ *
+ * Accumulates for the reason spelled out above `collectPositiveIntegers`: a variadic
+ * option paired with a non-accumulating parser keeps only the last value, so
+ * `--appid a b c` would yield `['c']`.
+ *
+ * It also splits on commas, which is not cosmetic. Commander wraps an environment
+ * variable's value in a one-element array **without splitting it**, so
+ * `BSI_QSEOW_CST_APP_ID=a,b,c` would otherwise become a single app whose id contains
+ * commas. Every option in this codebase has an `.env()` binding, so the environment is a
+ * first-class way to drive it and cannot be left broken. Commas are accepted on the
+ * command line too, so the separator does not depend on where the value came from - app
+ * ids are GUIDs, so a comma is never part of one.
+ *
+ * Empty entries are dropped, which makes a set-but-empty variable mean "none supplied"
+ * rather than one app with a blank id.
+ *
+ * @param {string} value - One raw value supplied by Commander.
+ * @param {string[]} [previous] - App ids accumulated so far.
+ *
+ * @returns {string[]} Every app id collected so far, including this value's.
+ *
+ * @example
+ * new Option('--appid <id...>', '...').argParser(collectAppIds)
+ */
+const collectAppIds = (value, previous = []) => [
+    ...previous,
+    ...`${value}`
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0),
+];
+
+export { parsePositiveInteger, collectPositiveIntegers, collectAppIds };

--- a/src/lib/commands/qscloud/create-sheet-thumbnails.js
+++ b/src/lib/commands/qscloud/create-sheet-thumbnails.js
@@ -7,7 +7,8 @@ import {
     describeBrowserVersionOption,
     parseBrowserVersionValue,
 } from '../../browser/browser-version.js';
-import { parsePositiveInteger, collectPositiveIntegers } from '../helpers.js';
+import { parsePositiveInteger, collectPositiveIntegers, collectAppIds } from '../helpers.js';
+import { toAppIdList } from '../../util/app-ids.js';
 import { runCommand } from '../run-command.js';
 
 /**
@@ -21,7 +22,9 @@ import { runCommand } from '../run-command.js';
 const handleCloudCreateSheetThumbnails = async (options = {}, cmd) => {
     logger.info(`App version: ${appVersion}`);
 
-    logger.verbose(`appid=${options.appid}`);
+    // Joined explicitly: --appid is variadic, and letting a template literal coerce the
+    // array reads as one strange id rather than as several.
+    logger.verbose(`appid=${toAppIdList(options.appid).join(', ')}`);
     return runCommand('CLOUD MAIN 3', () => qscloudCreateThumbnails(options, cmd));
 };
 
@@ -135,9 +138,12 @@ const buildCloudCreateSheetThumbnailsCommand = () => {
                 .env('BSI_QSCLOUD_CST_INCLUDE_SHEET_PART')
         )
         .addOption(
-            new Option('--appid <id>', 'Qlik Sense app whose sheet icons should be modified.').env(
-                'BSI_QSCLOUD_CST_APP_ID'
+            new Option(
+                '--appid <id...>',
+                'Qlik Sense app(s) whose sheet icons should be modified. Several ids can be given, separated by spaces or commas.\nCombines with --collectionid rather than replacing it: apps named either way are all updated, each one once.'
             )
+                .argParser(collectAppIds)
+                .env('BSI_QSCLOUD_CST_APP_ID')
         )
         .addOption(
             new Option(

--- a/src/lib/commands/qscloud/remove-sheet-icons.js
+++ b/src/lib/commands/qscloud/remove-sheet-icons.js
@@ -2,6 +2,7 @@ import { Command, Option } from 'commander';
 import { logger, appVersion } from '../../../globals.js';
 import { qscloudRemoveSheetIcons } from '../../cloud/cloud-remove-sheet-icons.js';
 import { runCommand } from '../run-command.js';
+import { collectAppIds } from '../helpers.js';
 
 /**
  * Commander action that removes sheet icons from specified Qlik Sense Cloud apps.
@@ -64,9 +65,12 @@ const buildCloudRemoveSheetIconsCommand = () => {
                 .env('BSI_QSCLOUD_RSI_APIKEY')
         )
         .addOption(
-            new Option('--appid <id>', 'Qlik Sense app whose sheet icons should be modified.').env(
-                'BSI_QSCLOUD_RSI_APPID'
+            new Option(
+                '--appid <id...>',
+                'Qlik Sense app(s) whose sheet icons should be modified. Several ids can be given, separated by spaces or commas.\nCombines with --collectionid rather than replacing it: apps named either way are all updated, each one once.'
             )
+                .argParser(collectAppIds)
+                .env('BSI_QSCLOUD_RSI_APPID')
         )
         .addOption(
             new Option(

--- a/src/lib/commands/qseow/index.js
+++ b/src/lib/commands/qseow/index.js
@@ -7,7 +7,8 @@ import {
     describeBrowserVersionOption,
     parseBrowserVersionValue,
 } from '../../browser/browser-version.js';
-import { parsePositiveInteger, collectPositiveIntegers } from '../helpers.js';
+import { parsePositiveInteger, collectPositiveIntegers, collectAppIds } from '../helpers.js';
+import { toAppIdList } from '../../util/app-ids.js';
 import { runCommand } from '../run-command.js';
 
 /**
@@ -21,7 +22,9 @@ import { runCommand } from '../run-command.js';
 const handleQseowCreateSheetThumbnails = async (options = {}, command) => {
     logger.info(`App version: ${appVersion}`);
 
-    logger.verbose(`appid=${options.appid}`);
+    // Joined explicitly: --appid is variadic, and letting a template literal coerce the
+    // array reads as one strange id rather than as several.
+    logger.verbose(`appid=${toAppIdList(options.appid).join(', ')}`);
     return runCommand('QSEOW MAIN 1', () => qseowCreateThumbnails(options, command));
 };
 
@@ -168,9 +171,12 @@ const buildQseowCommand = () => {
                 .env('BSI_QSEOW_CST_LOGON_PWD')
         )
         .addOption(
-            new Option('--appid <id>', 'Qlik Sense app whose sheet icons should be modified.').env(
-                'BSI_QSEOW_CST_APP_ID'
+            new Option(
+                '--appid <id...>',
+                'Qlik Sense app(s) whose sheet icons should be modified. Several ids can be given, separated by spaces or commas.\nCombines with --qliksensetag rather than replacing it: apps named either way are all updated, each one once.'
             )
+                .argParser(collectAppIds)
+                .env('BSI_QSEOW_CST_APP_ID')
         )
         .addOption(
             new Option(

--- a/src/lib/qseow/__tests__/qseowCreateThumbnails_fail.integration.test.js
+++ b/src/lib/qseow/__tests__/qseowCreateThumbnails_fail.integration.test.js
@@ -34,7 +34,7 @@ const buildOptions = (overrides = {}) => ({
     imagedir: process.env.BSI_IMAGE_DIR || 'img',
     contentlibrary: process.env.BSI_CONTENT_LIBRARY,
     host: process.env.BSI_HOST,
-    appid: process.env.BSI_APP_ID || 'a3e0f5d2-000a-464f-998d-33d333b175d7',
+    appid: [process.env.BSI_APP_ID || 'a3e0f5d2-000a-464f-998d-33d333b175d7'],
     apiuserdir: process.env.BSI_API_USER_DIR || 'Internal',
     apiuserid: process.env.BSI_API_USER_ID || 'sa_api',
     logonuserdir: process.env.BSI_LOGON_USER_DIR,
@@ -85,7 +85,7 @@ describe('qseow create sheet thumbnails - failure paths', () => {
         'a non-existent app id fails the run',
         async () => {
             const result = await qseowCreateThumbnails(
-                buildOptions({ appid: '00000000-0000-0000-0000-000000000000' })
+                buildOptions({ appid: ['00000000-0000-0000-0000-000000000000'] })
             );
 
             expect(result).toBe(false);

--- a/src/lib/qseow/__tests__/qseowCreateThumbnails_fail_missing_content_library.integration.test.js
+++ b/src/lib/qseow/__tests__/qseowCreateThumbnails_fail_missing_content_library.integration.test.js
@@ -20,7 +20,7 @@ const options = {
     imagedir: process.env.BSI_IAMGE_DIR || 'img',
     contentlibrary: process.env.BSI_CONTENT_LIBRARY,
     host: process.env.BSI_HOST,
-    appid: process.env.BSI_APP_ID || 'a3e0f5d2-000a-464f-998d-33d333b175d7',
+    appid: [process.env.BSI_APP_ID || 'a3e0f5d2-000a-464f-998d-33d333b175d7'],
     apiuserdir: process.env.BSI_API_USER_DIR || 'Internal',
     apiuserid: process.env.BSI_API_USER_ID || 'sa_api',
     logonuserdir: process.env.BSI_LOGON_USER_DIR,

--- a/src/lib/qseow/__tests__/qseowCreateThumbnails_success.integration.test.js
+++ b/src/lib/qseow/__tests__/qseowCreateThumbnails_success.integration.test.js
@@ -20,7 +20,7 @@ const options = {
     imagedir: process.env.BSI_IMAGE_DIR || 'img',
     contentlibrary: process.env.BSI_CONTENT_LIBRARY,
     host: process.env.BSI_HOST,
-    appid: process.env.BSI_APP_ID || 'a3e0f5d2-000a-464f-998d-33d333b175d7',
+    appid: [process.env.BSI_APP_ID || 'a3e0f5d2-000a-464f-998d-33d333b175d7'],
     apiuserdir: process.env.BSI_API_USER_DIR || 'Internal',
     apiuserid: process.env.BSI_API_USER_ID || 'sa_api',
     logonuserdir: process.env.BSI_LOGON_USER_DIR,

--- a/src/lib/qseow/__tests__/qseow_create_thumbnails_app_loop.test.js
+++ b/src/lib/qseow/__tests__/qseow_create_thumbnails_app_loop.test.js
@@ -51,7 +51,7 @@ const { qseowCreateThumbnails } = await import('../qseow-create-thumbnails.js');
 const OPTIONS = {
     host: 'sense.example.com',
     contentlibrary: 'test-library',
-    appid: 'test-app-id',
+    appid: ['test-app-id'],
     includesheetpart: '1',
     loglevel: 'info',
 };
@@ -87,6 +87,48 @@ describe('qseowCreateThumbnails app loop', () => {
 
         expect(runOverApps).toHaveBeenCalledTimes(1);
         expect(runOverApps.mock.calls[0][0]).toEqual(['test-app-id']);
+    });
+
+    test('hands every app id to the loop when several are named (issue #895)', async () => {
+        runOverApps.mockResolvedValue(true);
+
+        await qseowCreateThumbnails({ ...OPTIONS, appid: ['app-1', 'app-2', 'app-3'] });
+
+        expect(runOverApps.mock.calls[0][0]).toEqual(['app-1', 'app-2', 'app-3']);
+    });
+
+    test('never explodes a bare string into one app per character', async () => {
+        // A string is iterable, so a plain spread would push eleven
+        // single-character app ids. Nothing the CLI produces is a string any
+        // more, but a hand-built options bag can still be, and failing that way
+        // is silent rather than loud.
+        runOverApps.mockResolvedValue(true);
+
+        await qseowCreateThumbnails({ ...OPTIONS, appid: 'test-app-id' });
+
+        expect(runOverApps.mock.calls[0][0]).toEqual(['test-app-id']);
+    });
+
+    test('unions --appid with --qliksensetag rather than choosing between them', async () => {
+        // The two are additive. Several comments used to claim the tag was only
+        // consulted when no app id was given, which was never what the code did.
+        const Get = jest.fn().mockResolvedValue({
+            statusCode: 200,
+            body: [{ id: 'tagged-app' }, { id: 'app-1' }],
+        });
+        qrsInteract.mockImplementation(() => ({ Get }));
+        runOverApps.mockResolvedValue(true);
+
+        await qseowCreateThumbnails({ ...OPTIONS, appid: ['app-1', 'app-2'], qliksensetag: 'BSI' });
+
+        // runOverApps dedupes, so app-1 - named both ways - is still listed once
+        // by the time it decides what to process.
+        expect(runOverApps.mock.calls[0][0]).toEqual(['app-1', 'app-2', 'tagged-app', 'app-1']);
+        expect([...new Set(runOverApps.mock.calls[0][0])]).toEqual([
+            'app-1',
+            'app-2',
+            'tagged-app',
+        ]);
     });
 
     test('names the QSEoW options in the empty-selection hint, not the Cloud ones', async () => {

--- a/src/lib/qseow/__tests__/qseow_remove_sheet_icons.test.js
+++ b/src/lib/qseow/__tests__/qseow_remove_sheet_icons.test.js
@@ -51,7 +51,7 @@ const BASE_OPTIONS = {
     qrsport: '4242',
     senseVersion: '2024-May',
     loglevel: 'info',
-    appid: 'test-app-id',
+    appid: ['test-app-id'],
     certfile: './cert/client.pem',
     certkeyfile: './cert/client_key.pem',
 };

--- a/src/lib/qseow/qseow-create-thumbnails.js
+++ b/src/lib/qseow/qseow-create-thumbnails.js
@@ -5,6 +5,7 @@ import { qseowVerifyCertificatesExist } from './qseow-certificates.js';
 import { qseowProcessApp } from './qseow-process-app.js';
 import { runOverApps } from '../util/run-over-apps.js';
 import { getAppIdsByTag } from './qseow-app-lookup.js';
+import { toAppIdList } from '../util/app-ids.js';
 import { QSEOW_SHEET_PARTS } from './sheet-parts.js';
 
 /**
@@ -17,7 +18,8 @@ import { QSEOW_SHEET_PARTS } from './sheet-parts.js';
  * @param {string} options.userdirectory - User directory for QSEoW server.
  * @param {string} options.password - Password for QSEoW server.
  * @param {string} options.contentlibrary - Name of content library where thumbnails will be stored.
- * @param {string} options.appid - ID of app for which thumbnails will be created.
+ * @param {string[]} options.appid - IDs of apps for which thumbnails will be created. Added to
+ *     whatever `qliksensetag` matches rather than replacing it.
  * @param {string} options.qliksensetag - Tag for which apps will be processed.
  * @param {string} options.includesheetpart - Optional parameter to include sheet parts in the thumbnails. Values: 1, 2, 3, 4. Normalised to a string on entry, so a number is also accepted.
  * @param {string} options.certfile - Path to certificate file.
@@ -71,13 +73,12 @@ export const qseowCreateThumbnails = async (options) => {
             logger.verbose(`Content library '${options.contentlibrary}' exists`);
         }
 
-        // Is there a specific app ID specified?
-        if (options.appid) {
-            appIdsToProcess.push(options.appid);
-        }
+        // Apps named directly. --appid is variadic, so this is a list.
+        appIdsToProcess.push(...toAppIdList(options.appid));
 
-        // If --qliksensetag exists we should loop over all matching apps.
-        // If --qliksensetag does not exist the app specified by --appid should be processed.
+        // --appid and --qliksensetag are additive, not alternatives: apps named either
+        // way are all processed. runOverApps() dedupes, so an app that is both named by
+        // --appid and carries the tag is still processed once.
         if (options.qliksensetag && options.qliksensetag.length > 0) {
             // Get all apps matching the tag in --qliksensetag
             appIdsToProcess.push(...(await getAppIdsByTag(options)));

--- a/src/lib/qseow/qseow-remove-sheet-icons.js
+++ b/src/lib/qseow/qseow-remove-sheet-icons.js
@@ -12,6 +12,7 @@ import {
 } from '../util/sheet-list.js';
 import { runOverApps } from '../util/run-over-apps.js';
 import { getAppIdsByTag } from './qseow-app-lookup.js';
+import { toAppIdList } from '../util/app-ids.js';
 import { withEngineSession } from '../util/engine-session.js';
 
 /**
@@ -130,7 +131,8 @@ const removeSheetIconsQSEoWApp = async (appId, g, options) => {
  * @param {string} options.engineport - Engine port of the Qlik server.
  * @param {string} options.qrsport - Qlik Sense Repository Service (QRS) port of the Qlik server.
  * @param {string} options.senseVersion - The version of Qlik Sense being used.
- * @param {string} options.appid - The ID of the Qlik Sense Enterprise on Windows (QSEoW) application to process.
+ * @param {string[]} options.appid - IDs of the Qlik Sense Enterprise on Windows (QSEoW) applications
+ *     to process. Added to whatever `qliksensetag` matches rather than replacing it.
  * @param {string} options.qliksensetag - The tag for which apps will be processed. If specified, all apps with this tag will be processed.
  * @param {string} options.loglevel - The level of logging to output. Valid values are 'error', 'warn', 'info', 'verbose', 'debug', 'silly'.
  *
@@ -156,13 +158,12 @@ export const qseowRemoveSheetIcons = async (options) => {
             logger.verbose(`Certificate files found`);
         }
 
-        // Is there a specific app ID specified?
-        if (options.appid) {
-            appIdsToProcess.push(options.appid);
-        }
+        // Apps named directly. --appid is variadic, so this is a list.
+        appIdsToProcess.push(...toAppIdList(options.appid));
 
-        // If --qliksensetag exists we should loop over all matching apps.
-        // If --qliksensetag does not exist the app specified by --appid should be processed.
+        // --appid and --qliksensetag are additive, not alternatives: apps named either
+        // way are all processed. runOverApps() dedupes, so an app that is both named by
+        // --appid and carries the tag is still processed once.
         if (options.qliksensetag && options.qliksensetag.length > 0) {
             // Get all apps matching the tag in --qliksensetag
             appIdsToProcess.push(...(await getAppIdsByTag(options)));

--- a/src/lib/util/__tests__/app-ids.test.js
+++ b/src/lib/util/__tests__/app-ids.test.js
@@ -1,0 +1,38 @@
+import { describe, test, expect } from '@jest/globals';
+import { toAppIdList } from '../app-ids.js';
+
+describe('toAppIdList', () => {
+    test('passes an array through untouched', () => {
+        expect(toAppIdList(['a', 'b'])).toEqual(['a', 'b']);
+    });
+
+    test('wraps a single string instead of exploding it', () => {
+        // The reason this helper exists. A string is iterable, so
+        // `push(...'test-app-id')` does not throw - it pushes eleven
+        // single-character app ids, and the run then fails eleven times over
+        // ids nobody asked for. Loud is fine; silent and wrong is not.
+        expect(toAppIdList('test-app-id')).toEqual(['test-app-id']);
+    });
+
+    test('trims a string, so a stray space is not part of the id', () => {
+        expect(toAppIdList('  test-app-id  ')).toEqual(['test-app-id']);
+    });
+
+    test.each([
+        ['undefined', undefined],
+        ['null', null],
+        ['an empty string', ''],
+        ['whitespace only', '   '],
+        ['an empty array', []],
+    ])('gives an empty list for %s', (_label, input) => {
+        expect(toAppIdList(input)).toEqual([]);
+    });
+
+    test('does not treat an empty array as "nothing supplied" by returning something else', () => {
+        // `[]` is truthy, which is why the `if (options.appid)` guards that used
+        // to wrap these pushes stopped meaning anything once the option became
+        // variadic. The helper returns a list either way and the callers spread
+        // it unconditionally.
+        expect(Array.isArray(toAppIdList([]))).toBe(true);
+    });
+});

--- a/src/lib/util/app-ids.js
+++ b/src/lib/util/app-ids.js
@@ -1,0 +1,34 @@
+/**
+ * Normalise whatever `options.appid` holds into a list of app ids.
+ *
+ * `--appid` is variadic, so Commander always stores an array and the workers could in
+ * principle spread it directly. They do not, for one specific reason: **a string is
+ * iterable**. `appIdsToProcess.push(...'test-app-id')` does not throw - it pushes eleven
+ * single-character app ids, and the run then fails eleven times over ids that were never
+ * asked for. Anything still holding the pre-#895 string shape would fail that way,
+ * silently and confusingly, rather than loudly.
+ *
+ * So this is a boundary guard, not a second parsing rule. The splitting and trimming of
+ * user input belongs to `collectAppIds` in `src/lib/commands/helpers.js`; all this does is
+ * make the wrong shape safe.
+ *
+ * An empty array is deliberately not special-cased: `[]` is truthy, which is why the
+ * `if (options.appid)` guards that used to wrap these pushes stopped meaning anything the
+ * moment the option became variadic, and were removed rather than left to read like
+ * checks.
+ *
+ * @param {string[]|string|undefined} appid - The `appid` option, in any shape it has ever had.
+ *
+ * @returns {string[]} App ids to process, empty when none were supplied.
+ */
+export const toAppIdList = (appid) => {
+    if (Array.isArray(appid)) {
+        return appid;
+    }
+
+    if (typeof appid === 'string' && appid.trim().length > 0) {
+        return [appid.trim()];
+    }
+
+    return [];
+};


### PR DESCRIPTION
Closes #895.

`--appid` accepted exactly one app on all three commands that have it, so processing several named apps in one run was not expressible — even though everything downstream was already list-shaped. The workers build an array and `runOverApps()` dedupes it, so the limitation was purely in the option declaration.

```bash
--appid a1b2c3d4-... 9f8e7d6c-...        # spaces
--appid a1b2c3d4-...,9f8e7d6c-...        # or commas
BSI_QSEOW_CST_APP_ID=a1b2c3d4-...,9f8e7d6c-...
```

## The two halves of the parser, both load-bearing

Verified against the real `commander@15.0.0`:

- **Accumulating.** A variadic option paired with a non-accumulating `argParser` takes Commander's parser branch and keeps only the last value, so `--appid a b c` would yield `["c"]`. Same trap as #872, which is why this follows `collectPositiveIntegers`.
- **Comma-splitting.** Commander wraps an environment variable's value in a one-element array **without splitting it**, so `BSI_..._APP_ID=a,b,c` would otherwise be one app whose id contains commas. Every option here has an `.env()` binding, so that path cannot be left broken. Commas work on the command line too, so the separator does not depend on where the value came from — app ids are GUIDs, so a comma is never part of one.

## Why the workers do not just spread it

`toAppIdList()` sits at the boundary because **a string is iterable**: `push(...'test-app-id')` does not throw, it pushes eleven single-character app ids. Nothing the CLI produces is a string any more, but a hand-built options bag can still be, and failing that way is silent rather than loud.

The `if (options.appid)` guards went with it — `[]` is truthy, so they stopped meaning anything the moment the option became variadic, and leaving them would have read like a check that no longer checked.

## Corrected while here

Four comments and four JSDoc blocks claimed `--appid` and `--qliksensetag`/`--collectionid` were alternatives. They are additive and always have been: apps named either way are all processed, each one once. #895 records this; there are now tests for it on both platforms.

## Verification

- 1505 unit tests pass; lint clean. New coverage: the parser's accumulator contract, the option driven through **real Commander** on all three commands (space / comma / single / env / set-but-empty / argv-wins), the boundary helper, and union-with-dedup on both platforms.
- Output and exit codes **byte-identical to main** for every command line that does not use `--appid`; the only diff is the intended `--appid` help entry.
- A single `--appid <id>` behaves exactly as before, so existing scripts and scheduled tasks are unaffected.

**Not verified against a live server.** Both platforms check certificates or the tenant connection before app selection, so a local run cannot reach the loop. The union-and-dedup behaviour is covered by unit tests with `runOverApps` mocked. Worth one real multi-app run with `--loglevel debug` to see the `Will process these app IDs:` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
