### PR TITLE
Add the Qlik Sense Cloud create-sheet-thumbnails wizard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ dist
 build.cjs
 sea-prep.blob
 butler-sheet-icons
+
+# Added by ggshield
+.cache_ggshield

--- a/src/lib/commands/qscloud/__tests__/qscloud_wizard.test.js
+++ b/src/lib/commands/qscloud/__tests__/qscloud_wizard.test.js
@@ -1,0 +1,292 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+const qscloudTestConnection = jest.fn();
+const listCollections = jest.fn();
+const listApps = jest.fn();
+const listAppsByCollection = jest.fn();
+const qscloudCreateThumbnails = jest.fn().mockResolvedValue(true);
+
+jest.unstable_mockModule('../../../cloud/cloud-repo.js', () => ({
+    default: jest.fn().mockImplementation((config) => ({ config })),
+}));
+jest.unstable_mockModule('../../../cloud/cloud-test-connection.js', () => ({
+    qscloudTestConnection,
+}));
+jest.unstable_mockModule('../../../cloud/cloud-apps.js', () => ({
+    listCollections,
+    listApps,
+    listAppsByCollection,
+}));
+jest.unstable_mockModule('../../../cloud/cloud-create-thumbnails.js', () => ({
+    qscloudCreateThumbnails,
+}));
+
+const { runInteractive } = await import('../../../interactive/index.js');
+const { scriptedRuntime } = await import('../../../interactive/test-helpers/scripted-runtime.js');
+const { labelForApp, labelForCollection } =
+    await import('../create-sheet-thumbnails.interactive.js');
+
+const PATH = 'qscloud create-sheet-thumbnails';
+
+/**
+ * The answers a run needs when both gates are declined.
+ *
+ * Carries answers for the gated questions too, so a test that opens a gate only
+ * has to flip the gate rather than restate the whole conversation.
+ *
+ * @param {object} [overrides] - Answers to replace or add.
+ *
+ * @returns {object} Answers for the scripted runtime.
+ */
+const baseAnswers = (overrides = {}) => ({
+    tenanturl: 'acme.eu.qlikcloud.com',
+    apikey: 'a-real-key',
+    skipLogin: false,
+    logonuserid: 'user@acme.com',
+    logonpwd: 'secret',
+    _appSource: 'all',
+    appid: ['app-a'],
+    includesheetpart: '1',
+    excludeSheetStatus: [],
+    excludeSheetTag: '',
+    excludeSheetNumber: '',
+    excludeSheetTitle: '',
+    blurSheetStatus: [],
+    blurSheetTag: '',
+    blurSheetNumber: '',
+    blurSheetTitle: '',
+    blurFactor: '5',
+    _filtering: false,
+    _advanced: false,
+    _review: 'cancel',
+    ...overrides,
+});
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    qscloudTestConnection.mockResolvedValue({ user: 'someone' });
+    listApps.mockResolvedValue([
+        { id: 'app-a', name: 'Finance' },
+        { id: 'app-b', name: 'Sales' },
+    ]);
+    listAppsByCollection.mockResolvedValue([{ id: 'app-c', name: 'HR' }]);
+    listCollections.mockResolvedValue([{ id: 'coll-1', name: 'Finance', itemCount: 4 }]);
+});
+
+describe('the connection probe', () => {
+    test('runs as soon as the API key is given, not after every other question', async () => {
+        // The single biggest difference from the plain CLI, where a bad key is
+        // discovered only once the run starts - after 25 flags have been typed.
+        const runtime = scriptedRuntime(baseAnswers());
+
+        await runInteractive({ path: PATH, runtime });
+
+        const askedBeforeProbe = runtime.asked
+            .slice(0, runtime.asked.findIndex((a) => a.key === 'apikey') + 1)
+            .map((a) => a.key);
+
+        expect(qscloudTestConnection).toHaveBeenCalledTimes(1);
+        expect(askedBeforeProbe).toEqual(['tenanturl', 'apikey']);
+    });
+
+    test('re-asks the API key when the tenant rejects it', async () => {
+        qscloudTestConnection
+            .mockRejectedValueOnce(new Error('401 Unauthorized'))
+            .mockResolvedValue({ user: 'someone' });
+
+        const runtime = scriptedRuntime(baseAnswers({ apikey: ['wrong-key', 'a-real-key'] }));
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(runtime.asked.filter((a) => a.key === 'apikey')).toHaveLength(2);
+        expect(runtime.output()).toContain('401 Unauthorized');
+    });
+
+    test('reports the failure where the credential was typed', async () => {
+        qscloudTestConnection
+            .mockRejectedValueOnce(new Error('401 Unauthorized'))
+            .mockResolvedValue({ user: 'someone' });
+
+        const runtime = scriptedRuntime(baseAnswers({ apikey: ['wrong-key', 'a-real-key'] }));
+
+        await runInteractive({ path: PATH, runtime });
+
+        // Nothing beyond the credentials was asked before the complaint.
+        const asked = runtime.asked.map((a) => a.key);
+        expect(asked.indexOf('_appSource')).toBeGreaterThan(asked.lastIndexOf('apikey'));
+    });
+});
+
+describe('choosing which apps to update', () => {
+    test('offers the apps the tenant actually has', async () => {
+        const runtime = scriptedRuntime(baseAnswers());
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(listApps).toHaveBeenCalledTimes(1);
+        const question = runtime.asked.find((a) => a.key === 'appid');
+        expect(question.choices.map((c) => c.value)).toEqual(['app-a', 'app-b']);
+    });
+
+    test('labels every app with its id, marked as an id', async () => {
+        // App names are not unique - duplicates exist on real servers - so the
+        // name alone is ambiguous to whoever is choosing.
+        const runtime = scriptedRuntime(baseAnswers());
+
+        await runInteractive({ path: PATH, runtime });
+
+        const question = runtime.asked.find((a) => a.key === 'appid');
+        expect(question.choices[0].name).toBe('Finance  (id: app-a)');
+    });
+
+    test('lists apps from a collection when that is how they are chosen', async () => {
+        const runtime = scriptedRuntime(
+            baseAnswers({ _appSource: 'collection', collectionid: 'coll-1', appid: ['app-c'] })
+        );
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(listAppsByCollection).toHaveBeenCalledWith(expect.anything(), 'coll-1');
+        expect(listApps).not.toHaveBeenCalled();
+    });
+
+    test('shows how many items a collection holds, so an empty one is visible', async () => {
+        const runtime = scriptedRuntime(
+            baseAnswers({ _appSource: 'collection', collectionid: 'coll-1', appid: ['app-c'] })
+        );
+
+        await runInteractive({ path: PATH, runtime });
+
+        const question = runtime.asked.find((a) => a.key === 'collectionid');
+        expect(question.choices[0].name).toBe('Finance  (4 items)');
+    });
+
+    test('still lets an app id be typed, without fetching any list', async () => {
+        const runtime = scriptedRuntime(baseAnswers({ _appSource: 'typed', appid: 'app-z' }));
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(listApps).not.toHaveBeenCalled();
+        expect(listAppsByCollection).not.toHaveBeenCalled();
+    });
+
+    test('does not ask which collection when apps are chosen another way', async () => {
+        const runtime = scriptedRuntime(baseAnswers());
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(runtime.asked.map((a) => a.key)).not.toContain('collectionid');
+    });
+});
+
+describe('progressive disclosure', () => {
+    test('declining advanced options keeps the conversation short', async () => {
+        // The lever that matters. This command declares 25 options; a flat list
+        // of 25 questions is the problem no amount of styling fixes.
+        const runtime = scriptedRuntime(baseAnswers());
+
+        await runInteractive({ path: PATH, runtime });
+
+        const asked = runtime.asked.filter((a) => a.key !== '_review').map((a) => a.key);
+
+        // Pinned exactly rather than as a count, so a new option quietly
+        // joining the default path shows up here as a diff and has to be
+        // classified - gated, or deliberately part of the short conversation.
+        expect(asked).toEqual([
+            // Connection
+            'tenanturl',
+            'apikey',
+            'skipLogin',
+            'logonuserid',
+            'logonpwd',
+            // Apps
+            '_appSource',
+            'appid',
+            // Sheets
+            'includesheetpart',
+            // The two gates, both declined
+            '_filtering',
+            '_advanced',
+        ]);
+    });
+
+    test('accepting advanced options asks for them', async () => {
+        const runtime = scriptedRuntime(
+            baseAnswers({
+                _advanced: true,
+                loglevel: 'info',
+                schemaversion: '12.612.0',
+                pagewait: '5',
+                imagedir: './img',
+                browser: 'chrome',
+                browserVersion: 'recommended',
+                browserPageTimeout: '90',
+                headless: true,
+            })
+        );
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(runtime.asked.map((a) => a.key)).toContain('schemaversion');
+        expect(runtime.asked.map((a) => a.key)).toContain('browserPageTimeout');
+    });
+
+    test('never asks for the log level up front', async () => {
+        const runtime = scriptedRuntime(baseAnswers());
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(runtime.asked[0].key).toBe('tenanturl');
+    });
+});
+
+describe('the run itself', () => {
+    test('cancelling runs nothing', async () => {
+        const runtime = scriptedRuntime(baseAnswers());
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(qscloudCreateThumbnails).not.toHaveBeenCalled();
+    });
+
+    test('confirming calls the worker with a Commander-shaped bag', async () => {
+        const runtime = scriptedRuntime(baseAnswers({ _review: 'run' }));
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(qscloudCreateThumbnails).toHaveBeenCalledTimes(1);
+        const options = qscloudCreateThumbnails.mock.calls[0][0];
+        expect(options.tenanturl).toBe('acme.eu.qlikcloud.com');
+        expect(options.appid).toEqual(['app-a']);
+        // Synthetic questions must never reach the worker.
+        expect(options._appSource).toBeUndefined();
+        expect(options._advanced).toBeUndefined();
+    });
+
+    test('never prints the API key', async () => {
+        const runtime = scriptedRuntime(baseAnswers({ _review: 'run' }));
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(runtime.output()).not.toContain('a-real-key');
+    });
+});
+
+describe('the labels', () => {
+    test('an app label carries the full id, never truncated', () => {
+        const id = 'a1b2c3d4-1111-2222-3333-444455556666';
+
+        expect(labelForApp({ id, name: 'Finance' })).toBe(`Finance  (id: ${id})`);
+    });
+
+    test('two apps sharing a name stay distinguishable', () => {
+        const first = labelForApp({ id: 'app-a', name: 'Performance review' });
+        const second = labelForApp({ id: 'app-b', name: 'Performance review' });
+
+        expect(first).not.toBe(second);
+    });
+
+    test('a collection with no items says so', () => {
+        expect(labelForCollection({ name: 'Empty', itemCount: 0 })).toBe('Empty  (0 items)');
+    });
+});

--- a/src/lib/commands/qscloud/create-sheet-thumbnails.interactive.js
+++ b/src/lib/commands/qscloud/create-sheet-thumbnails.interactive.js
@@ -1,0 +1,295 @@
+import QlikSaas from '../../cloud/cloud-repo.js';
+import { qscloudTestConnection } from '../../cloud/cloud-test-connection.js';
+import { listCollections, listApps, listAppsByCollection } from '../../cloud/cloud-apps.js';
+import { qscloudCreateThumbnails } from '../../cloud/cloud-create-thumbnails.js';
+
+/** Key of the synthetic question asking how apps should be chosen. */
+const APP_SOURCE = '_appSource';
+
+/** Key of the synthetic question gating the long tail of options. */
+const ADVANCED = '_advanced';
+
+/** Key of the synthetic question gating the sheet exclude/blur filters. */
+const FILTERING = '_filtering';
+
+/**
+ * Options that pick out particular sheets to skip or blur.
+ *
+ * Gated as a block behind one question. They are eight of this command's
+ * twenty-five options and most runs use none of them - the common case is "every
+ * sheet in the app" - so asking about each one individually is what turns a
+ * short conversation into a long one.
+ */
+const FILTER_KEYS = new Set([
+    'excludeSheetStatus',
+    'excludeSheetTag',
+    'excludeSheetNumber',
+    'excludeSheetTitle',
+    'blurSheetStatus',
+    'blurSheetTag',
+    'blurSheetNumber',
+    'blurSheetTitle',
+    'blurFactor',
+]);
+
+/** How apps can be picked, in the order the choices are offered. */
+export const APP_SOURCES = Object.freeze({
+    ALL: 'all',
+    COLLECTION: 'collection',
+    TYPED: 'typed',
+});
+
+/**
+ * Label one app for a picker.
+ *
+ * The id is always shown, never truncated, and always marked as an id. App names
+ * are **not unique** - two apps on the same tenant may legitimately share one,
+ * and duplicates exist in practice - so a label showing the name alone is
+ * ambiguous to the person choosing even though the value behind it is not.
+ * Showing the full id also means it can be pasted straight into `--appid`, which
+ * is the point of echoing the equivalent command line at the end.
+ *
+ * @param {{id: string, name: string}} app - The app to label.
+ *
+ * @returns {string} The label to show.
+ */
+export const labelForApp = (app) => `${app.name}  (id: ${app.id})`;
+
+/**
+ * Label one collection for a picker.
+ *
+ * The item count is worth showing because an empty collection is a dead end, and
+ * seeing "0 items" before choosing it is better than a run that selects nothing.
+ *
+ * @param {object} collection - A collection as the tenant reported it.
+ *
+ * @returns {string} The label to show.
+ */
+export const labelForCollection = (collection) =>
+    `${collection.name}  (${collection.itemCount ?? 0} items)`;
+
+/** Options that only matter to someone who already knows they need them. */
+const ADVANCED_KEYS = new Set([
+    'schemaversion',
+    'pagewait',
+    'imagedir',
+    'browser',
+    'browserVersion',
+    'browserPageTimeout',
+    'headless',
+    'loglevel',
+]);
+
+/** Which section each question belongs under, in the order the sections run. */
+const GROUPS = [
+    ['Connection', ['tenanturl', 'apikey', 'skipLogin', 'logonuserid', 'logonpwd']],
+    ['Apps', [APP_SOURCE, 'collectionid', 'appid']],
+    ['Sheets', ['includesheetpart']],
+    ['Sheet filtering', [FILTERING, ...FILTER_KEYS]],
+    ['Advanced', [ADVANCED, ...ADVANCED_KEYS]],
+];
+
+/**
+ * Work out which section a question belongs to.
+ *
+ * @param {string} key - The question's key.
+ *
+ * @returns {string|undefined} The section heading, if the key has one.
+ */
+const groupFor = (key) => GROUPS.find(([, keys]) => [...keys].includes(key))?.[0];
+
+/**
+ * Order questions by section, keeping declaration order within each one.
+ *
+ * @param {Array} specs - Questions to order.
+ *
+ * @returns {Array} The same questions, grouped.
+ */
+const bySection = (specs) => {
+    const order = GROUPS.map(([name]) => name);
+
+    return [...specs].sort((a, b) => order.indexOf(a.group) - order.indexOf(b.group));
+};
+
+export default {
+    commandPath: 'qscloud create-sheet-thumbnails',
+    label: 'Create sheet thumbnails (Qlik Sense Cloud)',
+
+    /**
+     * Reshape the derived questions into a conversation.
+     *
+     * Three things happen here, in rough order of how much they matter.
+     *
+     * The API key carries a **probe**, so a wrong tenant url or key is reported
+     * at the prompt where it was typed rather than after twenty more questions.
+     * The probe also stashes the connected client, which is what lets the app
+     * and collection questions offer what is actually on the tenant.
+     *
+     * The **long tail is gated** behind one question. Answering "no" to advanced
+     * options takes this command from 25 questions to about 9, which is the
+     * single biggest usability lever available - no amount of styling fixes a
+     * flat list of 25.
+     *
+     * **App selection becomes a picker.** Typing a GUID from memory is the thing
+     * this feature exists to remove, so the default is to choose from the apps
+     * the tenant actually has, with typing one still available for anyone who
+     * has the id to hand.
+     *
+     * Pure: specs in, specs out, no I/O. The network calls all live behind
+     * `choices` and `probe`, which the driver invokes.
+     *
+     * @param {import('../../interactive/option-introspect.js').QuestionSpec[]} specs - Derived questions.
+     *
+     * @returns {Array} The questions to actually ask.
+     */
+    refine(specs) {
+        const byKey = Object.fromEntries(specs.map((spec) => [spec.key, spec]));
+
+        const connection = ['tenanturl', 'apikey', 'skipLogin', 'logonuserid', 'logonpwd']
+            .map((key) => byKey[key])
+            .filter(Boolean)
+            .map((spec) =>
+                spec.key === 'apikey'
+                    ? {
+                          ...spec,
+                          needs: ['tenanturl'],
+                          probe: async (ctx) => {
+                              const saas = new QlikSaas({
+                                  url: ctx.answers.tenanturl,
+                                  token: ctx.answers.apikey,
+                              });
+
+                              // Throws on a bad url or key, which is exactly
+                              // what the driver turns into a re-ask.
+                              await qscloudTestConnection(
+                                  { tenanturl: ctx.answers.tenanturl },
+                                  saas
+                              );
+
+                              ctx.clients = { ...ctx.clients, tenant: saas };
+                          },
+                      }
+                    : spec
+            );
+
+        const appSource = {
+            key: APP_SOURCE,
+            type: 'select',
+            message: 'Which apps should be updated?',
+            required: true,
+            variadic: false,
+            secret: false,
+            needs: ['apikey'],
+            choices: [
+                { name: 'Choose from all apps on the tenant', value: APP_SOURCES.ALL },
+                { name: 'Choose a collection, then apps within it', value: APP_SOURCES.COLLECTION },
+                { name: 'Type an app id', value: APP_SOURCES.TYPED },
+            ],
+        };
+
+        const collection = {
+            ...byKey.collectionid,
+            type: 'select',
+            message: 'Which collection?',
+            needs: [APP_SOURCE],
+            when: (ctx) => ctx.answers[APP_SOURCE] === APP_SOURCES.COLLECTION,
+            choices: async (ctx) => {
+                const collections = await listCollections(ctx.clients.tenant);
+
+                return collections.map((entry) => ({
+                    name: labelForCollection(entry),
+                    value: entry.id,
+                }));
+            },
+            fallback: { type: 'input', message: 'Collection id (could not fetch the list)' },
+        };
+
+        const app = {
+            ...byKey.appid,
+            type: 'checkbox',
+            message: 'Which apps?',
+            needs: [APP_SOURCE],
+            // Typing an id stays possible, so this is the derived question
+            // unchanged for anyone who already knows the id.
+            when: (ctx) => ctx.answers[APP_SOURCE] !== APP_SOURCES.TYPED,
+            choices: async (ctx) => {
+                const apps =
+                    ctx.answers[APP_SOURCE] === APP_SOURCES.COLLECTION
+                        ? await listAppsByCollection(ctx.clients.tenant, ctx.answers.collectionid)
+                        : await listApps(ctx.clients.tenant);
+
+                return apps.map((entry) => ({ name: labelForApp(entry), value: entry.id }));
+            },
+            fallback: { type: 'list', message: 'App id(s) (could not fetch the list)' },
+        };
+
+        const typedApp = {
+            ...byKey.appid,
+            key: 'appid',
+            when: (ctx) => ctx.answers[APP_SOURCE] === APP_SOURCES.TYPED,
+        };
+
+        const filteringGate = {
+            key: FILTERING,
+            type: 'confirm',
+            message: 'Exclude or blur any sheets?',
+            default: false,
+            required: false,
+            variadic: false,
+            secret: false,
+        };
+
+        const advancedGate = {
+            key: ADVANCED,
+            type: 'confirm',
+            message: 'Configure advanced options (ports, schema version, timeouts, browser)?',
+            default: false,
+            required: false,
+            variadic: false,
+            secret: false,
+        };
+
+        const rest = specs.filter(
+            (spec) =>
+                !['tenanturl', 'apikey', 'skipLogin', 'logonuserid', 'logonpwd'].includes(
+                    spec.key
+                ) &&
+                spec.key !== 'appid' &&
+                spec.key !== 'collectionid'
+        );
+
+        const gated = rest.map((spec) => {
+            if (ADVANCED_KEYS.has(spec.key)) {
+                return { ...spec, when: (ctx) => ctx.answers[ADVANCED] === true };
+            }
+
+            if (FILTER_KEYS.has(spec.key)) {
+                return { ...spec, when: (ctx) => ctx.answers[FILTERING] === true };
+            }
+
+            return spec;
+        });
+
+        return bySection(
+            [
+                ...connection,
+                appSource,
+                collection,
+                app,
+                typedApp,
+                filteringGate,
+                advancedGate,
+                ...gated,
+            ].map((spec) => ({ ...spec, group: spec.group ?? groupFor(spec.key) }))
+        );
+    },
+
+    /**
+     * Run the command with the options the wizard produced.
+     *
+     * @param {object} options - Commander-shaped options bag.
+     *
+     * @returns {Promise<boolean>} Whether the run succeeded.
+     */
+    run: (options) => qscloudCreateThumbnails(options),
+};

--- a/src/lib/commands/qscloud/create-sheet-thumbnails.js
+++ b/src/lib/commands/qscloud/create-sheet-thumbnails.js
@@ -9,6 +9,7 @@ import {
 } from '../../browser/browser-version.js';
 import { parsePositiveInteger, collectPositiveIntegers, collectAppIds } from '../helpers.js';
 import { toAppIdList } from '../../util/app-ids.js';
+import { addInteractiveOption } from '../../interactive/interactive-option.js';
 import { runCommand } from '../run-command.js';
 
 /**
@@ -25,6 +26,14 @@ const handleCloudCreateSheetThumbnails = async (options = {}, cmd) => {
     // Joined explicitly: --appid is variadic, and letting a template literal coerce the
     // array reads as one strange id rather than as several.
     logger.verbose(`appid=${toAppIdList(options.appid).join(', ')}`);
+
+    if (options?.interactive) {
+        // Loaded on demand; see the note in browser/uninstall.js for why this
+        // import is not at module scope.
+        const { launchInteractive } = await import('../../interactive/launch.js');
+
+        return launchInteractive('CLOUD MAIN 2', 'qscloud create-sheet-thumbnails', cmd);
+    }
     return runCommand('CLOUD MAIN 3', () => qscloudCreateThumbnails(options, cmd));
 };
 
@@ -264,6 +273,8 @@ const buildCloudCreateSheetThumbnailsCommand = () => {
                 .default('90')
                 .env('BSI_BROWSER_PAGE_TIMEOUT')
         );
+
+    addInteractiveOption(command);
 
     return command;
 };

--- a/src/lib/interactive/__tests__/registry.test.js
+++ b/src/lib/interactive/__tests__/registry.test.js
@@ -109,7 +109,13 @@ describe('the registered wizards', () => {
                 : refined.map((spec) => spec.key);
 
             for (const key of emitted) {
-                expect(`${path} -> ${key}: ${declared.has(key)}`).toBe(`${path} -> ${key}: true`);
+                // A `_`-prefixed key is allowed without a finalize, because
+                // to-cli-options drops those from the bag by itself - the next
+                // test is what holds that. Requiring a finalize here would mean
+                // writing one that does nothing, purely to satisfy a guard.
+                const ok = declared.has(key) || key.startsWith('_');
+
+                expect(`${path} -> ${key}: ${ok}`).toBe(`${path} -> ${key}: true`);
             }
         }
     );

--- a/src/lib/interactive/ask-questions.js
+++ b/src/lib/interactive/ask-questions.js
@@ -85,6 +85,38 @@ const resolveChoices = async (spec, ctx) => {
     }
 };
 
+/**
+ * Check an answer against the thing it describes, once it has been given.
+ *
+ * This is what makes a wrong credential surface at the credential prompt rather
+ * than after every other question has been answered - the single biggest
+ * usability difference between the wizard and the plain CLI, where a bad API key
+ * is discovered only once the run starts.
+ *
+ * Distinct from `validate`, which judges the text on its own. A probe reaches
+ * the network: it opens the connection the answer describes, and is the natural
+ * place to stash the resulting client on `ctx.clients` so later questions can
+ * list what is actually there instead of asking someone to type an id.
+ *
+ * Failure is a message, not an exception, because the driver's response is to
+ * re-ask rather than to abort.
+ *
+ * @param {import('./option-introspect.js').QuestionSpec} spec - The question just answered.
+ * @param {object} ctx - Wizard context, carrying the answers so far.
+ *
+ * @returns {Promise<string|undefined>} A message when the probe failed, otherwise undefined.
+ */
+const runProbe = async (spec, ctx) => {
+    try {
+        // Worker code logs, and a prompt is about to be on screen again.
+        await withQuietLogging(() => spec.probe(ctx));
+
+        return undefined;
+    } catch (err) {
+        return err?.message ?? String(err);
+    }
+};
+
 // The text shown for a choice, which may be a bare value or a {name, value}.
 const labelOf = (choice) =>
     typeof choice === 'object' && choice !== null ? choice.name : String(choice);
@@ -227,11 +259,28 @@ export const askQuestions = async (specs, ctx = {}, { runtime = defaultRuntime }
             runtime.write(`  ${theme.style.help(asked.hint)}\n`);
         }
 
-        const raw = await runtime.ask(asked, configFor(asked, choices, theme));
+        for (;;) {
+            const raw = await runtime.ask(asked, configFor(asked, choices, theme));
 
-        // Answers are written back as we go, so a later question's `when` or
-        // `choices` sees everything said so far.
-        answers[spec.key] = asked.type === 'list' ? splitEntries(raw) : raw;
+            // Answers are written back as we go, so a later question's `when` or
+            // `choices` sees everything said so far.
+            answers[spec.key] = asked.type === 'list' ? splitEntries(raw) : raw;
+
+            if (!spec.probe) {
+                break;
+            }
+
+            const failure = await runProbe(spec, context);
+
+            if (!failure) {
+                break;
+            }
+
+            // Re-ask this question rather than carrying on. A wrong credential
+            // has to be reported where it was typed: the alternative is what the
+            // CLI does today, failing after every other answer has been given.
+            runtime.write(`  ${theme.style.error(failure)}\n`);
+        }
     }
 
     return answers;

--- a/src/lib/interactive/registry.js
+++ b/src/lib/interactive/registry.js
@@ -10,6 +10,8 @@
 export const INTERACTIVE_COMMANDS = Object.freeze({
     'browser install': () => import('../commands/browser/install.interactive.js'),
     'browser uninstall': () => import('../commands/browser/uninstall.interactive.js'),
+    'qscloud create-sheet-thumbnails': () =>
+        import('../commands/qscloud/create-sheet-thumbnails.interactive.js'),
 });
 
 /**
@@ -25,7 +27,6 @@ export const NOT_INTERACTIVE = Object.freeze({
     'browser list-available': 'Takes nothing but a browser and a channel, both with defaults.',
     'browser uninstall-all': 'Takes nothing but a log level, and asks for confirmation itself.',
     'qseow create-sheet-thumbnails': 'Phase 2 - needs credentials and a live connection probe.',
-    'qscloud create-sheet-thumbnails': 'Phase 2 - needs credentials and a live connection probe.',
     'qscloud list-collections': 'Phase 2 - needs tenant credentials.',
     'qscloud remove-sheet-icons': 'Phase 2 - needs tenant credentials.',
 });


### PR DESCRIPTION
First of the two Qlik wizards from #897. `bsi qscloud create-sheet-thumbnails -i` now works.

## The connection probe

The driver gains `spec.probe` — an async check run once an answer is given, which **re-asks that question** when it fails. A wrong tenant url or API key is reported at the prompt where it was typed, rather than after every other question. That is the single biggest behavioural difference from the plain CLI, where a bad key is discovered only once the run starts and 25 flags have already been typed.

The probe also stashes the connected client on `ctx.clients`, which is what lets the app and collection questions offer what the tenant actually holds instead of asking someone to recall a GUID.

## Progressive disclosure: 25 options, 10 questions

```
tenanturl · apikey · skipLogin · logonuserid · logonpwd
_appSource · appid · includesheetpart
_filtering? · _advanced?
```

**The second gate was not planned.** The flow test pins the question list, and it came back at **18** — gating only the technical options leaves eight sheet exclude/blur questions that most runs never touch. #897 predicted "about 9", which is exactly why the number was worth measuring rather than asserting as a count.

The list is pinned exactly rather than by length, so a new option joining the default path shows up as a diff and has to be classified — gated, or deliberately part of the short conversation.

## The app picker

Over all apps on the tenant, or the apps in a chosen collection, with typing an id still available for anyone who has it to hand. Every entry is labelled:

```
❯ Finance  (id: a1b2c3d4-1111-2222-3333-444455556666)
```

**App names are not unique** — duplicates exist on the lab server today — so a label showing the name alone is ambiguous to whoever is choosing, even though the value behind it is not. The id is never truncated, so it can be pasted straight into `--appid`.

## One test guard was wrong

`registry.test.js` rejected `_`-prefixed synthetic keys unless a wizard also had a `finalize`, which would have meant writing an empty `finalize` purely to satisfy the guard. `to-cli-options` already drops those keys and the sibling test asserts exactly that, so the guard now allows them.

## Verification

1624 tests pass, lint clean. 18 new flow tests through the scripted runtime: the probe re-asking on a rejected key, the picker's contents and labels, both gates, and that the API key never reaches the output.

**Not exercised against a live tenant** — the wizard needs a TTY, so that means driving it by hand. Worth doing before the QSEoW twin lands, since the probe and picker are both new machinery.

## Still to come for #897

The QSEoW twin, the review-screen table, `.env` saving, and the run summary — the last needing `runOverApps()` to report per-app outcomes rather than a bare boolean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
