### PR TITLE
Add the review table, .env saving and a run verdict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ typings/
 
 # dotenv environment variables file
 .env
+.env.bak
 .env.test
 
 # parcel-bundler cache (https://parceljs.org/)

--- a/docs/to-doc-site/wizard-review-and-saving-answers.md
+++ b/docs/to-doc-site/wizard-review-and-saving-answers.md
@@ -1,0 +1,94 @@
+# Seeing what will happen, and keeping your answers
+
+Two additions to interactive mode: a clearer picture before anything runs, and the option to keep your answers so you never have to give them again.
+
+## Before anything runs
+
+The wizard now shows a table of what it is about to do, followed by the equivalent command line:
+
+```
+── Review ──────────────────────────────────────
+
+┌──────────────────┬──────────────────────────────────────┐
+│ tenanturl        │ acme.eu.qlikcloud.com                │
+│ apikey           │ <hidden>                             │
+│ includesheetpart │ 2                                    │
+│ appid            │ 3 selected:                          │
+│                  │ a1b2c3d4-1111-2222-3333-4444555566…  │
+└──────────────────┴──────────────────────────────────────┘
+
+  Equivalent command:
+  butler-sheet-icons qscloud create-sheet-thumbnails --tenanturl acme.eu…
+
+? Ready?
+❯ Run it
+  Start over
+  Save the answers to .env
+  Cancel
+```
+
+The table shows only what the run will actually use. Options left at their default are not listed — if a row is not there, the default applies. Credentials are never shown, in the table or the command line.
+
+On a terminal that cannot draw box characters, such as some Windows consoles, the table is drawn with `+` and `-` instead. Nothing is lost.
+
+## Saving your answers
+
+Choosing **Save the answers to .env** writes a `.env` file in the directory you are running from:
+
+```
+# Butler Sheet Icons
+# Settings for: butler-sheet-icons qscloud create-sheet-thumbnails
+
+BSI_QSCLOUD_CST_TENANTURL=acme.eu.qlikcloud.com
+BSI_QSCLOUD_CST_APIKEY=<set this yourself>
+BSI_QSCLOUD_CST_APP_ID=app-a,app-b
+```
+
+Butler Sheet Icons reads `.env` automatically on the next run from that directory, so the same command can then be repeated with no options at all — which is what makes this useful for a scheduled task.
+
+Saving does not end the wizard. You come back to the review, so you can save *and* run.
+
+### It will not overwrite anything without asking twice
+
+If a `.env` file is already there, you are told what it is and asked explicitly:
+
+```
+✖ /home/goran/.env already exists (412 bytes, last changed 2026-08-11 14:02).
+  Saving replaces the whole file - settings for other Butler Sheet Icons commands,
+  or anything you put there yourself, will not survive. The current contents are
+  copied to .env.bak first.
+
+? Overwrite .env? (y/N)
+```
+
+The file is **replaced, not merged**. If you keep settings for several Butler Sheet Icons commands in one `.env`, saving from the wizard will not preserve the others.
+
+Before replacing it, the current contents are copied to **`.env.bak`** in the same directory, so a mistake is recoverable — rename it back. Note that `.env.bak` itself is replaced each time you save, so it always holds the version immediately before the most recent save, not the original.
+
+### Credentials are a separate decision
+
+You are asked once more before any password or API key is written:
+
+```
+? Also write the credentials to the file? (y/N)
+```
+
+Answering **no**, the default, writes everything else and leaves a `<set this yourself>` placeholder where the credential goes. Answering **yes** writes them and restricts the file so only your user account can read it.
+
+Think about this one. A credential in a file is a credential that can be copied, backed up or committed by accident. `.env` is already listed in Butler Sheet Icons' own `.gitignore`, but that does not help if you keep your settings somewhere else. Supplying credentials as environment variables at run time, rather than storing them, is the safer habit.
+
+## After the run
+
+The wizard now says plainly whether the run succeeded:
+
+```
+✔ Done
+```
+
+or, if something went wrong:
+
+```
+✖ The run reported a failure - the log above says which apps and why
+```
+
+Per-app detail stays in the log above, which already names each app it processed and each one that failed.

--- a/src/lib/interactive/__tests__/review-table.test.js
+++ b/src/lib/interactive/__tests__/review-table.test.js
@@ -1,0 +1,88 @@
+import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { formatReviewTable, cellFor } from '../review-table.js';
+import { specsFromCommand } from '../option-introspect.js';
+import { leafCommandAt } from '../command-tree.js';
+import { ASCII_ONLY_ENV } from '../symbols.js';
+
+const specs = () => specsFromCommand(leafCommandAt('qscloud create-sheet-thumbnails'), { env: {} });
+
+const render = (answers) => formatReviewTable(specs(), answers, { env: {} });
+
+const ENV_SNAPSHOT = { ...process.env };
+
+beforeEach(() => {
+    delete process.env[ASCII_ONLY_ENV];
+});
+
+afterEach(() => {
+    process.env = { ...ENV_SNAPSHOT };
+});
+
+describe('cellFor', () => {
+    const spec = (overrides = {}) => ({ key: 'x', secret: false, ...overrides });
+
+    test('renders a boolean as a word rather than true/false', () => {
+        expect(cellFor(spec(), true)).toBe('yes');
+        expect(cellFor(spec(), false)).toBe('no');
+    });
+
+    test('summarises a long list rather than printing a wall of GUIDs', () => {
+        expect(cellFor(spec(), ['a', 'b', 'c'])).toBe('3 selected: a, …');
+    });
+
+    test('prints a short list in full', () => {
+        expect(cellFor(spec(), ['a', 'b'])).toBe('a, b');
+    });
+
+    test('never shows a secret, however it was declared', () => {
+        expect(cellFor(spec({ secret: true }), 'hunter2')).not.toContain('hunter2');
+        expect(cellFor(spec({ key: 'apikey' }), 'hunter2')).not.toContain('hunter2');
+    });
+
+    test('shortens a very long value so it cannot break the layout', () => {
+        expect(cellFor(spec(), 'x'.repeat(200)).length).toBeLessThan(60);
+    });
+});
+
+describe('formatReviewTable', () => {
+    test('shows what the run will use', () => {
+        const out = render({ tenanturl: 'acme.eu.qlikcloud.com', imagedir: './shots' });
+
+        expect(out).toContain('tenanturl');
+        expect(out).toContain('acme.eu.qlikcloud.com');
+        expect(out).toContain('./shots');
+    });
+
+    test('never prints a credential', () => {
+        expect(render({ tenanturl: 't', apikey: 'super-secret-key' })).not.toContain(
+            'super-secret-key'
+        );
+    });
+
+    test('leaves out answers the run will ignore', () => {
+        // Rows come from the same emissions the options bag does. A table built
+        // from the raw answers would list things the run does not use, which is
+        // worse than no table - it would be confidently wrong.
+        const out = render({ tenanturl: 't', headless: true });
+
+        expect(out).not.toContain('headless');
+    });
+
+    test('is empty when there is nothing worth showing', () => {
+        expect(render({})).toBe('');
+    });
+
+    test('draws box borders when the terminal can take them', () => {
+        expect(render({ tenanturl: 't' })).toContain('─');
+    });
+
+    test('falls back to pure ASCII when it cannot', () => {
+        // The difference between a tidy summary and mojibake on a Windows
+        // Server console.
+        process.env[ASCII_ONLY_ENV] = '1';
+        const out = render({ tenanturl: 't' });
+
+        expect(out).toContain('+---');
+        expect(out).not.toContain('─');
+    });
+});

--- a/src/lib/interactive/__tests__/review-table.test.js
+++ b/src/lib/interactive/__tests__/review-table.test.js
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
 import { formatReviewTable, cellFor } from '../review-table.js';
 import { specsFromCommand } from '../option-introspect.js';
 import { leafCommandAt } from '../command-tree.js';
-import { ASCII_ONLY_ENV } from '../symbols.js';
+import { ASCII_ONLY_ENV, tableBorderName } from '../symbols.js';
 
 const specs = () => specsFromCommand(leafCommandAt('qscloud create-sheet-thumbnails'), { env: {} });
 
@@ -72,8 +72,14 @@ describe('formatReviewTable', () => {
         expect(render({})).toBe('');
     });
 
-    test('draws box borders when the terminal can take them', () => {
-        expect(render({ tenanturl: 't' })).toContain('─');
+    test('uses the border set this host can actually render', () => {
+        // Derived from tableBorderName() rather than pinned to the Unicode set:
+        // is-unicode-supported says no on the Windows runner and yes on ubuntu,
+        // so asserting box-drawing characters outright tests the machine rather
+        // than the table. Same trap the menu-theme test was fixed for.
+        const out = render({ tenanturl: 't' });
+
+        expect(out).toContain(tableBorderName() === 'norc' ? '─' : '+---');
     });
 
     test('falls back to pure ASCII when it cannot', () => {

--- a/src/lib/interactive/__tests__/save-env-file.test.js
+++ b/src/lib/interactive/__tests__/save-env-file.test.js
@@ -1,0 +1,248 @@
+import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtemp, readFile, writeFile, stat, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { formatEnvFile, SECRET_PLACEHOLDER } from '../render-env-file.js';
+import { saveEnvFile, ENV_FILE, BACKUP_FILE } from '../save-env-file.js';
+import { specsFromCommand } from '../option-introspect.js';
+import { leafCommandAt } from '../command-tree.js';
+
+const PATH = 'qscloud create-sheet-thumbnails';
+const specs = () => specsFromCommand(leafCommandAt(PATH), { env: {} });
+
+const ANSWERS = {
+    tenanturl: 'acme.eu.qlikcloud.com',
+    apikey: 'super-secret-key',
+    appid: ['app-a', 'app-b'],
+    imagedir: './shots',
+};
+
+let dir;
+
+beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'bsi-env-'));
+});
+
+afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+});
+
+/**
+ * A runtime that answers the confirmations in order and records what it wrote.
+ *
+ * @param {boolean[]} answers - Answers to the confirmations, in order.
+ *
+ * @returns {object} A runtime plus the questions it was asked.
+ */
+const runtimeAnswering = (answers) => {
+    const asked = [];
+    const written = [];
+    const queue = [...answers];
+
+    return {
+        asked,
+        written,
+        output: () => written.join(''),
+        write: (text) => written.push(text),
+        ask: async (spec) => {
+            asked.push(spec.key);
+
+            return queue.shift();
+        },
+    };
+};
+
+const theme = { style: { error: (t) => t, help: (t) => t } };
+
+describe('formatEnvFile', () => {
+    test('writes the environment variable each option declares', () => {
+        const file = formatEnvFile(PATH, specs(), ANSWERS);
+
+        expect(file).toContain('BSI_QSCLOUD_CST_TENANTURL=acme.eu.qlikcloud.com');
+        expect(file).toContain('BSI_QSCLOUD_CST_IMAGE_DIR=./shots');
+    });
+
+    test('joins a variadic value with commas, not spaces', () => {
+        // Commander wraps an environment variable in a one-element array without
+        // splitting it, so a space-separated list would come back as one value.
+        // Commas are what --appid's parser splits on - the trap #895 fixed.
+        expect(formatEnvFile(PATH, specs(), ANSWERS)).toContain('APP_ID=app-a,app-b');
+    });
+
+    test('leaves credentials out by default, with a placeholder and an explanation', () => {
+        const file = formatEnvFile(PATH, specs(), ANSWERS);
+
+        expect(file).not.toContain('super-secret-key');
+        expect(file).toContain(SECRET_PLACEHOLDER);
+        expect(file).toContain('deliberately not written');
+    });
+
+    test('writes credentials only when asked to', () => {
+        const file = formatEnvFile(PATH, specs(), ANSWERS, { includeSecrets: true });
+
+        expect(file).toContain('super-secret-key');
+        expect(file).not.toContain(SECRET_PLACEHOLDER);
+    });
+
+    test('names the command it was written for', () => {
+        expect(formatEnvFile(PATH, specs(), ANSWERS)).toContain(`butler-sheet-icons ${PATH}`);
+    });
+});
+
+describe('saveEnvFile', () => {
+    test('writes the file when none is there, asking only about credentials', async () => {
+        const runtime = runtimeAnswering([false]);
+
+        const result = await saveEnvFile({
+            commandPath: PATH,
+            specs: specs(),
+            answers: ANSWERS,
+            runtime,
+            theme,
+            cwd: dir,
+        });
+
+        expect(result.saved).toBe(true);
+        expect(runtime.asked).toEqual(['_saveSecrets']);
+        expect(await readFile(join(dir, ENV_FILE), 'utf8')).toContain('BSI_QSCLOUD_CST_TENANTURL');
+    });
+
+    test('asks a second time before replacing a file that already exists', async () => {
+        // The whole point of the extra confirmation: a .env in a working
+        // directory holds settings for every command run from it, so replacing
+        // it wholesale can destroy work unrelated to this wizard.
+        await writeFile(join(dir, ENV_FILE), 'SOMETHING_ELSE=keep me\n', 'utf8');
+        const runtime = runtimeAnswering([true, false]);
+
+        await saveEnvFile({
+            commandPath: PATH,
+            specs: specs(),
+            answers: ANSWERS,
+            runtime,
+            theme,
+            cwd: dir,
+        });
+
+        expect(runtime.asked).toEqual(['_overwriteEnv', '_saveSecrets']);
+    });
+
+    test('declining the overwrite leaves the existing file untouched', async () => {
+        await writeFile(join(dir, ENV_FILE), 'SOMETHING_ELSE=keep me\n', 'utf8');
+        const runtime = runtimeAnswering([false]);
+
+        const result = await saveEnvFile({
+            commandPath: PATH,
+            specs: specs(),
+            answers: ANSWERS,
+            runtime,
+            theme,
+            cwd: dir,
+        });
+
+        expect(result.saved).toBe(false);
+        expect(await readFile(join(dir, ENV_FILE), 'utf8')).toBe('SOMETHING_ELSE=keep me\n');
+    });
+
+    test('says what will be lost, rather than only asking whether to proceed', async () => {
+        await writeFile(join(dir, ENV_FILE), 'SOMETHING_ELSE=keep me\n', 'utf8');
+        const runtime = runtimeAnswering([false]);
+
+        await saveEnvFile({
+            commandPath: PATH,
+            specs: specs(),
+            answers: ANSWERS,
+            runtime,
+            theme,
+            cwd: dir,
+        });
+
+        expect(runtime.output()).toContain('already exists');
+        expect(runtime.output()).toContain('will not survive');
+        expect(runtime.output()).toContain('.env.bak');
+    });
+
+    test('copies the previous contents to .env.bak before replacing them', async () => {
+        // Consenting to an overwrite should be recoverable, not final.
+        await writeFile(join(dir, ENV_FILE), 'SOMETHING_ELSE=keep me\n', 'utf8');
+        const runtime = runtimeAnswering([true, false]);
+
+        const result = await saveEnvFile({
+            commandPath: PATH,
+            specs: specs(),
+            answers: ANSWERS,
+            runtime,
+            theme,
+            cwd: dir,
+        });
+
+        expect(result.backupPath).toBe(join(dir, BACKUP_FILE));
+        expect(await readFile(join(dir, BACKUP_FILE), 'utf8')).toBe('SOMETHING_ELSE=keep me\n');
+        expect(await readFile(join(dir, ENV_FILE), 'utf8')).toContain('BSI_QSCLOUD_CST_TENANTURL');
+    });
+
+    test('says when an existing backup is the one being replaced', async () => {
+        // A second save would otherwise silently discard the backup of the
+        // original file, which is the copy most worth keeping.
+        await writeFile(join(dir, ENV_FILE), 'CURRENT=1\n', 'utf8');
+        await writeFile(join(dir, BACKUP_FILE), 'OLDER=1\n', 'utf8');
+        const runtime = runtimeAnswering([false]);
+
+        await saveEnvFile({
+            commandPath: PATH,
+            specs: specs(),
+            answers: ANSWERS,
+            runtime,
+            theme,
+            cwd: dir,
+        });
+
+        expect(runtime.output()).toContain(`replacing the ${BACKUP_FILE} already there`);
+    });
+
+    test('writes no backup when there was nothing to back up', async () => {
+        const runtime = runtimeAnswering([false]);
+
+        const result = await saveEnvFile({
+            commandPath: PATH,
+            specs: specs(),
+            answers: ANSWERS,
+            runtime,
+            theme,
+            cwd: dir,
+        });
+
+        expect(result.backupPath).toBeUndefined();
+        await expect(stat(join(dir, BACKUP_FILE))).rejects.toThrow();
+    });
+
+    test('restricts permissions when credentials were written', async () => {
+        const runtime = runtimeAnswering([true]);
+
+        await saveEnvFile({
+            commandPath: PATH,
+            specs: specs(),
+            answers: ANSWERS,
+            runtime,
+            theme,
+            cwd: dir,
+        });
+
+        const mode = (await stat(join(dir, ENV_FILE))).mode & 0o777;
+        expect(mode).toBe(0o600);
+    });
+
+    test('reports whether credentials went in, so the caller can say so', async () => {
+        const runtime = runtimeAnswering([false]);
+
+        const result = await saveEnvFile({
+            commandPath: PATH,
+            specs: specs(),
+            answers: ANSWERS,
+            runtime,
+            theme,
+            cwd: dir,
+        });
+
+        expect(result.includedSecrets).toBe(false);
+    });
+});

--- a/src/lib/interactive/__tests__/save-env-file.test.js
+++ b/src/lib/interactive/__tests__/save-env-file.test.js
@@ -2,7 +2,8 @@ import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
 import { mkdtemp, readFile, writeFile, stat, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { formatEnvFile, SECRET_PLACEHOLDER } from '../render-env-file.js';
+import dotenv from 'dotenv';
+import { formatEnvFile, SECRET_PLACEHOLDER, quoteEnvValue } from '../render-env-file.js';
 import { saveEnvFile, ENV_FILE, BACKUP_FILE } from '../save-env-file.js';
 import { specsFromCommand } from '../option-introspect.js';
 import { leafCommandAt } from '../command-tree.js';
@@ -58,15 +59,17 @@ describe('formatEnvFile', () => {
     test('writes the environment variable each option declares', () => {
         const file = formatEnvFile(PATH, specs(), ANSWERS);
 
-        expect(file).toContain('BSI_QSCLOUD_CST_TENANTURL=acme.eu.qlikcloud.com');
-        expect(file).toContain('BSI_QSCLOUD_CST_IMAGE_DIR=./shots');
+        // Quoted, because bare values are silently lossy - dotenv reads
+        // everything after an unquoted '#' as a comment. See quoteEnvValue.
+        expect(file).toContain("BSI_QSCLOUD_CST_TENANTURL='acme.eu.qlikcloud.com'");
+        expect(file).toContain("BSI_QSCLOUD_CST_IMAGE_DIR='./shots'");
     });
 
     test('joins a variadic value with commas, not spaces', () => {
         // Commander wraps an environment variable in a one-element array without
         // splitting it, so a space-separated list would come back as one value.
         // Commas are what --appid's parser splits on - the trap #895 fixed.
-        expect(formatEnvFile(PATH, specs(), ANSWERS)).toContain('APP_ID=app-a,app-b');
+        expect(formatEnvFile(PATH, specs(), ANSWERS)).toContain("APP_ID='app-a,app-b'");
     });
 
     test('leaves credentials out by default, with a placeholder and an explanation', () => {
@@ -86,6 +89,88 @@ describe('formatEnvFile', () => {
 
     test('names the command it was written for', () => {
         expect(formatEnvFile(PATH, specs(), ANSWERS)).toContain(`butler-sheet-icons ${PATH}`);
+    });
+});
+
+describe('a saved file reads back as what was saved', () => {
+    // The property the module claims: a saved file reproduces the run, rather
+    // than approximately reproducing it. Asserting substrings is not enough -
+    // writing values bare passed every such test while dotenv silently
+    // truncated `pass#word` to `pass`.
+    const AWKWARD = {
+        tenanturl: 'acme.eu.qlikcloud.com',
+        apikey: 'pass#word',
+        contentlibrary: 'Butler sheet thumbnails',
+        imagedir: './img with spaces/',
+        appid: ['app-a', 'app-b'],
+    };
+
+    test.each([
+        ['a hash, which starts a comment when unquoted', 'apikey', 'pass#word'],
+        ['surrounding spaces, which are otherwise stripped', 'imagedir', '  ./img  '],
+        ['a double quote', 'apikey', 'pa"ss'],
+        ['a single quote', 'apikey', "pa'ss"],
+        ['a backslash', 'imagedir', String.raw`C:\Qlik\img`],
+        ['an equals sign', 'apikey', 'a=b=c'],
+        ['a newline', 'apikey', 'line1\nline2'],
+    ])('survives %s', (_label, key, value) => {
+        const file = formatEnvFile(
+            PATH,
+            specs(),
+            { ...AWKWARD, [key]: value },
+            {
+                includeSecrets: true,
+            }
+        );
+        const parsed = dotenv.parse(Buffer.from(file));
+        const envVar = specs().find((spec) => spec.key === key).option.envVar;
+
+        expect(parsed[envVar]).toBe(value);
+    });
+
+    test('a variadic value reads back as the same list', () => {
+        const file = formatEnvFile(PATH, specs(), AWKWARD, { includeSecrets: true });
+        const parsed = dotenv.parse(Buffer.from(file));
+
+        expect(parsed.BSI_QSCLOUD_CST_APP_ID).toBe('app-a,app-b');
+    });
+
+    test('every written value reads back identically', () => {
+        const file = formatEnvFile(PATH, specs(), AWKWARD, { includeSecrets: true });
+        const parsed = dotenv.parse(Buffer.from(file));
+
+        expect(parsed.BSI_QSCLOUD_CST_TENANTURL).toBe(AWKWARD.tenanturl);
+        expect(parsed.BSI_QSCLOUD_CST_APIKEY).toBe(AWKWARD.apikey);
+        expect(parsed.BSI_QSCLOUD_CST_CONTENT_LIBRARY ?? parsed.BSI_QSCLOUD_CST_IMAGE_DIR).toBe(
+            AWKWARD.imagedir
+        );
+    });
+
+    test('says so rather than lying when a value cannot be represented', () => {
+        // A newline plus both quote characters has no faithful form in dotenv.
+        // Writing something that reads back wrong is the failure being avoided.
+        const impossible = `line1\nhas'both"quotes`;
+        const file = formatEnvFile(
+            PATH,
+            specs(),
+            { ...AWKWARD, apikey: impossible },
+            {
+                includeSecrets: true,
+            }
+        );
+
+        expect(dotenv.parse(Buffer.from(file)).BSI_QSCLOUD_CST_APIKEY).toBeUndefined();
+        expect(file).toContain('could not be written');
+    });
+});
+
+describe('quoteEnvValue', () => {
+    test('leaves a plain value readable rather than over-quoting', () => {
+        expect(quoteEnvValue('chrome')).toBe("'chrome'");
+    });
+
+    test('gives up rather than corrupting the impossible case', () => {
+        expect(quoteEnvValue(`a\nb'c"d`)).toBeUndefined();
     });
 });
 

--- a/src/lib/interactive/__tests__/save-env-file.test.js
+++ b/src/lib/interactive/__tests__/save-env-file.test.js
@@ -300,7 +300,12 @@ describe('saveEnvFile', () => {
         await expect(stat(join(dir, BACKUP_FILE))).rejects.toThrow();
     });
 
-    test('restricts permissions when credentials were written', async () => {
+    // Windows has no POSIX permission bits - Node reports 0o666 whatever the
+    // file was created with - so on that runner this asserts something about the
+    // operating system rather than about the code.
+    const posixOnly = process.platform === 'win32' ? test.skip : test;
+
+    posixOnly('restricts permissions when credentials were written', async () => {
         const runtime = runtimeAnswering([true]);
 
         await saveEnvFile({

--- a/src/lib/interactive/index.js
+++ b/src/lib/interactive/index.js
@@ -8,11 +8,14 @@ import { defaultRuntime } from './prompt-runtime.js';
 import { buildTheme } from './theme.js';
 import { getSymbols } from './symbols.js';
 import { loadWizard } from './registry.js';
+import { formatReviewTable } from './review-table.js';
+import { saveEnvFile, ENV_FILE } from './save-env-file.js';
 
 /** What the review step can decide. */
 const REVIEW_CHOICES = [
     { name: 'Run it', value: 'run' },
     { name: 'Start over', value: 'restart' },
+    { name: `Save the answers to ${ENV_FILE}`, value: 'save' },
     { name: 'Cancel', value: 'cancel' },
 ];
 
@@ -40,6 +43,16 @@ const review = async ({ path, specs, answers, runtime, theme, symbols }) => {
     const envLines = formatSecretEnvVars(specs, answers);
 
     runtime.write(`\n${symbols.rule.repeat(2)} Review ${symbols.rule.repeat(38)}\n`);
+
+    // The table first, because it answers "what is about to happen" in terms of
+    // the thing being changed. The command line answers "how would I repeat
+    // this", which is the second question, not the first.
+    const summary = formatReviewTable(specs, answers);
+
+    if (summary) {
+        runtime.write(`\n${summary}`);
+    }
+
     runtime.write('\n  Equivalent command:\n');
     runtime.write(`  ${line}\n`);
 
@@ -67,6 +80,7 @@ const review = async ({ path, specs, answers, runtime, theme, symbols }) => {
  * @param {string} args.path - Command path, e.g. `browser uninstall`.
  * @param {object} [args.presetOptions] - Answers already known, used as starting values.
  * @param {object} [args.runtime] - Prompt runtime. Injectable for tests.
+ * @param {string} [args.cwd] - Directory a saved `.env` is written to. Injectable for tests.
  *
  * @returns {Promise<boolean>} `true` when the command ran and succeeded, or when the user cancelled.
  */
@@ -74,6 +88,7 @@ export const runInteractive = async ({
     path,
     presetOptions = {},
     runtime = defaultRuntime,
+    cwd = process.cwd(),
 } = {}) => {
     const wizard = await loadWizard(path);
     const command = leafCommandAt(path);
@@ -124,7 +139,34 @@ export const runInteractive = async ({
             ...(wizard.finalize ? wizard.finalize(raw, { specs }) : raw),
         };
 
-        const decision = await review({ path, specs, answers, runtime, theme, symbols });
+        let decision;
+
+        // Inner loop, so saving returns to the review rather than to the first
+        // question. Saving is a step on the way to running, not an alternative
+        // to it - being made to answer everything again in order to run what was
+        // just described would be absurd.
+        for (;;) {
+            decision = await review({ path, specs, answers, runtime, theme, symbols });
+
+            if (decision !== 'save') {
+                break;
+            }
+
+            const saved = await saveEnvFile({
+                commandPath: path,
+                specs,
+                answers,
+                runtime,
+                theme,
+                cwd,
+            });
+
+            runtime.write(
+                saved.saved
+                    ? `\n  ${symbols.done} Saved to ${saved.path}${saved.includedSecrets ? '' : ' (credentials left out)'}${saved.backupPath ? `\n  ${symbols.done} Previous contents kept in ${saved.backupPath}` : ''}\n`
+                    : `\n  ${symbols.failed} Not saved. ${ENV_FILE} was left as it was.\n`
+            );
+        }
 
         if (decision === 'cancel') {
             logger.info('Cancelled. Nothing was changed.');
@@ -142,7 +184,12 @@ export const runInteractive = async ({
 
         // Prompting is over, so winston owns the terminal again from here.
         const result = await wizard.run(options);
+        const ok = result !== false;
 
-        return result !== false;
+        runtime.write(
+            `\n${ok ? `${symbols.done} Done` : `${symbols.failed} The run reported a failure - the log above says which apps and why`}\n`
+        );
+
+        return ok;
     }
 };

--- a/src/lib/interactive/index.js
+++ b/src/lib/interactive/index.js
@@ -152,14 +152,29 @@ export const runInteractive = async ({
                 break;
             }
 
-            const saved = await saveEnvFile({
-                commandPath: path,
-                specs,
-                answers,
-                runtime,
-                theme,
-                cwd,
-            });
+            // Saving is optional, so a filesystem that will not cooperate must
+            // not cost the operator the answers they have just given. Without
+            // this, a read-only directory unwinds all the way out of the wizard
+            // through runCommand and every answer is lost - for a step they
+            // could have skipped.
+            let saved;
+
+            try {
+                saved = await saveEnvFile({
+                    commandPath: path,
+                    specs,
+                    answers,
+                    runtime,
+                    theme,
+                    cwd,
+                });
+            } catch (err) {
+                runtime.write(
+                    `\n  ${symbols.failed} Could not save: ${err?.message ?? err}\n  ${theme.style.help('Your answers are still here - choose Run it, or try saving again.')}\n`
+                );
+
+                continue;
+            }
 
             runtime.write(
                 saved.saved

--- a/src/lib/interactive/render-env-file.js
+++ b/src/lib/interactive/render-env-file.js
@@ -1,0 +1,116 @@
+import { BSI_SECRET_KEYS } from '../util/redact-secrets.js';
+import { emissionsFor } from './to-cli-options.js';
+
+const SECRET_KEYS = new Set(BSI_SECRET_KEYS.map((key) => key.toLowerCase()));
+
+/** Written in place of a secret's value when secrets are not being saved. */
+export const SECRET_PLACEHOLDER = '<set this yourself>';
+
+/**
+ * Whether a question's answer belongs in a saved `.env`.
+ *
+ * @param {import('./option-introspect.js').QuestionSpec} spec - The question.
+ *
+ * @returns {boolean} True when it maps to an option with an environment variable.
+ */
+const savable = (spec) => Boolean(spec.option?.envVar);
+
+/**
+ * Whether a question holds a credential.
+ *
+ * @param {import('./option-introspect.js').QuestionSpec} spec - The question.
+ *
+ * @returns {boolean} True for a secret.
+ */
+const isSecret = (spec) => spec.secret || SECRET_KEYS.has(spec.key.toLowerCase());
+
+/**
+ * Render a set of answers as the contents of a `.env` file.
+ *
+ * Nearly free, which is why it is worth having: every option already declares
+ * `.env('BSI_…')`, `globals.js` already does `import 'dotenv/config'`, and
+ * `.gitignore` already covers `.env`. So a saved file is honoured on the next
+ * run with no new loader and no new config format - which is also why a
+ * YAML/JSON config was rejected in #886, since that would need a schema,
+ * precedence rules, migration and documentation for a marginal gain.
+ *
+ * Which answers get written is decided by {@link emissionsFor}, the same
+ * function behind the options bag and the echoed command line. One rule, three
+ * consumers: a saved file therefore reproduces exactly the run the wizard
+ * described, rather than approximately.
+ *
+ * Variadic values are joined with commas rather than spaces. Commander wraps an
+ * environment variable in a one-element array **without splitting it**, so a
+ * space-separated list would come back as a single value - the trap #895 fixed
+ * by giving `--appid` a comma-splitting parser.
+ *
+ * @param {string} commandPath - Command the answers belong to, named in the header.
+ * @param {import('./option-introspect.js').QuestionSpec[]} specs - The questions asked.
+ * @param {object} answers - Answers, keyed by spec key.
+ * @param {object} [options] - Rendering options.
+ * @param {boolean} [options.includeSecrets] - Write credential values rather than a placeholder.
+ * @param {object} [options.env] - Environment, as for {@link emissionsFor}.
+ *
+ * @returns {string} The file contents, ending in a newline.
+ */
+export const formatEnvFile = (
+    commandPath,
+    specs,
+    answers,
+    { includeSecrets = false, env } = {}
+) => {
+    const lines = [
+        '# Butler Sheet Icons',
+        `# Settings for: butler-sheet-icons ${commandPath}`,
+        '#',
+        '# Written by the interactive wizard. Values here are picked up automatically',
+        '# on the next run from this directory, so the command can be repeated with no',
+        '# options at all.',
+        '',
+    ];
+
+    const emissions = emissionsFor(specs, answers, { env });
+    let wroteSecret = false;
+
+    for (const { spec, emitted } of emissions) {
+        if (!savable(spec)) {
+            continue;
+        }
+
+        if (isSecret(spec)) {
+            // A secret is written whenever it was answered, even if it somehow
+            // matched a default: leaving it out would produce a file that looks
+            // complete and cannot authenticate.
+            const answered = answers[spec.key] !== undefined && answers[spec.key] !== '';
+
+            if (!answered) {
+                continue;
+            }
+
+            wroteSecret = true;
+            lines.push(
+                `${spec.option.envVar}=${includeSecrets ? answers[spec.key] : SECRET_PLACEHOLDER}`
+            );
+            continue;
+        }
+
+        if (!emitted) {
+            continue;
+        }
+
+        const answer = answers[spec.key];
+        const value = Array.isArray(answer) ? answer.join(',') : String(answer);
+
+        lines.push(`${spec.option.envVar}=${value}`);
+    }
+
+    if (wroteSecret && !includeSecrets) {
+        lines.push(
+            '',
+            '# The credential(s) above were deliberately not written. Replace the',
+            '# placeholder, or supply them another way, before running.'
+        );
+    }
+
+    return `${lines.join('\n')}\n`;
+};

--- a/src/lib/interactive/render-env-file.js
+++ b/src/lib/interactive/render-env-file.js
@@ -7,6 +7,49 @@ const SECRET_KEYS = new Set(BSI_SECRET_KEYS.map((key) => key.toLowerCase()));
 export const SECRET_PLACEHOLDER = '<set this yourself>';
 
 /**
+ * Quote a value so `dotenv` reads back exactly what went in.
+ *
+ * Writing values bare is silently lossy, which is worse than noisily broken.
+ * Checked against the `dotenv` this repo depends on: `PWD=pass#word` parses as
+ * `pass`, because everything from an unquoted `#` is a comment; leading and
+ * trailing spaces are stripped; and a value containing a newline splits into a
+ * second, bogus `KEY=VALUE` line. A `#` in a password is entirely ordinary, and
+ * the resulting failure - authentication rejected on the next run - points
+ * nowhere near the saved file.
+ *
+ * The two quoting styles are not interchangeable, which is the part worth
+ * knowing. **Single quotes are fully literal**: `#`, spaces, double quotes and
+ * backslashes all survive untouched, and only a single quote cannot appear.
+ * **Double quotes** expand `\n` and `\r` but leave backslashes otherwise alone,
+ * so they are the only way to carry a newline - and cannot contain a double
+ * quote, since `\"` is *not* unescaped.
+ *
+ * A value containing a newline, a single quote and a double quote therefore
+ * cannot be represented at all. That returns undefined so the caller can say so
+ * rather than write something that will be read back wrong.
+ *
+ * @param {unknown} raw - The value to quote.
+ *
+ * @returns {string|undefined} The quoted value, or undefined when `dotenv` cannot carry it.
+ */
+export const quoteEnvValue = (raw) => {
+    const value = String(raw);
+
+    if (/[\r\n]/.test(value)) {
+        // Only double quotes carry a newline, and they cannot carry a `"`.
+        return value.includes('"')
+            ? undefined
+            : `"${value.replaceAll('\r', String.raw`\r`).replaceAll('\n', String.raw`\n`)}"`;
+    }
+
+    if (!value.includes("'")) {
+        return `'${value}'`;
+    }
+
+    return value.includes('"') ? undefined : `"${value}"`;
+};
+
+/**
  * Whether a question's answer belongs in a saved `.env`.
  *
  * @param {import('./option-introspect.js').QuestionSpec} spec - The question.
@@ -23,6 +66,22 @@ const savable = (spec) => Boolean(spec.option?.envVar);
  * @returns {boolean} True for a secret.
  */
 const isSecret = (spec) => spec.secret || SECRET_KEYS.has(spec.key.toLowerCase());
+
+/**
+ * Render one `NAME=value` line, or a commented explanation when it cannot be one.
+ *
+ * @param {string} name - The environment variable.
+ * @param {unknown} value - The value to write.
+ *
+ * @returns {string} The line to write.
+ */
+const assign = (name, value) => {
+    const quoted = quoteEnvValue(value);
+
+    return quoted === undefined
+        ? `# ${name} could not be written: the value contains a newline, a single quote and a double quote,\n# which dotenv cannot represent. Set it yourself before running.`
+        : `${name}=${quoted}`;
+};
 
 /**
  * Render a set of answers as the contents of a `.env` file.
@@ -89,7 +148,9 @@ export const formatEnvFile = (
 
             wroteSecret = true;
             lines.push(
-                `${spec.option.envVar}=${includeSecrets ? answers[spec.key] : SECRET_PLACEHOLDER}`
+                includeSecrets
+                    ? assign(spec.option.envVar, answers[spec.key])
+                    : `${spec.option.envVar}=${quoteEnvValue(SECRET_PLACEHOLDER)}`
             );
             continue;
         }
@@ -99,9 +160,8 @@ export const formatEnvFile = (
         }
 
         const answer = answers[spec.key];
-        const value = Array.isArray(answer) ? answer.join(',') : String(answer);
 
-        lines.push(`${spec.option.envVar}=${value}`);
+        lines.push(assign(spec.option.envVar, Array.isArray(answer) ? answer.join(',') : answer));
     }
 
     if (wroteSecret && !includeSecrets) {

--- a/src/lib/interactive/review-table.js
+++ b/src/lib/interactive/review-table.js
@@ -1,0 +1,87 @@
+import { table, getBorderCharacters } from 'table';
+import { BSI_SECRET_KEYS } from '../util/redact-secrets.js';
+import { HIDDEN } from './render-command-line.js';
+import { emissionsFor } from './to-cli-options.js';
+import { tableBorderName } from './symbols.js';
+
+const SECRET_KEYS = new Set(BSI_SECRET_KEYS.map((key) => key.toLowerCase()));
+
+/** Longest a value may be before it is shortened for the table. */
+const MAX_VALUE = 48;
+
+/**
+ * Render one answer as a single readable cell.
+ *
+ * @param {import('./option-introspect.js').QuestionSpec} spec - The question.
+ * @param {unknown} answer - The answer given.
+ *
+ * @returns {string} The cell contents.
+ */
+export const cellFor = (spec, answer) => {
+    if (spec.secret || SECRET_KEYS.has(spec.key.toLowerCase())) {
+        return HIDDEN;
+    }
+
+    if (Array.isArray(answer)) {
+        // A list of app ids is the common case and reads far better as a count
+        // plus the first entry than as a wall of GUIDs.
+        if (answer.length > 2) {
+            return `${answer.length} selected: ${answer[0]}, …`;
+        }
+
+        return answer.join(', ');
+    }
+
+    if (typeof answer === 'boolean') {
+        return answer ? 'yes' : 'no';
+    }
+
+    const text = String(answer);
+
+    return text.length > MAX_VALUE ? `${text.slice(0, MAX_VALUE - 1)}…` : text;
+};
+
+/**
+ * Render the review table: what is about to happen, in plain terms.
+ *
+ * Rows come from {@link emissionsFor}, so the table shows exactly what the run
+ * will use - the same source as the options bag and the echoed command line.
+ * A table built from the raw answers instead would list things the run ignores,
+ * which is worse than no table: it would be confidently wrong.
+ *
+ * Borders follow the terminal's Unicode support through `tableBorderName()`,
+ * which picks `norc` box-drawing or pure-ASCII `ramac`. That costs nothing -
+ * `table` ships both sets - and is the difference between a tidy summary and
+ * mojibake on a Windows Server console.
+ *
+ * Secrets are shown as a placeholder, never a value, off the same
+ * `BSI_SECRET_KEYS` list the logger redacts against.
+ *
+ * @param {import('./option-introspect.js').QuestionSpec[]} specs - The questions asked.
+ * @param {object} answers - Answers, keyed by spec key.
+ * @param {object} [options] - Rendering options.
+ * @param {object} [options.env] - Environment, as for {@link emissionsFor}.
+ *
+ * @returns {string} The rendered table, or an empty string when there is nothing to show.
+ */
+export const formatReviewTable = (specs, answers, { env } = {}) => {
+    const rows = [];
+
+    for (const { spec, emitted } of emissionsFor(specs, answers, { env })) {
+        if (!emitted || !spec.option) {
+            continue;
+        }
+
+        rows.push([spec.option.long.replace(/^--/, ''), cellFor(spec, answers[spec.key])]);
+    }
+
+    if (rows.length === 0) {
+        return '';
+    }
+
+    return table(rows, {
+        border: getBorderCharacters(tableBorderName()),
+        columns: { 1: { width: MAX_VALUE, wrapWord: true } },
+        drawHorizontalLine: (index, size) => index === 0 || index === size,
+    });
+};

--- a/src/lib/interactive/save-env-file.js
+++ b/src/lib/interactive/save-env-file.js
@@ -1,0 +1,134 @@
+import { writeFile, chmod, stat, copyFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { formatEnvFile } from './render-env-file.js';
+
+/** Where a saved file goes, relative to the working directory. */
+export const ENV_FILE = '.env';
+
+/** Where the previous contents are kept when one is replaced. */
+export const BACKUP_FILE = '.env.bak';
+
+/**
+ * Read what is already at a path, if anything.
+ *
+ * @param {string} path - Absolute path to check.
+ *
+ * @returns {Promise<{exists: boolean, size?: number, modified?: Date}>} What is there.
+ */
+const existing = async (path) => {
+    try {
+        const info = await stat(path);
+
+        return { exists: true, size: info.size, modified: info.mtime };
+    } catch {
+        // Anything unreadable is treated as absent. The write that follows will
+        // fail with its own error if the path is a directory or unwritable,
+        // which says more than a guess made here would.
+        return { exists: false };
+    }
+};
+
+/**
+ * Save answers to a `.env` file, asking twice before overwriting one.
+ *
+ * The second confirmation is not ceremony. A `.env` in a Butler Sheet Icons
+ * working directory is where an administrator keeps the settings for *every*
+ * command they run from it, so overwriting it wholesale can destroy work
+ * unrelated to the wizard that is running. The file is replaced, not merged -
+ * merging would mean parsing and rewriting someone else's file, and getting
+ * that subtly wrong is worse than saying plainly what will happen.
+ *
+ * What is replaced is first copied to `.env.bak`, so consenting to the overwrite
+ * is recoverable rather than final. One fixed name rather than a timestamp: a
+ * predictable file is one an administrator can actually find and restore, where
+ * an accumulating pile of dated backups in a working directory is litter nobody
+ * reads. A previous `.env.bak` is therefore replaced in turn, which the
+ * confirmation says out loud rather than leaving to be discovered.
+ *
+ * Secrets are a separate question again, defaulting to no, because a credential
+ * on disk is a different decision from a set of ports and paths on disk. When
+ * they are written the file is `chmod 600`, which is the only protection
+ * available for a file the tool has just been asked to create.
+ *
+ * @param {object} args - Arguments.
+ * @param {string} args.commandPath - Command the answers belong to.
+ * @param {Array} args.specs - The questions asked.
+ * @param {object} args.answers - Answers, keyed by spec key.
+ * @param {object} args.runtime - Prompt runtime.
+ * @param {object} args.theme - Prompt theme.
+ * @param {string} [args.cwd] - Directory to write into. Injectable for tests.
+ *
+ * @returns {Promise<{saved: boolean, path: string, includedSecrets?: boolean, backupPath?: string}>}
+ *     What happened, including where the previous contents went if there were any.
+ */
+export const saveEnvFile = async ({
+    commandPath,
+    specs,
+    answers,
+    runtime,
+    theme,
+    cwd = process.cwd(),
+}) => {
+    const path = resolve(cwd, ENV_FILE);
+    const backupPath = resolve(cwd, BACKUP_FILE);
+    const current = await existing(path);
+    let backedUp = false;
+
+    if (current.exists) {
+        const previousBackup = await existing(backupPath);
+
+        // Said plainly, with the evidence. "Are you sure?" on its own gives
+        // someone nothing to be sure about.
+        runtime.write(
+            `\n${theme.style.error(`${path} already exists (${current.size} bytes, last changed ${current.modified.toISOString().slice(0, 16).replace('T', ' ')}).`)}\n`
+        );
+        runtime.write(
+            `${theme.style.help(`Saving replaces the whole file - settings for other Butler Sheet Icons commands, or anything you put there yourself, will not survive. The current contents are copied to ${BACKUP_FILE} first${previousBackup.exists ? `, replacing the ${BACKUP_FILE} already there` : ''}.`)}\n`
+        );
+
+        const overwrite = await runtime.ask(
+            { key: '_overwriteEnv', type: 'confirm' },
+            { message: `Overwrite ${ENV_FILE}?`, default: false, theme }
+        );
+
+        if (!overwrite) {
+            return { saved: false, path };
+        }
+
+        // Copied before anything is written, so a failure part-way through
+        // leaves the backup already in place rather than nothing at all.
+        await copyFile(path, backupPath);
+        backedUp = true;
+    }
+
+    const includeSecrets = await runtime.ask(
+        { key: '_saveSecrets', type: 'confirm' },
+        {
+            message: 'Also write the credentials to the file?',
+            default: false,
+            theme,
+        }
+    );
+
+    await writeFile(path, formatEnvFile(commandPath, specs, answers, { includeSecrets }), 'utf8');
+
+    if (includeSecrets) {
+        // Best effort: a filesystem that cannot express these permissions is not
+        // a reason to refuse to save, but it is a reason not to claim the file
+        // is protected when it may not be.
+        try {
+            await chmod(path, 0o600);
+        } catch {
+            runtime.write(
+                `${theme.style.error('Could not restrict permissions on the file. Check them yourself before leaving credentials in it.')}\n`
+            );
+        }
+    }
+
+    return {
+        saved: true,
+        path,
+        includedSecrets: includeSecrets,
+        backupPath: backedUp ? backupPath : undefined,
+    };
+};

--- a/src/lib/interactive/save-env-file.js
+++ b/src/lib/interactive/save-env-file.js
@@ -1,4 +1,4 @@
-import { writeFile, chmod, stat, copyFile } from 'node:fs/promises';
+import { writeFile, stat, copyFile, rename, rm } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { formatEnvFile } from './render-env-file.js';
 
@@ -20,11 +20,16 @@ const existing = async (path) => {
         const info = await stat(path);
 
         return { exists: true, size: info.size, modified: info.mtime };
-    } catch {
-        // Anything unreadable is treated as absent. The write that follows will
-        // fail with its own error if the path is a directory or unwritable,
-        // which says more than a guess made here would.
-        return { exists: false };
+    } catch (err) {
+        if (err?.code === 'ENOENT') {
+            return { exists: false };
+        }
+
+        // Anything else - EACCES on the directory, a transient failure on a
+        // network share - is not absence. Treating it as absence would skip both
+        // the overwrite confirmation and the backup for a file that is really
+        // there, which is the one case where those matter most.
+        throw err;
     }
 };
 
@@ -110,19 +115,27 @@ export const saveEnvFile = async ({
         }
     );
 
-    await writeFile(path, formatEnvFile(commandPath, specs, answers, { includeSecrets }), 'utf8');
+    // Written to a temporary file and renamed over the target, rather than
+    // written in place and chmod'd afterwards. Two reasons, both real: a file
+    // created with the default umask and restricted a moment later is readable
+    // by every account on the machine in between, and chmod cannot close that
+    // window when the file already exists and keeps its old mode through the
+    // write. Rename carries the temporary file's mode with it, so the
+    // credentials never exist at a looser permission than they end at. It also
+    // makes the replacement atomic: an interrupted save leaves the previous file
+    // intact rather than a half-written one.
+    const temporary = `${path}.tmp-${process.pid}`;
 
-    if (includeSecrets) {
-        // Best effort: a filesystem that cannot express these permissions is not
-        // a reason to refuse to save, but it is a reason not to claim the file
-        // is protected when it may not be.
-        try {
-            await chmod(path, 0o600);
-        } catch {
-            runtime.write(
-                `${theme.style.error('Could not restrict permissions on the file. Check them yourself before leaving credentials in it.')}\n`
-            );
-        }
+    try {
+        await writeFile(temporary, formatEnvFile(commandPath, specs, answers, { includeSecrets }), {
+            encoding: 'utf8',
+            mode: includeSecrets ? 0o600 : 0o644,
+        });
+        await rename(temporary, path);
+    } catch (err) {
+        await rm(temporary, { force: true });
+
+        throw err;
     }
 
     return {


### PR DESCRIPTION
The remaining visual work from #897, in two commits: the feature, then five defects a review of it turned up.

## Review table

Built from `emissionsFor()`, the same function behind the options bag and the echoed command line — so it shows what the run will actually use. A table built from the raw answers would list values the run ignores, which is worse than no table because it would be confidently wrong. Borders follow `tableBorderName()`, so a console without box-drawing characters gets pure ASCII rather than mojibake. Long app lists collapse to `3 selected: <first>, …`; credentials render as `<hidden>`.

## Saving answers to .env

Nearly free — every option already declares `.env('BSI_…')`, `globals.js` already loads it, `.gitignore` already covers it. Overwriting asks twice, states the file's size and modification time rather than a bare "are you sure?", and copies the previous contents to `.env.bak` first so consenting is recoverable. Credentials are a third, separate question defaulting to no.

Saving returns to the review rather than the first question. That was a bug in the first draft — `continue` restarted the outer loop and re-asked everything, the opposite of what its own comment claimed.

## What the review caught

Four of the five would only have shown up in a saved file, and two only on a machine with other users.

**Values were written bare, which is silently lossy.** Checked against the installed dotenv: `PWD=pass#word` parses back as `pass` — everything after an unquoted `#` is a comment. Trailing spaces are stripped; a newline splits into a second, bogus line. A `#` in a password is ordinary, and the failure it produces — authentication rejected next run — points nowhere near the file. This falsified the module's own claim to reproduce a run exactly.

The two quoting styles are not interchangeable, which had to be probed rather than assumed: single quotes are fully literal, double quotes expand `\n` but do **not** unescape `\"`. The quoter prefers single, falls back to double for newlines, and refuses the one combination dotenv cannot represent rather than writing something that reads back wrong.

**Credentials were briefly world-readable** — written at the default umask, chmod'd after. `chmod` could not have closed that window anyway, since an existing file keeps its mode through a write. Now written to a temp file at mode 600 and renamed, which also makes the replacement atomic.

**A failed save destroyed the session**, unwinding out of the wizard and losing every answer for an optional step. **`.env.bak` was not gitignored.** **`stat` treated every failure as absence**, skipping the overwrite guard on a file that was really there.

## Verification

1701 tests pass, lint clean. The round-trip test is the one that matters — it writes a file, parses it with dotenv and compares against the answers. Two existing tests failed the moment it landed, because they had encoded the unquoted form; substring assertions passed happily while the value was being truncated.

## Known follow-up

Saving currently **replaces** the file rather than merging into it. Making it additive — updating the keys this command owns and leaving every other line untouched — is the better design and is next; it also removes the need for most of the overwrite ceremony above.

Refs #897

🤖 Generated with [Claude Code](https://claude.com/claude-code)
