### PR TITLE
Add the QSEoW create-sheet-thumbnails wizard

### DIFF
--- a/src/lib/commands/qseow/__tests__/qseow_wizard.test.js
+++ b/src/lib/commands/qseow/__tests__/qseow_wizard.test.js
@@ -1,0 +1,286 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+// QSEoW twin of qscloud_wizard.test.js. Same shape of conversation, different
+// things that can be wrong first: QSEoW authenticates with certificate files on
+// disk, so a bad path is the first failure an operator can hit.
+
+const qseowVerifyCertificatesExist = jest.fn();
+const qseowVerifyContentLibraryExists = jest.fn();
+const listAppsByTag = jest.fn();
+const listAllApps = jest.fn();
+const qseowCreateThumbnails = jest.fn().mockResolvedValue(true);
+
+jest.unstable_mockModule('../../../qseow/qseow-certificates.js', () => ({
+    qseowVerifyCertificatesExist,
+}));
+jest.unstable_mockModule('../../../qseow/qseow-contentlibrary.js', () => ({
+    qseowVerifyContentLibraryExists,
+}));
+jest.unstable_mockModule('../../../qseow/qseow-app-lookup.js', () => ({
+    listAppsByTag,
+    listAllApps,
+}));
+jest.unstable_mockModule('../../../qseow/qseow-create-thumbnails.js', () => ({
+    qseowCreateThumbnails,
+}));
+
+const { runInteractive } = await import('../../../interactive/index.js');
+const { scriptedRuntime } = await import('../../../interactive/test-helpers/scripted-runtime.js');
+const { labelForApp } = await import('../create-sheet-thumbnails.interactive.js');
+
+const PATH = 'qseow create-sheet-thumbnails';
+
+/**
+ * The answers a run needs when both gates are declined.
+ *
+ * @param {object} [overrides] - Answers to replace or add.
+ *
+ * @returns {object} Answers for the scripted runtime.
+ */
+const baseAnswers = (overrides = {}) => ({
+    host: 'sense.acme.com',
+    certfile: './cert/client.pem',
+    certkeyfile: './cert/client_key.pem',
+    apiuserdir: 'INTERNAL',
+    apiuserid: 'sa_api',
+    logonuserdir: 'ACME',
+    logonuserid: 'goran',
+    logonpwd: 'a-password',
+    _appSource: 'all',
+    appid: ['app-a'],
+    contentlibrary: 'Butler sheet thumbnails',
+    includesheetpart: '1',
+    _filtering: false,
+    _advanced: false,
+    _review: 'cancel',
+    ...overrides,
+});
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    qseowVerifyCertificatesExist.mockResolvedValue(true);
+    qseowVerifyContentLibraryExists.mockResolvedValue(true);
+    listAllApps.mockResolvedValue([
+        { id: 'app-a', name: 'Finance' },
+        { id: 'app-b', name: 'Sales' },
+    ]);
+    listAppsByTag.mockResolvedValue([{ id: 'app-c', name: 'Tagged' }]);
+});
+
+describe('the certificate probe', () => {
+    test('checks the files as soon as both paths are given', async () => {
+        const runtime = scriptedRuntime(baseAnswers());
+
+        await runInteractive({ path: PATH, runtime });
+
+        const asked = runtime.asked.map((a) => a.key);
+        expect(qseowVerifyCertificatesExist).toHaveBeenCalledTimes(1);
+        // Nothing beyond the two paths was asked before the check.
+        expect(asked.slice(0, 3)).toEqual(['host', 'certfile', 'certkeyfile']);
+    });
+
+    test('re-asks the key file when the certificates are not found', async () => {
+        qseowVerifyCertificatesExist.mockResolvedValueOnce(false).mockResolvedValue(true);
+
+        const runtime = scriptedRuntime(
+            baseAnswers({ certkeyfile: ['./wrong.pem', './cert/client_key.pem'] })
+        );
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(runtime.asked.filter((a) => a.key === 'certkeyfile')).toHaveLength(2);
+        expect(runtime.output()).toContain('Certificate file(s) not found');
+    });
+
+    test('reports it before the credentials are asked for', async () => {
+        // The point of probing here: today this failure surfaces after every one
+        // of the command's 36 options has been supplied.
+        qseowVerifyCertificatesExist.mockResolvedValueOnce(false).mockResolvedValue(true);
+
+        const runtime = scriptedRuntime(
+            baseAnswers({ certkeyfile: ['./wrong.pem', './cert/client_key.pem'] })
+        );
+
+        await runInteractive({ path: PATH, runtime });
+
+        const asked = runtime.asked.map((a) => a.key);
+        expect(asked.indexOf('logonpwd')).toBeGreaterThan(asked.lastIndexOf('certkeyfile'));
+    });
+});
+
+describe('the content library probe', () => {
+    test('re-asks when the library does not exist on the server', async () => {
+        // A missing content library aborts the run only after every screenshot
+        // has already been taken.
+        qseowVerifyContentLibraryExists.mockResolvedValueOnce(false).mockResolvedValue(true);
+
+        const runtime = scriptedRuntime(
+            baseAnswers({ contentlibrary: ['Nope', 'Butler sheet thumbnails'] })
+        );
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(runtime.asked.filter((a) => a.key === 'contentlibrary')).toHaveLength(2);
+        expect(runtime.output()).toContain("Content library 'Nope' does not exist");
+    });
+});
+
+describe('choosing which apps to update', () => {
+    test('offers every app on the server', async () => {
+        const runtime = scriptedRuntime(baseAnswers());
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(listAllApps).toHaveBeenCalledTimes(1);
+        const question = runtime.asked.find((a) => a.key === 'appid');
+        expect(question.choices.map((c) => c.value)).toEqual(['app-a', 'app-b']);
+    });
+
+    test('labels every app with its id, marked as an id', async () => {
+        const runtime = scriptedRuntime(baseAnswers());
+
+        await runInteractive({ path: PATH, runtime });
+
+        const question = runtime.asked.find((a) => a.key === 'appid');
+        expect(question.choices[0].name).toBe('Finance  (id: app-a)');
+    });
+
+    test('lists apps carrying a tag when that is how they are chosen', async () => {
+        const runtime = scriptedRuntime(
+            baseAnswers({ _appSource: 'tag', qliksensetag: 'BSI', appid: ['app-c'] })
+        );
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(listAppsByTag).toHaveBeenCalledTimes(1);
+        expect(listAllApps).not.toHaveBeenCalled();
+    });
+
+    test('still lets an app id be typed, without fetching any list', async () => {
+        const runtime = scriptedRuntime(baseAnswers({ _appSource: 'typed', appid: 'app-z' }));
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(listAllApps).not.toHaveBeenCalled();
+        expect(listAppsByTag).not.toHaveBeenCalled();
+    });
+
+    test('does not ask for a tag when apps are chosen another way', async () => {
+        const runtime = scriptedRuntime(baseAnswers());
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(runtime.asked.map((a) => a.key)).not.toContain('qliksensetag');
+    });
+});
+
+describe('progressive disclosure', () => {
+    test('declining both gates keeps the conversation short', async () => {
+        // This command declares 36 options, the most in the CLI, which is what
+        // makes the gating matter more here than anywhere else.
+        const runtime = scriptedRuntime(baseAnswers());
+
+        await runInteractive({ path: PATH, runtime });
+
+        const asked = runtime.asked.filter((a) => a.key !== '_review').map((a) => a.key);
+
+        // Pinned exactly, so an option quietly joining the default path shows up
+        // as a diff and has to be classified.
+        expect(asked).toEqual([
+            // Connection
+            'host',
+            'certfile',
+            'certkeyfile',
+            'apiuserdir',
+            'apiuserid',
+            'logonuserdir',
+            'logonuserid',
+            'logonpwd',
+            // Apps
+            '_appSource',
+            'appid',
+            // Sheets
+            'contentlibrary',
+            'includesheetpart',
+            // The two gates, both declined
+            '_filtering',
+            '_advanced',
+        ]);
+    });
+
+    test('accepting advanced options asks for the ports and the rest', async () => {
+        const runtime = scriptedRuntime(
+            baseAnswers({
+                _advanced: true,
+                loglevel: 'info',
+                engineport: '4747',
+                qrsport: '4242',
+                port: '', // optional, left blank on purpose
+                schemaversion: '12.612.0',
+                rejectUnauthorized: false,
+                secure: true,
+                prefix: '',
+                headless: true,
+                pagewait: '5',
+                imagedir: './img',
+                senseVersion: '2025-Nov',
+                browser: 'chrome',
+                browserVersion: 'recommended',
+                browserPageTimeout: '90',
+            })
+        );
+
+        await runInteractive({ path: PATH, runtime });
+
+        const asked = runtime.asked.map((a) => a.key);
+        expect(asked).toContain('engineport');
+        expect(asked).toContain('senseVersion');
+    });
+});
+
+describe('the run itself', () => {
+    test('cancelling runs nothing', async () => {
+        const runtime = scriptedRuntime(baseAnswers());
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(qseowCreateThumbnails).not.toHaveBeenCalled();
+    });
+
+    test('confirming calls the worker with a Commander-shaped bag', async () => {
+        const runtime = scriptedRuntime(baseAnswers({ _review: 'run' }));
+
+        await runInteractive({ path: PATH, runtime });
+
+        const options = qseowCreateThumbnails.mock.calls[0][0];
+        expect(options.host).toBe('sense.acme.com');
+        expect(options.appid).toEqual(['app-a']);
+        expect(options._appSource).toBeUndefined();
+        expect(options._filtering).toBeUndefined();
+    });
+
+    test('never prints the logon password', async () => {
+        const runtime = scriptedRuntime(baseAnswers({ _review: 'run' }));
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(runtime.output()).not.toContain('a-password');
+    });
+});
+
+describe('both platforms label an app the same way', () => {
+    // The two wizards must not drift: an operator moving between a QSEoW server
+    // and a Cloud tenant should read the same thing.
+    test('the label carries the full id, never truncated', () => {
+        const id = 'a1b2c3d4-1111-2222-3333-444455556666';
+
+        expect(labelForApp({ id, name: 'Finance' })).toBe(`Finance  (id: ${id})`);
+    });
+
+    test('two apps sharing a name stay distinguishable', () => {
+        // Three duplicated names exist on the QSEoW test server today.
+        expect(labelForApp({ id: 'app-a', name: 'Performance review' })).not.toBe(
+            labelForApp({ id: 'app-b', name: 'Performance review' })
+        );
+    });
+});

--- a/src/lib/commands/qseow/create-sheet-thumbnails.interactive.js
+++ b/src/lib/commands/qseow/create-sheet-thumbnails.interactive.js
@@ -1,0 +1,293 @@
+import { qseowVerifyCertificatesExist } from '../../qseow/qseow-certificates.js';
+import { qseowVerifyContentLibraryExists } from '../../qseow/qseow-contentlibrary.js';
+import { listAppsByTag, listAllApps } from '../../qseow/qseow-app-lookup.js';
+import { qseowCreateThumbnails } from '../../qseow/qseow-create-thumbnails.js';
+
+/** Key of the synthetic question asking how apps should be chosen. */
+const APP_SOURCE = '_appSource';
+
+/** Key of the synthetic question gating the sheet exclude/blur filters. */
+const FILTERING = '_filtering';
+
+/** Key of the synthetic question gating the long tail of options. */
+const ADVANCED = '_advanced';
+
+/** How apps can be picked, in the order the choices are offered. */
+export const APP_SOURCES = Object.freeze({
+    ALL: 'all',
+    TAG: 'tag',
+    TYPED: 'typed',
+});
+
+/**
+ * Label one app for a picker.
+ *
+ * Identical in shape to the Cloud wizard's, deliberately: the two platforms
+ * describe an app the same way, so the labels must too. App names are **not
+ * unique** - three are duplicated on the QSEoW test server alone - so the id is
+ * always shown, always marked as an id, and never truncated. Untruncated also
+ * means it can be pasted straight into `--appid`.
+ *
+ * @param {{id: string, name: string}} app - The app to label.
+ *
+ * @returns {string} The label to show.
+ */
+export const labelForApp = (app) => `${app.name}  (id: ${app.id})`;
+
+/** Options that pick out particular sheets to skip or blur. */
+const FILTER_KEYS = new Set([
+    'excludeSheetStatus',
+    'excludeSheetTag',
+    'excludeSheetNumber',
+    'excludeSheetTitle',
+    'blurSheetStatus',
+    'blurSheetTag',
+    'blurSheetNumber',
+    'blurSheetTitle',
+    'blurFactor',
+]);
+
+/**
+ * Options that only matter to someone who already knows they need them.
+ *
+ * Larger than the Cloud set because QSEoW carries the ports, the TLS switches and
+ * the virtual proxy prefix as well. All twelve have defaults that work against a
+ * stock installation, which is what makes gating them safe rather than merely
+ * convenient.
+ */
+const ADVANCED_KEYS = new Set([
+    'loglevel',
+    'engineport',
+    'qrsport',
+    'port',
+    'schemaversion',
+    'rejectUnauthorized',
+    'secure',
+    'prefix',
+    'headless',
+    'pagewait',
+    'imagedir',
+    'senseVersion',
+    'browser',
+    'browserVersion',
+    'browserPageTimeout',
+]);
+
+/** Which section each question belongs under, in the order the sections run. */
+const GROUPS = [
+    [
+        'Connection',
+        [
+            'host',
+            'certfile',
+            'certkeyfile',
+            'apiuserdir',
+            'apiuserid',
+            'logonuserdir',
+            'logonuserid',
+            'logonpwd',
+        ],
+    ],
+    ['Apps', [APP_SOURCE, 'qliksensetag', 'appid']],
+    ['Sheets', ['includesheetpart', 'contentlibrary']],
+    ['Sheet filtering', [FILTERING, ...FILTER_KEYS]],
+    ['Advanced', [ADVANCED, ...ADVANCED_KEYS]],
+];
+
+/** Questions asked before anything else, in this order. */
+const CONNECTION_KEYS = GROUPS[0][1];
+
+/**
+ * Work out which section a question belongs to.
+ *
+ * @param {string} key - The question's key.
+ *
+ * @returns {string|undefined} The section heading, if the key has one.
+ */
+const groupFor = (key) => GROUPS.find(([, keys]) => [...keys].includes(key))?.[0];
+
+/**
+ * Order questions by section, keeping declaration order within each one.
+ *
+ * @param {Array} specs - Questions to order.
+ *
+ * @returns {Array} The same questions, grouped.
+ */
+const bySection = (specs) => {
+    const order = GROUPS.map(([name]) => name);
+
+    return [...specs].sort((a, b) => order.indexOf(a.group) - order.indexOf(b.group));
+};
+
+export default {
+    commandPath: 'qseow create-sheet-thumbnails',
+    label: 'Create sheet thumbnails (Qlik Sense Enterprise on Windows)',
+
+    /**
+     * Reshape the derived questions into a conversation.
+     *
+     * The QSEoW twin of the Cloud wizard, and deliberately the same shape: two
+     * gates, an app picker, and a probe that reports a bad answer where it was
+     * given. Where it differs is what can go wrong first.
+     *
+     * QSEoW authenticates with **certificate files on disk**, so the first thing
+     * that can be wrong is a path - and `qseowVerifyCertificatesExist()` says so
+     * at the certificate prompt rather than after the credentials, the app
+     * selection and everything else have been answered. The content library is
+     * checked the same way, because a missing one aborts the run after every
+     * screenshot has already been taken.
+     *
+     * This command declares 36 options, the most in the CLI, which is what makes
+     * the gating matter more here than anywhere else.
+     *
+     * Pure: specs in, specs out. The network and filesystem calls live behind
+     * `choices` and `probe`, which the driver invokes.
+     *
+     * @param {import('../../interactive/option-introspect.js').QuestionSpec[]} specs - Derived questions.
+     *
+     * @returns {Array} The questions to actually ask.
+     */
+    refine(specs) {
+        const byKey = Object.fromEntries(specs.map((spec) => [spec.key, spec]));
+
+        const connection = CONNECTION_KEYS.map((key) => byKey[key])
+            .filter(Boolean)
+            .map((spec) =>
+                spec.key === 'certkeyfile'
+                    ? {
+                          ...spec,
+                          needs: ['certfile'],
+                          probe: async (ctx) => {
+                              const ok = await qseowVerifyCertificatesExist(ctx.answers);
+
+                              if (!ok) {
+                                  // The helper logs which file is missing; this
+                                  // is what the prompt itself shows.
+                                  throw new Error(
+                                      'Certificate file(s) not found. Check --certfile and --certkeyfile.'
+                                  );
+                              }
+                          },
+                      }
+                    : spec
+            );
+
+        const appSource = {
+            key: APP_SOURCE,
+            type: 'select',
+            message: 'Which apps should be updated?',
+            required: true,
+            variadic: false,
+            secret: false,
+            needs: ['logonpwd'],
+            choices: [
+                { name: 'Choose from all apps on the server', value: APP_SOURCES.ALL },
+                { name: 'Choose a tag, then apps carrying it', value: APP_SOURCES.TAG },
+                { name: 'Type an app id', value: APP_SOURCES.TYPED },
+            ],
+        };
+
+        const tag = {
+            ...byKey.qliksensetag,
+            needs: [APP_SOURCE],
+            when: (ctx) => ctx.answers[APP_SOURCE] === APP_SOURCES.TAG,
+        };
+
+        const app = {
+            ...byKey.appid,
+            type: 'checkbox',
+            message: 'Which apps?',
+            needs: [APP_SOURCE],
+            when: (ctx) => ctx.answers[APP_SOURCE] !== APP_SOURCES.TYPED,
+            choices: async (ctx) => {
+                const apps =
+                    ctx.answers[APP_SOURCE] === APP_SOURCES.TAG
+                        ? await listAppsByTag(ctx.answers)
+                        : await listAllApps(ctx.answers);
+
+                return apps.map((entry) => ({ name: labelForApp(entry), value: entry.id }));
+            },
+            fallback: { type: 'list', message: 'App id(s) (could not fetch the list)' },
+        };
+
+        const typedApp = {
+            ...byKey.appid,
+            key: 'appid',
+            when: (ctx) => ctx.answers[APP_SOURCE] === APP_SOURCES.TYPED,
+        };
+
+        const contentLibrary = {
+            ...byKey.contentlibrary,
+            probe: async (ctx) => {
+                const exists = await qseowVerifyContentLibraryExists(ctx.answers);
+
+                if (!exists) {
+                    throw new Error(
+                        `Content library '${ctx.answers.contentlibrary}' does not exist on ${ctx.answers.host}.`
+                    );
+                }
+            },
+        };
+
+        const filteringGate = {
+            key: FILTERING,
+            type: 'confirm',
+            message: 'Exclude or blur any sheets?',
+            default: false,
+            required: false,
+            variadic: false,
+            secret: false,
+        };
+
+        const advancedGate = {
+            key: ADVANCED,
+            type: 'confirm',
+            message: 'Configure advanced options (ports, certificates, schema version, browser)?',
+            default: false,
+            required: false,
+            variadic: false,
+            secret: false,
+        };
+
+        const rest = specs.filter(
+            (spec) =>
+                !CONNECTION_KEYS.includes(spec.key) &&
+                !['appid', 'qliksensetag', 'contentlibrary'].includes(spec.key)
+        );
+
+        const gated = rest.map((spec) => {
+            if (ADVANCED_KEYS.has(spec.key)) {
+                return { ...spec, when: (ctx) => ctx.answers[ADVANCED] === true };
+            }
+
+            if (FILTER_KEYS.has(spec.key)) {
+                return { ...spec, when: (ctx) => ctx.answers[FILTERING] === true };
+            }
+
+            return spec;
+        });
+
+        return bySection(
+            [
+                ...connection,
+                appSource,
+                tag,
+                app,
+                typedApp,
+                contentLibrary,
+                filteringGate,
+                advancedGate,
+                ...gated,
+            ].map((spec) => ({ ...spec, group: spec.group ?? groupFor(spec.key) }))
+        );
+    },
+
+    /**
+     * Run the command with the options the wizard produced.
+     *
+     * @param {object} options - Commander-shaped options bag.
+     *
+     * @returns {Promise<boolean>} Whether the run succeeded.
+     */
+    run: (options) => qseowCreateThumbnails(options),
+};

--- a/src/lib/commands/qseow/index.js
+++ b/src/lib/commands/qseow/index.js
@@ -10,6 +10,7 @@ import {
 } from '../../browser/browser-version.js';
 import { parsePositiveInteger, collectPositiveIntegers, collectAppIds } from '../helpers.js';
 import { toAppIdList } from '../../util/app-ids.js';
+import { addInteractiveOption } from '../../interactive/interactive-option.js';
 import { runCommand } from '../run-command.js';
 
 /**
@@ -26,6 +27,15 @@ const handleQseowCreateSheetThumbnails = async (options = {}, command) => {
     // Joined explicitly: --appid is variadic, and letting a template literal coerce the
     // array reads as one strange id rather than as several.
     logger.verbose(`appid=${toAppIdList(options.appid).join(', ')}`);
+
+    if (options?.interactive) {
+        // Loaded on demand; see the note in browser/uninstall.js for why this
+        // import is not at module scope.
+        const { launchInteractive } = await import('../../interactive/launch.js');
+
+        return launchInteractive('QSEOW MAIN 1', 'qseow create-sheet-thumbnails', command);
+    }
+
     return runCommand('QSEOW MAIN 1', () => qseowCreateThumbnails(options, command));
 };
 
@@ -358,6 +368,8 @@ const buildQseowCommand = () => {
                 .default('90')
                 .env('BSI_BROWSER_PAGE_TIMEOUT')
         );
+
+    addInteractiveOption(qseow.commands[0]);
 
     return qseow;
 };

--- a/src/lib/interactive/__tests__/launch.test.js
+++ b/src/lib/interactive/__tests__/launch.test.js
@@ -29,7 +29,11 @@ const parseQseow = (tail) => {
     const namespace = buildQseowCommand();
     const leaf = namespace.commands[0];
 
-    addInteractiveOption(leaf);
+    // The builder declares -i itself now that this command has a wizard; adding
+    // it again would give Commander two options storing under the same key.
+    if (!leaf.options.some((option) => option.long === '--interactive')) {
+        addInteractiveOption(leaf);
+    }
     leaf.exitOverride().configureOutput({ writeOut: () => {}, writeErr: () => {} });
     leaf._actionHandler = undefined;
     leaf.action(() => {});

--- a/src/lib/interactive/__tests__/registry.test.js
+++ b/src/lib/interactive/__tests__/registry.test.js
@@ -81,7 +81,9 @@ describe('the registered wizards', () => {
     );
 
     test('an unregistered path is refused, naming what is available', async () => {
-        await expect(loadWizard('qseow create-sheet-thumbnails')).rejects.toThrow(/Available:/);
+        // A real leaf command that is deliberately not interactive, so this
+        // stays meaningful as wizards are added.
+        await expect(loadWizard('browser list-installed')).rejects.toThrow(/Available:/);
     });
 
     // Every key a wizard can produce must be a real option on its own command.

--- a/src/lib/interactive/__tests__/round-trip.test.js
+++ b/src/lib/interactive/__tests__/round-trip.test.js
@@ -246,6 +246,26 @@ describe('the traps this invariant exists to catch', () => {
         expect(bag.excludeSheetStatus).toEqual(['private', 'published']);
     });
 
+    test('an optional option left blank is simply absent', () => {
+        // qseow's --port takes no default, so the CLI is happy without it, but
+        // its parser rejects an empty string. Emitting `--port ''` would build a
+        // command line the parser then refuses - a line the wizard printed as
+        // the way to reproduce its own run.
+        const specs = specsFromCommand(qseow.command);
+        const bag = answersToOptions(specs, { port: '' });
+
+        expect(bag.port).toBeUndefined();
+        expect(formatCommandLine('qseow x', specs, { port: '' })).not.toContain('--port');
+    });
+
+    test('a required option left blank is still emitted, so the failure is visible', () => {
+        // The opposite case: silently dropping a required answer would produce a
+        // command line that looks complete and is not.
+        const specs = specsFromCommand(qseow.command);
+
+        expect(formatCommandLine('qseow x', specs, { host: '' })).toContain('--host');
+    });
+
     test('synthetic answers never reach the options bag or the command line', () => {
         const specs = specsFromCommand(qseow.command);
         const answers = { _howToPick: 'by collection', host: 'sense.example.com' };

--- a/src/lib/interactive/ask-questions.js
+++ b/src/lib/interactive/ask-questions.js
@@ -179,8 +179,17 @@ const textConfig = (spec) => {
     }
 
     if (spec.validate) {
-        config.validate =
+        const validate =
             spec.type === 'list' ? (value) => spec.validate(splitEntries(value)) : spec.validate;
+
+        // An optional option has to be leaveable. `--port` on qseow is the case
+        // that showed this up: it takes no default, so the CLI is happy without
+        // it, but its parser rejects an empty string - which in a prompt means
+        // the question can never be answered and the wizard cannot continue.
+        // Blank is how someone says "not this one", and to-cli-options drops it
+        // rather than emitting an empty flag value the parser would then refuse.
+        config.validate = (value) =>
+            !spec.required && String(value ?? '').trim().length === 0 ? true : validate(value);
     } else if (spec.required) {
         config.validate = (value) =>
             String(value ?? '').trim().length > 0 ? true : 'This one is required.';

--- a/src/lib/interactive/registry.js
+++ b/src/lib/interactive/registry.js
@@ -12,6 +12,8 @@ export const INTERACTIVE_COMMANDS = Object.freeze({
     'browser uninstall': () => import('../commands/browser/uninstall.interactive.js'),
     'qscloud create-sheet-thumbnails': () =>
         import('../commands/qscloud/create-sheet-thumbnails.interactive.js'),
+    'qseow create-sheet-thumbnails': () =>
+        import('../commands/qseow/create-sheet-thumbnails.interactive.js'),
 });
 
 /**
@@ -26,7 +28,6 @@ export const NOT_INTERACTIVE = Object.freeze({
     'browser list-installed': 'Takes nothing but a log level; there is nothing to ask.',
     'browser list-available': 'Takes nothing but a browser and a channel, both with defaults.',
     'browser uninstall-all': 'Takes nothing but a log level, and asks for confirmation itself.',
-    'qseow create-sheet-thumbnails': 'Phase 2 - needs credentials and a live connection probe.',
     'qscloud list-collections': 'Phase 2 - needs tenant credentials.',
     'qscloud remove-sheet-icons': 'Phase 2 - needs tenant credentials.',
 });

--- a/src/lib/interactive/to-cli-options.js
+++ b/src/lib/interactive/to-cli-options.js
@@ -123,6 +123,15 @@ export const emissionsFor = (specs, answers, { env = process.env } = {}) =>
             return notEmitted('no answer');
         }
 
+        // Blank means "not this one". An optional option with a parser - qseow's
+        // `--port` - would otherwise be emitted as `--port ''`, and the parser
+        // that let the prompt accept a blank would then reject the command line
+        // built from it. Options whose declared default *is* an empty string,
+        // like `--prefix`, are caught by the default check below either way.
+        if (answer === '' && !spec.required) {
+            return notEmitted('left blank');
+        }
+
         const envIsSet = Boolean(spec.option.envVar && spec.option.envVar in env);
 
         if (!envIsSet && matchesDeclaredDefault(spec, answer)) {

--- a/src/lib/qseow/qseow-app-lookup.js
+++ b/src/lib/qseow/qseow-app-lookup.js
@@ -6,6 +6,20 @@ import { qrsGetList } from './qrs-response.js';
 import { qrsFilterAnyOf, qrsPathWithFilter } from './qrs-filter.js';
 
 /**
+ * Reduce a QRS app entry to what a caller needs.
+ *
+ * Shared by both lookups so "apps with this tag" and "every app" describe an app
+ * the same way - the property that lets a picker treat the two lists
+ * interchangeably. `name` falls back to `id` on the off chance the reply omits
+ * it; against a real server all 17 apps carried one.
+ *
+ * @param {object} app - An entry from `app/full`.
+ *
+ * @returns {{id: string, name: string}} The app.
+ */
+const asApp = (app) => ({ id: app.id, name: app.name ?? app.id });
+
+/**
  * Looks up all QSEoW apps carrying a given tag.
  *
  * Shared by the two commands that accept `--qliksensetag`. They previously held byte-identical
@@ -52,5 +66,32 @@ export const listAppsByTag = async (options) => {
     // `TypeError: result.body.map is not a function` from somewhere further down.
     const apps = await qrsGetList(qrsInteractInstance, qrsPathWithFilter('app/full', filter));
 
-    return apps.map((app) => ({ id: app.id, name: app.name ?? app.id }));
+    return apps.map(asApp);
+};
+
+/**
+ * Returns every app the API user can see on the server.
+ *
+ * The QSEoW counterpart of `listApps()` on the Cloud side, and it exists for the
+ * same reason: an app picker has to be able to offer a list when the operator has
+ * neither a tag nor an app id to hand, which is the position a first-time user is
+ * in. Unfiltered, so what comes back is scoped by what the certificate's account
+ * may read - the same scoping every other QRS call in this codebase inherits.
+ *
+ * **App names are not unique** - only ids are. See {@link listAppsByTag}.
+ *
+ * @param {object} options - QSEoW options, as passed to the command.
+ * @param {string} options.host - Qlik Sense server hostname.
+ * @param {number} options.qrsport - QRS port number.
+ * @param {string} options.certfile - Path to the certificate file.
+ * @param {string} options.certkeyfile - Path to the certificate key file.
+ *
+ * @returns {Promise<Array<{id: string, name: string}>>} Every readable app.
+ */
+export const listAllApps = async (options) => {
+    const qrsInteractInstance = new qrsInteract(setupQseowQrsConnection(options));
+
+    const apps = await qrsGetList(qrsInteractInstance, 'app/full');
+
+    return apps.map(asApp);
 };


### PR DESCRIPTION
The QSEoW twin of #990, and deliberately the same conversation: two gates, an app picker, and probes that report a bad answer where it was given. `bsi qseow create-sheet-thumbnails -i`.

## What differs from the Cloud side

QSEoW authenticates with **certificate files on disk**, so a wrong path is the earliest failure available. `qseowVerifyCertificatesExist()` now runs at the certificate prompt rather than after the credentials, the app selection and everything else have been answered. The content library is probed the same way, because a missing one currently aborts the run *after every screenshot has already been taken*.

This command declares 36 options, the most in the CLI. With both gates declined it asks **14 questions**, pinned exactly in the flow test so a new option joining the default path shows up as a diff and has to be classified.

`listAllApps()` joins `listAppsByTag()` in `qseow-app-lookup.js`, mirroring `listApps()` on the Cloud side: a picker has to offer a list when the operator has neither a tag nor an app id to hand, which is exactly where a first-time user starts. Both lookups share one item mapping, so the two lists describe an app identically.

## Two framework fixes that fell out of building it

**An optional option has to be leaveable.** `--port` takes no default, so the CLI is happy without it — but its parser rejects an empty string, which in a prompt means the question can never be answered and the wizard cannot continue. Blank now passes validation for any non-required question, *and* `to-cli-options` drops it rather than emitting `--port ''`, which the same parser would refuse. Without the second half the wizard would have printed a command line it could not itself run. Both directions are pinned in `round-trip.test.js`.

**Two stale fixtures**: `launch.test.js` added `-i` by hand to a command whose builder now declares it, and `registry.test.js` used `qseow create-sheet-thumbnails` as its example of an unregistered path.

## A gap this exposed

ESLint, not a test, caught a real bug — the handler's second parameter is `command`, not `cmd`, so `-i` would have thrown at runtime. It was caught only because the names happened to differ. **The `-i` handler routing is unit-untested on all four commands**; worth closing separately.

## Verification

1644 tests pass, lint clean. 16 new flow tests: both probes re-asking, the picker by tag / by server / by typed id, the pinned question list, and that the logon password never reaches the output.

**Neither wizard has been driven against a live server yet** — that needs a TTY, so it needs a person. Worth doing before the review screen and `.env` saving land on top.

## Still to come for #897

The review-screen table, `.env` saving, and the run summary — the last needing `runOverApps()` to report per-app outcomes rather than a bare boolean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
