### PR TITLE
Update .env in place instead of replacing it

### DIFF
--- a/docs/to-doc-site/wizard-review-and-saving-answers.md
+++ b/docs/to-doc-site/wizard-review-and-saving-answers.md
@@ -48,22 +48,21 @@ Butler Sheet Icons reads `.env` automatically on the next run from that director
 
 Saving does not end the wizard. You come back to the review, so you can save *and* run.
 
-### It will not overwrite anything without asking twice
+### It updates, it does not replace
 
-If a `.env` file is already there, you are told what it is and asked explicitly:
+If a `.env` file is already there, only the settings belonging to the command you just ran are changed. Everything else — settings for other Butler Sheet Icons commands, comments, anything you put there yourself — is left exactly as it was, byte for byte.
+
+You are told what will change before it happens:
 
 ```
-✖ /home/goran/.env already exists (412 bytes, last changed 2026-08-11 14:02).
-  Saving replaces the whole file - settings for other Butler Sheet Icons commands,
-  or anything you put there yourself, will not survive. The current contents are
-  copied to .env.bak first.
+/home/goran/.env already exists. 6 setting(s) belonging to this command will be
+updated or added; everything else in the file is left untouched. A copy is kept
+in .env.bak either way.
 
-? Overwrite .env? (y/N)
+? Update .env? (Y/n)
 ```
 
-The file is **replaced, not merged**. If you keep settings for several Butler Sheet Icons commands in one `.env`, saving from the wizard will not preserve the others.
-
-Before replacing it, the current contents are copied to **`.env.bak`** in the same directory, so a mistake is recoverable — rename it back. Note that `.env.bak` itself is replaced each time you save, so it always holds the version immediately before the most recent save, not the original.
+A setting already in the file is updated in place. One that is not there is added at the end. A copy of the file as it was is kept in **`.env.bak`**, so even an unwanted update is recoverable — note that `.env.bak` is replaced on each save, so it always holds the version immediately before the most recent one.
 
 ### Credentials are a separate decision
 

--- a/src/lib/interactive/__tests__/merge-env-file.test.js
+++ b/src/lib/interactive/__tests__/merge-env-file.test.js
@@ -1,0 +1,108 @@
+import { describe, test, expect } from '@jest/globals';
+import dotenv from 'dotenv';
+import { mergeEnvContents, locateAssignments } from '../merge-env-file.js';
+
+const DQ = String.fromCharCode(34);
+
+const apply = (current, entries) => mergeEnvContents(current, entries);
+const parse = (text) => dotenv.parse(Buffer.from(text));
+
+describe('what the merge must not touch', () => {
+    test('carries comments and unrelated settings across unchanged', () => {
+        // The whole reason for merging rather than replacing: a .env holds the
+        // settings for every command run from that directory, plus whatever the
+        // operator put there themselves.
+        const current = ['# my notes', 'UNRELATED=keep me', 'OWNED=old'].join('\n') + '\n';
+        const { contents } = apply(current, [{ name: 'OWNED', line: "OWNED='new'" }]);
+
+        expect(contents).toContain('# my notes');
+        expect(contents).toContain('UNRELATED=keep me');
+        expect(parse(contents).UNRELATED).toBe('keep me');
+    });
+
+    test('leaves another command’s value byte-identical, quoting and all', () => {
+        const current = `OTHER=${DQ}kept  verbatim${DQ}\nOWNED=old\n`;
+        const { contents } = apply(current, [{ name: 'OWNED', line: "OWNED='new'" }]);
+
+        expect(contents).toContain(`OTHER=${DQ}kept  verbatim${DQ}`);
+    });
+
+    test('preserves an export prefix on a line it rewrites', () => {
+        // Presumably there because something else sources the file.
+        const { contents } = apply('export OWNED=old\n', [{ name: 'OWNED', line: "OWNED='new'" }]);
+
+        expect(contents).toContain("export OWNED='new'");
+        expect(parse(contents).OWNED).toBe('new');
+    });
+});
+
+describe('the cases that would silently corrupt a file', () => {
+    test('replaces a multiline value as one unit, leaving no orphan', () => {
+        // Replacing only the opening line would leave the tail behind as a
+        // fragment, which parses as garbage or breaks the rest of the file.
+        const current = [`OWNED=${DQ}line one`, `line two${DQ}`, 'AFTER=intact'].join('\n') + '\n';
+        const { contents } = apply(current, [{ name: 'OWNED', line: "OWNED='new'" }]);
+
+        expect(contents).not.toContain('line two');
+        expect(parse(contents)).toEqual({ OWNED: 'new', AFTER: 'intact' });
+    });
+
+    test('rewrites the last duplicate, which is the one dotenv actually uses', () => {
+        // Verified against dotenv: the last occurrence wins. Rewriting the first
+        // would look correct in a diff and change nothing about the run.
+        const current = 'OWNED=first\nOTHER=x\nOWNED=second\n';
+        const { contents } = apply(current, [{ name: 'OWNED', line: "OWNED='new'" }]);
+
+        expect(parse(contents).OWNED).toBe('new');
+    });
+});
+
+describe('adding what is not there', () => {
+    test('appends a setting the file does not have', () => {
+        const { contents, added } = apply('EXISTING=x\n', [{ name: 'NEW', line: "NEW='y'" }]);
+
+        expect(added).toEqual(['NEW']);
+        expect(parse(contents)).toEqual({ EXISTING: 'x', NEW: 'y' });
+    });
+
+    test('reports updates and additions separately, so the caller can say which', () => {
+        const { updated, added } = apply('A=old\n', [
+            { name: 'A', line: "A='new'" },
+            { name: 'B', line: "B='fresh'" },
+        ]);
+
+        expect(updated).toEqual(['A']);
+        expect(added).toEqual(['B']);
+    });
+
+    test('does not accumulate blank lines when saved repeatedly', () => {
+        let contents = 'EXISTING=x\n';
+
+        for (let i = 0; i < 3; i += 1) {
+            contents = apply(contents, [{ name: 'NEW', line: "NEW='y'" }]).contents;
+        }
+
+        expect(contents.match(/\n\n\n/)).toBeNull();
+        expect(parse(contents)).toEqual({ EXISTING: 'x', NEW: 'y' });
+    });
+
+    test('handles an empty file', () => {
+        const { contents } = apply('', [{ name: 'A', line: "A='1'" }]);
+
+        expect(parse(contents)).toEqual({ A: '1' });
+    });
+});
+
+describe('locateAssignments', () => {
+    test('ignores keys it was not asked about', () => {
+        const found = locateAssignments(['A=1', 'B=2'], new Set(['A']));
+
+        expect([...found.keys()]).toEqual(['A']);
+    });
+
+    test('reports the full range of a multiline value', () => {
+        const found = locateAssignments([`A=${DQ}one`, 'two', `three${DQ}`], new Set(['A']));
+
+        expect(found.get('A')).toMatchObject({ start: 0, end: 2 });
+    });
+});

--- a/src/lib/interactive/__tests__/save-env-file.test.js
+++ b/src/lib/interactive/__tests__/save-env-file.test.js
@@ -228,8 +228,58 @@ describe('saveEnvFile', () => {
         expect(await readFile(join(dir, ENV_FILE), 'utf8')).toBe('SOMETHING_ELSE=keep me\n');
     });
 
-    test('says what will be lost, rather than only asking whether to proceed', async () => {
-        await writeFile(join(dir, ENV_FILE), 'SOMETHING_ELSE=keep me\n', 'utf8');
+    test('keeps every setting the command does not own', async () => {
+        // The whole point of merging. A .env holds settings for every Butler
+        // Sheet Icons command run from that directory, plus whatever the
+        // operator put there themselves; saving one command's answers must not
+        // cost them the rest.
+        await writeFile(
+            join(dir, ENV_FILE),
+            ['# my notes', 'BSI_QSEOW_CST_HOST=sense.acme.com', 'UNRELATED=keep me'].join('\n') +
+                '\n',
+            'utf8'
+        );
+        const runtime = runtimeAnswering([true, false]);
+
+        await saveEnvFile({
+            commandPath: PATH,
+            specs: specs(),
+            answers: ANSWERS,
+            runtime,
+            theme,
+            cwd: dir,
+        });
+
+        const after = await readFile(join(dir, ENV_FILE), 'utf8');
+        expect(after).toContain('# my notes');
+        expect(after).toContain('BSI_QSEOW_CST_HOST=sense.acme.com');
+        expect(after).toContain('UNRELATED=keep me');
+        expect(after).toContain("BSI_QSCLOUD_CST_TENANTURL='acme.eu.qlikcloud.com'");
+    });
+
+    test('updates a setting it owns rather than appending a second copy', async () => {
+        await writeFile(join(dir, ENV_FILE), 'BSI_QSCLOUD_CST_TENANTURL=old.tenant\n', 'utf8');
+        const runtime = runtimeAnswering([true, false]);
+
+        const result = await saveEnvFile({
+            commandPath: PATH,
+            specs: specs(),
+            answers: ANSWERS,
+            runtime,
+            theme,
+            cwd: dir,
+        });
+
+        const after = await readFile(join(dir, ENV_FILE), 'utf8');
+        expect(after).not.toContain('old.tenant');
+        expect(result.updated).toContain('BSI_QSCLOUD_CST_TENANTURL');
+        expect(dotenv.parse(Buffer.from(after)).BSI_QSCLOUD_CST_TENANTURL).toBe(
+            'acme.eu.qlikcloud.com'
+        );
+    });
+
+    test('names how many settings will change rather than threatening the file', async () => {
+        await writeFile(join(dir, ENV_FILE), 'UNRELATED=keep me\n', 'utf8');
         const runtime = runtimeAnswering([false]);
 
         await saveEnvFile({
@@ -241,9 +291,7 @@ describe('saveEnvFile', () => {
             cwd: dir,
         });
 
-        expect(runtime.output()).toContain('already exists');
-        expect(runtime.output()).toContain('will not survive');
-        expect(runtime.output()).toContain('.env.bak');
+        expect(runtime.output()).toContain('everything else in the file is left untouched');
     });
 
     test('copies the previous contents to .env.bak before replacing them', async () => {
@@ -265,25 +313,6 @@ describe('saveEnvFile', () => {
         expect(await readFile(join(dir, ENV_FILE), 'utf8')).toContain('BSI_QSCLOUD_CST_TENANTURL');
     });
 
-    test('says when an existing backup is the one being replaced', async () => {
-        // A second save would otherwise silently discard the backup of the
-        // original file, which is the copy most worth keeping.
-        await writeFile(join(dir, ENV_FILE), 'CURRENT=1\n', 'utf8');
-        await writeFile(join(dir, BACKUP_FILE), 'OLDER=1\n', 'utf8');
-        const runtime = runtimeAnswering([false]);
-
-        await saveEnvFile({
-            commandPath: PATH,
-            specs: specs(),
-            answers: ANSWERS,
-            runtime,
-            theme,
-            cwd: dir,
-        });
-
-        expect(runtime.output()).toContain(`replacing the ${BACKUP_FILE} already there`);
-    });
-
     test('writes no backup when there was nothing to back up', async () => {
         const runtime = runtimeAnswering([false]);
 
@@ -301,8 +330,8 @@ describe('saveEnvFile', () => {
     });
 
     // Windows has no POSIX permission bits - Node reports 0o666 whatever the
-    // file was created with - so on that runner this asserts something about the
-    // operating system rather than about the code.
+    // file was created with - so this asserts something about the operating
+    // system rather than about the code when it runs there.
     const posixOnly = process.platform === 'win32' ? test.skip : test;
 
     posixOnly('restricts permissions when credentials were written', async () => {

--- a/src/lib/interactive/merge-env-file.js
+++ b/src/lib/interactive/merge-env-file.js
@@ -1,0 +1,164 @@
+/**
+ * Update the settings a command owns in an existing `.env`, leaving the rest alone.
+ *
+ * A `.env` in a working directory is shared: it holds the settings for every
+ * Butler Sheet Icons command run from there, and often things the operator put
+ * there themselves. Replacing it wholesale to save one command's answers
+ * destroys all of that, which is why the earlier version needed a warning, a
+ * confirmation and a backup file. Updating in place removes the destruction
+ * rather than apologising for it.
+ *
+ * This is a **line-level edit, not a parse and rewrite**. Values belonging to
+ * keys this command does not own are never read, re-quoted or reformatted - the
+ * bytes are carried across untouched. That is what makes merging safe here,
+ * where a full round-trip through a parser would risk changing someone else's
+ * settings as a side effect of saving ours.
+ *
+ * Three details of `dotenv`'s format drive the implementation, all checked
+ * against the version this repo depends on rather than assumed:
+ *
+ * - **The last occurrence of a key wins**, not the first. Replacing an earlier
+ *   duplicate would leave the file parsing to the old value, so the *last* one
+ *   is the one that has to be rewritten.
+ * - **`export NAME=value` is valid** and parses the same as `NAME=value`, so the
+ *   matcher has to allow the prefix - and preserves it, since it is presumably
+ *   there because something else sources the file.
+ * - **A quoted value may span physical lines.** Replacing only the first line of
+ *   one would leave the remainder behind as an orphan fragment, corrupting the
+ *   file. A key's entry is therefore a line *range*, not a line.
+ */
+
+/** Matches the start of an assignment, capturing the optional export and the key. */
+const ASSIGNMENT = /^(\s*(?:export\s+)?)([A-Za-z_][A-Za-z0-9_]*)\s*=(.*)$/;
+
+/**
+ * Whether a value fragment leaves a quote open at the end of the line.
+ *
+ * @param {string} fragment - The text after the `=` on the opening line.
+ *
+ * @returns {false|string} The unterminated quote character, or false.
+ */
+const opensQuote = (fragment) => {
+    const text = fragment.trimStart();
+    const quote = text[0];
+
+    if (quote !== '"' && quote !== "'") {
+        return false;
+    }
+
+    // Closed on the same line when the quote appears again after the opener.
+    return text.indexOf(quote, 1) === -1 ? quote : false;
+};
+
+/**
+ * Find the line range each key occupies, keeping only the effective one.
+ *
+ * @param {string[]} lines - The file, split into lines.
+ * @param {Set<string>} keys - Keys to look for.
+ *
+ * @returns {Map<string, {start: number, end: number, prefix: string}>} Where each key lives.
+ */
+export const locateAssignments = (lines, keys) => {
+    const found = new Map();
+
+    for (let index = 0; index < lines.length; index += 1) {
+        const match = ASSIGNMENT.exec(lines[index]);
+
+        if (!match) {
+            continue;
+        }
+
+        const [, prefix, key, valueFragment] = match;
+        let end = index;
+        const openQuote = opensQuote(valueFragment);
+
+        if (openQuote) {
+            // Consume until the quote closes, so a multiline value is replaced
+            // as one unit rather than leaving its tail behind.
+            while (end + 1 < lines.length && !lines[end + 1].includes(openQuote)) {
+                end += 1;
+            }
+
+            if (end + 1 < lines.length) {
+                end += 1;
+            }
+        }
+
+        if (keys.has(key)) {
+            // Overwrites any earlier sighting, which is what "last one wins"
+            // requires: rewriting an earlier duplicate would leave the file
+            // still parsing to the later value.
+            found.set(key, { start: index, end, prefix });
+        }
+
+        index = end;
+    }
+
+    return found;
+};
+
+/**
+ * Merge a set of `NAME=value` assignments into an existing file's contents.
+ *
+ * @param {string} current - The existing file contents.
+ * @param {Array<{name: string, line: string}>} assignments - Lines to apply, already quoted.
+ *
+ * @returns {{contents: string, updated: string[], added: string[]}} The new contents and what changed.
+ */
+export const mergeEnvContents = (current, assignments) => {
+    const lines = current.split('\n');
+    const byName = new Map(assignments.map((entry) => [entry.name, entry]));
+    const located = locateAssignments(lines, new Set(byName.keys()));
+
+    const updated = [];
+    const added = [];
+    const replacements = new Map();
+
+    for (const [name, where] of located) {
+        replacements.set(where.start, {
+            ...where,
+            line: `${where.prefix}${byName.get(name).line}`,
+        });
+        updated.push(name);
+    }
+
+    const out = [];
+
+    for (let index = 0; index < lines.length; index += 1) {
+        const replacement = replacements.get(index);
+
+        if (replacement) {
+            out.push(replacement.line);
+            // Skip the rest of a multiline value, which the new line replaces.
+            index = replacement.end;
+            continue;
+        }
+
+        out.push(lines[index]);
+    }
+
+    const missing = assignments.filter((entry) => !located.has(entry.name));
+
+    if (missing.length > 0) {
+        // Trailing blank lines are dropped before appending so the additions do
+        // not drift further from the content each time the file is saved.
+        while (out.length > 0 && out[out.length - 1].trim() === '') {
+            out.pop();
+        }
+
+        out.push('', `# Added by the Butler Sheet Icons wizard`);
+
+        for (const entry of missing) {
+            out.push(entry.line);
+            added.push(entry.name);
+        }
+    }
+
+    const contents = out.join('\n');
+
+    return {
+        contents: contents.endsWith('\n') ? contents : `${contents}\n`,
+        updated,
+        added,
+    };
+};

--- a/src/lib/interactive/render-env-file.js
+++ b/src/lib/interactive/render-env-file.js
@@ -84,6 +84,61 @@ const assign = (name, value) => {
 };
 
 /**
+ * The `NAME=value` lines a set of answers produces, without the file around them.
+ *
+ * Shared by the whole-file renderer and the merger, so both decide what to write
+ * and how to quote it in exactly one place.
+ *
+ * @param {import('./option-introspect.js').QuestionSpec[]} specs - The questions asked.
+ * @param {object} answers - Answers, keyed by spec key.
+ * @param {object} [options] - Rendering options.
+ * @param {boolean} [options.includeSecrets] - Write credential values rather than a placeholder.
+ * @param {object} [options.env] - Environment, as for {@link emissionsFor}.
+ *
+ * @returns {Array<{name: string, line: string, secret: boolean}>} One entry per setting.
+ */
+export const envAssignments = (specs, answers, { includeSecrets = false, env } = {}) => {
+    const out = [];
+
+    for (const { spec, emitted } of emissionsFor(specs, answers, { env })) {
+        if (!savable(spec)) {
+            continue;
+        }
+
+        if (isSecret(spec)) {
+            const answered = answers[spec.key] !== undefined && answers[spec.key] !== '';
+
+            if (!answered) {
+                continue;
+            }
+
+            out.push({
+                name: spec.option.envVar,
+                secret: true,
+                line: includeSecrets
+                    ? assign(spec.option.envVar, answers[spec.key])
+                    : `${spec.option.envVar}=${quoteEnvValue(SECRET_PLACEHOLDER)}`,
+            });
+            continue;
+        }
+
+        if (!emitted) {
+            continue;
+        }
+
+        const answer = answers[spec.key];
+
+        out.push({
+            name: spec.option.envVar,
+            secret: false,
+            line: assign(spec.option.envVar, Array.isArray(answer) ? answer.join(',') : answer),
+        });
+    }
+
+    return out;
+};
+
+/**
  * Render a set of answers as the contents of a `.env` file.
  *
  * Nearly free, which is why it is worth having: every option already declares
@@ -128,43 +183,13 @@ export const formatEnvFile = (
         '',
     ];
 
-    const emissions = emissionsFor(specs, answers, { env });
-    let wroteSecret = false;
+    const assignments = envAssignments(specs, answers, { includeSecrets, env });
 
-    for (const { spec, emitted } of emissions) {
-        if (!savable(spec)) {
-            continue;
-        }
-
-        if (isSecret(spec)) {
-            // A secret is written whenever it was answered, even if it somehow
-            // matched a default: leaving it out would produce a file that looks
-            // complete and cannot authenticate.
-            const answered = answers[spec.key] !== undefined && answers[spec.key] !== '';
-
-            if (!answered) {
-                continue;
-            }
-
-            wroteSecret = true;
-            lines.push(
-                includeSecrets
-                    ? assign(spec.option.envVar, answers[spec.key])
-                    : `${spec.option.envVar}=${quoteEnvValue(SECRET_PLACEHOLDER)}`
-            );
-            continue;
-        }
-
-        if (!emitted) {
-            continue;
-        }
-
-        const answer = answers[spec.key];
-
-        lines.push(assign(spec.option.envVar, Array.isArray(answer) ? answer.join(',') : answer));
+    for (const entry of assignments) {
+        lines.push(entry.line);
     }
 
-    if (wroteSecret && !includeSecrets) {
+    if (!includeSecrets && assignments.some((entry) => entry.secret)) {
         lines.push(
             '',
             '# The credential(s) above were deliberately not written. Replace the',

--- a/src/lib/interactive/save-env-file.js
+++ b/src/lib/interactive/save-env-file.js
@@ -1,6 +1,7 @@
-import { writeFile, stat, copyFile, rename, rm } from 'node:fs/promises';
+import { writeFile, stat, copyFile, rename, rm, readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
-import { formatEnvFile } from './render-env-file.js';
+import { formatEnvFile, envAssignments } from './render-env-file.js';
+import { mergeEnvContents } from './merge-env-file.js';
 
 /** Where a saved file goes, relative to the working directory. */
 export const ENV_FILE = '.env';
@@ -80,28 +81,28 @@ export const saveEnvFile = async ({
     let backedUp = false;
 
     if (current.exists) {
-        const previousBackup = await existing(backupPath);
-
-        // Said plainly, with the evidence. "Are you sure?" on its own gives
-        // someone nothing to be sure about.
-        runtime.write(
-            `\n${theme.style.error(`${path} already exists (${current.size} bytes, last changed ${current.modified.toISOString().slice(0, 16).replace('T', ' ')}).`)}\n`
-        );
-        runtime.write(
-            `${theme.style.help(`Saving replaces the whole file - settings for other Butler Sheet Icons commands, or anything you put there yourself, will not survive. The current contents are copied to ${BACKUP_FILE} first${previousBackup.exists ? `, replacing the ${BACKUP_FILE} already there` : ''}.`)}\n`
+        // Merged, not replaced. Only the settings this command owns change; every
+        // other line - other commands' settings, comments, anything the operator
+        // put there - is carried across byte for byte. So the question is no
+        // longer "may I destroy this file" but the far smaller "may I change
+        // these settings in it", and it names them.
+        const names = envAssignments(specs, answers, { includeSecrets: false }).map(
+            (entry) => entry.name
         );
 
-        const overwrite = await runtime.ask(
+        runtime.write(
+            `\n${theme.style.help(`${path} already exists. ${names.length} setting(s) belonging to this command will be updated or added; everything else in the file is left untouched. A copy is kept in ${BACKUP_FILE} either way.`)}\n`
+        );
+
+        const proceed = await runtime.ask(
             { key: '_overwriteEnv', type: 'confirm' },
-            { message: `Overwrite ${ENV_FILE}?`, default: false, theme }
+            { message: `Update ${ENV_FILE}?`, default: true, theme }
         );
 
-        if (!overwrite) {
+        if (!proceed) {
             return { saved: false, path };
         }
 
-        // Copied before anything is written, so a failure part-way through
-        // leaves the backup already in place rather than nothing at all.
         await copyFile(path, backupPath);
         backedUp = true;
     }
@@ -126,8 +127,23 @@ export const saveEnvFile = async ({
     // intact rather than a half-written one.
     const temporary = `${path}.tmp-${process.pid}`;
 
+    let contents;
+    let changed = { updated: [], added: [] };
+
+    if (current.exists) {
+        const existingText = await readFile(path, 'utf8');
+
+        changed = mergeEnvContents(
+            existingText,
+            envAssignments(specs, answers, { includeSecrets })
+        );
+        contents = changed.contents;
+    } else {
+        contents = formatEnvFile(commandPath, specs, answers, { includeSecrets });
+    }
+
     try {
-        await writeFile(temporary, formatEnvFile(commandPath, specs, answers, { includeSecrets }), {
+        await writeFile(temporary, contents, {
             encoding: 'utf8',
             mode: includeSecrets ? 0o600 : 0o644,
         });
@@ -143,5 +159,7 @@ export const saveEnvFile = async ({
         path,
         includedSecrets: includeSecrets,
         backupPath: backedUp ? backupPath : undefined,
+        updated: changed.updated,
+        added: changed.added,
     };
 };


### PR DESCRIPTION
Saving one command's answers replaced the whole `.env`, which is why #996 needed a warning, a confirmation and a backup file. A `.env` in a working directory holds the settings for *every* Butler Sheet Icons command run from there, plus whatever the operator put there themselves. Updating in place removes the destruction rather than apologising for it.

**The earlier reasoning was wrong and is worth naming as wrong**, because it is what justified the destructive version: I wrote that merging "would mean parsing and rewriting someone else's file". No parse is needed. Only lines whose key this command owns are touched; every other byte is carried across, so values we do not own are never read, re-quoted or reformatted.

## Three format details, each of which would have corrupted a real file

All checked against the `dotenv` this repo depends on rather than assumed:

| | why it matters |
|---|---|
| **The last occurrence of a key wins**, not the first | Rewriting an earlier duplicate looks right in a diff and changes nothing about the run |
| **`export NAME=value` is valid** | The matcher allows the prefix, and keeps it — it is presumably there because something else sources the file |
| **A quoted value may span physical lines** | Replacing only its opening line leaves the tail behind as a fragment. A key's entry is a line *range*, not a line |

## The confirmation changes character with it

Rather than warning that the file will be destroyed, it says how many settings will change and that everything else is untouched — and defaults to **yes**, because it is no longer a dangerous operation:

```
/home/goran/.env already exists. 6 setting(s) belonging to this command will be
updated or added; everything else in the file is left untouched. A copy is kept
in .env.bak either way.

? Update .env? (Y/n)
```

`.env.bak` stays as cheap insurance.

This also disposes of a finding from the review of #996: `browser uninstall` offering to save could previously wipe a `.env` holding a full QSEoW connection. Now it can only touch the two browser settings.

## Verification

1713 tests pass, lint clean. 11 new tests covering exactly the cases that would have gone wrong quietly — multiline value replaced as one unit with no orphan, the *last* duplicate rewritten, `export` preserved, another command's value kept byte-identical, and no blank-line drift when the same file is saved repeatedly.

`envAssignments()` is now shared by the whole-file writer and the merger, so what gets written and how it is quoted is decided in one place regardless of which path runs.

Refs #897

🤖 Generated with [Claude Code](https://claude.com/claude-code)
