### PR TITLE
Cover multi-app selection in the integration tests

### DIFF
--- a/.claude/skills/generated/cloud/SKILL.md
+++ b/.claude/skills/generated/cloud/SKILL.md
@@ -5,7 +5,7 @@ description: "Skill for the Cloud area of butler-sheet-icons. 17 symbols across 
 
 # Cloud
 
-17 symbols | 12 files | Cohesion: 79%
+17 symbols | 12 files | Cohesion: 77%
 
 ## When to Use
 
@@ -66,6 +66,7 @@ Start here when exploring this area:
 |------|------|-------|
 | `ProcessCloudApp → Sleep` | intra_community | 3 |
 | `QscloudRemoveSheetIcons → AssertAllProcessed` | intra_community | 3 |
+| `QseowLogout → Sleep` | cross_community | 3 |
 | `QseowRemoveSheetIcons → AssertAllProcessed` | intra_community | 3 |
 | `QlikSaas → BufferToStream` | intra_community | 3 |
 | `QlikSaas → MakeRequest` | intra_community | 3 |

--- a/.claude/skills/generated/qscloud/SKILL.md
+++ b/.claude/skills/generated/qscloud/SKILL.md
@@ -44,7 +44,7 @@ Start here when exploring this area:
 | `buildQscloudCommand` | Function | `src/lib/commands/qscloud/index.js` | 10 |
 | `buildCloudListCollectionsCommand` | Function | `src/lib/commands/qscloud/list-collections.js` | 24 |
 | `buildCloudRemoveSheetIconsCommand` | Function | `src/lib/commands/qscloud/remove-sheet-icons.js` | 25 |
-| `buildQseowCommand` | Function | `src/lib/commands/qseow/index.js` | 35 |
+| `buildQseowCommand` | Function | `src/lib/commands/qseow/index.js` | 36 |
 
 ## Execution Flows
 

--- a/.claude/skills/generated/qseow/SKILL.md
+++ b/.claude/skills/generated/qseow/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: qseow
-description: "Skill for the Qseow area of butler-sheet-icons. 12 symbols across 8 files."
+description: "Skill for the Qseow area of butler-sheet-icons. 16 symbols across 9 files."
 ---
 
 # Qseow
 
-12 symbols | 8 files | Cohesion: 81%
+16 symbols | 9 files | Cohesion: 82%
 
 ## When to Use
 
@@ -17,6 +17,7 @@ description: "Skill for the Qseow area of butler-sheet-icons. 12 symbols across 
 
 | File | Symbols |
 |------|---------|
+| `src/lib/qseow/qseow-logout.js` | qpsUserPath, logoutViaApi, logoutViaHub, qseowLogout |
 | `src/lib/qseow/qseow-process-app.js` | getSheetsTaggedWith, qseowProcessApp |
 | `src/lib/util/errors.js` | QseowError, CertError |
 | `src/lib/qseow/qseow-certificates.js` | exists, qseowVerifyCertificatesExist |
@@ -31,7 +32,7 @@ description: "Skill for the Qseow area of butler-sheet-icons. 12 symbols across 
 Start here when exploring this area:
 
 - **`qrsGetList`** (Function) — `src/lib/qseow/qrs-response.js:28`
-- **`qseowProcessApp`** (Function) — `src/lib/qseow/qseow-process-app.js:162`
+- **`qseowProcessApp`** (Function) — `src/lib/qseow/qseow-process-app.js:115`
 - **`qseowUpdateSheetThumbnails`** (Function) — `src/lib/qseow/qseow-updatesheets.js:33`
 - **`qseowUploadToContentLibrary`** (Function) — `src/lib/qseow/qseow-upload.js:32`
 - **`qseowVerifyCertificatesExist`** (Function) — `src/lib/qseow/qseow-certificates.js:49`
@@ -43,21 +44,32 @@ Start here when exploring this area:
 | `QseowError` | Class | `src/lib/util/errors.js` | 91 |
 | `CertError` | Class | `src/lib/util/errors.js` | 43 |
 | `qrsGetList` | Function | `src/lib/qseow/qrs-response.js` | 28 |
-| `qseowProcessApp` | Function | `src/lib/qseow/qseow-process-app.js` | 162 |
+| `qseowProcessApp` | Function | `src/lib/qseow/qseow-process-app.js` | 115 |
 | `qseowUpdateSheetThumbnails` | Function | `src/lib/qseow/qseow-updatesheets.js` | 33 |
 | `qseowUploadToContentLibrary` | Function | `src/lib/qseow/qseow-upload.js` | 32 |
 | `qseowVerifyCertificatesExist` | Function | `src/lib/qseow/qseow-certificates.js` | 49 |
 | `getCertFilePaths` | Function | `src/lib/util/cert.js` | 18 |
+| `qseowLogout` | Function | `src/lib/qseow/qseow-logout.js` | 140 |
 | `createSocket` | Function | `src/lib/qseow/qseow-enigma.js` | 76 |
-| `getSheetsTaggedWith` | Function | `src/lib/qseow/qseow-process-app.js` | 44 |
+| `getSheetsTaggedWith` | Function | `src/lib/qseow/qseow-process-app.js` | 46 |
 | `exists` | Function | `src/lib/qseow/qseow-certificates.js` | 21 |
+| `qpsUserPath` | Function | `src/lib/qseow/qseow-logout.js` | 21 |
+| `logoutViaApi` | Function | `src/lib/qseow/qseow-logout.js` | 32 |
+| `logoutViaHub` | Function | `src/lib/qseow/qseow-logout.js` | 74 |
 | `readCert` | Function | `src/lib/qseow/qseow-enigma.js` | 16 |
+
+## Execution Flows
+
+| Flow | Type | Steps |
+|------|------|-------|
+| `QseowLogout → QpsUserPath` | intra_community | 3 |
+| `QseowLogout → Sleep` | cross_community | 3 |
 
 ## Connected Areas
 
 | Area | Connections |
 |------|-------------|
-| Cloud | 2 calls |
+| Cloud | 3 calls |
 | Browser | 1 calls |
 
 ## How to Explore

--- a/src/lib/cloud/__tests__/qscloudCreateThumbnails_fail.integration.test.js
+++ b/src/lib/cloud/__tests__/qscloudCreateThumbnails_fail.integration.test.js
@@ -3,6 +3,7 @@ import 'dotenv/config';
 
 import { qscloudCreateThumbnails } from '../cloud-create-thumbnails.js';
 import { assertEnv, getTestTimeout } from '../../util/env-check.js';
+import { collectAppIds } from '../../commands/helpers.js';
 
 // Failure paths for Qlik Sense Cloud. QSEoW has had a failure integration test since early on
 // (a non-existing content library) while Cloud had only a success test, so a Cloud run that
@@ -61,7 +62,7 @@ describe('qs cloud create sheet thumbnails - failure paths', () => {
             const result = await qscloudCreateThumbnails(
                 buildOptions({
                     apikey: 'not-a-valid-api-key',
-                    appid: [process.env.BSI_CLOUD_APP_ID],
+                    appid: collectAppIds(process.env.BSI_CLOUD_APP_ID ?? ''),
                 })
             );
 
@@ -79,7 +80,7 @@ describe('qs cloud create sheet thumbnails - failure paths', () => {
             const result = await qscloudCreateThumbnails(
                 buildOptions({
                     tenanturl: 'no-such-tenant.invalid',
-                    appid: [process.env.BSI_CLOUD_APP_ID],
+                    appid: collectAppIds(process.env.BSI_CLOUD_APP_ID ?? ''),
                 })
             );
 
@@ -131,7 +132,7 @@ describe('qs cloud create sheet thumbnails - failure paths', () => {
         async () => {
             const result = await qscloudCreateThumbnails(
                 buildOptions({
-                    appid: [process.env.BSI_CLOUD_APP_ID],
+                    appid: collectAppIds(process.env.BSI_CLOUD_APP_ID ?? ''),
                     browserVersion: '99.0.1234.56',
                 })
             );

--- a/src/lib/cloud/__tests__/qscloudCreateThumbnails_success.integration.test.js
+++ b/src/lib/cloud/__tests__/qscloudCreateThumbnails_success.integration.test.js
@@ -5,6 +5,7 @@ import { qscloudCreateThumbnails } from '../cloud-create-thumbnails.js';
 import { browserInstalled } from '../../browser/browser-installed.js';
 import { browserUninstallAll } from '../../browser/browser-uninstall.js';
 import { assertEnv, getTestTimeout } from '../../util/env-check.js';
+import { collectAppIds } from '../../commands/helpers.js';
 
 const defaultTestTimeout = getTestTimeout(process.env);
 
@@ -19,7 +20,13 @@ const options = {
     pagewait: process.env.BSI_PAGE_WAIT || '10',
     imagedir: process.env.BSI_IMAGE_DIR || 'img',
     schemaversion: process.env.BSI_CLOUD_SCHEMA_VERSION || '12.612.0',
-    appid: [process.env.BSI_CLOUD_APP_ID],
+    // Split with the CLI's own parser, so BSI_CLOUD_APP_ID=id1,id2 names two apps and is split
+    // exactly as a real run would split it. The `?? ''` matters because this suite is driven
+    // either by an app id or by a collection id: with the variable unset, a bare
+    // `[process.env.BSI_CLOUD_APP_ID]` is `[undefined]`, and undefined would be pushed as if it
+    // were an app to process. An empty string yields an empty list, which is what "not supplied"
+    // should mean.
+    appid: collectAppIds(process.env.BSI_CLOUD_APP_ID ?? ''),
     includesheetpart: process.env.BSI_INCLUDE_SHEET_PART || '1',
     browser: process.env.BSI_BROWSER || 'chrome',
     // These options bypass Commander, so the CLI default is not applied for them - the fallback

--- a/src/lib/qseow/__tests__/qseowCreateThumbnails_fail.integration.test.js
+++ b/src/lib/qseow/__tests__/qseowCreateThumbnails_fail.integration.test.js
@@ -3,6 +3,7 @@ import 'dotenv/config';
 
 import { qseowCreateThumbnails } from '../qseow-create-thumbnails.js';
 import { assertEnv, getTestTimeout } from '../../util/env-check.js';
+import { collectAppIds } from '../../commands/helpers.js';
 
 // Failure paths for QSEoW, matching the Qlik Sense Cloud set case for case. The two platforms are
 // mirrors of each other, and a scenario covered on one but not the other is where this codebase
@@ -34,7 +35,10 @@ const buildOptions = (overrides = {}) => ({
     imagedir: process.env.BSI_IMAGE_DIR || 'img',
     contentlibrary: process.env.BSI_CONTENT_LIBRARY,
     host: process.env.BSI_HOST,
-    appid: [process.env.BSI_APP_ID || 'a3e0f5d2-000a-464f-998d-33d333b175d7'],
+    // Split with the CLI's own parser, so BSI_APP_ID=id1,id2 names two apps and is
+    // split exactly as a real run would split it - rather than becoming one id
+    // containing a comma.
+    appid: collectAppIds(process.env.BSI_APP_ID || 'a3e0f5d2-000a-464f-998d-33d333b175d7'),
     apiuserdir: process.env.BSI_API_USER_DIR || 'Internal',
     apiuserid: process.env.BSI_API_USER_ID || 'sa_api',
     logonuserdir: process.env.BSI_LOGON_USER_DIR,

--- a/src/lib/qseow/__tests__/qseowCreateThumbnails_fail_missing_content_library.integration.test.js
+++ b/src/lib/qseow/__tests__/qseowCreateThumbnails_fail_missing_content_library.integration.test.js
@@ -3,6 +3,7 @@ import 'dotenv/config';
 
 import { qseowCreateThumbnails } from '../qseow-create-thumbnails.js';
 import { assertEnv, getTestTimeout } from '../../util/env-check.js';
+import { collectAppIds } from '../../commands/helpers.js';
 
 const defaultTestTimeout = getTestTimeout(process.env);
 
@@ -20,7 +21,10 @@ const options = {
     imagedir: process.env.BSI_IAMGE_DIR || 'img',
     contentlibrary: process.env.BSI_CONTENT_LIBRARY,
     host: process.env.BSI_HOST,
-    appid: [process.env.BSI_APP_ID || 'a3e0f5d2-000a-464f-998d-33d333b175d7'],
+    // Split with the CLI's own parser, so BSI_APP_ID=id1,id2 names two apps and is
+    // split exactly as a real run would split it - rather than becoming one id
+    // containing a comma.
+    appid: collectAppIds(process.env.BSI_APP_ID || 'a3e0f5d2-000a-464f-998d-33d333b175d7'),
     apiuserdir: process.env.BSI_API_USER_DIR || 'Internal',
     apiuserid: process.env.BSI_API_USER_ID || 'sa_api',
     logonuserdir: process.env.BSI_LOGON_USER_DIR,

--- a/src/lib/qseow/__tests__/qseowCreateThumbnails_success.integration.test.js
+++ b/src/lib/qseow/__tests__/qseowCreateThumbnails_success.integration.test.js
@@ -5,6 +5,7 @@ import { Writable } from 'node:stream';
 
 import { qseowCreateThumbnails } from '../qseow-create-thumbnails.js';
 import { assertEnv, getTestTimeout } from '../../util/env-check.js';
+import { collectAppIds } from '../../commands/helpers.js';
 import { logger } from '../../../globals.js';
 
 const defaultTestTimeout = getTestTimeout(process.env);
@@ -23,7 +24,10 @@ const options = {
     imagedir: process.env.BSI_IMAGE_DIR || 'img',
     contentlibrary: process.env.BSI_CONTENT_LIBRARY,
     host: process.env.BSI_HOST,
-    appid: [process.env.BSI_APP_ID || 'a3e0f5d2-000a-464f-998d-33d333b175d7'],
+    // Split with the CLI's own parser, so BSI_APP_ID=id1,id2 names two apps and is
+    // split exactly as a real run would split it - rather than becoming one id
+    // containing a comma.
+    appid: collectAppIds(process.env.BSI_APP_ID || 'a3e0f5d2-000a-464f-998d-33d333b175d7'),
     apiuserdir: process.env.BSI_API_USER_DIR || 'Internal',
     apiuserid: process.env.BSI_API_USER_ID || 'sa_api',
     logonuserdir: process.env.BSI_LOGON_USER_DIR,


### PR DESCRIPTION
Refs #910, #895.

`--appid` became variadic in #979, but the integration suites could not exercise that: they built their options bag as `appid: [process.env.BSI_APP_ID]`, wrapping the raw value themselves. `BSI_APP_ID=id1,id2` therefore became a single app whose id contained a comma. The headline capability of #895 had no coverage against a real server.

They now call **`collectAppIds()`, the same parser the CLI uses**, rather than a fourth copy of the splitting rule — so the tests split app ids exactly as a real run does and cannot drift from the parser they exist to exercise.

## A latent bug fixed along the way

The Cloud suites additionally needed `?? ''`. They carry no default app id, because they run either from `BSI_CLOUD_APP_ID` **or** from `BSI_CLOUD_COLLECTION_ID` — `assertEnv`'s `xor` rule enforces exactly one. With the variable unset, the previous `[process.env.BSI_CLOUD_APP_ID]` evaluated to `[undefined]`, and since #979 removed the `if (options.appid)` guard, that `undefined` would have been pushed as though it were an app to process.

Found by reading the code rather than by a test, because the collection path has no coverage at all. That gap is now filed as #984.

## Verified against live systems

Two apps named on each platform. Thumbnails were written for **both** apps in **both** runs, minutes apart — the app loop walking a two-element list, not one app processed twice:

| | Tests | Time (1 app → 2 apps) | Thumbnails written |
|---|---|---|---|
| QSEoW | 7/7 | 94s → 159s | 13:54 `a3e0f5d2-…`, 13:55 `acdbc130-…` |
| Cloud | 10/10 | 279s → 366s | 15:06 `97089caf-…`, 15:08 `3b859501-…` |

`runOverApps()` returns `true` only when *every* selected app succeeds, so all tests passing means both apps completed cleanly on both platforms.

## Scope

This covers the `--appid` half of #910 only. Tag-based (QSEoW) and collection-based (Cloud) selection remain uncovered and are now split out as **#983** and **#984**, each carrying the fixture decisions they need.

Also includes a GitNexus index refresh, picking up `qseow-logout.js` from #982.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
