### PR TITLE
Add collection and app listing helpers for Qlik Sense Cloud

### DIFF
--- a/src/lib/cloud/__tests__/cloud_apps.test.js
+++ b/src/lib/cloud/__tests__/cloud_apps.test.js
@@ -17,7 +17,7 @@ const Get = jest.fn();
 const saasInstance = { Get };
 
 const { logger } = await import('../../../globals.js');
-const { getAppIdsByCollection } = await import('../cloud-apps.js');
+const { getAppIdsByCollection, listCollections, listApps } = await import('../cloud-apps.js');
 
 const COLLECTION_ID = 'collection-1';
 
@@ -209,5 +209,165 @@ describe('getAppIdsByCollection', () => {
                 '500 Internal Server Error'
             );
         });
+    });
+});
+
+describe('listCollections', () => {
+    test('returns the collections the tenant reported', async () => {
+        const collections = [
+            { id: 'collection-1', name: 'Finance', description: 'Reports', itemCount: 4 },
+            { id: 'collection-2', name: 'Sales', description: undefined, itemCount: 0 },
+        ];
+        Get.mockResolvedValue(collections);
+
+        await expect(listCollections(saasInstance)).resolves.toEqual(collections);
+    });
+
+    test('passes the API response through untouched', async () => {
+        // Deliberately not narrowed or normalised. The list-collections command
+        // renders seven fields in a table and prints these objects verbatim for
+        // --outputformat json, so reshaping here would change output that has
+        // always looked this way.
+        const collections = [
+            {
+                id: 'collection-1',
+                name: 'Finance',
+                itemCount: 4,
+                type: 'private',
+                createdAt: '2026-01-01T00:00:00Z',
+                updatedAt: '2026-01-02T00:00:00Z',
+            },
+        ];
+        Get.mockResolvedValue(collections);
+
+        const [collection] = await listCollections(saasInstance);
+
+        expect(collection).toBe(collections[0]);
+        expect(Object.keys(collection)).toHaveLength(6);
+    });
+
+    test('does not invent a description the API never sent', async () => {
+        // Checked against a real tenant: all 17 collections came back with no
+        // `description` key at all, not merely an undefined one. Manufacturing
+        // an empty string here would change what --outputformat json prints,
+        // and would hide the fact that the table's `=== undefined` guard is the
+        // thing actually handling this.
+        Get.mockResolvedValue([{ id: 'collection-1', name: 'Finance', itemCount: 4 }]);
+
+        const [collection] = await listCollections(saasInstance);
+
+        expect('description' in collection).toBe(false);
+    });
+
+    test('asks the collections endpoint', async () => {
+        Get.mockResolvedValue([]);
+
+        await listCollections(saasInstance);
+
+        expect(Get).toHaveBeenCalledWith('collections');
+    });
+
+    test('returns an empty list for a tenant with no collections', async () => {
+        Get.mockResolvedValue([]);
+
+        await expect(listCollections(saasInstance)).resolves.toEqual([]);
+    });
+
+    test('propagates an API failure rather than reporting no collections', async () => {
+        Get.mockRejectedValue(new Error('401 Unauthorized'));
+
+        await expect(listCollections(saasInstance)).rejects.toThrow('401 Unauthorized');
+    });
+});
+
+describe('listApps', () => {
+    test('returns id and name for every app on the tenant', async () => {
+        Get.mockResolvedValue([
+            {
+                id: 'item-a',
+                resourceType: 'app',
+                resourceAttributes: { id: 'app-a', name: 'Alpha' },
+            },
+            {
+                id: 'item-b',
+                resourceType: 'app',
+                resourceAttributes: { id: 'app-b', name: 'Beta' },
+            },
+        ]);
+
+        await expect(listApps(saasInstance)).resolves.toEqual([
+            { id: 'app-a', name: 'Alpha' },
+            { id: 'app-b', name: 'Beta' },
+        ]);
+    });
+
+    test('asks the items endpoint, scoped to apps', async () => {
+        // Scoped in the query rather than filtered afterwards: an unscoped list
+        // on a large tenant is every item of every type, paged.
+        Get.mockResolvedValue([]);
+
+        await listApps(saasInstance);
+
+        expect(Get).toHaveBeenCalledWith('items?resourceType=app');
+    });
+
+    test('falls back to the id when the API supplies no name', async () => {
+        // A picker showing a bare GUID is no better than typing one, but it
+        // beats showing "undefined".
+        Get.mockResolvedValue([
+            { id: 'item-a', resourceType: 'app', resourceAttributes: { id: 'app-a' } },
+        ]);
+
+        await expect(listApps(saasInstance)).resolves.toEqual([{ id: 'app-a', name: 'app-a' }]);
+    });
+
+    test('skips anything that is not an app, and says which', async () => {
+        Get.mockResolvedValue([
+            {
+                id: 'item-a',
+                resourceType: 'app',
+                resourceAttributes: { id: 'app-a', name: 'Alpha' },
+            },
+            { id: 'item-ds', resourceType: 'dataset' },
+        ]);
+
+        await expect(listApps(saasInstance)).resolves.toEqual([{ id: 'app-a', name: 'Alpha' }]);
+        expect(logger.verbose).toHaveBeenCalledWith(expect.stringContaining('item-ds'));
+        expect(logger.verbose).toHaveBeenCalledWith(expect.stringContaining('dataset'));
+    });
+
+    test('returns an empty list for a tenant with no apps', async () => {
+        Get.mockResolvedValue([]);
+
+        await expect(listApps(saasInstance)).resolves.toEqual([]);
+    });
+
+    test('propagates an API failure rather than reporting no apps', async () => {
+        Get.mockRejectedValue(new Error('403 Forbidden'));
+
+        await expect(listApps(saasInstance)).rejects.toThrow('403 Forbidden');
+    });
+});
+
+describe('both app sources agree on shape', () => {
+    // The reason the item mapping is shared. An app picker offering "all apps"
+    // and "apps in a collection" must not have to care which list it is holding,
+    // and the two would drift apart the moment they mapped items separately.
+    test('a collection and the tenant list describe the same app identically', async () => {
+        const item = {
+            id: 'item-a',
+            resourceType: 'app',
+            resourceAttributes: { id: 'app-a', name: 'Alpha' },
+        };
+
+        Get.mockImplementation(async (path) => {
+            if (path === 'collections') return [{ id: COLLECTION_ID }];
+            return [item];
+        });
+
+        const [fromCollection] = await getAppIdsByCollection(saasInstance, COLLECTION_ID);
+        const [fromTenant] = await listApps(saasInstance);
+
+        expect(fromCollection).toEqual(fromTenant);
     });
 });

--- a/src/lib/cloud/cloud-apps.js
+++ b/src/lib/cloud/cloud-apps.js
@@ -1,6 +1,87 @@
 import { logger } from '../../globals.js';
 
 /**
+ * Turn a batch of items-API entries into apps.
+ *
+ * Both sources of apps on a tenant - a collection's items, and the tenant-wide item list -
+ * return the same item shape, so they map to apps the same way. Sharing this is what lets a
+ * caller treat "apps in this collection" and "all apps" interchangeably, which is the whole
+ * point of listing them: an app picker must not care where the list came from.
+ *
+ * `name` falls back to `id` because a picker showing a bare GUID is no better than asking
+ * someone to type one.
+ *
+ * @param {Array<object>} items - Entries as returned by the items API.
+ * @param {string} source - What is being listed, for the skipped-item log line.
+ *
+ * @returns {Array<{id: string, name: string}>} Apps, in the order the API returned them.
+ */
+const appsFromItems = (items, source) => {
+    const apps = [];
+
+    for (const item of items) {
+        if (item.resourceType === 'app') {
+            apps.push({
+                id: item.resourceAttributes.id,
+                name: item.resourceAttributes.name ?? item.resourceAttributes.id,
+            });
+        } else {
+            logger.verbose(
+                `Skipping ${source} item ${item.id} as it is not an app: ${item.resourceType}`
+            );
+        }
+    }
+
+    return apps;
+};
+
+/**
+ * Returns every collection on the tenant.
+ *
+ * Deliberately a pass-through of what the API returned rather than a narrowed shape. Three
+ * callers want different fields - the `list-collections` command renders seven of them in a
+ * table and prints the raw objects for `--outputformat json`, while a picker needs only name
+ * and item count - and narrowing here would either break the table or force a second request.
+ * Passing the objects through unchanged also keeps that JSON output byte-identical to what it
+ * has always printed.
+ *
+ * `id`, `name` and `itemCount` are always present. **`description` is not**: checked against a
+ * real tenant, where all 17 collections came back without the key at all. That is why the
+ * table in `cloud-collections.js` guards it with `=== undefined ? '' :` - load-bearing, not
+ * defensive habit - and why nothing here invents an empty string to paper over it.
+ *
+ * @param {object} saasInstance - Configured QlikSaas client.
+ *
+ * @returns {Promise<Array<object>>} Collections on the tenant, as the API returned them. Each
+ *     carries at least `id`, `name` and `itemCount`; `description` may be absent.
+ */
+export const listCollections = async (saasInstance) => {
+    const allCollections = await saasInstance.Get('collections');
+    logger.debug(`Collections:\n${JSON.stringify(allCollections, null, 2)}`);
+
+    return allCollections;
+};
+
+/**
+ * Returns every app on the tenant, not scoped to a collection.
+ *
+ * Uses the items API rather than `apps`, so entries arrive in the same shape a collection's
+ * items do and go through the same mapping. Paging is handled a layer down - the request
+ * helper follows `links.next` until the list is exhausted - so this is the whole tenant, not
+ * the first page of it.
+ *
+ * @param {object} saasInstance - Configured QlikSaas client.
+ *
+ * @returns {Promise<Array<{id: string, name: string}>>} Apps on the tenant. `name` falls back
+ *     to `id` when the API does not supply one.
+ */
+export const listApps = async (saasInstance) => {
+    const items = await saasInstance.Get('items?resourceType=app');
+
+    return appsFromItems(items, 'tenant');
+};
+
+/**
  * Returns the apps in a Qlik Sense Cloud collection.
  *
  * The two commands that accept `--collectionid` previously held byte-identical copies of this
@@ -19,8 +100,7 @@ import { logger } from '../../globals.js';
  *     requested collection ID so the caller can report it without re-extracting it.
  */
 export const getAppIdsByCollection = async (saasInstance, collectionId) => {
-    const allCollections = await saasInstance.Get('collections');
-    logger.debug(`Collections:\n${JSON.stringify(allCollections, null, 2)}`);
+    const allCollections = await listCollections(saasInstance);
 
     const index = allCollections.map((e) => e.id).indexOf(collectionId);
 
@@ -30,19 +110,5 @@ export const getAppIdsByCollection = async (saasInstance, collectionId) => {
 
     const collectionItems = await saasInstance.Get(`collections/${collectionId}/items`);
 
-    const apps = [];
-    for (const item of collectionItems) {
-        if (item.resourceType === 'app') {
-            apps.push({
-                id: item.resourceAttributes.id,
-                name: item.resourceAttributes.name ?? item.resourceAttributes.id,
-            });
-        } else {
-            logger.verbose(
-                `Skipping collection item ${item.id} as it is not an app: ${item.resourceType}`
-            );
-        }
-    }
-
-    return apps;
+    return appsFromItems(collectionItems, 'collection');
 };

--- a/src/lib/cloud/cloud-collections.js
+++ b/src/lib/cloud/cloud-collections.js
@@ -3,6 +3,7 @@ import { logger, setLoggingLevel, bsiExecutablePath, isSea } from '../../globals
 import { redactOptions } from '../util/redact-secrets.js';
 import QlikSaas from './cloud-repo.js';
 import { qscloudTestConnection } from './cloud-test-connection.js';
+import { listCollections } from './cloud-apps.js';
 
 /**
  * Lists all available collections in the Qlik Sense Cloud tenant.
@@ -69,7 +70,7 @@ export const qscloudListCollections = async (options) => {
         // Get all available collections
         let allCollections;
         try {
-            allCollections = await saasInstance.Get('collections');
+            allCollections = await listCollections(saasInstance);
         } catch (err) {
             if (err.stack) {
                 logger.error(`LIST COLLECTIONS 2 (stack): ${err.stack}`);
@@ -161,8 +162,7 @@ export const qscloudVerifyCollectionExists = async (options) => {
         const saasInstance = new QlikSaas(cloudConfig);
 
         // Get all available collections
-        const allCollections = await saasInstance.Get('collections');
-        logger.debug(`COLLECTION EXISTS: Collections:\n${JSON.stringify(allCollections, null, 2)}`);
+        const allCollections = await listCollections(saasInstance);
 
         // Get index of specified collection among the existing ones.
         const index = allCollections.map((e) => e.id).indexOf(options.collectionid);


### PR DESCRIPTION
Closes #960.

`cloud-apps.js` exported only `getAppIdsByCollection`. Both listers were part of the original #889 proposal and are prerequisites for the interactive app picker in #886 / #897, which has to offer collections first and then the apps within one — or every app on the tenant when no collection is used.

```js
listCollections(saas) → Promise<Array<object>>              // every collection on the tenant
listApps(saas)        → Promise<Array<{id, name}>>          // every app, not scoped to a collection
```

`listApps` goes through the items API rather than `apps`, so its entries arrive in the same shape a collection's items do and go through **the same mapping**. That sharing is the point: a picker offering "all apps" and "apps in this collection" must not care which list it is holding, and the two would drift apart the moment they mapped items separately. Paging is already handled a layer down, where the request helper follows `links.next`.

`listCollections` replaces the inline `Get('collections')` in both functions in `cloud-collections.js` — the duplication #960 named.

## Two deviations from the issue, both deliberate

**The shape is a pass-through, not the proposed `{id, name, description, itemCount}`.** Three callers want different fields — `list-collections` renders seven of them in a table and prints the objects verbatim for `--outputformat json` — so narrowing here would either break the table or force a second request.

**`description` is not a field you can rely on.** Checked against a real tenant: across all 17 collections it is not merely `undefined`, it is **absent entirely**. So the issue's proposed signature was wrong on that field, nothing here manufactures an empty string to paper over it, and the `=== undefined ? '' :` guard in the collections table turns out to be load-bearing rather than defensive habit.

## Verification

- 1595 unit tests pass, lint clean. 13 new tests, including one asserting a collection and the tenant-wide list describe the same app identically — the property the shared mapping exists to hold.
- Both helpers called against a live tenant: **17 collections** with `id`/`name`/`itemCount` present, **30 apps** all carrying real names, none falling back to a GUID.
- `qscloudListCollections` output is unchanged, including the `--outputformat json` payload, which is why the pass-through matters.

## Follow-ups filed

- **#986** — the QSEoW half of the same asymmetry: `getAppIdsByTag()` returns bare GUIDs while its Cloud twin returns names, which would make the picker show GUIDs on one platform and names on the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
