### PR TITLE
Share the wizard scaffolding between the two Qlik twins

### DIFF
--- a/src/lib/commands/qscloud/create-sheet-thumbnails.interactive.js
+++ b/src/lib/commands/qscloud/create-sheet-thumbnails.interactive.js
@@ -2,35 +2,21 @@ import QlikSaas from '../../cloud/cloud-repo.js';
 import { qscloudTestConnection } from '../../cloud/cloud-test-connection.js';
 import { listCollections, listApps, listAppsByCollection } from '../../cloud/cloud-apps.js';
 import { qscloudCreateThumbnails } from '../../cloud/cloud-create-thumbnails.js';
+import { gate, gatedBy, inSections, SHEET_FILTER_KEYS } from '../../interactive/spec-ops.js';
+import { labelForApp, labelForCollection } from '../../interactive/labels.js';
+
+// Re-exported so a reader following this wizard finds the labels it uses without
+// having to know they are shared with the QSEoW twin.
+export { labelForApp, labelForCollection };
 
 /** Key of the synthetic question asking how apps should be chosen. */
 const APP_SOURCE = '_appSource';
 
-/** Key of the synthetic question gating the long tail of options. */
-const ADVANCED = '_advanced';
-
 /** Key of the synthetic question gating the sheet exclude/blur filters. */
 const FILTERING = '_filtering';
 
-/**
- * Options that pick out particular sheets to skip or blur.
- *
- * Gated as a block behind one question. They are eight of this command's
- * twenty-five options and most runs use none of them - the common case is "every
- * sheet in the app" - so asking about each one individually is what turns a
- * short conversation into a long one.
- */
-const FILTER_KEYS = new Set([
-    'excludeSheetStatus',
-    'excludeSheetTag',
-    'excludeSheetNumber',
-    'excludeSheetTitle',
-    'blurSheetStatus',
-    'blurSheetTag',
-    'blurSheetNumber',
-    'blurSheetTitle',
-    'blurFactor',
-]);
+/** Key of the synthetic question gating the long tail of options. */
+const ADVANCED = '_advanced';
 
 /** How apps can be picked, in the order the choices are offered. */
 export const APP_SOURCES = Object.freeze({
@@ -39,37 +25,12 @@ export const APP_SOURCES = Object.freeze({
     TYPED: 'typed',
 });
 
-/**
- * Label one app for a picker.
- *
- * The id is always shown, never truncated, and always marked as an id. App names
- * are **not unique** - two apps on the same tenant may legitimately share one,
- * and duplicates exist in practice - so a label showing the name alone is
- * ambiguous to the person choosing even though the value behind it is not.
- * Showing the full id also means it can be pasted straight into `--appid`, which
- * is the point of echoing the equivalent command line at the end.
- *
- * @param {{id: string, name: string}} app - The app to label.
- *
- * @returns {string} The label to show.
- */
-export const labelForApp = (app) => `${app.name}  (id: ${app.id})`;
-
-/**
- * Label one collection for a picker.
- *
- * The item count is worth showing because an empty collection is a dead end, and
- * seeing "0 items" before choosing it is better than a run that selects nothing.
- *
- * @param {object} collection - A collection as the tenant reported it.
- *
- * @returns {string} The label to show.
- */
-export const labelForCollection = (collection) =>
-    `${collection.name}  (${collection.itemCount ?? 0} items)`;
+/** Questions asked before anything else, in this order. */
+const CONNECTION_KEYS = ['tenanturl', 'apikey', 'skipLogin', 'logonuserid', 'logonpwd'];
 
 /** Options that only matter to someone who already knows they need them. */
-const ADVANCED_KEYS = new Set([
+const ADVANCED_KEYS = [
+    'loglevel',
     'schemaversion',
     'pagewait',
     'imagedir',
@@ -77,39 +38,16 @@ const ADVANCED_KEYS = new Set([
     'browserVersion',
     'browserPageTimeout',
     'headless',
-    'loglevel',
-]);
-
-/** Which section each question belongs under, in the order the sections run. */
-const GROUPS = [
-    ['Connection', ['tenanturl', 'apikey', 'skipLogin', 'logonuserid', 'logonpwd']],
-    ['Apps', [APP_SOURCE, 'collectionid', 'appid']],
-    ['Sheets', ['includesheetpart']],
-    ['Sheet filtering', [FILTERING, ...FILTER_KEYS]],
-    ['Advanced', [ADVANCED, ...ADVANCED_KEYS]],
 ];
 
-/**
- * Work out which section a question belongs to.
- *
- * @param {string} key - The question's key.
- *
- * @returns {string|undefined} The section heading, if the key has one.
- */
-const groupFor = (key) => GROUPS.find(([, keys]) => [...keys].includes(key))?.[0];
-
-/**
- * Order questions by section, keeping declaration order within each one.
- *
- * @param {Array} specs - Questions to order.
- *
- * @returns {Array} The same questions, grouped.
- */
-const bySection = (specs) => {
-    const order = GROUPS.map(([name]) => name);
-
-    return [...specs].sort((a, b) => order.indexOf(a.group) - order.indexOf(b.group));
-};
+/** Which section each question belongs under, in the order the sections run. */
+const SECTIONS = [
+    ['Connection', CONNECTION_KEYS],
+    ['Apps', [APP_SOURCE, 'collectionid', 'appid']],
+    ['Sheets', ['includesheetpart']],
+    ['Sheet filtering', [FILTERING, ...SHEET_FILTER_KEYS]],
+    ['Advanced', [ADVANCED, ...ADVANCED_KEYS]],
+];
 
 export default {
     commandPath: 'qscloud create-sheet-thumbnails',
@@ -118,25 +56,21 @@ export default {
     /**
      * Reshape the derived questions into a conversation.
      *
-     * Three things happen here, in rough order of how much they matter.
-     *
      * The API key carries a **probe**, so a wrong tenant url or key is reported
      * at the prompt where it was typed rather than after twenty more questions.
-     * The probe also stashes the connected client, which is what lets the app
-     * and collection questions offer what is actually on the tenant.
+     * The probe also stashes the connected client, which is what lets the app and
+     * collection questions offer what the tenant actually holds.
      *
-     * The **long tail is gated** behind one question. Answering "no" to advanced
-     * options takes this command from 25 questions to about 9, which is the
-     * single biggest usability lever available - no amount of styling fixes a
-     * flat list of 25.
+     * The **long tail is gated** twice, once for the sheet filters and once for
+     * the technical options. Declining both takes this command from 25 options to
+     * 10 questions, the single biggest usability lever available.
      *
      * **App selection becomes a picker.** Typing a GUID from memory is the thing
-     * this feature exists to remove, so the default is to choose from the apps
-     * the tenant actually has, with typing one still available for anyone who
-     * has the id to hand.
+     * this feature exists to remove, so the default is to choose from the apps the
+     * tenant actually has, with typing one still available.
      *
-     * Pure: specs in, specs out, no I/O. The network calls all live behind
-     * `choices` and `probe`, which the driver invokes.
+     * Pure: specs in, specs out. The network calls live behind `choices` and
+     * `probe`, which the driver invokes.
      *
      * @param {import('../../interactive/option-introspect.js').QuestionSpec[]} specs - Derived questions.
      *
@@ -145,8 +79,7 @@ export default {
     refine(specs) {
         const byKey = Object.fromEntries(specs.map((spec) => [spec.key, spec]));
 
-        const connection = ['tenanturl', 'apikey', 'skipLogin', 'logonuserid', 'logonpwd']
-            .map((key) => byKey[key])
+        const connection = CONNECTION_KEYS.map((key) => byKey[key])
             .filter(Boolean)
             .map((spec) =>
                 spec.key === 'apikey'
@@ -159,8 +92,8 @@ export default {
                                   token: ctx.answers.apikey,
                               });
 
-                              // Throws on a bad url or key, which is exactly
-                              // what the driver turns into a re-ask.
+                              // Throws on a bad url or key, which is what the
+                              // driver turns into a re-ask.
                               await qscloudTestConnection(
                                   { tenanturl: ctx.answers.tenanturl },
                                   saas
@@ -209,8 +142,6 @@ export default {
             type: 'checkbox',
             message: 'Which apps?',
             needs: [APP_SOURCE],
-            // Typing an id stays possible, so this is the derived question
-            // unchanged for anyone who already knows the id.
             when: (ctx) => ctx.answers[APP_SOURCE] !== APP_SOURCES.TYPED,
             choices: async (ctx) => {
                 const apps =
@@ -223,64 +154,36 @@ export default {
             fallback: { type: 'list', message: 'App id(s) (could not fetch the list)' },
         };
 
+        // The derived question unchanged, for anyone who already knows the id.
         const typedApp = {
             ...byKey.appid,
-            key: 'appid',
             when: (ctx) => ctx.answers[APP_SOURCE] === APP_SOURCES.TYPED,
         };
 
-        const filteringGate = {
-            key: FILTERING,
-            type: 'confirm',
-            message: 'Exclude or blur any sheets?',
-            default: false,
-            required: false,
-            variadic: false,
-            secret: false,
-        };
+        const rest = specs
+            .filter(
+                (spec) =>
+                    !CONNECTION_KEYS.includes(spec.key) &&
+                    !['appid', 'collectionid'].includes(spec.key)
+            )
+            .map(gatedBy(ADVANCED, ADVANCED_KEYS))
+            .map(gatedBy(FILTERING, SHEET_FILTER_KEYS));
 
-        const advancedGate = {
-            key: ADVANCED,
-            type: 'confirm',
-            message: 'Configure advanced options (ports, schema version, timeouts, browser)?',
-            default: false,
-            required: false,
-            variadic: false,
-            secret: false,
-        };
-
-        const rest = specs.filter(
-            (spec) =>
-                !['tenanturl', 'apikey', 'skipLogin', 'logonuserid', 'logonpwd'].includes(
-                    spec.key
-                ) &&
-                spec.key !== 'appid' &&
-                spec.key !== 'collectionid'
-        );
-
-        const gated = rest.map((spec) => {
-            if (ADVANCED_KEYS.has(spec.key)) {
-                return { ...spec, when: (ctx) => ctx.answers[ADVANCED] === true };
-            }
-
-            if (FILTER_KEYS.has(spec.key)) {
-                return { ...spec, when: (ctx) => ctx.answers[FILTERING] === true };
-            }
-
-            return spec;
-        });
-
-        return bySection(
+        return inSections(
             [
                 ...connection,
                 appSource,
                 collection,
                 app,
                 typedApp,
-                filteringGate,
-                advancedGate,
-                ...gated,
-            ].map((spec) => ({ ...spec, group: spec.group ?? groupFor(spec.key) }))
+                gate({ key: FILTERING, message: 'Exclude or blur any sheets?' }),
+                gate({
+                    key: ADVANCED,
+                    message: 'Configure advanced options (schema version, timeouts, browser)?',
+                }),
+                ...rest,
+            ],
+            SECTIONS
         );
     },
 

--- a/src/lib/commands/qseow/create-sheet-thumbnails.interactive.js
+++ b/src/lib/commands/qseow/create-sheet-thumbnails.interactive.js
@@ -2,6 +2,12 @@ import { qseowVerifyCertificatesExist } from '../../qseow/qseow-certificates.js'
 import { qseowVerifyContentLibraryExists } from '../../qseow/qseow-contentlibrary.js';
 import { listAppsByTag, listAllApps } from '../../qseow/qseow-app-lookup.js';
 import { qseowCreateThumbnails } from '../../qseow/qseow-create-thumbnails.js';
+import { gate, gatedBy, inSections, SHEET_FILTER_KEYS } from '../../interactive/spec-ops.js';
+import { labelForApp } from '../../interactive/labels.js';
+
+// Re-exported so a reader following this wizard finds the label it uses without
+// having to know it is shared with the Cloud twin.
+export { labelForApp };
 
 /** Key of the synthetic question asking how apps should be chosen. */
 const APP_SOURCE = '_appSource';
@@ -19,43 +25,27 @@ export const APP_SOURCES = Object.freeze({
     TYPED: 'typed',
 });
 
-/**
- * Label one app for a picker.
- *
- * Identical in shape to the Cloud wizard's, deliberately: the two platforms
- * describe an app the same way, so the labels must too. App names are **not
- * unique** - three are duplicated on the QSEoW test server alone - so the id is
- * always shown, always marked as an id, and never truncated. Untruncated also
- * means it can be pasted straight into `--appid`.
- *
- * @param {{id: string, name: string}} app - The app to label.
- *
- * @returns {string} The label to show.
- */
-export const labelForApp = (app) => `${app.name}  (id: ${app.id})`;
-
-/** Options that pick out particular sheets to skip or blur. */
-const FILTER_KEYS = new Set([
-    'excludeSheetStatus',
-    'excludeSheetTag',
-    'excludeSheetNumber',
-    'excludeSheetTitle',
-    'blurSheetStatus',
-    'blurSheetTag',
-    'blurSheetNumber',
-    'blurSheetTitle',
-    'blurFactor',
-]);
+/** Questions asked before anything else, in this order. */
+const CONNECTION_KEYS = [
+    'host',
+    'certfile',
+    'certkeyfile',
+    'apiuserdir',
+    'apiuserid',
+    'logonuserdir',
+    'logonuserid',
+    'logonpwd',
+];
 
 /**
  * Options that only matter to someone who already knows they need them.
  *
  * Larger than the Cloud set because QSEoW carries the ports, the TLS switches and
- * the virtual proxy prefix as well. All twelve have defaults that work against a
+ * the virtual proxy prefix as well. All of them have defaults that work against a
  * stock installation, which is what makes gating them safe rather than merely
  * convenient.
  */
-const ADVANCED_KEYS = new Set([
+const ADVANCED_KEYS = [
     'loglevel',
     'engineport',
     'qrsport',
@@ -71,53 +61,16 @@ const ADVANCED_KEYS = new Set([
     'browser',
     'browserVersion',
     'browserPageTimeout',
-]);
-
-/** Which section each question belongs under, in the order the sections run. */
-const GROUPS = [
-    [
-        'Connection',
-        [
-            'host',
-            'certfile',
-            'certkeyfile',
-            'apiuserdir',
-            'apiuserid',
-            'logonuserdir',
-            'logonuserid',
-            'logonpwd',
-        ],
-    ],
-    ['Apps', [APP_SOURCE, 'qliksensetag', 'appid']],
-    ['Sheets', ['includesheetpart', 'contentlibrary']],
-    ['Sheet filtering', [FILTERING, ...FILTER_KEYS]],
-    ['Advanced', [ADVANCED, ...ADVANCED_KEYS]],
 ];
 
-/** Questions asked before anything else, in this order. */
-const CONNECTION_KEYS = GROUPS[0][1];
-
-/**
- * Work out which section a question belongs to.
- *
- * @param {string} key - The question's key.
- *
- * @returns {string|undefined} The section heading, if the key has one.
- */
-const groupFor = (key) => GROUPS.find(([, keys]) => [...keys].includes(key))?.[0];
-
-/**
- * Order questions by section, keeping declaration order within each one.
- *
- * @param {Array} specs - Questions to order.
- *
- * @returns {Array} The same questions, grouped.
- */
-const bySection = (specs) => {
-    const order = GROUPS.map(([name]) => name);
-
-    return [...specs].sort((a, b) => order.indexOf(a.group) - order.indexOf(b.group));
-};
+/** Which section each question belongs under, in the order the sections run. */
+const SECTIONS = [
+    ['Connection', CONNECTION_KEYS],
+    ['Apps', [APP_SOURCE, 'qliksensetag', 'appid']],
+    ['Sheets', ['contentlibrary', 'includesheetpart']],
+    ['Sheet filtering', [FILTERING, ...SHEET_FILTER_KEYS]],
+    ['Advanced', [ADVANCED, ...ADVANCED_KEYS]],
+];
 
 export default {
     commandPath: 'qseow create-sheet-thumbnails',
@@ -127,21 +80,22 @@ export default {
      * Reshape the derived questions into a conversation.
      *
      * The QSEoW twin of the Cloud wizard, and deliberately the same shape: two
-     * gates, an app picker, and a probe that reports a bad answer where it was
-     * given. Where it differs is what can go wrong first.
+     * gates, an app picker, and probes that report a bad answer where it was
+     * given. Both are built from the same helpers in `spec-ops.js`, so the two
+     * conversations cannot drift apart in structure - only in the parts that are
+     * genuinely different between the platforms.
      *
-     * QSEoW authenticates with **certificate files on disk**, so the first thing
-     * that can be wrong is a path - and `qseowVerifyCertificatesExist()` says so
-     * at the certificate prompt rather than after the credentials, the app
-     * selection and everything else have been answered. The content library is
-     * checked the same way, because a missing one aborts the run after every
-     * screenshot has already been taken.
+     * What differs is what can be wrong first. QSEoW authenticates with
+     * **certificate files on disk**, so the first thing that can be wrong is a
+     * path - and `qseowVerifyCertificatesExist()` says so at the certificate
+     * prompt rather than after the credentials, the app selection and everything
+     * else have been answered. The content library is checked the same way,
+     * because a missing one aborts the run after every screenshot has already
+     * been taken.
      *
      * This command declares 36 options, the most in the CLI, which is what makes
-     * the gating matter more here than anywhere else.
-     *
-     * Pure: specs in, specs out. The network and filesystem calls live behind
-     * `choices` and `probe`, which the driver invokes.
+     * the gating matter more here than anywhere else: both gates declined, it
+     * asks 14 questions.
      *
      * @param {import('../../interactive/option-introspect.js').QuestionSpec[]} specs - Derived questions.
      *
@@ -210,9 +164,9 @@ export default {
             fallback: { type: 'list', message: 'App id(s) (could not fetch the list)' },
         };
 
+        // The derived question unchanged, for anyone who already knows the id.
         const typedApp = {
             ...byKey.appid,
-            key: 'appid',
             when: (ctx) => ctx.answers[APP_SOURCE] === APP_SOURCES.TYPED,
         };
 
@@ -229,45 +183,16 @@ export default {
             },
         };
 
-        const filteringGate = {
-            key: FILTERING,
-            type: 'confirm',
-            message: 'Exclude or blur any sheets?',
-            default: false,
-            required: false,
-            variadic: false,
-            secret: false,
-        };
+        const rest = specs
+            .filter(
+                (spec) =>
+                    !CONNECTION_KEYS.includes(spec.key) &&
+                    !['appid', 'qliksensetag', 'contentlibrary'].includes(spec.key)
+            )
+            .map(gatedBy(ADVANCED, ADVANCED_KEYS))
+            .map(gatedBy(FILTERING, SHEET_FILTER_KEYS));
 
-        const advancedGate = {
-            key: ADVANCED,
-            type: 'confirm',
-            message: 'Configure advanced options (ports, certificates, schema version, browser)?',
-            default: false,
-            required: false,
-            variadic: false,
-            secret: false,
-        };
-
-        const rest = specs.filter(
-            (spec) =>
-                !CONNECTION_KEYS.includes(spec.key) &&
-                !['appid', 'qliksensetag', 'contentlibrary'].includes(spec.key)
-        );
-
-        const gated = rest.map((spec) => {
-            if (ADVANCED_KEYS.has(spec.key)) {
-                return { ...spec, when: (ctx) => ctx.answers[ADVANCED] === true };
-            }
-
-            if (FILTER_KEYS.has(spec.key)) {
-                return { ...spec, when: (ctx) => ctx.answers[FILTERING] === true };
-            }
-
-            return spec;
-        });
-
-        return bySection(
+        return inSections(
             [
                 ...connection,
                 appSource,
@@ -275,10 +200,15 @@ export default {
                 app,
                 typedApp,
                 contentLibrary,
-                filteringGate,
-                advancedGate,
-                ...gated,
-            ].map((spec) => ({ ...spec, group: spec.group ?? groupFor(spec.key) }))
+                gate({ key: FILTERING, message: 'Exclude or blur any sheets?' }),
+                gate({
+                    key: ADVANCED,
+                    message:
+                        'Configure advanced options (ports, certificates, schema version, browser)?',
+                }),
+                ...rest,
+            ],
+            SECTIONS
         );
     },
 

--- a/src/lib/interactive/__tests__/spec-ops.test.js
+++ b/src/lib/interactive/__tests__/spec-ops.test.js
@@ -1,0 +1,167 @@
+import { describe, test, expect } from '@jest/globals';
+import { gate, gatedBy, inSections, SHEET_FILTER_KEYS } from '../spec-ops.js';
+import { labelForApp, labelForCollection } from '../labels.js';
+
+const spec = (key, overrides = {}) => ({
+    key,
+    type: 'input',
+    message: `${key}?`,
+    required: false,
+    variadic: false,
+    secret: false,
+    ...overrides,
+});
+
+describe('gate', () => {
+    test('builds a confirm that defaults to declining the block', () => {
+        // Defaulting to yes would defeat the point: the gate exists so the
+        // common case is short.
+        const built = gate({ key: '_advanced', message: 'Advanced?' });
+
+        expect(built.type).toBe('confirm');
+        expect(built.default).toBe(false);
+        expect(built.required).toBe(false);
+    });
+
+    test('can be told to offer the block by default', () => {
+        expect(gate({ key: '_x', message: 'x?', default: true }).default).toBe(true);
+    });
+
+    test('refuses a key that would reach the options bag', () => {
+        // `_` is what to-cli-options keys off to drop synthetic answers. A gate
+        // named `advanced` would be emitted as `--advanced`, which no command
+        // declares - so this fails loudly at build time rather than producing a
+        // command line that cannot be run.
+        expect(() => gate({ key: 'advanced', message: 'Advanced?' })).toThrow(/must start with/);
+    });
+});
+
+describe('gatedBy', () => {
+    test('hides the named questions behind the gate', () => {
+        const hide = gatedBy('_advanced', ['pagewait']);
+        const hidden = hide(spec('pagewait'));
+
+        expect(hidden.when({ answers: { _advanced: true } })).toBe(true);
+        expect(hidden.when({ answers: { _advanced: false } })).toBe(false);
+    });
+
+    test('treats an unanswered gate as declined', () => {
+        const hidden = gatedBy('_advanced', ['pagewait'])(spec('pagewait'));
+
+        expect(hidden.when({ answers: {} })).toBe(false);
+    });
+
+    test('leaves other questions untouched, identity included', () => {
+        const untouched = spec('host');
+
+        expect(gatedBy('_advanced', ['pagewait'])(untouched)).toBe(untouched);
+    });
+
+    test('accepts a Set as well as an array', () => {
+        const hidden = gatedBy('_x', new Set(['a']))(spec('a'));
+
+        expect(typeof hidden.when).toBe('function');
+    });
+
+    test('composes, so a question can only be behind one gate at a time', () => {
+        // Applied in sequence by the wizards. The first gate to claim a key wins,
+        // because the second mapper no longer matches it.
+        const both = gatedBy('_filtering', ['blurFactor'])(
+            gatedBy('_advanced', ['pagewait'])(spec('blurFactor'))
+        );
+
+        expect(both.when({ answers: { _filtering: true, _advanced: false } })).toBe(true);
+    });
+});
+
+describe('inSections', () => {
+    const SECTIONS = [
+        ['Connection', ['host', 'apikey']],
+        ['Apps', ['appid']],
+    ];
+
+    test('labels every question with its section', () => {
+        const ordered = inSections([spec('appid'), spec('host')], SECTIONS);
+
+        expect(ordered.map((s) => s.group)).toEqual(['Connection', 'Apps']);
+    });
+
+    test('orders by section, whatever order they arrived in', () => {
+        const ordered = inSections([spec('appid'), spec('apikey'), spec('host')], SECTIONS);
+
+        expect(ordered.map((s) => s.key)).toEqual(['apikey', 'host', 'appid']);
+    });
+
+    test('keeps the incoming order within a section', () => {
+        // Load-bearing: the wizards build the connection block in the order they
+        // want it asked, and rely on the sort not shuffling it.
+        const ordered = inSections([spec('host'), spec('apikey')], SECTIONS);
+
+        expect(ordered.map((s) => s.key)).toEqual(['host', 'apikey']);
+    });
+
+    test('respects a group a question already carries', () => {
+        const ordered = inSections([spec('mystery', { group: 'Apps' })], SECTIONS);
+
+        expect(ordered[0].group).toBe('Apps');
+    });
+
+    test('sorts an unplaced question last rather than first', () => {
+        // A key nobody assigned to a section would otherwise sort to index -1 and
+        // silently become the opening question of the wizard.
+        const ordered = inSections([spec('stray'), spec('host')], SECTIONS);
+
+        expect(ordered.map((s) => s.key)).toEqual(['host', 'stray']);
+    });
+
+    test('does not mutate the list it was given', () => {
+        const input = [spec('appid'), spec('host')];
+        inSections(input, SECTIONS);
+
+        expect(input.map((s) => s.key)).toEqual(['appid', 'host']);
+    });
+});
+
+describe('SHEET_FILTER_KEYS', () => {
+    test('covers every exclude and blur option both platforms share', () => {
+        expect([...SHEET_FILTER_KEYS].sort()).toEqual([
+            'blurFactor',
+            'blurSheetNumber',
+            'blurSheetStatus',
+            'blurSheetTag',
+            'blurSheetTitle',
+            'excludeSheetNumber',
+            'excludeSheetStatus',
+            'excludeSheetTag',
+            'excludeSheetTitle',
+        ]);
+    });
+
+    test('is frozen, so one wizard cannot reshape the other list', () => {
+        expect(Object.isFrozen(SHEET_FILTER_KEYS)).toBe(true);
+    });
+});
+
+describe('labels', () => {
+    test('an app carries its full id, marked as an id', () => {
+        const id = 'a1b2c3d4-1111-2222-3333-444455556666';
+
+        expect(labelForApp({ id, name: 'Finance' })).toBe(`Finance  (id: ${id})`);
+    });
+
+    test('two apps sharing a name stay distinguishable', () => {
+        // Not hypothetical: three names are shared by two apps each on the QSEoW
+        // test server.
+        expect(labelForApp({ id: 'a', name: 'Performance review' })).not.toBe(
+            labelForApp({ id: 'b', name: 'Performance review' })
+        );
+    });
+
+    test('a collection says how many items it holds', () => {
+        expect(labelForCollection({ name: 'Finance', itemCount: 4 })).toBe('Finance  (4 items)');
+    });
+
+    test('a collection with no item count reads as empty rather than undefined', () => {
+        expect(labelForCollection({ name: 'Finance' })).toBe('Finance  (0 items)');
+    });
+});

--- a/src/lib/interactive/labels.js
+++ b/src/lib/interactive/labels.js
@@ -1,0 +1,45 @@
+/**
+ * How Qlik entities are described in a picker.
+ *
+ * Shared between the platforms deliberately. An administrator moving between a
+ * QSEoW server and a Cloud tenant should read the same thing, and #986 was filed
+ * because the two sides had already drifted once - QSEoW returning bare GUIDs
+ * while Cloud returned names. Formatting them in each wizard would reintroduce
+ * that drift one layer up, where it is harder to notice because both would look
+ * reasonable on their own.
+ */
+
+/**
+ * Label one app for a picker.
+ *
+ * The id is always shown, always marked as an id, and never truncated.
+ *
+ * **App names are not unique.** Only ids are, and duplicates are not theoretical:
+ * three names are shared by two apps each on the QSEoW test server, so a label
+ * showing the name alone is ambiguous to the person choosing even though the
+ * value behind it is not. Showing the id only when names collide was considered
+ * and rejected - it makes the label format depend on the contents of the list, so
+ * the same app can be presented differently between two runs.
+ *
+ * Untruncated because the id is what gets pasted into `--appid` afterwards, which
+ * is the point of echoing the equivalent command line; half an id cannot be.
+ *
+ * @param {{id: string, name: string}} app - The app to label.
+ *
+ * @returns {string} The label to show.
+ */
+export const labelForApp = (app) => `${app.name}  (id: ${app.id})`;
+
+/**
+ * Label one Qlik Sense Cloud collection for a picker.
+ *
+ * The item count is worth the space: an empty collection is a dead end, and
+ * seeing `(0 items)` before choosing it is better than a run that selects
+ * nothing and says so afterwards.
+ *
+ * @param {{name: string, itemCount?: number}} collection - The collection to label.
+ *
+ * @returns {string} The label to show.
+ */
+export const labelForCollection = (collection) =>
+    `${collection.name}  (${collection.itemCount ?? 0} items)`;

--- a/src/lib/interactive/spec-ops.js
+++ b/src/lib/interactive/spec-ops.js
@@ -1,0 +1,120 @@
+/**
+ * Reshaping helpers for the question list a wizard's `refine()` returns.
+ *
+ * These exist because the two Qlik wizards are the same conversation over
+ * different options: connection, apps, sheets, a gated block of filters, a gated
+ * block of advanced settings. Written twice, they were 134 identical lines and
+ * tripped SonarCloud's duplication gate at more than double its threshold - but
+ * the count is the symptom. The real cost is that nothing kept them in step, so
+ * the two platforms could drift apart in how they ask the same question, which
+ * is exactly the failure #986 fixed one layer further down.
+ *
+ * Everything here is pure: specs in, specs out, no I/O. Live data belongs behind
+ * a spec's `choices` or `probe`, which the driver invokes.
+ */
+
+/**
+ * The sheet exclude and blur options, which are identical on both platforms.
+ *
+ * Gated as a block rather than asked one by one. They are nine of the twenty-five
+ * options on Cloud and of the thirty-six on QSEoW, and most runs use none of them
+ * - the common case is "every sheet in the app" - so asking about each in turn is
+ * what turns a short conversation into a long one.
+ */
+export const SHEET_FILTER_KEYS = Object.freeze([
+    'excludeSheetStatus',
+    'excludeSheetTag',
+    'excludeSheetNumber',
+    'excludeSheetTitle',
+    'blurSheetStatus',
+    'blurSheetTag',
+    'blurSheetNumber',
+    'blurSheetTitle',
+    'blurFactor',
+]);
+
+/**
+ * Build a synthetic yes/no question that hides a block of others behind it.
+ *
+ * Synthetic keys are `_`-prefixed by convention, and `to-cli-options` drops those
+ * from the options bag and the echoed command line - so a gate can never be
+ * mistaken for something the command accepts.
+ *
+ * @param {object} args - Arguments.
+ * @param {string} args.key - The gate's key. Must start with `_`.
+ * @param {string} args.message - The question to ask.
+ * @param {boolean} [args.default] - Whether the block is offered by default.
+ *
+ * @returns {object} A question spec.
+ *
+ * @throws {Error} If the key is not `_`-prefixed, which would let it reach the options bag.
+ */
+export const gate = ({ key, message, default: defaultValue = false }) => {
+    if (!key.startsWith('_')) {
+        throw new Error(`Interactive: gate key "${key}" must start with "_" to stay synthetic.`);
+    }
+
+    return {
+        key,
+        type: 'confirm',
+        message,
+        default: defaultValue,
+        required: false,
+        variadic: false,
+        secret: false,
+    };
+};
+
+/**
+ * Hide a set of questions behind a gate.
+ *
+ * Returns a mapper, so it composes with the other reshaping a wizard does rather
+ * than needing its own pass over the list.
+ *
+ * @param {string} gateKey - Key of the gate question.
+ * @param {string[]|Set<string>} keys - Keys to hide behind it.
+ *
+ * @returns {(spec: object) => object} A mapper leaving other questions untouched.
+ */
+export const gatedBy = (gateKey, keys) => {
+    const hidden = new Set(keys);
+
+    return (spec) =>
+        hidden.has(spec.key) ? { ...spec, when: (ctx) => ctx.answers[gateKey] === true } : spec;
+};
+
+/**
+ * Put every question in a section, and order the list by section.
+ *
+ * Sections are declared once, as `[heading, keys]` pairs, and drive both the
+ * grouping and the order questions are asked in - so a wizard cannot end up
+ * showing a heading in one order and asking in another.
+ *
+ * Within a section the incoming order is kept, which `Array.prototype.sort` being
+ * stable is what guarantees. A question whose key appears in no section keeps
+ * whatever group it already had and sorts last.
+ *
+ * @param {Array} specs - The questions.
+ * @param {Array<[string, Array<string>]>} sections - Section headings and the keys under each.
+ *
+ * @returns {Array} The questions, grouped and ordered.
+ */
+export const inSections = (specs, sections) => {
+    const headings = sections.map(([heading]) => heading);
+    const headingFor = (key) => sections.find(([, keys]) => [...keys].includes(key))?.[0];
+
+    const grouped = specs.map((spec) => ({
+        ...spec,
+        group: spec.group ?? headingFor(spec.key),
+    }));
+
+    const rank = (spec) => {
+        const index = headings.indexOf(spec.group);
+
+        // An unsectioned question sorts last rather than first, so a key someone
+        // forgot to place does not silently become the opening question.
+        return index === -1 ? headings.length : index;
+    };
+
+    return [...grouped].sort((a, b) => rank(a) - rank(b));
+};


### PR DESCRIPTION
SonarCloud's duplication gate failed on #991 at **6.6% against a 3% threshold** — double what #979 tripped. Unlike that one, it was pointing at something real.

The QSEoW wizard was a near-copy of the Cloud one: **134 identical lines** of `GROUPS`, `groupFor`, `bySection`, the filter-key list, the label helpers and both gate definitions, differing only in which keys went into which group.

The count is the symptom. The cost is that nothing kept the two in step — they were similar by coincidence rather than by construction. That is the same failure #986 fixed one layer down, where QSEoW returned bare GUIDs while Cloud returned names, and it would have recurred every time either wizard gained a feature.

## What moved

**`spec-ops.js`** — the module #886 planned, which I skipped to get one wizard working end to end:

```js
gate()              // a synthetic yes/no question hiding a block of others
gatedBy()           // a mapper putting the named keys behind a gate
inSections()        // assign a section to every question, order by section
SHEET_FILTER_KEYS   // the nine exclude/blur options, identical on both platforms
```

**`labels.js`** — `labelForApp` and `labelForCollection`, shared for the reason #986 recorded: an administrator moving between a server and a tenant should read the same thing, and formatting them per-wizard would reintroduce the drift one layer up, where both sides look reasonable on their own.

## Two small hardenings

`gate()` **throws on a key that is not `_`-prefixed**. That prefix is what `to-cli-options` keys off to drop synthetic answers, so a gate named `advanced` would be emitted as `--advanced`, which no command declares — now a build-time failure rather than a command line that cannot be run.

`inSections()` sorts an **unplaced question last rather than first**. `indexOf` returns `-1` for a key nobody assigned to a section, which would otherwise make it sort ahead of everything and silently become the opening question of the wizard.

## Why this is a refactor, not a rewrite

Both wizards' **pinned question lists pass unchanged** — 10 questions for Cloud, 14 for QSEoW. Those tests assert the exact sequence rather than a count, so any behavioural drift from the extraction would have surfaced as a diff. That is what they were pinned for.

1664 tests pass, lint clean. 20 new tests cover the two extracted modules directly.

## What this does not settle

Identical lines are down from 134 to 89, but **whether that clears the 3% gate is unknown until this runs**. Sonar detects token-level blocks rather than identical lines; the large clones are gone, but the `appSource`/`app`/`typedApp` spec shapes remain structurally similar while differing in string literals and function bodies. If the gate still fails, the question worth asking is whether the gate or the remaining similarity is wrong — not how to contort the code further.

Refs #897

🤖 Generated with [Claude Code](https://claude.com/claude-code)
