### PR TITLE
Stop prettier and the skill generator rewriting each other

### DIFF
--- a/.claude/skills/generated/browser/SKILL.md
+++ b/.claude/skills/generated/browser/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browser
-description: 'Skill for the Browser area of butler-sheet-icons. 43 symbols across 23 files.'
+description: "Skill for the Browser area of butler-sheet-icons. 43 symbols across 23 files."
 ---
 
 # Browser
@@ -15,18 +15,18 @@ description: 'Skill for the Browser area of butler-sheet-icons. 43 symbols acros
 
 ## Key Files
 
-| File                                        | Symbols                                                                                                                       |
-| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `src/lib/browser/browser-launch.js`         | logUnusableBrowser, watchForUnexpectedDisconnect, launchBrowserForApp, detectDocker, buildBrowserArgs (+2)                    |
-| `src/lib/browser/browser-version.js`        | normalizeVersionKeyword, assertExplicitVersionIsWellFormed, markLookupFailure, logVersionLookupFailure, resolveBrowserVersion |
-| `src/lib/browser/browser-list-available.js` | extractVersions, mapPlatformToChrome, fetchAvailableVersions, browserListAvailable, getMostRecentUsableChromeBuildId          |
-| `src/lib/util/image-dir.js`                 | createAppImageDir, logPermissionAdvice, isProbablyContainer                                                                   |
-| `src/lib/util/reported-error.js`            | markReported, alreadyReported                                                                                                 |
-| `src/globals.js`                            | getLoggingLevel, setLoggingLevel                                                                                              |
-| `src/lib/browser/browser-uninstall.js`      | browserUninstall, browserUninstallAll                                                                                         |
-| `src/lib/browser/browser-detect.js`         | sortNewestFirst, detectAvailableBrowser                                                                                       |
-| `src/lib/interactive/tty.js`                | assertInteractiveCapable                                                                                                      |
-| `src/lib/browser/browser-installed.js`      | browserInstalled                                                                                                              |
+| File | Symbols |
+|------|---------|
+| `src/lib/browser/browser-launch.js` | logUnusableBrowser, watchForUnexpectedDisconnect, launchBrowserForApp, detectDocker, buildBrowserArgs (+2) |
+| `src/lib/browser/browser-version.js` | normalizeVersionKeyword, assertExplicitVersionIsWellFormed, markLookupFailure, logVersionLookupFailure, resolveBrowserVersion |
+| `src/lib/browser/browser-list-available.js` | extractVersions, mapPlatformToChrome, fetchAvailableVersions, browserListAvailable, getMostRecentUsableChromeBuildId |
+| `src/lib/util/image-dir.js` | createAppImageDir, logPermissionAdvice, isProbablyContainer |
+| `src/lib/util/reported-error.js` | markReported, alreadyReported |
+| `src/globals.js` | getLoggingLevel, setLoggingLevel |
+| `src/lib/browser/browser-uninstall.js` | browserUninstall, browserUninstallAll |
+| `src/lib/browser/browser-detect.js` | sortNewestFirst, detectAvailableBrowser |
+| `src/lib/interactive/tty.js` | assertInteractiveCapable |
+| `src/lib/browser/browser-installed.js` | browserInstalled |
 
 ## Entry Points
 
@@ -40,49 +40,49 @@ Start here when exploring this area:
 
 ## Key Symbols
 
-| Symbol                             | Type     | File                                              | Line |
-| ---------------------------------- | -------- | ------------------------------------------------- | ---- |
-| `launchBrowserForApp`              | Function | `src/lib/browser/browser-launch.js`               | 287  |
-| `resolveBrowserVersion`            | Function | `src/lib/browser/browser-version.js`              | 354  |
-| `assertInteractiveCapable`         | Function | `src/lib/interactive/tty.js`                      | 121  |
-| `createAppImageDir`                | Function | `src/lib/util/image-dir.js`                       | 32   |
-| `markReported`                     | Function | `src/lib/util/reported-error.js`                  | 32   |
-| `browserInstalled`                 | Function | `src/lib/browser/browser-installed.js`            | 17   |
-| `browserUninstall`                 | Function | `src/lib/browser/browser-uninstall.js`            | 24   |
-| `browserUninstallAll`              | Function | `src/lib/browser/browser-uninstall.js`            | 138  |
-| `qscloudListCollections`           | Function | `src/lib/cloud/cloud-collections.js`              | 19   |
-| `qscloudCreateThumbnails`          | Function | `src/lib/cloud/cloud-create-thumbnails.js`        | 33   |
-| `withQuietLogging`                 | Function | `src/lib/interactive/quiet.js`                    | 27   |
-| `qseowCreateThumbnails`            | Function | `src/lib/qseow/qseow-create-thumbnails.js`        | 28   |
-| `buildInteractiveCommand`          | Function | `src/lib/interactive/interactive-command.js`      | 112  |
-| `description`                      | Function | `src/lib/interactive/theme.js`                    | 54   |
-| `fetchAvailableVersions`           | Function | `src/lib/browser/browser-list-available.js`       | 146  |
-| `browserListAvailable`             | Function | `src/lib/browser/browser-list-available.js`       | 197  |
-| `getMostRecentUsableChromeBuildId` | Function | `src/lib/browser/browser-list-available.js`       | 335  |
-| `choices`                          | Function | `src/lib/commands/browser/install.interactive.js` | 51   |
-| `alreadyReported`                  | Function | `src/lib/util/reported-error.js`                  | 47   |
-| `detectAvailableBrowser`           | Function | `src/lib/browser/browser-detect.js`               | 61   |
+| Symbol | Type | File | Line |
+|--------|------|------|------|
+| `launchBrowserForApp` | Function | `src/lib/browser/browser-launch.js` | 287 |
+| `resolveBrowserVersion` | Function | `src/lib/browser/browser-version.js` | 354 |
+| `assertInteractiveCapable` | Function | `src/lib/interactive/tty.js` | 121 |
+| `createAppImageDir` | Function | `src/lib/util/image-dir.js` | 32 |
+| `markReported` | Function | `src/lib/util/reported-error.js` | 32 |
+| `browserInstalled` | Function | `src/lib/browser/browser-installed.js` | 17 |
+| `browserUninstall` | Function | `src/lib/browser/browser-uninstall.js` | 24 |
+| `browserUninstallAll` | Function | `src/lib/browser/browser-uninstall.js` | 138 |
+| `qscloudListCollections` | Function | `src/lib/cloud/cloud-collections.js` | 19 |
+| `qscloudCreateThumbnails` | Function | `src/lib/cloud/cloud-create-thumbnails.js` | 35 |
+| `withQuietLogging` | Function | `src/lib/interactive/quiet.js` | 27 |
+| `qseowCreateThumbnails` | Function | `src/lib/qseow/qseow-create-thumbnails.js` | 30 |
+| `buildInteractiveCommand` | Function | `src/lib/interactive/interactive-command.js` | 112 |
+| `description` | Function | `src/lib/interactive/theme.js` | 54 |
+| `fetchAvailableVersions` | Function | `src/lib/browser/browser-list-available.js` | 146 |
+| `browserListAvailable` | Function | `src/lib/browser/browser-list-available.js` | 197 |
+| `getMostRecentUsableChromeBuildId` | Function | `src/lib/browser/browser-list-available.js` | 335 |
+| `choices` | Function | `src/lib/commands/browser/install.interactive.js` | 51 |
+| `alreadyReported` | Function | `src/lib/util/reported-error.js` | 47 |
+| `detectAvailableBrowser` | Function | `src/lib/browser/browser-detect.js` | 61 |
 
 ## Execution Flows
 
-| Flow                                                  | Type            | Steps |
-| ----------------------------------------------------- | --------------- | ----- |
-| `EveryLeafCommand → Description`                      | cross_community | 4     |
-| `BrowserListAvailable → GetErrorCategory`             | cross_community | 4     |
-| `BrowserListAvailable → MarkReported`                 | cross_community | 4     |
-| `Choices → GetErrorCategory`                          | cross_community | 4     |
-| `Choices → MarkReported`                              | cross_community | 4     |
-| `GetMostRecentUsableChromeBuildId → GetErrorCategory` | cross_community | 4     |
-| `GetMostRecentUsableChromeBuildId → MarkReported`     | cross_community | 4     |
-| `ResolveBrowserVersion → MarkReported`                | intra_community | 3     |
-| `ResolveBrowserVersion → GetErrorCategory`            | cross_community | 3     |
-| `LaunchBrowserForApp → LogUnusableBrowser`            | intra_community | 3     |
+| Flow | Type | Steps |
+|------|------|-------|
+| `EveryLeafCommand → Description` | cross_community | 4 |
+| `BrowserListAvailable → GetErrorCategory` | cross_community | 4 |
+| `BrowserListAvailable → MarkReported` | cross_community | 4 |
+| `Choices → GetErrorCategory` | cross_community | 4 |
+| `Choices → MarkReported` | cross_community | 4 |
+| `GetMostRecentUsableChromeBuildId → GetErrorCategory` | cross_community | 4 |
+| `GetMostRecentUsableChromeBuildId → MarkReported` | cross_community | 4 |
+| `ResolveBrowserVersion → MarkReported` | intra_community | 3 |
+| `ResolveBrowserVersion → GetErrorCategory` | cross_community | 3 |
+| `LaunchBrowserForApp → LogUnusableBrowser` | intra_community | 3 |
 
 ## Connected Areas
 
 | Area | Connections |
-| ---- | ----------- |
-| Util | 2 calls     |
+|------|-------------|
+| Util | 2 calls |
 
 ## How to Explore
 

--- a/.claude/skills/generated/cloud/SKILL.md
+++ b/.claude/skills/generated/cloud/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cloud
-description: 'Skill for the Cloud area of butler-sheet-icons. 17 symbols across 12 files.'
+description: "Skill for the Cloud area of butler-sheet-icons. 17 symbols across 12 files."
 ---
 
 # Cloud
@@ -15,18 +15,18 @@ description: 'Skill for the Cloud area of butler-sheet-icons. 17 symbols across 
 
 ## Key Files
 
-| File                                        | Symbols                                           |
-| ------------------------------------------- | ------------------------------------------------- |
-| `src/lib/cloud/cloud-repo-request.js`       | bufferToStream, makeRequest, request              |
-| `src/lib/util/socket-keepalive.js`          | attachSocketKeepalive, stop                       |
+| File | Symbols |
+|------|---------|
+| `src/lib/cloud/cloud-repo-request.js` | bufferToStream, makeRequest, request |
+| `src/lib/util/socket-keepalive.js` | attachSocketKeepalive, stop |
 | `src/lib/cloud/cloud-remove-sheet-icons.js` | removeSheetIconsCloudApp, qscloudRemoveSheetIcons |
-| `src/lib/qseow/qseow-remove-sheet-icons.js` | removeSheetIconsQSEoWApp, qseowRemoveSheetIcons   |
-| `src/globals.js`                            | sleep                                             |
-| `src/lib/browser/browser-install.js`        | browserInstall                                    |
-| `src/lib/cloud/cloud-delete-thumbnails.js`  | deleteCloudAppThumbnail                           |
-| `src/lib/cloud/process-cloud-app.js`        | processCloudApp                                   |
-| `src/lib/cloud/sheet-screenshot.js`         | takeSheetScreenshot                               |
-| `src/lib/cloud/cloud-updatesheets.js`       | qscloudUpdateSheetThumbnails                      |
+| `src/lib/qseow/qseow-remove-sheet-icons.js` | removeSheetIconsQSEoWApp, qseowRemoveSheetIcons |
+| `src/globals.js` | sleep |
+| `src/lib/browser/browser-install.js` | browserInstall |
+| `src/lib/cloud/cloud-delete-thumbnails.js` | deleteCloudAppThumbnail |
+| `src/lib/cloud/process-cloud-app.js` | processCloudApp |
+| `src/lib/cloud/sheet-screenshot.js` | takeSheetScreenshot |
+| `src/lib/cloud/cloud-updatesheets.js` | qscloudUpdateSheetThumbnails |
 
 ## Entry Points
 
@@ -40,42 +40,42 @@ Start here when exploring this area:
 
 ## Key Symbols
 
-| Symbol                         | Type     | File                                        | Line |
-| ------------------------------ | -------- | ------------------------------------------- | ---- |
-| `browserInstall`               | Function | `src/lib/browser/browser-install.js`        | 34   |
-| `deleteCloudAppThumbnail`      | Function | `src/lib/cloud/cloud-delete-thumbnails.js`  | 10   |
-| `processCloudApp`              | Function | `src/lib/cloud/process-cloud-app.js`        | 33   |
-| `takeSheetScreenshot`          | Function | `src/lib/cloud/sheet-screenshot.js`         | 19   |
-| `attachSocketKeepalive`        | Function | `src/lib/util/socket-keepalive.js`          | 38   |
-| `stop`                         | Function | `src/lib/util/socket-keepalive.js`          | 48   |
-| `qscloudRemoveSheetIcons`      | Function | `src/lib/cloud/cloud-remove-sheet-icons.js` | 169  |
-| `qscloudUpdateSheetThumbnails` | Function | `src/lib/cloud/cloud-updatesheets.js`       | 36   |
-| `qseowRemoveSheetIcons`        | Function | `src/lib/qseow/qseow-remove-sheet-icons.js` | 138  |
-| `assertAllProcessed`           | Function | `src/lib/util/sheet-list.js`                | 337  |
-| `sleep`                        | Function | `src/globals.js`                            | 291  |
-| `removeSheetIconsCloudApp`     | Function | `src/lib/cloud/cloud-remove-sheet-icons.js` | 34   |
-| `removeSheetIconsQSEoWApp`     | Function | `src/lib/qseow/qseow-remove-sheet-icons.js` | 34   |
-| `bufferToStream`               | Function | `src/lib/cloud/cloud-repo-request.js`       | 59   |
-| `makeRequest`                  | Function | `src/lib/cloud/cloud-repo-request.js`       | 75   |
-| `request`                      | Function | `src/lib/cloud/cloud-repo-request.js`       | 143  |
-| `qlikSaas`                     | Function | `src/lib/cloud/cloud-repo.js`               | 19   |
+| Symbol | Type | File | Line |
+|--------|------|------|------|
+| `browserInstall` | Function | `src/lib/browser/browser-install.js` | 34 |
+| `deleteCloudAppThumbnail` | Function | `src/lib/cloud/cloud-delete-thumbnails.js` | 10 |
+| `processCloudApp` | Function | `src/lib/cloud/process-cloud-app.js` | 33 |
+| `takeSheetScreenshot` | Function | `src/lib/cloud/sheet-screenshot.js` | 19 |
+| `attachSocketKeepalive` | Function | `src/lib/util/socket-keepalive.js` | 38 |
+| `stop` | Function | `src/lib/util/socket-keepalive.js` | 48 |
+| `qscloudRemoveSheetIcons` | Function | `src/lib/cloud/cloud-remove-sheet-icons.js` | 171 |
+| `qscloudUpdateSheetThumbnails` | Function | `src/lib/cloud/cloud-updatesheets.js` | 36 |
+| `qseowRemoveSheetIcons` | Function | `src/lib/qseow/qseow-remove-sheet-icons.js` | 140 |
+| `assertAllProcessed` | Function | `src/lib/util/sheet-list.js` | 337 |
+| `sleep` | Function | `src/globals.js` | 291 |
+| `removeSheetIconsCloudApp` | Function | `src/lib/cloud/cloud-remove-sheet-icons.js` | 35 |
+| `removeSheetIconsQSEoWApp` | Function | `src/lib/qseow/qseow-remove-sheet-icons.js` | 35 |
+| `bufferToStream` | Function | `src/lib/cloud/cloud-repo-request.js` | 59 |
+| `makeRequest` | Function | `src/lib/cloud/cloud-repo-request.js` | 75 |
+| `request` | Function | `src/lib/cloud/cloud-repo-request.js` | 143 |
+| `qlikSaas` | Function | `src/lib/cloud/cloud-repo.js` | 19 |
 
 ## Execution Flows
 
-| Flow                                           | Type            | Steps |
-| ---------------------------------------------- | --------------- | ----- |
-| `ProcessCloudApp → Sleep`                      | intra_community | 3     |
-| `QscloudRemoveSheetIcons → AssertAllProcessed` | intra_community | 3     |
-| `QseowRemoveSheetIcons → AssertAllProcessed`   | intra_community | 3     |
-| `QlikSaas → BufferToStream`                    | intra_community | 3     |
-| `QlikSaas → MakeRequest`                       | intra_community | 3     |
+| Flow | Type | Steps |
+|------|------|-------|
+| `ProcessCloudApp → Sleep` | intra_community | 3 |
+| `QscloudRemoveSheetIcons → AssertAllProcessed` | intra_community | 3 |
+| `QseowRemoveSheetIcons → AssertAllProcessed` | intra_community | 3 |
+| `QlikSaas → BufferToStream` | intra_community | 3 |
+| `QlikSaas → MakeRequest` | intra_community | 3 |
 
 ## Connected Areas
 
-| Area    | Connections |
-| ------- | ----------- |
-| Browser | 4 calls     |
-| Util    | 1 calls     |
+| Area | Connections |
+|------|-------------|
+| Browser | 4 calls |
+| Util | 1 calls |
 
 ## How to Explore
 

--- a/.claude/skills/generated/interactive/SKILL.md
+++ b/.claude/skills/generated/interactive/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: interactive
-description: 'Skill for the Interactive area of butler-sheet-icons. 44 symbols across 10 files.'
+description: "Skill for the Interactive area of butler-sheet-icons. 44 symbols across 10 files."
 ---
 
 # Interactive
@@ -15,18 +15,18 @@ description: 'Skill for the Interactive area of butler-sheet-icons. 44 symbols a
 
 ## Key Files
 
-| File                                          | Symbols                                                                             |
-| --------------------------------------------- | ----------------------------------------------------------------------------------- |
-| `src/lib/interactive/self-test.js`            | heading, formatCapabilities, renderStaticReport, runPromptGallery, runSelfTest (+6) |
-| `src/lib/interactive/ask-questions.js`        | resolveChoices, configFor, askQuestions, hasDefault, select (+5)                    |
-| `src/lib/interactive/theme.js`                | help, answer, message, defaultAnswer                                                |
-| `src/lib/interactive/to-cli-options.js`       | matchesDeclaredDefault, tokensFor, emissionsFor, notEmitted                         |
-| `src/lib/interactive/prompt-runtime.js`       | loadPrompts, ask, write                                                             |
-| `src/lib/interactive/interactive-command.js`  | runSelfTestUnlessCancelled, runWizardUnlessCancelled, handleInteractive             |
-| `src/lib/interactive/mandatory-relaxation.js` | commandAndAncestors, relaxMandatoryOptionsIfInteractive, relax                      |
-| `src/lib/interactive/option-introspect.js`    | typeForOption, defaultForOption, specFromOption                                     |
-| `src/lib/interactive/index.js`                | review, runInteractive                                                              |
-| `src/lib/interactive/menu.js`                 | runMenu                                                                             |
+| File | Symbols |
+|------|---------|
+| `src/lib/interactive/self-test.js` | heading, formatCapabilities, renderStaticReport, runPromptGallery, runSelfTest (+6) |
+| `src/lib/interactive/ask-questions.js` | resolveChoices, configFor, askQuestions, hasDefault, select (+5) |
+| `src/lib/interactive/theme.js` | help, answer, message, defaultAnswer |
+| `src/lib/interactive/to-cli-options.js` | matchesDeclaredDefault, tokensFor, emissionsFor, notEmitted |
+| `src/lib/interactive/prompt-runtime.js` | loadPrompts, ask, write |
+| `src/lib/interactive/interactive-command.js` | runSelfTestUnlessCancelled, runWizardUnlessCancelled, handleInteractive |
+| `src/lib/interactive/mandatory-relaxation.js` | commandAndAncestors, relaxMandatoryOptionsIfInteractive, relax |
+| `src/lib/interactive/option-introspect.js` | typeForOption, defaultForOption, specFromOption |
+| `src/lib/interactive/index.js` | review, runInteractive |
+| `src/lib/interactive/menu.js` | runMenu |
 
 ## Entry Points
 
@@ -40,38 +40,38 @@ Start here when exploring this area:
 
 ## Key Symbols
 
-| Symbol                               | Type     | File                                          | Line |
-| ------------------------------------ | -------- | --------------------------------------------- | ---- |
-| `askQuestions`                       | Function | `src/lib/interactive/ask-questions.js`        | 196  |
-| `runInteractive`                     | Function | `src/lib/interactive/index.js`                | 72   |
-| `runMenu`                            | Function | `src/lib/interactive/menu.js`                 | 24   |
-| `formatCapabilities`                 | Function | `src/lib/interactive/self-test.js`            | 152  |
-| `renderStaticReport`                 | Function | `src/lib/interactive/self-test.js`            | 283  |
-| `runSelfTest`                        | Function | `src/lib/interactive/self-test.js`            | 364  |
-| `help`                               | Function | `src/lib/interactive/theme.js`                | 48   |
-| `formatPalette`                      | Function | `src/lib/interactive/self-test.js`            | 250  |
-| `answer`                             | Function | `src/lib/interactive/theme.js`                | 44   |
-| `message`                            | Function | `src/lib/interactive/theme.js`                | 45   |
-| `defaultAnswer`                      | Function | `src/lib/interactive/theme.js`                | 47   |
-| `emissionsFor`                       | Function | `src/lib/interactive/to-cli-options.js`       | 105  |
-| `notEmitted`                         | Function | `src/lib/interactive/to-cli-options.js`       | 107  |
-| `relaxMandatoryOptionsIfInteractive` | Function | `src/lib/interactive/mandatory-relaxation.js` | 92   |
-| `relax`                              | Function | `src/lib/interactive/mandatory-relaxation.js` | 100  |
-| `specFromOption`                     | Function | `src/lib/interactive/option-introspect.js`    | 140  |
-| `collectCapabilities`                | Function | `src/lib/interactive/self-test.js`            | 74   |
-| `formatSymbolMatrix`                 | Function | `src/lib/interactive/self-test.js`            | 185  |
-| `frames`                             | Function | `src/lib/interactive/self-test.js`            | 188  |
-| `resolveChoices`                     | Function | `src/lib/interactive/ask-questions.js`        | 53   |
+| Symbol | Type | File | Line |
+|--------|------|------|------|
+| `askQuestions` | Function | `src/lib/interactive/ask-questions.js` | 196 |
+| `runInteractive` | Function | `src/lib/interactive/index.js` | 72 |
+| `runMenu` | Function | `src/lib/interactive/menu.js` | 24 |
+| `formatCapabilities` | Function | `src/lib/interactive/self-test.js` | 152 |
+| `renderStaticReport` | Function | `src/lib/interactive/self-test.js` | 283 |
+| `runSelfTest` | Function | `src/lib/interactive/self-test.js` | 364 |
+| `help` | Function | `src/lib/interactive/theme.js` | 48 |
+| `formatPalette` | Function | `src/lib/interactive/self-test.js` | 250 |
+| `answer` | Function | `src/lib/interactive/theme.js` | 44 |
+| `message` | Function | `src/lib/interactive/theme.js` | 45 |
+| `defaultAnswer` | Function | `src/lib/interactive/theme.js` | 47 |
+| `emissionsFor` | Function | `src/lib/interactive/to-cli-options.js` | 105 |
+| `notEmitted` | Function | `src/lib/interactive/to-cli-options.js` | 107 |
+| `relaxMandatoryOptionsIfInteractive` | Function | `src/lib/interactive/mandatory-relaxation.js` | 92 |
+| `relax` | Function | `src/lib/interactive/mandatory-relaxation.js` | 100 |
+| `specFromOption` | Function | `src/lib/interactive/option-introspect.js` | 140 |
+| `collectCapabilities` | Function | `src/lib/interactive/self-test.js` | 74 |
+| `formatSymbolMatrix` | Function | `src/lib/interactive/self-test.js` | 185 |
+| `frames` | Function | `src/lib/interactive/self-test.js` | 188 |
+| `resolveChoices` | Function | `src/lib/interactive/ask-questions.js` | 53 |
 
 ## Execution Flows
 
-| Flow                           | Type            | Steps |
-| ------------------------------ | --------------- | ----- |
-| `RunInteractive → LoadPrompts` | intra_community | 4     |
-| `RunSelfTest → LoadPrompts`    | intra_community | 4     |
-| `AskQuestions → LoadPrompts`   | intra_community | 3     |
-| `RunInteractive → Write`       | intra_community | 3     |
-| `RunMenu → LoadPrompts`        | intra_community | 3     |
+| Flow | Type | Steps |
+|------|------|-------|
+| `RunInteractive → LoadPrompts` | intra_community | 4 |
+| `RunSelfTest → LoadPrompts` | intra_community | 4 |
+| `AskQuestions → LoadPrompts` | intra_community | 3 |
+| `RunInteractive → Write` | intra_community | 3 |
+| `RunMenu → LoadPrompts` | intra_community | 3 |
 
 ## How to Explore
 

--- a/.claude/skills/generated/qscloud/SKILL.md
+++ b/.claude/skills/generated/qscloud/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qscloud
-description: 'Skill for the Qscloud area of butler-sheet-icons. 9 symbols across 7 files.'
+description: "Skill for the Qscloud area of butler-sheet-icons. 9 symbols across 7 files."
 ---
 
 # Qscloud
@@ -15,15 +15,15 @@ description: 'Skill for the Qscloud area of butler-sheet-icons. 9 symbols across
 
 ## Key Files
 
-| File                                                  | Symbols                                       |
-| ----------------------------------------------------- | --------------------------------------------- |
-| `src/lib/commands/helpers.js`                         | parsePositiveInteger, collectPositiveIntegers |
-| `src/lib/interactive/command-tree.js`                 | everyLeafCommand, walk                        |
-| `src/lib/commands/qscloud/create-sheet-thumbnails.js` | buildCloudCreateSheetThumbnailsCommand        |
-| `src/lib/commands/qscloud/index.js`                   | buildQscloudCommand                           |
-| `src/lib/commands/qscloud/list-collections.js`        | buildCloudListCollectionsCommand              |
-| `src/lib/commands/qscloud/remove-sheet-icons.js`      | buildCloudRemoveSheetIconsCommand             |
-| `src/lib/commands/qseow/index.js`                     | buildQseowCommand                             |
+| File | Symbols |
+|------|---------|
+| `src/lib/commands/helpers.js` | parsePositiveInteger, collectPositiveIntegers |
+| `src/lib/interactive/command-tree.js` | everyLeafCommand, walk |
+| `src/lib/commands/qscloud/create-sheet-thumbnails.js` | buildCloudCreateSheetThumbnailsCommand |
+| `src/lib/commands/qscloud/index.js` | buildQscloudCommand |
+| `src/lib/commands/qscloud/list-collections.js` | buildCloudListCollectionsCommand |
+| `src/lib/commands/qscloud/remove-sheet-icons.js` | buildCloudRemoveSheetIconsCommand |
+| `src/lib/commands/qseow/index.js` | buildQseowCommand |
 
 ## Entry Points
 
@@ -34,30 +34,30 @@ Start here when exploring this area:
 
 ## Key Symbols
 
-| Symbol                                   | Type     | File                                                  | Line |
-| ---------------------------------------- | -------- | ----------------------------------------------------- | ---- |
-| `everyLeafCommand`                       | Function | `src/lib/interactive/command-tree.js`                 | 26   |
-| `walk`                                   | Function | `src/lib/interactive/command-tree.js`                 | 29   |
-| `parsePositiveInteger`                   | Function | `src/lib/commands/helpers.js`                         | 16   |
-| `collectPositiveIntegers`                | Function | `src/lib/commands/helpers.js`                         | 78   |
-| `buildCloudCreateSheetThumbnailsCommand` | Function | `src/lib/commands/qscloud/create-sheet-thumbnails.js` | 32   |
-| `buildQscloudCommand`                    | Function | `src/lib/commands/qscloud/index.js`                   | 10   |
-| `buildCloudListCollectionsCommand`       | Function | `src/lib/commands/qscloud/list-collections.js`        | 24   |
-| `buildCloudRemoveSheetIconsCommand`      | Function | `src/lib/commands/qscloud/remove-sheet-icons.js`      | 24   |
-| `buildQseowCommand`                      | Function | `src/lib/commands/qseow/index.js`                     | 32   |
+| Symbol | Type | File | Line |
+|--------|------|------|------|
+| `everyLeafCommand` | Function | `src/lib/interactive/command-tree.js` | 26 |
+| `walk` | Function | `src/lib/interactive/command-tree.js` | 29 |
+| `parsePositiveInteger` | Function | `src/lib/commands/helpers.js` | 16 |
+| `collectPositiveIntegers` | Function | `src/lib/commands/helpers.js` | 78 |
+| `buildCloudCreateSheetThumbnailsCommand` | Function | `src/lib/commands/qscloud/create-sheet-thumbnails.js` | 35 |
+| `buildQscloudCommand` | Function | `src/lib/commands/qscloud/index.js` | 10 |
+| `buildCloudListCollectionsCommand` | Function | `src/lib/commands/qscloud/list-collections.js` | 24 |
+| `buildCloudRemoveSheetIconsCommand` | Function | `src/lib/commands/qscloud/remove-sheet-icons.js` | 25 |
+| `buildQseowCommand` | Function | `src/lib/commands/qseow/index.js` | 35 |
 
 ## Execution Flows
 
-| Flow                                      | Type            | Steps |
-| ----------------------------------------- | --------------- | ----- |
-| `EveryLeafCommand → ParsePositiveInteger` | intra_community | 5     |
-| `EveryLeafCommand → Description`          | cross_community | 4     |
+| Flow | Type | Steps |
+|------|------|-------|
+| `EveryLeafCommand → ParsePositiveInteger` | intra_community | 5 |
+| `EveryLeafCommand → Description` | cross_community | 4 |
 
 ## Connected Areas
 
-| Area    | Connections |
-| ------- | ----------- |
-| Browser | 5 calls     |
+| Area | Connections |
+|------|-------------|
+| Browser | 5 calls |
 
 ## How to Explore
 

--- a/.claude/skills/generated/qseow/SKILL.md
+++ b/.claude/skills/generated/qseow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qseow
-description: 'Skill for the Qseow area of butler-sheet-icons. 12 symbols across 8 files.'
+description: "Skill for the Qseow area of butler-sheet-icons. 12 symbols across 8 files."
 ---
 
 # Qseow
@@ -15,16 +15,16 @@ description: 'Skill for the Qseow area of butler-sheet-icons. 12 symbols across 
 
 ## Key Files
 
-| File                                  | Symbols                              |
-| ------------------------------------- | ------------------------------------ |
-| `src/lib/qseow/qseow-process-app.js`  | getSheetsTaggedWith, qseowProcessApp |
-| `src/lib/util/errors.js`              | QseowError, CertError                |
+| File | Symbols |
+|------|---------|
+| `src/lib/qseow/qseow-process-app.js` | getSheetsTaggedWith, qseowProcessApp |
+| `src/lib/util/errors.js` | QseowError, CertError |
 | `src/lib/qseow/qseow-certificates.js` | exists, qseowVerifyCertificatesExist |
-| `src/lib/qseow/qseow-enigma.js`       | readCert, createSocket               |
-| `src/lib/qseow/qrs-response.js`       | qrsGetList                           |
-| `src/lib/qseow/qseow-updatesheets.js` | qseowUpdateSheetThumbnails           |
-| `src/lib/qseow/qseow-upload.js`       | qseowUploadToContentLibrary          |
-| `src/lib/util/cert.js`                | getCertFilePaths                     |
+| `src/lib/qseow/qseow-enigma.js` | readCert, createSocket |
+| `src/lib/qseow/qrs-response.js` | qrsGetList |
+| `src/lib/qseow/qseow-updatesheets.js` | qseowUpdateSheetThumbnails |
+| `src/lib/qseow/qseow-upload.js` | qseowUploadToContentLibrary |
+| `src/lib/util/cert.js` | getCertFilePaths |
 
 ## Entry Points
 
@@ -38,27 +38,27 @@ Start here when exploring this area:
 
 ## Key Symbols
 
-| Symbol                         | Type     | File                                  | Line |
-| ------------------------------ | -------- | ------------------------------------- | ---- |
-| `QseowError`                   | Class    | `src/lib/util/errors.js`              | 91   |
-| `CertError`                    | Class    | `src/lib/util/errors.js`              | 43   |
-| `qrsGetList`                   | Function | `src/lib/qseow/qrs-response.js`       | 28   |
-| `qseowProcessApp`              | Function | `src/lib/qseow/qseow-process-app.js`  | 162  |
-| `qseowUpdateSheetThumbnails`   | Function | `src/lib/qseow/qseow-updatesheets.js` | 33   |
-| `qseowUploadToContentLibrary`  | Function | `src/lib/qseow/qseow-upload.js`       | 32   |
-| `qseowVerifyCertificatesExist` | Function | `src/lib/qseow/qseow-certificates.js` | 49   |
-| `getCertFilePaths`             | Function | `src/lib/util/cert.js`                | 18   |
-| `createSocket`                 | Function | `src/lib/qseow/qseow-enigma.js`       | 76   |
-| `getSheetsTaggedWith`          | Function | `src/lib/qseow/qseow-process-app.js`  | 44   |
-| `exists`                       | Function | `src/lib/qseow/qseow-certificates.js` | 21   |
-| `readCert`                     | Function | `src/lib/qseow/qseow-enigma.js`       | 16   |
+| Symbol | Type | File | Line |
+|--------|------|------|------|
+| `QseowError` | Class | `src/lib/util/errors.js` | 91 |
+| `CertError` | Class | `src/lib/util/errors.js` | 43 |
+| `qrsGetList` | Function | `src/lib/qseow/qrs-response.js` | 28 |
+| `qseowProcessApp` | Function | `src/lib/qseow/qseow-process-app.js` | 162 |
+| `qseowUpdateSheetThumbnails` | Function | `src/lib/qseow/qseow-updatesheets.js` | 33 |
+| `qseowUploadToContentLibrary` | Function | `src/lib/qseow/qseow-upload.js` | 32 |
+| `qseowVerifyCertificatesExist` | Function | `src/lib/qseow/qseow-certificates.js` | 49 |
+| `getCertFilePaths` | Function | `src/lib/util/cert.js` | 18 |
+| `createSocket` | Function | `src/lib/qseow/qseow-enigma.js` | 76 |
+| `getSheetsTaggedWith` | Function | `src/lib/qseow/qseow-process-app.js` | 44 |
+| `exists` | Function | `src/lib/qseow/qseow-certificates.js` | 21 |
+| `readCert` | Function | `src/lib/qseow/qseow-enigma.js` | 16 |
 
 ## Connected Areas
 
-| Area    | Connections |
-| ------- | ----------- |
-| Cloud   | 2 calls     |
-| Browser | 1 calls     |
+| Area | Connections |
+|------|-------------|
+| Cloud | 2 calls |
+| Browser | 1 calls |
 
 ## How to Explore
 

--- a/.claude/skills/generated/util/SKILL.md
+++ b/.claude/skills/generated/util/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: util
-description: 'Skill for the Util area of butler-sheet-icons. 47 symbols across 13 files.'
+description: "Skill for the Util area of butler-sheet-icons. 47 symbols across 13 files."
 ---
 
 # Util
@@ -15,18 +15,18 @@ description: 'Skill for the Util area of butler-sheet-icons. 47 symbols across 1
 
 ## Key Files
 
-| File                                     | Symbols                                                                                     |
-| ---------------------------------------- | ------------------------------------------------------------------------------------------- |
-| `src/lib/util/fatal-handlers.js`         | toError, logFatalLine, exitOnce, armWatchdog, handleFatal (+5)                              |
-| `src/lib/util/crash-dump.js`             | envBool, parseMaxDumps, buildTimestampForFilename, sanitizeStackTrace, resolveCrashDir (+1) |
-| `src/lib/util/log-error.js`              | logErrorWithLevel, logError, logWarn, logInfo, logVerbose (+1)                              |
-| `src/lib/util/env-check.js`              | isMissing, present, toHex, formatSecret, checkEnv (+1)                                      |
-| `src/lib/util/redact-secrets.js`         | isSecretKey, isProseWord, redactValue, redactOptions, redactSensitivePatterns               |
-| `src/lib/util/errors.js`                 | BsiError, EnigmaError, CloudError                                                           |
-| `src/lib/util/sheet-list.js`             | isSessionLevelFailure, describeCloseEvent, runOverSheets                                    |
-| `src/globals.js`                         | sanitizeLogValue, sanitizeFormat                                                            |
-| `src/lib/util/error-categorizer.js`      | getErrorCategory, getErrorMetadata                                                          |
-| `src/lib/cloud/cloud-test-connection.js` | qscloudTestConnection                                                                       |
+| File | Symbols |
+|------|---------|
+| `src/lib/util/fatal-handlers.js` | toError, logFatalLine, exitOnce, armWatchdog, handleFatal (+5) |
+| `src/lib/util/crash-dump.js` | envBool, parseMaxDumps, buildTimestampForFilename, sanitizeStackTrace, resolveCrashDir (+1) |
+| `src/lib/util/log-error.js` | logErrorWithLevel, logError, logWarn, logInfo, logVerbose (+1) |
+| `src/lib/util/env-check.js` | isMissing, present, toHex, formatSecret, checkEnv (+1) |
+| `src/lib/util/redact-secrets.js` | isSecretKey, isProseWord, redactValue, redactOptions, redactSensitivePatterns |
+| `src/lib/util/errors.js` | BsiError, EnigmaError, CloudError |
+| `src/lib/util/sheet-list.js` | isSessionLevelFailure, describeCloseEvent, runOverSheets |
+| `src/globals.js` | sanitizeLogValue, sanitizeFormat |
+| `src/lib/util/error-categorizer.js` | getErrorCategory, getErrorMetadata |
+| `src/lib/cloud/cloud-test-connection.js` | qscloudTestConnection |
 
 ## Entry Points
 
@@ -40,49 +40,49 @@ Start here when exploring this area:
 
 ## Key Symbols
 
-| Symbol                    | Type     | File                                     | Line |
-| ------------------------- | -------- | ---------------------------------------- | ---- |
-| `BsiError`                | Class    | `src/lib/util/errors.js`                 | 26   |
-| `EnigmaError`             | Class    | `src/lib/util/errors.js`                 | 59   |
-| `CloudError`              | Class    | `src/lib/util/errors.js`                 | 75   |
-| `redactValue`             | Function | `src/lib/util/redact-secrets.js`         | 112  |
-| `redactOptions`           | Function | `src/lib/util/redact-secrets.js`         | 149  |
-| `redactSensitivePatterns` | Function | `src/lib/util/redact-secrets.js`         | 160  |
-| `onUncaughtException`     | Function | `src/lib/util/fatal-handlers.js`         | 277  |
-| `onUnhandledRejection`    | Function | `src/lib/util/fatal-handlers.js`         | 291  |
-| `qscloudTestConnection`   | Function | `src/lib/cloud/cloud-test-connection.js` | 31   |
-| `qscloudUploadToApp`      | Function | `src/lib/cloud/cloud-upload.js`          | 29   |
-| `getEnigmaSchema`         | Function | `src/lib/util/enigma-util.js`            | 45   |
-| `writeCrashDump`          | Function | `src/lib/util/crash-dump.js`             | 203  |
-| `logError`                | Function | `src/lib/util/log-error.js`              | 77   |
-| `logWarn`                 | Function | `src/lib/util/log-error.js`              | 88   |
-| `logInfo`                 | Function | `src/lib/util/log-error.js`              | 99   |
-| `logVerbose`              | Function | `src/lib/util/log-error.js`              | 110  |
-| `logDebug`                | Function | `src/lib/util/log-error.js`              | 121  |
-| `getErrorCategory`        | Function | `src/lib/util/error-categorizer.js`      | 32   |
-| `getErrorMetadata`        | Function | `src/lib/util/error-categorizer.js`      | 81   |
-| `isSessionLevelFailure`   | Function | `src/lib/util/sheet-list.js`             | 190  |
+| Symbol | Type | File | Line |
+|--------|------|------|------|
+| `BsiError` | Class | `src/lib/util/errors.js` | 26 |
+| `EnigmaError` | Class | `src/lib/util/errors.js` | 59 |
+| `CloudError` | Class | `src/lib/util/errors.js` | 75 |
+| `redactValue` | Function | `src/lib/util/redact-secrets.js` | 112 |
+| `redactOptions` | Function | `src/lib/util/redact-secrets.js` | 149 |
+| `redactSensitivePatterns` | Function | `src/lib/util/redact-secrets.js` | 160 |
+| `onUncaughtException` | Function | `src/lib/util/fatal-handlers.js` | 277 |
+| `onUnhandledRejection` | Function | `src/lib/util/fatal-handlers.js` | 291 |
+| `qscloudTestConnection` | Function | `src/lib/cloud/cloud-test-connection.js` | 31 |
+| `qscloudUploadToApp` | Function | `src/lib/cloud/cloud-upload.js` | 29 |
+| `getEnigmaSchema` | Function | `src/lib/util/enigma-util.js` | 45 |
+| `writeCrashDump` | Function | `src/lib/util/crash-dump.js` | 203 |
+| `logError` | Function | `src/lib/util/log-error.js` | 77 |
+| `logWarn` | Function | `src/lib/util/log-error.js` | 88 |
+| `logInfo` | Function | `src/lib/util/log-error.js` | 99 |
+| `logVerbose` | Function | `src/lib/util/log-error.js` | 110 |
+| `logDebug` | Function | `src/lib/util/log-error.js` | 121 |
+| `getErrorCategory` | Function | `src/lib/util/error-categorizer.js` | 32 |
+| `getErrorMetadata` | Function | `src/lib/util/error-categorizer.js` | 81 |
+| `isSessionLevelFailure` | Function | `src/lib/util/sheet-list.js` | 190 |
 
 ## Execution Flows
 
-| Flow                                       | Type            | Steps |
-| ------------------------------------------ | --------------- | ----- |
-| `OnUncaughtException → IsProseWord`        | cross_community | 5     |
-| `OnUnhandledRejection → IsProseWord`       | cross_community | 5     |
-| `BrowserListAvailable → GetErrorCategory`  | cross_community | 4     |
-| `BrowserListAvailable → MarkReported`      | cross_community | 4     |
-| `OnUncaughtException → ExitOnce`           | intra_community | 4     |
-| `OnUncaughtException → EnvBool`            | cross_community | 4     |
-| `OnUncaughtException → ParseMaxDumps`      | cross_community | 4     |
-| `OnUncaughtException → SanitizeStackTrace` | cross_community | 4     |
-| `OnUnhandledRejection → ExitOnce`          | intra_community | 4     |
-| `OnUnhandledRejection → EnvBool`           | cross_community | 4     |
+| Flow | Type | Steps |
+|------|------|-------|
+| `OnUncaughtException → IsProseWord` | cross_community | 5 |
+| `OnUnhandledRejection → IsProseWord` | cross_community | 5 |
+| `BrowserListAvailable → GetErrorCategory` | cross_community | 4 |
+| `BrowserListAvailable → MarkReported` | cross_community | 4 |
+| `OnUncaughtException → ExitOnce` | intra_community | 4 |
+| `OnUncaughtException → EnvBool` | cross_community | 4 |
+| `OnUncaughtException → ParseMaxDumps` | cross_community | 4 |
+| `OnUncaughtException → SanitizeStackTrace` | cross_community | 4 |
+| `OnUnhandledRejection → ExitOnce` | intra_community | 4 |
+| `OnUnhandledRejection → EnvBool` | cross_community | 4 |
 
 ## Connected Areas
 
-| Area    | Connections |
-| ------- | ----------- |
-| Browser | 2 calls     |
+| Area | Connections |
+|------|-------------|
+| Browser | 2 calls |
 
 ## How to Explore
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,7 @@ repos:
             files: '\.(js|json|ya?ml|md)$'
             exclude: |
                 (?x)^(
+                    .claude/skills/.*|
                     .github/.*|
                     CHANGELOG.md|
                     docs/.*|


### PR DESCRIPTION
Running `npm run gitnexus:refresh` after the recent merges produced a 239-line diff across six `SKILL.md` files. Reviewing it, **229 of those lines were formatting**, not content.

## What was happening

Everything under `.claude/skills/` is written by `gitnexus analyze`, and the generator and prettier disagree about how to format it:

| | generator | prettier |
|---|---|---|
| markdown tables | unpadded | padded to column width |
| frontmatter | `"double quoted"` | `'single quoted'` |

The pre-commit prettier hook matches `*.md` and excludes `.github/`, `CHANGELOG.md` and `docs/` — but not this tree. So the two rewrote each other in turn: a refresh reformatted the files, any commit touching them flipped them back, and the next refresh flipped them again.

The cost is not the churn itself but what it hides. The only real change in that 239-line diff was **line numbers for about ten symbols**, which had moved as imports were added — invisible among the padding.

## The change

Adds `.claude/skills/.*` to the hook's exclude list, making the generator authoritative for files it owns. Then commits the regenerated files, so what is checked in matches what the tool produces.

## Verified

Running `npm run gitnexus:refresh` twice now leaves the working tree **completely clean**, where before every run produced the same 239-line diff. Future refreshes will show only content that actually changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
