### PR TITLE
Return app names alongside ids when looking up QSEoW apps by tag

### DIFF
--- a/src/lib/cloud/__tests__/cloud_apps.test.js
+++ b/src/lib/cloud/__tests__/cloud_apps.test.js
@@ -17,7 +17,7 @@ const Get = jest.fn();
 const saasInstance = { Get };
 
 const { logger } = await import('../../../globals.js');
-const { getAppIdsByCollection, listCollections, listApps } = await import('../cloud-apps.js');
+const { listAppsByCollection, listCollections, listApps } = await import('../cloud-apps.js');
 
 const COLLECTION_ID = 'collection-1';
 
@@ -40,7 +40,7 @@ beforeEach(() => {
     jest.clearAllMocks();
 });
 
-describe('getAppIdsByCollection', () => {
+describe('listAppsByCollection', () => {
     describe('happy path', () => {
         test('returns id and name for every app in the collection', async () => {
             withCollectionItems([
@@ -56,7 +56,7 @@ describe('getAppIdsByCollection', () => {
                 },
             ]);
 
-            const apps = await getAppIdsByCollection(saasInstance, COLLECTION_ID);
+            const apps = await listAppsByCollection(saasInstance, COLLECTION_ID);
 
             expect(apps).toEqual([
                 { id: 'app-a', name: 'Alpha' },
@@ -67,7 +67,7 @@ describe('getAppIdsByCollection', () => {
         test('fetches collections and then collection items, in that order', async () => {
             withCollectionItems([]);
 
-            await getAppIdsByCollection(saasInstance, COLLECTION_ID);
+            await listAppsByCollection(saasInstance, COLLECTION_ID);
 
             expect(Get).toHaveBeenCalledTimes(2);
             expect(Get.mock.calls[0][0]).toBe('collections');
@@ -77,7 +77,7 @@ describe('getAppIdsByCollection', () => {
         test('returns an empty array for a collection with no apps', async () => {
             withCollectionItems([]);
 
-            const apps = await getAppIdsByCollection(saasInstance, COLLECTION_ID);
+            const apps = await listAppsByCollection(saasInstance, COLLECTION_ID);
 
             expect(apps).toEqual([]);
         });
@@ -99,7 +99,7 @@ describe('getAppIdsByCollection', () => {
                 },
             ]);
 
-            const apps = await getAppIdsByCollection(saasInstance, COLLECTION_ID);
+            const apps = await listAppsByCollection(saasInstance, COLLECTION_ID);
 
             expect(apps).toEqual([
                 { id: 'app-a', name: 'Alpha' },
@@ -110,7 +110,7 @@ describe('getAppIdsByCollection', () => {
         test('logs a verbose line for each skipped non-app item', async () => {
             withCollectionItems([{ id: 'item-ds', resourceType: 'dataset' }]);
 
-            await getAppIdsByCollection(saasInstance, COLLECTION_ID);
+            await listAppsByCollection(saasInstance, COLLECTION_ID);
 
             const verbose = logger.verbose.mock.calls.map((c) => String(c[0])).join('\n');
             expect(verbose).toContain('item-ds');
@@ -123,7 +123,7 @@ describe('getAppIdsByCollection', () => {
                 { id: 'ds-2', resourceType: 'dataset' },
             ]);
 
-            const apps = await getAppIdsByCollection(saasInstance, COLLECTION_ID);
+            const apps = await listAppsByCollection(saasInstance, COLLECTION_ID);
 
             expect(apps).toEqual([]);
         });
@@ -135,7 +135,7 @@ describe('getAppIdsByCollection', () => {
                 { id: 'item-a', resourceType: 'app', resourceAttributes: { id: 'app-a' } },
             ]);
 
-            const apps = await getAppIdsByCollection(saasInstance, COLLECTION_ID);
+            const apps = await listAppsByCollection(saasInstance, COLLECTION_ID);
 
             expect(apps).toEqual([{ id: 'app-a', name: 'app-a' }]);
         });
@@ -149,7 +149,7 @@ describe('getAppIdsByCollection', () => {
                 },
             ]);
 
-            const apps = await getAppIdsByCollection(saasInstance, COLLECTION_ID);
+            const apps = await listAppsByCollection(saasInstance, COLLECTION_ID);
 
             expect(apps).toEqual([{ id: 'app-a', name: 'app-a' }]);
         });
@@ -159,7 +159,7 @@ describe('getAppIdsByCollection', () => {
         test('throws when the collection does not exist on the tenant', async () => {
             Get.mockResolvedValue([{ id: 'some-other-collection' }]);
 
-            await expect(getAppIdsByCollection(saasInstance, COLLECTION_ID)).rejects.toThrow(
+            await expect(listAppsByCollection(saasInstance, COLLECTION_ID)).rejects.toThrow(
                 /does not exist/
             );
         });
@@ -167,7 +167,7 @@ describe('getAppIdsByCollection', () => {
         test('the error message names the requested collection', async () => {
             Get.mockResolvedValue([{ id: 'some-other-collection' }]);
 
-            await expect(getAppIdsByCollection(saasInstance, COLLECTION_ID)).rejects.toThrow(
+            await expect(listAppsByCollection(saasInstance, COLLECTION_ID)).rejects.toThrow(
                 COLLECTION_ID
             );
         });
@@ -175,7 +175,7 @@ describe('getAppIdsByCollection', () => {
         test('does not fetch items when the collection is missing', async () => {
             Get.mockResolvedValue([{ id: 'some-other-collection' }]);
 
-            await expect(getAppIdsByCollection(saasInstance, COLLECTION_ID)).rejects.toThrow();
+            await expect(listAppsByCollection(saasInstance, COLLECTION_ID)).rejects.toThrow();
 
             expect(Get).toHaveBeenCalledTimes(1);
             expect(Get).toHaveBeenCalledWith('collections');
@@ -184,7 +184,7 @@ describe('getAppIdsByCollection', () => {
         test('throws when the tenant has no collections at all', async () => {
             Get.mockResolvedValue([]);
 
-            await expect(getAppIdsByCollection(saasInstance, COLLECTION_ID)).rejects.toThrow(
+            await expect(listAppsByCollection(saasInstance, COLLECTION_ID)).rejects.toThrow(
                 /does not exist/
             );
         });
@@ -194,7 +194,7 @@ describe('getAppIdsByCollection', () => {
         test('propagates errors from the collections call', async () => {
             Get.mockRejectedValue(new Error('401 Unauthorized'));
 
-            await expect(getAppIdsByCollection(saasInstance, COLLECTION_ID)).rejects.toThrow(
+            await expect(listAppsByCollection(saasInstance, COLLECTION_ID)).rejects.toThrow(
                 '401 Unauthorized'
             );
         });
@@ -205,7 +205,7 @@ describe('getAppIdsByCollection', () => {
                 throw new Error('500 Internal Server Error');
             });
 
-            await expect(getAppIdsByCollection(saasInstance, COLLECTION_ID)).rejects.toThrow(
+            await expect(listAppsByCollection(saasInstance, COLLECTION_ID)).rejects.toThrow(
                 '500 Internal Server Error'
             );
         });
@@ -365,7 +365,7 @@ describe('both app sources agree on shape', () => {
             return [item];
         });
 
-        const [fromCollection] = await getAppIdsByCollection(saasInstance, COLLECTION_ID);
+        const [fromCollection] = await listAppsByCollection(saasInstance, COLLECTION_ID);
         const [fromTenant] = await listApps(saasInstance);
 
         expect(fromCollection).toEqual(fromTenant);

--- a/src/lib/cloud/cloud-apps.js
+++ b/src/lib/cloud/cloud-apps.js
@@ -11,6 +11,9 @@ import { logger } from '../../globals.js';
  * `name` falls back to `id` because a picker showing a bare GUID is no better than asking
  * someone to type one.
  *
+ * **App names are not unique** - only ids are. Two apps may legitimately share a name, so
+ * anything acting on a choice must key on `id`; `name` is a label and nothing more.
+ *
  * @param {Array<object>} items - Entries as returned by the items API.
  * @param {string} source - What is being listed, for the skipped-item log line.
  *
@@ -99,7 +102,7 @@ export const listApps = async (saasInstance) => {
  * @throws {Error} If the collection does not exist on the tenant. The message includes the
  *     requested collection ID so the caller can report it without re-extracting it.
  */
-export const getAppIdsByCollection = async (saasInstance, collectionId) => {
+export const listAppsByCollection = async (saasInstance, collectionId) => {
     const allCollections = await listCollections(saasInstance);
 
     const index = allCollections.map((e) => e.id).indexOf(collectionId);

--- a/src/lib/cloud/cloud-create-thumbnails.js
+++ b/src/lib/cloud/cloud-create-thumbnails.js
@@ -4,7 +4,7 @@ import QlikSaas from './cloud-repo.js';
 import { qscloudTestConnection } from './cloud-test-connection.js';
 import { processCloudApp } from './process-cloud-app.js';
 import { runOverApps } from '../util/run-over-apps.js';
-import { getAppIdsByCollection } from './cloud-apps.js';
+import { listAppsByCollection } from './cloud-apps.js';
 import { toAppIdList } from '../util/app-ids.js';
 import { CLOUD_SHEET_PARTS } from './sheet-parts.js';
 
@@ -117,7 +117,7 @@ export const qscloudCreateThumbnails = async (options) => {
         // way are all processed. runOverApps() dedupes, so an app that is both named by
         // --appid and in the collection is still processed once.
         if (options.collectionid && options.collectionid.length > 0) {
-            const apps = await getAppIdsByCollection(saasInstance, options.collectionid);
+            const apps = await listAppsByCollection(saasInstance, options.collectionid);
             logger.verbose(`Collection '${options.collectionid}' exists`);
             appIdsToProcess.push(...apps.map((app) => app.id));
         }

--- a/src/lib/cloud/cloud-remove-sheet-icons.js
+++ b/src/lib/cloud/cloud-remove-sheet-icons.js
@@ -13,7 +13,7 @@ import {
     SHEET_LIST_FIELDS_EXTENDED,
 } from '../util/sheet-list.js';
 import { withEngineSession } from '../util/engine-session.js';
-import { getAppIdsByCollection } from './cloud-apps.js';
+import { listAppsByCollection } from './cloud-apps.js';
 import { toAppIdList } from '../util/app-ids.js';
 
 /**
@@ -216,7 +216,7 @@ export const qscloudRemoveSheetIcons = async (options) => {
         // way are all processed. runOverApps() dedupes, so an app that is both named by
         // --appid and in the collection is still processed once.
         if (options.collectionid && options.collectionid.length > 0) {
-            const apps = await getAppIdsByCollection(saasInstance, options.collectionid);
+            const apps = await listAppsByCollection(saasInstance, options.collectionid);
             logger.verbose(`Collection '${options.collectionid}' exists`);
             appIdsToProcess.push(...apps.map((app) => app.id));
         }

--- a/src/lib/qseow/__tests__/qseow_app_lookup.test.js
+++ b/src/lib/qseow/__tests__/qseow_app_lookup.test.js
@@ -1,0 +1,139 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+// QSEoW twin of cloud_apps.test.js. listAppsByTag had no dedicated coverage at all - it was
+// only ever exercised sideways, through the two workers that call it - so the one thing that
+// actually matters about its return value, that it carries app names and not just ids, was
+// asserted nowhere.
+
+jest.unstable_mockModule('../../../globals.js', () => ({
+    logger: {
+        info: jest.fn(),
+        verbose: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+    },
+    setLoggingLevel: jest.fn(),
+    bsiExecutablePath: '/test/path',
+    isSea: false,
+}));
+
+jest.unstable_mockModule('../qseow-qrs.js', () => ({
+    setupQseowQrsConnection: jest.fn().mockReturnValue({ hostname: 'sense.example.com' }),
+}));
+
+const Get = jest.fn();
+jest.unstable_mockModule('qrs-interact', () => ({
+    default: jest.fn().mockImplementation(() => ({ Get })),
+}));
+
+const { listAppsByTag } = await import('../qseow-app-lookup.js');
+
+const OPTIONS = {
+    host: 'sense.example.com',
+    qrsport: '4242',
+    certfile: './cert/client.pem',
+    certkeyfile: './cert/client_key.pem',
+    qliksensetag: 'BSI',
+};
+
+/**
+ * Points the mocked QRS at a server holding the given apps.
+ *
+ * @param {Array<object>} apps - Apps the `app/full` query should report.
+ *
+ * @returns {void}
+ */
+const withApps = (apps) => {
+    Get.mockResolvedValue({ statusCode: 200, body: apps });
+};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('listAppsByTag', () => {
+    test('returns id and name for every tagged app', async () => {
+        withApps([
+            { id: 'app-a', name: 'Finance' },
+            { id: 'app-b', name: 'Sales' },
+        ]);
+
+        await expect(listAppsByTag(OPTIONS)).resolves.toEqual([
+            { id: 'app-a', name: 'Finance' },
+            { id: 'app-b', name: 'Sales' },
+        ]);
+    });
+
+    test('keeps the name the QRS reply already carried', async () => {
+        // The regression this file exists for. `app/full` has always returned the
+        // name and this helper used to throw it away with `apps.map((a) => a.id)`,
+        // which would have left an app picker showing GUIDs on QSEoW and names on
+        // Cloud - see #986.
+        withApps([{ id: 'app-a', name: 'Finance' }]);
+
+        const [app] = await listAppsByTag(OPTIONS);
+
+        expect(app.name).toBe('Finance');
+        expect(app.name).not.toBe(app.id);
+    });
+
+    test('falls back to the id when the reply carries no name', async () => {
+        withApps([{ id: 'app-a' }]);
+
+        await expect(listAppsByTag(OPTIONS)).resolves.toEqual([{ id: 'app-a', name: 'app-a' }]);
+    });
+
+    test('returns an empty list when the tag matched nothing', async () => {
+        withApps([]);
+
+        await expect(listAppsByTag(OPTIONS)).resolves.toEqual([]);
+    });
+
+    test('queries app/full filtered by tag name', async () => {
+        withApps([]);
+
+        await listAppsByTag(OPTIONS);
+
+        expect(decodeURIComponent(Get.mock.calls[0][0])).toBe(
+            "app/full?filter=(tags.name eq 'BSI')"
+        );
+    });
+
+    test('accepts several tags', async () => {
+        withApps([]);
+
+        await listAppsByTag({ ...OPTIONS, qliksensetag: ['BSI', 'Finance'] });
+
+        expect(decodeURIComponent(Get.mock.calls[0][0])).toBe(
+            "app/full?filter=(tags.name eq 'BSI' or tags.name eq 'Finance')"
+        );
+    });
+
+    test('propagates a QRS failure rather than reporting no apps', async () => {
+        Get.mockRejectedValue(new Error('401 Unauthorized'));
+
+        await expect(listAppsByTag(OPTIONS)).rejects.toThrow('401 Unauthorized');
+    });
+
+    test('reports an unusable QRS reply as itself', async () => {
+        // Through qrsGetList, so a reply that is not a list fails as a named
+        // problem rather than as `result.body.map is not a function`.
+        Get.mockResolvedValue({ statusCode: 200, body: { error: 'proxy failure' } });
+
+        await expect(listAppsByTag(OPTIONS)).rejects.toThrow(/unusable response/);
+    });
+});
+
+describe('the two platforms describe an app the same way', () => {
+    // The asymmetry #986 was filed about. Cloud has always returned { id, name };
+    // QSEoW returned bare ids, so a picker would have needed different code per
+    // platform for no reason other than this.
+    test('a tagged app has exactly the id and name keys, as on Cloud', async () => {
+        withApps([{ id: 'app-a', name: 'Finance', published: true, stream: null }]);
+
+        const [app] = await listAppsByTag(OPTIONS);
+
+        expect(Object.keys(app).sort()).toEqual(['id', 'name']);
+    });
+});

--- a/src/lib/qseow/qseow-app-lookup.js
+++ b/src/lib/qseow/qseow-app-lookup.js
@@ -6,11 +6,19 @@ import { qrsGetList } from './qrs-response.js';
 import { qrsFilterAnyOf, qrsPathWithFilter } from './qrs-filter.js';
 
 /**
- * Looks up the IDs of all QSEoW apps carrying a given tag.
+ * Looks up all QSEoW apps carrying a given tag.
  *
  * Shared by the two commands that accept `--qliksensetag`. They previously held byte-identical
  * copies of this block, which is the drift this repo keeps paying for - and duplication the
  * quality gate counts.
+ *
+ * Returns `{ id, name }` rather than bare ids, matching `listAppsByCollection()` on the Cloud
+ * side. The QRS reply already carries the name and this used to discard it, which would have
+ * left an app picker showing GUIDs on QSEoW and names on Cloud.
+ *
+ * **App names are not unique** - only ids are. Two apps may legitimately share a name, so
+ * anything acting on a choice must key on `id`; `name` is a label and nothing more. `name`
+ * falls back to `id` if the reply ever omits it.
  *
  * @param {object} options - QSEoW options, as passed to the command.
  * @param {string|string[]} options.qliksensetag - Tag(s) an app must carry to be included.
@@ -21,9 +29,10 @@ import { qrsFilterAnyOf, qrsPathWithFilter } from './qrs-filter.js';
  * @param {string} options.certfile - Path to the certificate file.
  * @param {string} options.certkeyfile - Path to the certificate key file.
  *
- * @returns {Promise<string[]>} IDs of the matching apps, empty if the tag matched nothing.
+ * @returns {Promise<Array<{id: string, name: string}>>} The matching apps, empty if the tag
+ *     matched nothing.
  */
-export const getAppIdsByTag = async (options) => {
+export const listAppsByTag = async (options) => {
     const qseowConfigQrs = setupQseowQrsConnection(options);
 
     const qrsInteractInstance = new qrsInteract(qseowConfigQrs);
@@ -43,5 +52,5 @@ export const getAppIdsByTag = async (options) => {
     // `TypeError: result.body.map is not a function` from somewhere further down.
     const apps = await qrsGetList(qrsInteractInstance, qrsPathWithFilter('app/full', filter));
 
-    return apps.map((app) => app.id);
+    return apps.map((app) => ({ id: app.id, name: app.name ?? app.id }));
 };

--- a/src/lib/qseow/qseow-create-thumbnails.js
+++ b/src/lib/qseow/qseow-create-thumbnails.js
@@ -4,7 +4,7 @@ import { qseowVerifyContentLibraryExists } from './qseow-contentlibrary.js';
 import { qseowVerifyCertificatesExist } from './qseow-certificates.js';
 import { qseowProcessApp } from './qseow-process-app.js';
 import { runOverApps } from '../util/run-over-apps.js';
-import { getAppIdsByTag } from './qseow-app-lookup.js';
+import { listAppsByTag } from './qseow-app-lookup.js';
 import { toAppIdList } from '../util/app-ids.js';
 import { QSEOW_SHEET_PARTS } from './sheet-parts.js';
 
@@ -80,8 +80,10 @@ export const qseowCreateThumbnails = async (options) => {
         // way are all processed. runOverApps() dedupes, so an app that is both named by
         // --appid and carries the tag is still processed once.
         if (options.qliksensetag && options.qliksensetag.length > 0) {
-            // Get all apps matching the tag in --qliksensetag
-            appIdsToProcess.push(...(await getAppIdsByTag(options)));
+            // Get all apps matching the tag in --qliksensetag. listAppsByTag returns
+            // { id, name } so a picker can label them; only the ids matter here.
+            const taggedApps = await listAppsByTag(options);
+            appIdsToProcess.push(...taggedApps.map((app) => app.id));
         }
 
         return await runOverApps(

--- a/src/lib/qseow/qseow-remove-sheet-icons.js
+++ b/src/lib/qseow/qseow-remove-sheet-icons.js
@@ -11,7 +11,7 @@ import {
     SHEET_LIST_FIELDS_EXTENDED,
 } from '../util/sheet-list.js';
 import { runOverApps } from '../util/run-over-apps.js';
-import { getAppIdsByTag } from './qseow-app-lookup.js';
+import { listAppsByTag } from './qseow-app-lookup.js';
 import { toAppIdList } from '../util/app-ids.js';
 import { withEngineSession } from '../util/engine-session.js';
 
@@ -165,8 +165,10 @@ export const qseowRemoveSheetIcons = async (options) => {
         // way are all processed. runOverApps() dedupes, so an app that is both named by
         // --appid and carries the tag is still processed once.
         if (options.qliksensetag && options.qliksensetag.length > 0) {
-            // Get all apps matching the tag in --qliksensetag
-            appIdsToProcess.push(...(await getAppIdsByTag(options)));
+            // Get all apps matching the tag in --qliksensetag. listAppsByTag returns
+            // { id, name } so a picker can label them; only the ids matter here.
+            const taggedApps = await listAppsByTag(options);
+            appIdsToProcess.push(...taggedApps.map((app) => app.id));
         }
 
         return await runOverApps(


### PR DESCRIPTION
Closes #986.

`getAppIdsByTag` returned bare GUIDs while its Cloud twin returned `{ id, name }` — even though the QRS reply already carried the name and the helper discarded it:

```js
return apps.map((app) => app.id);   // the name was right there
```

An app picker built on that would have shown names on Cloud and GUIDs on QSEoW, needing different code per platform for no reason other than this asymmetry.

Both helpers are now renamed to say what they do — `listAppsByTag` and `listAppsByCollection` — and the two QSEoW callers gained the `.map((app) => app.id)` their Cloud counterparts already had.

**Renaming the Cloud one is slightly beyond what #986 asked for.** Leaving a `getAppIds…` that returns objects would have propagated the wart this change exists to remove, and the four helpers across these two modules now read as a set. Happy to drop that half if you'd rather keep the diff minimal.

## Verified against the lab server, not only against mocks

This mattered more than usual. The tests supply the QRS reply, so had `app/full` not carried a name, **every app would have fallen back to its GUID with all 1604 tests still passing** — a change that looked done while achieving nothing. It does carry it: 17 apps, all with non-empty names.

The same check settled an open design question from #897. **App names are not unique, and duplicates already exist on that server** — three of them, including two apps both called `Performance review_2022-03-28`. So a picker labelled by name alone is ambiguous today, not one day in theory. Decision recorded on #897: always show the id, clearly marked as an id, never truncated.

Every helper that returns apps now states the invariant in its JSDoc — *names are not unique, key on `id`* — because the failure it guards against, `apps.find((a) => a.name === answer)`, looks correct right until it silently picks the wrong app.

## Tests

1604 passing, lint clean. `listAppsByTag` gains the dedicated test file it never had: it was previously exercised only sideways through the two workers, so the one property worth asserting about its return value was asserted nowhere. Includes a test that both platforms describe an app with exactly the same keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
