### PR TITLE
Harden QSEoW logout across Sense releases

### DIFF
--- a/docs/to-doc-site/qseow-2026-may-support.md
+++ b/docs/to-doc-site/qseow-2026-may-support.md
@@ -1,0 +1,31 @@
+# QSEoW 2026-May support and browser logout
+
+Butler Sheet Icons supports Qlik Sense Enterprise on Windows (QSEoW) 2026-May.
+
+The `qseow create-sheet-thumbnails` command now uses `2026-May` when `--sense-version` is not
+specified. This is the correct default for new QSEoW 2026-May installations.
+
+## Older Qlik Sense versions
+
+If your QSEoW server is older than 2026-May, set the version explicitly:
+
+```text
+butler-sheet-icons qseow create-sheet-thumbnails --sense-version 2025-Nov ...
+```
+
+The same setting can be supplied through the `BSI_QSEOW_CST_SENSE_VERSION` environment variable.
+
+## Logout after thumbnail creation
+
+After creating thumbnails, Butler Sheet Icons ends the Qlik Sense browser session through the Qlik
+Proxy Service. This does not depend on the position of the logout item in the Sense user menu, so
+changes to menu contents or user permissions are less likely to affect a run.
+
+If the proxy-session request is not accepted, Butler Sheet Icons falls back to the Qlik Sense hub
+user menu. It first looks for the stable logout hook and then tries the selector used by the
+configured Sense version for older hub layouts. A logout problem does not discard thumbnails that
+were already created; the browser and engine sessions are still closed and processing continues.
+
+If both logout methods fail, the log includes the configured Sense version and asks you to report
+the problem to `support@ptarmiganlabs.com` or through the Butler Sheet Icons issue tracker. Include
+the complete logout error and the Qlik Sense release and service-release information.

--- a/src/lib/commands/__tests__/commands.test.js
+++ b/src/lib/commands/__tests__/commands.test.js
@@ -3,6 +3,7 @@ import { Command, InvalidArgumentError } from 'commander';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { DEFAULT_QSEOW_SENSE_VERSION, QSEOW_SENSE_VERSIONS } from '../../qseow/qseow-selectors.js';
 
 // Root of the platform code that consumes CLI options, resolved from this file so the
 // option-name guard below does not depend on the working directory jest was started in.
@@ -351,6 +352,27 @@ describe('--browser-version defaults (issue #878)', () => {
         const opts = parseOptionInIsolation(build(), '--browser-version', ['']);
 
         expect(opts.browserVersion).toBe('recommended');
+    });
+});
+
+describe('--sense-version choices', () => {
+    test('uses the shared QSEoW version list and defaults to 2026-May', () => {
+        const option = thumbnailCommand(buildQseowCommand()).options.find(
+            (opt) => opt.long === '--sense-version'
+        );
+
+        expect(option.argChoices).toEqual(QSEOW_SENSE_VERSIONS);
+        expect(option.defaultValue).toBe(DEFAULT_QSEOW_SENSE_VERSION);
+    });
+
+    test.each(['2025-Nov', '2026-May'])('accepts %s explicitly', (senseVersion) => {
+        const opts = parseOptionInIsolation(
+            thumbnailCommand(buildQseowCommand()),
+            '--sense-version',
+            [senseVersion]
+        );
+
+        expect(opts.senseVersion).toBe(senseVersion);
     });
 });
 

--- a/src/lib/commands/qseow/index.js
+++ b/src/lib/commands/qseow/index.js
@@ -2,6 +2,7 @@ import { Command, Option } from 'commander';
 import { logger, appVersion } from '../../../globals.js';
 import { qseowCreateThumbnails } from '../../qseow/qseow-create-thumbnails.js';
 import { QSEOW_SHEET_PARTS } from '../../qseow/sheet-parts.js';
+import { DEFAULT_QSEOW_SENSE_VERSION, QSEOW_SENSE_VERSIONS } from '../../qseow/qseow-selectors.js';
 import {
     VERSION_RECOMMENDED,
     describeBrowserVersionOption,
@@ -321,20 +322,8 @@ const buildQseowCommand = () => {
         )
         .addOption(
             new Option('--sense-version <version>', 'Version of the QSEoW server to connect to')
-                .choices([
-                    'pre-2022-Nov',
-                    '2022-Nov',
-                    '2023-Feb',
-                    '2023-May',
-                    '2023-Aug',
-                    '2023-Nov',
-                    '2024-Feb',
-                    '2024-May',
-                    '2024-Nov',
-                    '2025-May',
-                    '2025-Nov',
-                ])
-                .default('2025-Nov')
+                .choices(QSEOW_SENSE_VERSIONS)
+                .default(DEFAULT_QSEOW_SENSE_VERSION)
                 .env('BSI_QSEOW_CST_SENSE_VERSION')
         )
         .addOption(

--- a/src/lib/qseow/__tests__/qseowCreateThumbnails_success.integration.test.js
+++ b/src/lib/qseow/__tests__/qseowCreateThumbnails_success.integration.test.js
@@ -1,8 +1,11 @@
 import { test, expect } from '@jest/globals';
 import 'dotenv/config';
+import winston from 'winston';
+import { Writable } from 'node:stream';
 
 import { qseowCreateThumbnails } from '../qseow-create-thumbnails.js';
 import { assertEnv, getTestTimeout } from '../../util/env-check.js';
+import { logger } from '../../../globals.js';
 
 const defaultTestTimeout = getTestTimeout(process.env);
 
@@ -83,8 +86,27 @@ test(
             ],
         });
 
-        const data = await qseowCreateThumbnails(options);
+        const capturedErrors = [];
+        const capture = new winston.transports.Stream({
+            level: 'error',
+            stream: new Writable({
+                write(chunk, _encoding, callback) {
+                    capturedErrors.push(String(chunk));
+                    callback();
+                },
+            }),
+        });
+        logger.add(capture);
+
+        let data;
+        try {
+            data = await qseowCreateThumbnails(options);
+        } finally {
+            logger.remove(capture);
+        }
+
         expect(data).toBe(true);
+        expect(capturedErrors.join('\n')).toBe('');
     },
     defaultTestTimeout
 );

--- a/src/lib/qseow/__tests__/qseow_logout.test.js
+++ b/src/lib/qseow/__tests__/qseow_logout.test.js
@@ -1,0 +1,190 @@
+import { describe, expect, jest, test } from '@jest/globals';
+
+const logger = {
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    verbose: jest.fn(),
+};
+const sleep = jest.fn().mockResolvedValue(undefined);
+
+jest.unstable_mockModule('../../../globals.js', () => ({ logger, sleep }));
+
+const { QSEOW_LOGOUT_API_TIMEOUT_MS, QSEOW_LOGOUT_BUTTON_SELECTOR, qseowLogout } =
+    await import('../qseow-logout.js');
+
+/**
+ * Builds a page mock for the API and hub logout paths.
+ *
+ * @returns {object} Puppeteer-shaped page mock.
+ */
+const buildPage = () => {
+    const userMenuButton = { click: jest.fn().mockResolvedValue(undefined) };
+    const logoutButton = { click: jest.fn().mockResolvedValue(undefined) };
+
+    return {
+        evaluate: jest.fn().mockResolvedValue(204),
+        goto: jest.fn().mockResolvedValue(undefined),
+        waitForSelector: jest.fn().mockResolvedValue(undefined),
+        $$: jest.fn().mockResolvedValueOnce([userMenuButton]).mockResolvedValueOnce([logoutButton]),
+        userMenuButton,
+        logoutButton,
+    };
+};
+
+const logoutOptions = {
+    prefix: '',
+    hubUrl: 'https://sense.example.com/form/hub',
+    pageTimeout: 90000,
+    pagewait: 0,
+    senseVersion: '2026-May',
+};
+const hubUserPageButton =
+    'xpath/.//*[@id="q-hub-toolbar"]/div[2]/div[5]/div/div/div/button/span/span';
+const legacyLogoutButton = 'xpath/.//*[@id="q-hub-menu-override"]/ng-transclude/ul/li[4]/span[2]';
+
+describe('qseowLogout', () => {
+    test('uses the QPS API and does not open the hub when it returns 204', async () => {
+        const page = buildPage();
+
+        await expect(qseowLogout(page, logoutOptions, hubUserPageButton)).resolves.toBe(true);
+
+        expect(page.evaluate).toHaveBeenCalledTimes(1);
+        const [evaluateFn, path, xrfKey, timeoutMs] = page.evaluate.mock.calls[0];
+        expect(path).toBe('/qps/user');
+        expect(xrfKey).toMatch(/^[a-f0-9]{16}$/);
+        expect(timeoutMs).toBe(QSEOW_LOGOUT_API_TIMEOUT_MS);
+        expect(page.goto).not.toHaveBeenCalled();
+        expect(logger.error).not.toHaveBeenCalled();
+
+        const fetchMock = jest.fn().mockResolvedValue({ status: 204 });
+        const previousFetch = globalThis.fetch;
+        globalThis.fetch = fetchMock;
+
+        try {
+            await evaluateFn(path, xrfKey, timeoutMs);
+        } finally {
+            globalThis.fetch = previousFetch;
+        }
+
+        expect(fetchMock).toHaveBeenCalledWith(`${path}?xrfkey=${xrfKey}`, {
+            method: 'DELETE',
+            credentials: 'same-origin',
+            headers: { 'X-Qlik-Xrfkey': xrfKey },
+            signal: expect.any(Object),
+        });
+    });
+
+    test('includes the virtual proxy prefix in the QPS API path', async () => {
+        const page = buildPage();
+
+        await qseowLogout(page, { ...logoutOptions, prefix: 'form' }, hubUserPageButton);
+
+        expect(page.evaluate.mock.calls[0][1]).toBe('/form/qps/user');
+    });
+
+    test('aborts a hung API request at the configured timeout and reaches the DOM fallback', async () => {
+        const page = buildPage();
+        const fetchMock = jest.fn().mockImplementation(
+            (_url, requestOptions) =>
+                new Promise((_resolve, reject) => {
+                    requestOptions.signal.addEventListener('abort', () => {
+                        const error = new Error('The operation was aborted');
+                        error.name = 'AbortError';
+                        reject(error);
+                    });
+                })
+        );
+        const previousFetch = globalThis.fetch;
+        globalThis.fetch = fetchMock;
+        page.evaluate.mockImplementation((evaluateFn, ...args) => evaluateFn(...args));
+        jest.useFakeTimers();
+
+        try {
+            const logoutPromise = qseowLogout(page, logoutOptions, hubUserPageButton);
+            await Promise.resolve();
+            jest.advanceTimersByTime(QSEOW_LOGOUT_API_TIMEOUT_MS);
+
+            await expect(logoutPromise).resolves.toBe(true);
+            expect(page.goto).toHaveBeenCalledWith(logoutOptions.hubUrl, {
+                waitUntil: 'networkidle2',
+                timeout: logoutOptions.pageTimeout,
+            });
+            expect(logger.info).toHaveBeenCalledWith(
+                expect.stringContaining('operation was aborted')
+            );
+        } finally {
+            jest.useRealTimers();
+            globalThis.fetch = previousFetch;
+        }
+    });
+
+    test('treats a navigation during the API request as a successful logout', async () => {
+        const page = buildPage();
+        page.evaluate.mockRejectedValue(
+            new Error('Execution context was destroyed, most likely because of a navigation.')
+        );
+
+        await expect(qseowLogout(page, logoutOptions, hubUserPageButton)).resolves.toBe(true);
+
+        expect(page.goto).not.toHaveBeenCalled();
+        expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    test('falls back to the stable hub logout selector after a non-204 API response', async () => {
+        const page = buildPage();
+        page.evaluate.mockResolvedValue(400);
+
+        await expect(qseowLogout(page, logoutOptions, hubUserPageButton)).resolves.toBe(true);
+
+        expect(page.goto).toHaveBeenCalledWith(logoutOptions.hubUrl, {
+            waitUntil: 'networkidle2',
+            timeout: logoutOptions.pageTimeout,
+        });
+        expect(page.waitForSelector).toHaveBeenNthCalledWith(1, hubUserPageButton, {
+            timeout: 15000,
+        });
+        expect(page.waitForSelector).toHaveBeenNthCalledWith(2, QSEOW_LOGOUT_BUTTON_SELECTOR, {
+            timeout: 15000,
+        });
+        expect(page.logoutButton.click).toHaveBeenCalledTimes(1);
+        expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('HTTP 400'));
+        expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    test('tries the legacy positional selector when the stable selector is unavailable', async () => {
+        const page = buildPage();
+        page.evaluate.mockResolvedValue(400);
+        page.waitForSelector
+            .mockResolvedValueOnce(undefined)
+            .mockRejectedValueOnce(new Error('stable selector missing'))
+            .mockResolvedValueOnce(undefined);
+
+        await expect(
+            qseowLogout(page, logoutOptions, hubUserPageButton, legacyLogoutButton)
+        ).resolves.toBe(true);
+
+        expect(page.waitForSelector).toHaveBeenNthCalledWith(3, legacyLogoutButton, {
+            timeout: 15000,
+        });
+        expect(page.logoutButton.click).toHaveBeenCalledTimes(1);
+        expect(logger.info).toHaveBeenCalledWith(
+            expect.stringContaining('Stable hub logout selector failed')
+        );
+        expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    test('reports both logout paths without throwing when the fallback also fails', async () => {
+        const page = buildPage();
+        page.evaluate.mockRejectedValue(new Error('QPS unavailable'));
+        page.goto.mockRejectedValue(new Error('hub unavailable'));
+
+        await expect(qseowLogout(page, logoutOptions, hubUserPageButton)).resolves.toBe(false);
+
+        const loggedErrors = logger.error.mock.calls.map(([message]) => String(message)).join('\n');
+        expect(loggedErrors).toContain("both the proxy session API and the hub's user menu failed");
+        expect(loggedErrors).toContain('--sense-version 2026-May');
+        expect(loggedErrors).toContain('support@ptarmiganlabs.com');
+        expect(logger.debug).toHaveBeenCalled();
+    });
+});

--- a/src/lib/qseow/__tests__/qseow_process_app.test.js
+++ b/src/lib/qseow/__tests__/qseow_process_app.test.js
@@ -67,6 +67,10 @@ const mockQseowUpdateSheets = jest.unstable_mockModule('../qseow-updatesheets.js
     qseowUpdateSheetThumbnails: jest.fn().mockResolvedValue(true),
 }));
 
+const mockQseowLogout = jest.unstable_mockModule('../qseow-logout.js', () => ({
+    qseowLogout: jest.fn().mockResolvedValue(true),
+}));
+
 const mockQseowQrs = jest.unstable_mockModule('../qseow-qrs.js', () => ({
     setupQseowQrsConnection: jest.fn().mockReturnValue({ host: 'test', cert: 'cert' }),
 }));
@@ -102,6 +106,7 @@ let determineSheetExcludeStatus;
 let Jimp;
 let qseowUploadToContentLibrary;
 let qseowUpdateSheetThumbnails;
+let qseowLogout;
 
 beforeAll(async () => {
     await Promise.all([
@@ -115,6 +120,7 @@ beforeAll(async () => {
         mockQseowEnigma,
         mockQseowUpload,
         mockQseowUpdateSheets,
+        mockQseowLogout,
         mockQseowQrs,
         mockBrowserInstall,
         mockBrowserDetect,
@@ -131,6 +137,7 @@ beforeAll(async () => {
     ({ Jimp } = await import('jimp'));
     ({ qseowUploadToContentLibrary } = await import('../qseow-upload.js'));
     ({ qseowUpdateSheetThumbnails } = await import('../qseow-updatesheets.js'));
+    ({ qseowLogout } = await import('../qseow-logout.js'));
     ({ qseowProcessApp } = await import('../qseow-process-app.js'));
 });
 
@@ -734,6 +741,37 @@ describe('qseow-process-app.js — puppeteer launch and click options', () => {
             await qseowProcessApp('test-app-id', defaultOptions);
 
             expect(browser.close).toHaveBeenCalledTimes(1);
+        });
+
+        test('uses the API-first logout flow with the configured hub and version selector', async () => {
+            const browser = setupHappyPath();
+
+            await qseowProcessApp('test-app-id', {
+                ...defaultOptions,
+                prefix: 'form',
+                senseVersion: '2026-May',
+            });
+
+            expect(qseowLogout).toHaveBeenCalledWith(
+                browser._page,
+                expect.objectContaining({
+                    prefix: 'form',
+                    hubUrl: 'https://test-server.example.com/form/hub',
+                    senseVersion: '2026-May',
+                }),
+                'xpath/.//*[@id="q-hub-toolbar"]/div[2]/div[5]/div/div/div/button/span/span',
+                'xpath/.//*[@id="q-hub-menu-override"]/ng-transclude/ul/li[4]/span[2]'
+            );
+        });
+
+        test('continues uploading and updating when logout cannot be completed', async () => {
+            setupHappyPath();
+            qseowLogout.mockResolvedValueOnce(false);
+
+            await qseowProcessApp('test-app-id', defaultOptions);
+
+            expect(qseowUploadToContentLibrary).toHaveBeenCalledTimes(1);
+            expect(qseowUpdateSheetThumbnails).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/src/lib/qseow/__tests__/qseow_selectors.test.js
+++ b/src/lib/qseow/__tests__/qseow_selectors.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, test } from '@jest/globals';
+
+import {
+    DEFAULT_QSEOW_SENSE_VERSION,
+    QSEOW_SENSE_VERSIONS,
+    getQseowHubSelectors,
+} from '../qseow-selectors.js';
+
+describe('QSEoW Sense-version selectors', () => {
+    test('has a hub user-menu selector for every supported Sense version', () => {
+        for (const senseVersion of QSEOW_SENSE_VERSIONS) {
+            const selectors = getQseowHubSelectors(senseVersion);
+
+            expect(selectors.userMenuButton).toEqual(expect.stringContaining('xpath/'));
+            expect(selectors.legacyLogoutButton).toEqual(expect.stringContaining('xpath/'));
+        }
+    });
+
+    test('uses 2026-May as the default and maps it to the modern hub toolbar', () => {
+        expect(DEFAULT_QSEOW_SENSE_VERSION).toBe('2026-May');
+        const selectors = getQseowHubSelectors('2026-May');
+
+        expect(selectors.userMenuButton).toContain('q-hub-toolbar');
+        expect(selectors.legacyLogoutButton).toContain('/li[4]/span[2]');
+    });
+
+    test('returns undefined for an unsupported Sense version', () => {
+        expect(getQseowHubSelectors('2030-Nov')).toBeUndefined();
+    });
+});

--- a/src/lib/qseow/qseow-logout.js
+++ b/src/lib/qseow/qseow-logout.js
@@ -1,0 +1,187 @@
+import crypto from 'node:crypto';
+
+import { logger, sleep } from '../../globals.js';
+
+/** The stable selector for the Qlik Sense hub logout item. */
+export const QSEOW_LOGOUT_BUTTON_SELECTOR =
+    'xpath/.//*[@id="q-hub-menu-override"]//li[@tid="globalmenu-logout"]/span[2]';
+
+/** Maximum time allowed for the browser-side QPS logout request. */
+export const QSEOW_LOGOUT_API_TIMEOUT_MS = 30000;
+
+const FALLBACK_SELECTOR_TIMEOUT = 15000;
+const DEFAULT_PAGE_TIMEOUT = 90000;
+
+/**
+ * Builds the Qlik Proxy Service session endpoint for a virtual proxy.
+ *
+ * @param {string} [prefix] - Qlik Sense virtual proxy prefix.
+ *
+ * @returns {string} Relative QPS user-session path.
+ */
+const qpsUserPath = (prefix) => (prefix ? `/${prefix}/qps/user` : '/qps/user');
+
+/**
+ * Deletes the authenticated proxy session without depending on the Sense web client's DOM.
+ *
+ * @param {object} page - Puppeteer page holding the authenticated session.
+ * @param {string} [prefix] - Qlik Sense virtual proxy prefix.
+ * @param {number} timeoutMs - Maximum time to wait for the QPS response.
+ *
+ * @returns {Promise<number>} HTTP status returned by the QPS session endpoint.
+ */
+const logoutViaApi = async (page, prefix, timeoutMs) => {
+    // QPS requires an xrfkey of exactly 16 characters, repeated in the header.
+    const xrfKey = crypto.randomBytes(8).toString('hex');
+    const path = qpsUserPath(prefix);
+
+    return page.evaluate(
+        async (logoutPath, key, requestTimeoutMs) => {
+            const controller = new AbortController();
+            const timeoutId = setTimeout(() => controller.abort(), requestTimeoutMs);
+
+            try {
+                const response = await fetch(`${logoutPath}?xrfkey=${key}`, {
+                    method: 'DELETE',
+                    credentials: 'same-origin',
+                    headers: { 'X-Qlik-Xrfkey': key },
+                    signal: controller.signal,
+                });
+
+                return response.status;
+            } finally {
+                clearTimeout(timeoutId);
+            }
+        },
+        path,
+        xrfKey,
+        timeoutMs
+    );
+};
+
+/**
+ * Logs out through the hub UI when the proxy session API cannot do so.
+ *
+ * @param {object} page - Puppeteer page holding the authenticated session.
+ * @param {object} logoutOptions - Logout options.
+ * @param {string} logoutOptions.hubUrl - URL of the Qlik Sense hub.
+ * @param {number} logoutOptions.pageTimeout - Navigation timeout in milliseconds.
+ * @param {number|string} logoutOptions.pagewait - Delay between browser actions in seconds.
+ * @param {string} xpathHubUserPageButton - Version-specific user-menu button selector.
+ * @param {string} legacyLogoutButton - Version-specific positional logout selector.
+ *
+ * @returns {Promise<void>} Resolves after the hub logout action has been clicked.
+ */
+const logoutViaHub = async (page, logoutOptions, xpathHubUserPageButton, legacyLogoutButton) => {
+    const pageTimeout =
+        logoutOptions.pageTimeout > 0 ? logoutOptions.pageTimeout : DEFAULT_PAGE_TIMEOUT;
+    const pagewait = Number(logoutOptions.pagewait) > 0 ? Number(logoutOptions.pagewait) * 1000 : 0;
+
+    await page.goto(logoutOptions.hubUrl, {
+        waitUntil: 'networkidle2',
+        timeout: pageTimeout,
+    });
+
+    await page.waitForSelector(xpathHubUserPageButton, {
+        timeout: FALLBACK_SELECTOR_TIMEOUT,
+    });
+    const [userMenuButton] = await page.$$(xpathHubUserPageButton);
+
+    await sleep(pagewait);
+    await userMenuButton.click();
+
+    try {
+        await page.waitForSelector(QSEOW_LOGOUT_BUTTON_SELECTOR, {
+            timeout: FALLBACK_SELECTOR_TIMEOUT,
+        });
+        const [logoutButton] = await page.$$(QSEOW_LOGOUT_BUTTON_SELECTOR);
+
+        await sleep(pagewait);
+        await logoutButton.click();
+        await sleep(pagewait);
+        return;
+    } catch (err) {
+        logger.info(
+            `QSEOW: Stable hub logout selector failed: ${err?.message ?? err}; trying the legacy selector`
+        );
+        logger.debug(`QSEOW: Stable hub logout selector failure: ${err?.stack ?? err}`);
+    }
+
+    await page.waitForSelector(legacyLogoutButton, {
+        timeout: FALLBACK_SELECTOR_TIMEOUT,
+    });
+    const [legacyLogout] = await page.$$(legacyLogoutButton);
+
+    await sleep(pagewait);
+    await legacyLogout.click();
+    await sleep(pagewait);
+};
+
+/**
+ * Ends the authenticated QSEoW browser session.
+ *
+ * The QPS API is preferred because it is independent of Sense web-client markup and of the
+ * logged-in user's menu contents. The DOM path remains as a compatibility fallback for virtual
+ * proxies or authentication modes where the browser-side DELETE is not accepted.
+ *
+ * @param {object} page - Puppeteer page holding the authenticated session.
+ * @param {object} options - Logout options.
+ * @param {string} [options.prefix] - Qlik Sense virtual proxy prefix.
+ * @param {string} options.hubUrl - URL of the Qlik Sense hub.
+ * @param {number} options.pageTimeout - Navigation timeout in milliseconds.
+ * @param {number|string} options.pagewait - Delay between browser actions in seconds.
+ * @param {string} options.senseVersion - Configured Qlik Sense release label.
+ * @param {string} xpathHubUserPageButton - Version-specific user-menu button selector.
+ * @param {string} legacyLogoutButton - Version-specific positional logout selector.
+ *
+ * @returns {Promise<boolean>} `true` when either logout path succeeds, otherwise `false`. Logout
+ *     failure is nonfatal because thumbnail processing has already completed and the caller must
+ *     still close the browser and release the engine session.
+ */
+export const qseowLogout = async (page, options, xpathHubUserPageButton, legacyLogoutButton) => {
+    let apiStatus;
+
+    try {
+        apiStatus = await logoutViaApi(page, options.prefix, QSEOW_LOGOUT_API_TIMEOUT_MS);
+        if (apiStatus === 204) {
+            logger.verbose(`QSEOW: Logged out via QPS session API`);
+            return true;
+        }
+
+        logger.info(`QSEOW: QPS logout returned HTTP ${apiStatus}, falling back to hub UI`);
+    } catch (err) {
+        if (err?.message?.includes('Execution context was destroyed')) {
+            // Deleting the QPS session can cause the authenticated Sense page to redirect or unload
+            // before the browser-side fetch promise can return its 204 status. At this point the
+            // page navigation is the result of the logout, not a reason to try the now-invalid
+            // hub session again.
+            logger.verbose(`QSEOW: QPS logout triggered a browser navigation`);
+            return true;
+        }
+
+        logger.info(`QSEOW: QPS logout failed: ${err?.message ?? err}; falling back to hub UI`);
+        logger.debug(`QSEOW: QPS logout failure: ${err?.stack ?? err}`);
+    }
+
+    try {
+        await logoutViaHub(page, options, xpathHubUserPageButton, legacyLogoutButton);
+        logger.verbose(`QSEOW: Logged out through the hub user menu`);
+        return true;
+    } catch (hubError) {
+        logger.info(`QSEOW: Legacy hub logout fallback failed: ${hubError?.message ?? hubError}`);
+        logger.debug(`QSEOW: Legacy hub logout fallback failure: ${hubError?.stack ?? hubError}`);
+        logger.error(
+            `QSEOW: Could not log out of Qlik Sense - both the proxy session API and the hub's user menu failed.`
+        );
+        logger.error(
+            `QSEOW: This usually means the Qlik Sense web client or proxy has changed and Butler Sheet Icons needs updating. You ran with --sense-version ${options.senseVersion}.`
+        );
+        logger.error(
+            `QSEOW: Thumbnail generation completed, but logout was skipped. Processing will continue; if upload and sheet updates complete, only logout will have failed.`
+        );
+        logger.error(
+            `QSEOW: Please report this to support@ptarmiganlabs.com or https://github.com/ptarmiganlabs/butler-sheet-icons/issues/new, including the Qlik Sense version and --sense-version value.`
+        );
+        return false;
+    }
+};

--- a/src/lib/qseow/qseow-process-app.js
+++ b/src/lib/qseow/qseow-process-app.js
@@ -19,6 +19,8 @@ import { createAppImageDir } from '../util/image-dir.js';
 import { qrsFilterAnyOf, qrsPathWithFilter, toFilterValueList } from './qrs-filter.js';
 import { qrsGetList } from './qrs-response.js';
 import { QSEOW_SHEET_PART_SELECTORS } from './sheet-parts.js';
+import { qseowLogout } from './qseow-logout.js';
+import { getQseowHubSelectors } from './qseow-selectors.js';
 
 /**
  * Looks up the sheets in an app that carry any of the supplied tags.
@@ -83,55 +85,6 @@ const selectorLoginPageUserName = '#username-input';
 const selectorLoginPageUserPwd = '#password-input';
 const selectorLoginPageLoginButton = '#loginbtn';
 
-const xpathHubUserPageButtonPre2022Nov = 'xpath/.//*[@id="hub-sidebar"]/div[1]/div[1]/div/div/div';
-const xpathLogoutButtonPre2022Nov =
-    'xpath/.//*[@id="q-hub-user-popover-override"]/ng-transclude/div[2]/button';
-
-const xpathHubUserPageButton2022Nov =
-    'xpath/.//*[@id="q-hub-toolbar"]/header/div/div[5]/div/div/div/button';
-const xpathLogoutButton2022Nov =
-    'xpath/.//*[@id="q-hub-menu-override"]/ng-transclude/ul/li[6]/span[2]';
-
-const xpathHubUserPageButton2023Feb =
-    'xpath/.//*[@id="q-hub-toolbar"]/header/div/div[5]/div/div/div/button/span/span';
-const xpathLogoutButton2023Feb =
-    'xpath/.//*[@id="q-hub-menu-override"]/ng-transclude/ul/li[5]/span[2]';
-
-const xpathHubUserPageButton2023May =
-    'xpath/.//*[@id="q-hub-toolbar"]/div[2]/div[5]/div/div/div/button/span/span';
-const xpathLogoutButton2023May =
-    'xpath/.//*[@id="q-hub-menu-override"]/ng-transclude/ul/li[6]/span[2]';
-
-const xpathHubUserPageButton2023Aug =
-    'xpath/.//*[@id="q-hub-toolbar"]/div[2]/div[5]/div/div/div/button/span/span';
-const xpathLogoutButton2023Aug =
-    'xpath/.//*[@id="q-hub-menu-override"]/ng-transclude/ul/li[6]/span[2]';
-
-const xpathHubUserPageButton2023Nov =
-    'xpath/.//*[@id="q-hub-toolbar"]/div[2]/div[5]/div/div/div/button/span/span';
-const xpathLogoutButton2023Nov =
-    'xpath/.//*[@id="q-hub-menu-override"]/ng-transclude/ul/li[6]/span[2]';
-
-const xpathHubUserPageButton2024Feb =
-    'xpath/.//*[@id="q-hub-toolbar"]/div[2]/div[5]/div/div/div/button/span/span';
-const xpathLogoutButton2024Feb =
-    'xpath/.//*[@id="q-hub-menu-override"]/ng-transclude/ul/li[6]/span[2]';
-
-const xpathHubUserPageButton2024Nov =
-    'xpath/.//*[@id="q-hub-toolbar"]/div[2]/div[5]/div/div/div/button/span/span';
-const xpathLogoutButton2024Nov =
-    'xpath/.//*[@id="q-hub-menu-override"]/ng-transclude/ul/li[6]/span[2]';
-
-const xpathHubUserPageButton2025May =
-    'xpath/.//*[@id="q-hub-toolbar"]/div[2]/div[5]/div/div/div/button/span/span';
-const xpathLogoutButton2025May =
-    'xpath/.//*[@id="q-hub-menu-override"]/ng-transclude/ul/li[4]/span[2]';
-
-const xpathHubUserPageButton2025Nov =
-    'xpath/.//*[@id="q-hub-toolbar"]/div[2]/div[5]/div/div/div/button/span/span';
-const xpathLogoutButton2025Nov =
-    'xpath/.//*[@id="q-hub-menu-override"]/ng-transclude/ul/li[5]/span[2]';
-
 /**
  * Processes a Qlik Sense Enterprise on Windows (QSEoW) application to generate
  * and manage thumbnails for app sheets. It handles browser setup, logging in,
@@ -167,50 +120,16 @@ export const qseowProcessApp = async (appId, options) => {
         pageTimeout = options.browserPageTimeout * 1000; // Convert to milliseconds
     }
 
-    // Get correct XPaths to UI elements (user menu, logout button etc) in the Sense web UI
-    // As Qlik update their Sense web client these xpaths may/will change.
-    let xpathHubUserPageButton;
-    let xpathLogoutButton;
-
-    if (options.senseVersion === 'pre-2022-Nov') {
-        xpathHubUserPageButton = xpathHubUserPageButtonPre2022Nov;
-        xpathLogoutButton = xpathLogoutButtonPre2022Nov;
-    } else if (options.senseVersion === '2022-Nov') {
-        xpathHubUserPageButton = xpathHubUserPageButton2022Nov;
-        xpathLogoutButton = xpathLogoutButton2022Nov;
-    } else if (options.senseVersion === '2023-Feb') {
-        xpathHubUserPageButton = xpathHubUserPageButton2023Feb;
-        xpathLogoutButton = xpathLogoutButton2023Feb;
-    } else if (options.senseVersion === '2023-May') {
-        xpathHubUserPageButton = xpathHubUserPageButton2023May;
-        xpathLogoutButton = xpathLogoutButton2023May;
-    } else if (options.senseVersion === '2023-Aug') {
-        xpathHubUserPageButton = xpathHubUserPageButton2023Aug;
-        xpathLogoutButton = xpathLogoutButton2023Aug;
-    } else if (options.senseVersion === '2023-Nov') {
-        xpathHubUserPageButton = xpathHubUserPageButton2023Nov;
-        xpathLogoutButton = xpathLogoutButton2023Nov;
-    } else if (options.senseVersion === '2024-Feb') {
-        xpathHubUserPageButton = xpathHubUserPageButton2024Feb;
-        xpathLogoutButton = xpathLogoutButton2024Feb;
-    } else if (options.senseVersion === '2024-May') {
-        xpathHubUserPageButton = xpathHubUserPageButton2024Feb;
-        xpathLogoutButton = xpathLogoutButton2024Feb;
-    } else if (options.senseVersion === '2024-Nov') {
-        xpathHubUserPageButton = xpathHubUserPageButton2024Nov;
-        xpathLogoutButton = xpathLogoutButton2024Nov;
-    } else if (options.senseVersion === '2025-May') {
-        xpathHubUserPageButton = xpathHubUserPageButton2025May;
-        xpathLogoutButton = xpathLogoutButton2025May;
-    } else if (options.senseVersion === '2025-Nov') {
-        xpathHubUserPageButton = xpathHubUserPageButton2025Nov;
-        xpathLogoutButton = xpathLogoutButton2025Nov;
-    } else {
+    // The version-specific user-menu selector is only needed if the API logout fallback runs. The
+    // logout item itself is selected by its stable `tid`, not by its position in the menu.
+    const hubSelectors = getQseowHubSelectors(options.senseVersion);
+    if (!hubSelectors) {
         logger.error(
             `CREATE QSEoW THUMBNAILS: Invalid Sense version specified as parameter when starting Butler Sheet Icons: "${options.senseVersion}"`
         );
         throw new QseowError(`Invalid QSEoW Sense version specified: ${options.senseVersion}`);
     }
+    const { userMenuButton: xpathHubUserPageButton, legacyLogoutButton } = hubSelectors;
 
     // Create image directory for this app
     let blurFailures = 0;
@@ -539,86 +458,23 @@ export const qseowProcessApp = async (appId, options) => {
                             iSheetNum += 1;
                         }
 
-                        logger.verbose(
-                            `QSEoW APP: Done creating thumbnails. Opening hub at ${hubUrl}`
+                        logger.verbose(`QSEoW APP: Done creating thumbnails`);
+
+                        // The API path avoids a version- and privilege-dependent hub menu. The
+                        // fallback remains available for virtual proxies or authentication modes
+                        // that do not accept the browser-side QPS DELETE.
+                        await qseowLogout(
+                            page,
+                            {
+                                prefix: options.prefix,
+                                hubUrl,
+                                pageTimeout,
+                                pagewait: options.pagewait,
+                                senseVersion: options.senseVersion,
+                            },
+                            xpathHubUserPageButton,
+                            legacyLogoutButton
                         );
-
-                        try {
-                            // Log out
-                            await Promise.all([
-                                page.goto(hubUrl, {
-                                    waitUntil: 'networkidle2',
-                                    timeout: pageTimeout,
-                                }),
-                            ]);
-                        } catch (err) {
-                            if (err.stack) {
-                                logger.error(
-                                    `QSEOW: Could not open hub after generating thumbnail images (stack): ${err.stack}`
-                                );
-                            } else if (err.message) {
-                                logger.error(
-                                    `QSEOW: Could not open hub after generating thumbnail images (message): ${err.message}`
-                                );
-                            } else {
-                                logger.error(
-                                    `QSEOW: Could not open hub after generating thumbnail images: ${err}`
-                                );
-                            }
-                        }
-
-                        let elementHandle;
-                        try {
-                            // wait for user button to become visible, then click it to open the user menu
-                            await page.waitForSelector(xpathHubUserPageButton);
-                            // evaluate XPath expression of the target selector (it returns array of ElementHandle)
-                            elementHandle = await page.$$(xpathHubUserPageButton);
-
-                            await sleep(options.pagewait * 1000);
-
-                            // Click user button and wait for page to load
-                            await Promise.all([elementHandle[0].click()]);
-                        } catch (err) {
-                            if (err.stack) {
-                                logger.error(
-                                    `QSEOW: Error waiting for, or clicking, user button in hub default view (stack): ${err.stack}`
-                                );
-                            } else if (err.message) {
-                                logger.error(
-                                    `QSEOW: Error waiting for, or clicking, user button in hub default view (message): ${err.message}`
-                                );
-                            } else {
-                                logger.error(
-                                    `QSEOW: Error waiting for, or clicking, user button in hub default view: ${err}`
-                                );
-                            }
-                        }
-
-                        try {
-                            // Wait for logout button to become visible, then click it
-                            await page.waitForSelector(xpathLogoutButton);
-                            elementHandle = await page.$$(xpathLogoutButton);
-
-                            await sleep(options.pagewait * 1000);
-
-                            // Click logout button and wait for page to load
-                            await Promise.all([elementHandle[0].click()]);
-                            await sleep(options.pagewait * 1000);
-                        } catch (err) {
-                            if (err.stack) {
-                                logger.error(
-                                    `QSEOW: Error while waiting for, or clicking, logout button in hub's user menu (stack): ${err.stack}`
-                                );
-                            } else if (err.message) {
-                                logger.error(
-                                    `QSEOW: Error while waiting for, or clicking, logout button in hub's user menu (message): ${err.message}`
-                                );
-                            } else {
-                                logger.error(
-                                    `QSEOW: Error while waiting for, or clicking, logout button in hub's user menu: ${err}`
-                                );
-                            }
-                        }
                     } finally {
                         await closeBrowserQuietly(browser, 'QSEOW');
                     }

--- a/src/lib/qseow/qseow-selectors.js
+++ b/src/lib/qseow/qseow-selectors.js
@@ -1,0 +1,106 @@
+/**
+ * Sense release labels accepted by the QSEoW thumbnail command.
+ *
+ * Keep this list beside the selector map so a new release cannot be accepted by Commander without
+ * also having a browser selector for the logout fallback.
+ */
+export const QSEOW_SENSE_VERSIONS = Object.freeze([
+    'pre-2022-Nov',
+    '2022-Nov',
+    '2023-Feb',
+    '2023-May',
+    '2023-Aug',
+    '2023-Nov',
+    '2024-Feb',
+    '2024-May',
+    '2024-Nov',
+    '2025-May',
+    '2025-Nov',
+    '2026-May',
+]);
+
+/** The release used when no Sense version is specified. */
+export const DEFAULT_QSEOW_SENSE_VERSION = '2026-May';
+
+const HUB_USER_PAGE_BUTTON_PRE_2022_NOV = 'xpath/.//*[@id="hub-sidebar"]/div[1]/div[1]/div/div/div';
+const HUB_USER_PAGE_BUTTON_2022_NOV =
+    'xpath/.//*[@id="q-hub-toolbar"]/header/div/div[5]/div/div/div/button';
+const HUB_USER_PAGE_BUTTON_2023_FEB =
+    'xpath/.//*[@id="q-hub-toolbar"]/header/div/div[5]/div/div/div/button/span/span';
+const HUB_USER_PAGE_BUTTON_MODERN =
+    'xpath/.//*[@id="q-hub-toolbar"]/div[2]/div[5]/div/div/div/button/span/span';
+
+const HUB_LOGOUT_BUTTON_PRE_2022_NOV =
+    'xpath/.//*[@id="q-hub-user-popover-override"]/ng-transclude/div[2]/button';
+const HUB_LOGOUT_BUTTON_2022_NOV =
+    'xpath/.//*[@id="q-hub-menu-override"]/ng-transclude/ul/li[6]/span[2]';
+const HUB_LOGOUT_BUTTON_2023_FEB =
+    'xpath/.//*[@id="q-hub-menu-override"]/ng-transclude/ul/li[5]/span[2]';
+const HUB_LOGOUT_BUTTON_2023_MAY =
+    'xpath/.//*[@id="q-hub-menu-override"]/ng-transclude/ul/li[6]/span[2]';
+const HUB_LOGOUT_BUTTON_2025_MAY =
+    'xpath/.//*[@id="q-hub-menu-override"]/ng-transclude/ul/li[4]/span[2]';
+const HUB_LOGOUT_BUTTON_2025_NOV =
+    'xpath/.//*[@id="q-hub-menu-override"]/ng-transclude/ul/li[5]/span[2]';
+
+const HUB_SELECTORS_BY_SENSE_VERSION = Object.freeze({
+    'pre-2022-Nov': {
+        userMenuButton: HUB_USER_PAGE_BUTTON_PRE_2022_NOV,
+        legacyLogoutButton: HUB_LOGOUT_BUTTON_PRE_2022_NOV,
+    },
+    '2022-Nov': {
+        userMenuButton: HUB_USER_PAGE_BUTTON_2022_NOV,
+        legacyLogoutButton: HUB_LOGOUT_BUTTON_2022_NOV,
+    },
+    '2023-Feb': {
+        userMenuButton: HUB_USER_PAGE_BUTTON_2023_FEB,
+        legacyLogoutButton: HUB_LOGOUT_BUTTON_2023_FEB,
+    },
+    '2023-May': {
+        userMenuButton: HUB_USER_PAGE_BUTTON_MODERN,
+        legacyLogoutButton: HUB_LOGOUT_BUTTON_2023_MAY,
+    },
+    '2023-Aug': {
+        userMenuButton: HUB_USER_PAGE_BUTTON_MODERN,
+        legacyLogoutButton: HUB_LOGOUT_BUTTON_2023_MAY,
+    },
+    '2023-Nov': {
+        userMenuButton: HUB_USER_PAGE_BUTTON_MODERN,
+        legacyLogoutButton: HUB_LOGOUT_BUTTON_2023_MAY,
+    },
+    '2024-Feb': {
+        userMenuButton: HUB_USER_PAGE_BUTTON_MODERN,
+        legacyLogoutButton: HUB_LOGOUT_BUTTON_2023_MAY,
+    },
+    '2024-May': {
+        userMenuButton: HUB_USER_PAGE_BUTTON_MODERN,
+        legacyLogoutButton: HUB_LOGOUT_BUTTON_2023_MAY,
+    },
+    '2024-Nov': {
+        userMenuButton: HUB_USER_PAGE_BUTTON_MODERN,
+        legacyLogoutButton: HUB_LOGOUT_BUTTON_2023_MAY,
+    },
+    '2025-May': {
+        userMenuButton: HUB_USER_PAGE_BUTTON_MODERN,
+        legacyLogoutButton: HUB_LOGOUT_BUTTON_2025_MAY,
+    },
+    '2025-Nov': {
+        userMenuButton: HUB_USER_PAGE_BUTTON_MODERN,
+        legacyLogoutButton: HUB_LOGOUT_BUTTON_2025_NOV,
+    },
+    '2026-May': {
+        userMenuButton: HUB_USER_PAGE_BUTTON_MODERN,
+        // The 2026-May server verified for #883 has the same four-item menu as 2025-May.
+        legacyLogoutButton: HUB_LOGOUT_BUTTON_2025_MAY,
+    },
+});
+
+/**
+ * Returns the hub selectors for a QSEoW Sense release.
+ *
+ * @param {string} senseVersion - Qlik Sense release label.
+ *
+ * @returns {{userMenuButton: string, legacyLogoutButton: string}|undefined} Hub selectors, or
+ *     `undefined` for an unsupported release.
+ */
+export const getQseowHubSelectors = (senseVersion) => HUB_SELECTORS_BY_SENSE_VERSION[senseVersion];


### PR DESCRIPTION
## Summary
- fix QSEoW logout for Sense 2026-May with API-first QPS session deletion
- bound stalled logout requests to 30 seconds and report fallback causes at info level
- preserve version-specific legacy logout selectors after the stable `tid` selector
- make `2026-May` the default Sense version and document the behavior

## Verification
- `npm run lint:fix`
- `npm run test:unit` (79 suites, 1,582 tests)
- focused logout/selector/process/command tests (205 tests)
- QSEoW failure integration tests (6 tests)
- live QSEoW 2026-May success integration test

Fixes #883