### PR TITLE
Stop the uninstall wizard asking an unanswerable question when no browsers are installed

### DIFF
--- a/docs/to-doc-site/browser-uninstall-when-nothing-is-installed.md
+++ b/docs/to-doc-site/browser-uninstall-when-nothing-is-installed.md
@@ -1,0 +1,57 @@
+# "Uninstall a browser" now says when there is nothing to uninstall
+
+If you ran `butler-sheet-icons browser uninstall -i` on a server with no browsers in the cache, it asked
+you which build to remove anyway — and the question it asked was the help text for `--browser-version`:
+
+```
+? Browser build to uninstall: an exact build id (for Chrome e.g. "151.0.7922.77", for Firefox e.g.
+"stable_153.0.3"), or "recommended" for the build Butler Sheet Icons is tested with.
+```
+
+There was no answer to that question that could work. Whatever you typed, the run ended with
+`Browser not found in cache`.
+
+It now reports the situation and stops, without asking anything:
+
+```
+2026-08-11T20:12:38.100Z info: App version: 4.1.0
+2026-08-11T20:12:38.102Z info: No browsers installed, so there is nothing to uninstall. Use "butler-sheet-icons browser install" to install one.
+```
+
+The exit code is **0**. Nothing was asked for, so nothing failed — the same answer
+`butler-sheet-icons browser list-installed` gives on that machine.
+
+## When you have a build id set from an earlier run
+
+The confusing part of the old behaviour showed up most often on a machine where a previous session had
+left `BSI_BROWSER_UI_BROWSER_VERSION` in a `.env` file. Butler Sheet Icons announced that it would not
+ask about `--browser-version`, and then asked for exactly that.
+
+Two things changed:
+
+- With **no browsers installed**, you get the message above. The leftover value makes no difference —
+  there is nothing to remove either way.
+- With **browsers installed**, you are still asked to pick one, and Butler Sheet Icons now says why
+  rather than claiming the question was skipped:
+
+  ```
+  Supplied, but asked about again so the answer can be picked from what is actually there: --browser-version.
+
+  ? Which browser build should be removed?
+  ❯ chrome  151.0.7922.108  (mac_arm)
+  ```
+
+  This is deliberate. A build id remembered from an earlier run may name a build you have since removed,
+  or one that was never on this machine. The list is read from the cache each time, so what you pick
+  always exists.
+
+## What has not changed
+
+Running `browser uninstall` **without** `-i` behaves exactly as before. Naming a build that is not in
+the cache still reports it and still exits 1, which is what your scheduler or CI job sees:
+
+```
+info: Browser not found in cache: chrome build 151.0.7922.77. Use "butler-sheet-icons browser list-installed" to see what is installed.
+```
+
+`browser install -i`, `browser list-installed` and `browser uninstall-all` are unaffected.

--- a/docs/to-doc-site/interactive-flag-on-commands.md
+++ b/docs/to-doc-site/interactive-flag-on-commands.md
@@ -21,15 +21,16 @@ This is the part worth knowing about. Options you have already given are treated
 about again. So you can supply the parts you know and let Butler Sheet Icons ask for the rest:
 
 ```bash
-butler-sheet-icons browser uninstall --browser chrome -i
+butler-sheet-icons browser install --browser firefox -i
 ```
 
 ```
 Already supplied, so not asked about again: --browser.
 
-? Which browser build should be removed?
-❯ chrome  151.0.7922.108  (mac_arm)
-  chrome  151.0.7922.47   (mac_arm)
+  Type to filter, or take one of the first two entries.
+? Which build should be installed?
+❯ Recommended - the build this version of Butler Sheet Icons is tested with
+  Latest stable - whatever the vendor currently publishes
 ```
 
 This works for `BSI_*` environment variables too. If `BSI_BROWSER_UI_BROWSER` is set in your shell or in
@@ -37,6 +38,17 @@ a `.env` file, the browser question is skipped in exactly the same way.
 
 Values that merely fall back to a **default** are still asked about, with the default offered as the
 pre-filled answer. Only values you actually chose are treated as settled.
+
+### One exception, and it says so
+
+`browser uninstall` asks a single question that stands in for both `--browser` and `--browser-version`,
+because it offers the builds that are actually in the cache. Supplying either of those does not skip
+that question — a build id you gave from memory may name something that is no longer installed, so the
+list wins. Butler Sheet Icons tells you when this is happening:
+
+```
+Supplied, but asked about again so the answer can be picked from what is actually there: --browser.
+```
 
 ## Which commands accept it
 

--- a/src/lib/commands/browser/__tests__/browser_wizards.test.js
+++ b/src/lib/commands/browser/__tests__/browser_wizards.test.js
@@ -260,6 +260,63 @@ describe('the uninstall wizard with an empty cache', () => {
     });
 });
 
+describe('an option a synthetic question stands in for', () => {
+    // The other half of issue #1013: the wizard announced that
+    // --browser-version would not be asked about, and then asked for exactly
+    // that. `_build` collects it under another name, which the key-based filter
+    // could not see.
+    const PRESET = { browserVersion: '150.0.7871.24' };
+
+    test('is not announced as skipped', async () => {
+        const runtime = scriptedRuntime({ _build: MAC_BUILD, _review: 'cancel' });
+
+        await runInteractive({ path: 'browser uninstall', presetOptions: PRESET, runtime });
+
+        expect(runtime.output()).not.toContain('not asked about again: --browser-version');
+    });
+
+    test('is named as asked about again, so an ignored value is not a mystery', async () => {
+        const runtime = scriptedRuntime({ _build: MAC_BUILD, _review: 'cancel' });
+
+        await runInteractive({ path: 'browser uninstall', presetOptions: PRESET, runtime });
+
+        const output = runtime.output();
+        expect(output).toContain('asked about again so the answer can be picked');
+        expect(output).toContain('--browser-version');
+    });
+
+    test('is still asked about, and the answer wins over the supplied value', async () => {
+        // Deliberate: a picker over the real cache beats a build id remembered
+        // in .env from a run before, which may name something since removed.
+        const runtime = scriptedRuntime({
+            _build: { browser: 'chrome', buildId: '151.0.7922.47' },
+            _review: 'run',
+        });
+
+        await runInteractive({ path: 'browser uninstall', presetOptions: PRESET, runtime });
+
+        expect(runtime.asked.map((a) => a.key)).toEqual(['_build', '_review']);
+        expect(browserUninstall.mock.calls[0][0].browserVersion).toBe('151.0.7922.47');
+    });
+
+    test('leaves an ordinary supplied option announced as before', async () => {
+        // The replaces handling must not swallow the existing banner: --browser
+        // is covered by the picker too, so this checks the case that is not -
+        // an option no question stands in for.
+        const runtime = scriptedRuntime({ browserVersion: '151.0.7922.47', _review: 'cancel' });
+
+        await runInteractive({
+            path: 'browser install',
+            presetOptions: { browser: 'firefox' },
+            runtime,
+        });
+
+        expect(runtime.output()).toContain(
+            'Already supplied, so not asked about again: --browser.'
+        );
+    });
+});
+
 describe('options already supplied on the command line', () => {
     // What makes `-i` compose rather than merely exist:
     // `bsi browser install --browser firefox -i` should ask which build, not

--- a/src/lib/commands/browser/__tests__/browser_wizards.test.js
+++ b/src/lib/commands/browser/__tests__/browser_wizards.test.js
@@ -5,6 +5,32 @@ const browserUninstall = jest.fn().mockResolvedValue(true);
 const fetchAvailableVersions = jest.fn();
 const browserInstall = jest.fn().mockResolvedValue({ buildId: '151.0.7922.47' });
 
+// Mocked so that what a wizard *reports* is an assertable fact rather than
+// something that merely scrolls past. A wizard that declines to run says so
+// through the logger, in the same words `browser list-installed` uses, and that
+// wording is the whole user-facing half of issue #1013.
+const logger = {
+    info: jest.fn(),
+    error: jest.fn(),
+    verbose: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+};
+
+jest.unstable_mockModule('../../../../globals.js', () => ({
+    logger,
+    appVersion: '0.0.0-test',
+    // Plain functions rather than jest.fn(), because `clearMocks` runs before
+    // every test and a level of `undefined` would be pinned into the real
+    // logger by withQuietLogging's restore.
+    getLoggingLevel: () => 'info',
+    setLoggingLevel: () => {},
+    isSea: false,
+    bsiExecutablePath: '/test',
+    getChromiumRevision: () => 'test-revision',
+    sleep: () => Promise.resolve(),
+}));
+
 jest.unstable_mockModule('../../../browser/browser-inventory.js', () => ({
     getBrowserInventory,
     getBrowserCacheDir: () => '/cache',
@@ -63,7 +89,11 @@ describe('the uninstall wizard', () => {
         await runInteractive({ path: 'browser uninstall', runtime });
 
         expect(runtime.asked.map((a) => a.key)).toEqual(['_build', '_review']);
-        expect(getBrowserInventory).toHaveBeenCalledTimes(1);
+        // Twice: once by the precheck deciding whether there is anything to do
+        // at all, once by the picker building its list. Two reads of a local
+        // directory, rather than caching an inventory that "Start over" would
+        // then show after it had gone stale.
+        expect(getBrowserInventory).toHaveBeenCalledTimes(2);
     });
 
     test('never asks for the log level, which nobody wants as question one', async () => {
@@ -132,6 +162,10 @@ describe('the uninstall wizard', () => {
     });
 
     test('falls back to typing a version when the cache cannot be read', async () => {
+        // "Not found" and "found but unusable" are different answers. A cache
+        // that cannot be read is not an empty one, so the precheck must let it
+        // through rather than reporting there is nothing to uninstall - the
+        // question's own fallback is how an operator recovers here.
         getBrowserInventory.mockRejectedValue(new Error('EACCES'));
         const runtime = scriptedRuntime({ _build: '151.0.7922.47', _review: 'run' });
 
@@ -139,6 +173,9 @@ describe('the uninstall wizard', () => {
 
         expect(runtime.asked[0].type).toBe('input');
         expect(browserUninstall.mock.calls[0][0].browserVersion).toBe('151.0.7922.47');
+        expect(logger.info).not.toHaveBeenCalledWith(
+            expect.stringContaining('No browsers installed')
+        );
     });
 
     test('cancelling runs nothing', async () => {
@@ -170,6 +207,56 @@ describe('the uninstall wizard', () => {
         });
 
         await expect(runInteractive({ path: 'browser uninstall', runtime })).resolves.toBe(false);
+    });
+});
+
+describe('the uninstall wizard with an empty cache', () => {
+    // Issue #1013. An empty cache reached the same code path as a failed
+    // lookup, so the wizard offered the free-text fallback - whose prompt is
+    // --browser-version's own help text - and every answer to it ended in
+    // "Browser not found in cache". There is no answer that can succeed, so
+    // there is no question worth asking.
+    beforeEach(() => {
+        getBrowserInventory.mockResolvedValue([]);
+    });
+
+    test('asks nothing and runs nothing', async () => {
+        // An unqueued key makes scriptedRuntime throw, so an empty script is
+        // itself an assertion that no question was reached.
+        const runtime = scriptedRuntime({});
+
+        const result = await runInteractive({ path: 'browser uninstall', runtime });
+
+        expect(result).toBe(true);
+        expect(runtime.asked).toEqual([]);
+        expect(browserUninstall).not.toHaveBeenCalled();
+    });
+
+    test('stops before announcing itself, rather than after', async () => {
+        // The transcript in the bug report is the wizard preamble followed by
+        // an unanswerable question. Printing the preamble and only then backing
+        // out would fix half of it.
+        const runtime = scriptedRuntime({});
+
+        await runInteractive({ path: 'browser uninstall', runtime });
+
+        expect(runtime.output()).toBe('');
+    });
+
+    test('says so in the words list-installed already uses', async () => {
+        await runInteractive({ path: 'browser uninstall', runtime: scriptedRuntime({}) });
+
+        expect(logger.info).toHaveBeenCalledWith(
+            expect.stringContaining('No browsers installed, so there is nothing to uninstall.')
+        );
+    });
+
+    test('points at the command that fixes it', async () => {
+        await runInteractive({ path: 'browser uninstall', runtime: scriptedRuntime({}) });
+
+        expect(logger.info).toHaveBeenCalledWith(
+            expect.stringContaining('butler-sheet-icons browser install')
+        );
     });
 });
 

--- a/src/lib/commands/browser/uninstall.interactive.js
+++ b/src/lib/commands/browser/uninstall.interactive.js
@@ -93,6 +93,13 @@ export default {
                 required: true,
                 variadic: false,
                 secret: false,
+                // This one question collects both of these, so a value already
+                // supplied for either is not "not asked about again" - it is
+                // asked about under another name, and overwritten by the
+                // answer. Without saying so, the wizard announced that
+                // --browser-version would be skipped and then asked for it
+                // (issue #1013).
+                replaces: ['browser', 'browserVersion'],
                 choices: async () => {
                     const inventory = await getBrowserInventory();
 

--- a/src/lib/commands/browser/uninstall.interactive.js
+++ b/src/lib/commands/browser/uninstall.interactive.js
@@ -28,6 +28,44 @@ export default {
     label: 'Uninstall a browser from the cache',
 
     /**
+     * Decline to run at all when the cache is empty.
+     *
+     * An empty cache is not a lookup that went wrong, it is a command with
+     * nothing to do - and the generic empty-list handling cannot tell the two
+     * apart. Left to it, the wizard offers the free-text fallback below, whose
+     * prompt is `--browser-version`'s own help text, and no answer to it can
+     * succeed: every one of them ends in "Browser not found in cache"
+     * (issue #1013).
+     *
+     * `browser list-installed` already answers this question correctly on the
+     * same machine, and says so in one line. This says the same thing.
+     *
+     * @returns {Promise<{reason: string}|undefined>} A reason to stop, or `undefined` to carry on.
+     */
+    async precheck() {
+        let inventory;
+
+        try {
+            inventory = await getBrowserInventory();
+        } catch {
+            // "Not found" and "found but unusable" are different answers and
+            // must not share one. A cache that cannot be read is not an empty
+            // cache, so this carries on and lets the question's own fallback
+            // offer a typed build id - which is the whole point of that
+            // fallback, and how an operator recovers.
+            return undefined;
+        }
+
+        if (inventory.length > 0) {
+            return undefined;
+        }
+
+        return {
+            reason: 'No browsers installed, so there is nothing to uninstall. Use "butler-sheet-icons browser install" to install one.',
+        };
+    },
+
+    /**
      * Ask which installed build to remove, rather than for a version from memory.
      *
      * Today this command takes `--browser` and `--browser-version`, both

--- a/src/lib/interactive/__tests__/registry.test.js
+++ b/src/lib/interactive/__tests__/registry.test.js
@@ -122,6 +122,32 @@ describe('the registered wizards', () => {
         }
     );
 
+    // `replaces` is how a synthetic question tells the wizard which real
+    // options it collects, so that a value already supplied for one of them is
+    // reported as asked about rather than as skipped. A typo in it fails
+    // silently - the banner simply goes back to claiming the option was
+    // skipped and then asking for it, which is issue #1013 - so it is checked
+    // the same way the emitted keys are.
+    test.each(REGISTERED.map((path) => [path]))(
+        '%s only claims to replace options its command declares',
+        async (path) => {
+            const wizard = await loadWizard(path);
+            const { command } = everyLeafCommand().find((leaf) => leaf.path === path);
+            const declared = new Set(command.options.map((option) => option.attributeName()));
+
+            const specs = specsFromCommand(command);
+            const refined = wizard.refine ? wizard.refine(specs, { answers: {} }) : specs;
+
+            for (const spec of refined) {
+                for (const key of spec.replaces ?? []) {
+                    expect(`${path} -> replaces ${key}: ${declared.has(key)}`).toBe(
+                        `${path} -> replaces ${key}: true`
+                    );
+                }
+            }
+        }
+    );
+
     test('synthetic questions are prefixed, so they can never reach the options bag', async () => {
         for (const path of REGISTERED) {
             const wizard = await loadWizard(path);

--- a/src/lib/interactive/__tests__/tty.test.js
+++ b/src/lib/interactive/__tests__/tty.test.js
@@ -107,7 +107,15 @@ describe('interactiveBlocker', () => {
     });
 
     test('survives streams that are missing entirely', () => {
-        expect(interactiveBlocker({ stdin: undefined, stdout: undefined, env: {} }).reason).toBe(
+        // `null` rather than `undefined`, and it has to stay that way: the
+        // parameters are declared `stdin = process.stdin, stdout =
+        // process.stdout`, and a default fires on `undefined`. Passing
+        // `undefined` therefore handed the function the real stdin, so this
+        // asserted nothing about a missing stream - it passed in CI, where
+        // stdin is not a TTY, and threw "Cannot read properties of null" for
+        // anyone running the suite from a terminal, where there is no blocker
+        // to read `.reason` from.
+        expect(interactiveBlocker({ stdin: null, stdout: null, env: {} }).reason).toBe(
             BLOCKER.STDIN_NOT_TTY
         );
     });

--- a/src/lib/interactive/index.js
+++ b/src/lib/interactive/index.js
@@ -82,7 +82,8 @@ const review = async ({ path, specs, answers, runtime, theme, symbols }) => {
  * @param {object} [args.runtime] - Prompt runtime. Injectable for tests.
  * @param {string} [args.cwd] - Directory a saved `.env` is written to. Injectable for tests.
  *
- * @returns {Promise<boolean>} `true` when the command ran and succeeded, or when the user cancelled.
+ * @returns {Promise<boolean>} `true` when the command ran and succeeded, when the user cancelled, or
+ *     when the wizard's `precheck` declined to start.
  */
 export const runInteractive = async ({
     path,
@@ -91,6 +92,30 @@ export const runInteractive = async ({
     cwd = process.cwd(),
 } = {}) => {
     const wizard = await loadWizard(path);
+
+    // Asked before anything at all is printed, because a wizard with no valid
+    // answer to offer must not first announce itself and then bail.
+    //
+    // Optional, and only a wizard can implement it: `resolveChoices` cannot tell
+    // "nothing to do" from "could not find out what there is to do", and treats
+    // both as a reason to offer free text. That is right for the app and
+    // collection pickers, where an empty list means a tag matched nothing and
+    // typing an id by hand is a genuine escape - and wrong for `browser
+    // uninstall`, where an empty cache means there is no answer that can
+    // succeed (issue #1013).
+    //
+    // Returns `undefined` to carry on, or `{ reason }` to stop. Stopping is not
+    // a failure: nothing was asked for, so nothing failed, and the exit code
+    // stays 0 exactly as it does for `browser list-installed` on the same
+    // machine.
+    const stop = await wizard.precheck?.();
+
+    if (stop) {
+        logger.info(stop.reason);
+
+        return true;
+    }
+
     const command = leafCommandAt(path);
     const symbols = getSymbols();
     const theme = buildTheme({ symbols });

--- a/src/lib/interactive/index.js
+++ b/src/lib/interactive/index.js
@@ -124,11 +124,31 @@ export const runInteractive = async ({
     // about without anyone editing the wizard.
     const specs = specsFromCommand(command);
 
+    const refined = wizard.refine ? wizard.refine(specs, { answers: presetOptions }) : specs;
+
+    // Anything already given on the command line or through a BSI_* environment
+    // variable is an answer, not a question. Dropped here rather than in
+    // `refine`, so every wizard composes with `-i` without having to remember
+    // to.
+    //
+    // Computed once rather than per restart: `refine` sees the same specs and
+    // the same preset answers every time round the loop, and the banner below
+    // has to be built from the result before the first question is asked.
+    const asked = refined.filter((spec) => !(spec.key in presetOptions));
+
+    // What a question stands in for counts as asked, even though its key
+    // differs. uninstall's picker is keyed `_build` and collects `browser` and
+    // `browserVersion` between them, so without this the banner announced that
+    // --browser-version would not be asked about and the wizard then asked for
+    // exactly that, using that option's help text as the prompt (issue #1013).
+    const covered = new Set(asked.flatMap((spec) => spec.replaces ?? []));
+
     // Named by flag rather than by storage key, because the flag is what the
     // user typed. Secrets are named but never shown.
-    const prefilled = specs
-        .filter((spec) => spec.key in presetOptions)
-        .map((spec) => spec.option?.long ?? spec.key);
+    const nameOf = (spec) => spec.option?.long ?? spec.key;
+    const supplied = specs.filter((spec) => spec.key in presetOptions);
+    const prefilled = supplied.filter((spec) => !covered.has(spec.key)).map(nameOf);
+    const overridden = supplied.filter((spec) => covered.has(spec.key)).map(nameOf);
 
     // Said once, up front. There is no way back to a previous question - the
     // prompt library has no such gesture - so the two things a user can do
@@ -143,15 +163,17 @@ export const runInteractive = async ({
         );
     }
 
+    if (overridden.length > 0) {
+        // Deliberately still asked. A picker over what is really there beats a
+        // value remembered from an earlier run - which may name something that
+        // has since been removed - but saying nothing would leave someone who
+        // set the value wondering why it was ignored.
+        runtime.write(
+            `${theme.style.help(`Supplied, but asked about again so the answer can be picked from what is actually there: ${overridden.join(', ')}.`)}\n`
+        );
+    }
+
     for (;;) {
-        const refined = wizard.refine ? wizard.refine(specs, { answers: presetOptions }) : specs;
-
-        // Anything already given on the command line or through a BSI_*
-        // environment variable is an answer, not a question. Dropped here rather
-        // than in `refine`, so every wizard composes with `-i` without having to
-        // remember to.
-        const asked = refined.filter((spec) => !(spec.key in presetOptions));
-
         const raw = await askQuestions(
             // Seeded with what is already known, so a later `when` or `choices`
             // sees the pre-filled answers as well as the typed ones.

--- a/src/lib/interactive/option-introspect.js
+++ b/src/lib/interactive/option-introspect.js
@@ -20,6 +20,8 @@ const SECRET_KEYS = new Set(BSI_SECRET_KEYS.map((key) => key.toLowerCase()));
  * @property {string} [group] - Section heading this question belongs under.
  * @property {string[]} [needs] - Keys that must be answered before this one.
  * @property {QuestionSpec} [fallback] - Used when an async `choices` throws.
+ * @property {string[]} [replaces] - Real option keys a synthetic question collects between them, so
+ *     the wizard knows a value supplied for one of them is asked about rather than skipped.
  * @property {import('commander').Option} [option] - The option this was derived from.
  */
 

--- a/src/lib/util/__tests__/colour.test.js
+++ b/src/lib/util/__tests__/colour.test.js
@@ -16,7 +16,15 @@ describe('isColourEnabled', () => {
 
         test('disabled when the stream is missing entirely', () => {
             // process.stdout can be undefined in exotic embeddings; never throw.
-            expect(isColourEnabled(undefined, {})).toBe(false);
+            //
+            // `null` rather than `undefined`, and it has to stay that way: the
+            // parameter is declared `stream = process.stdout`, and a default
+            // fires on `undefined`. Passing `undefined` therefore tested the
+            // real stdout rather than a missing stream, so this passed in CI -
+            // where stdout is not a TTY - and failed for anyone running the
+            // suite from a terminal. `null` skips the default and is what
+            // "missing entirely" actually looks like here.
+            expect(isColourEnabled(null, {})).toBe(false);
         });
 
         test('disabled for a dumb terminal even when it is a TTY', () => {


### PR DESCRIPTION
Fixes #1013.

On a machine with an empty browser cache, `browser uninstall -i` asked which build to remove — using `--browser-version`'s own help text as the prompt, one line after announcing it would *not* ask about `--browser-version`. No answer could succeed; every one ended the run with "Browser not found in cache".

Two independent defects met there, and they are one commit each.

## 1. An empty cache was handled as a failed lookup

`resolveChoices()` sends both an empty result and a thrown error to the question's `fallback`. That is right for the app and collection pickers — an empty list there means a tag matched nothing, and typing an id by hand is a genuine escape — and wrong for this command, where an empty cache means there is nothing to do at all. Fixing it in `resolveChoices` would break the pickers and the test that pins their behaviour, so the decision belongs to the wizard, the only party that can tell the two apart. `browser uninstall-all` is already excused from the registry for handling its own empty case.

Adds an optional `precheck` hook, run before anything is printed — a wizard with no valid answer to offer must not first announce itself and then bail. It reports the same answer `browser list-installed` gives on that machine and exits **0**: nothing was asked for, so nothing failed.

A cache that cannot be *read* is deliberately let through. "Not found" and "found but unusable" are different answers, so an unreadable cache still reaches the free-text fallback, which is how an operator recovers there.

## 2. A synthetic question escaped the already-supplied filter

The filter keys on `spec.key`, but this wizard replaces the browser/version pair with one question keyed `_build`. That key is not in the preset options, so the question survived the filter while the values it collects were reported as settled.

A question can now declare `replaces`, and the banner is computed from what will actually be asked. The picker still asks and still wins — a build id remembered in `.env` may name something since removed, while the list always names something that exists — but it now says so:

```
Supplied, but asked about again so the answer can be picked from what is actually there: --browser-version.
```

That line appears only when a supplied value is genuinely overridden.

## Verification

Against the issue's own reproduction, under a pty (`-i` needs one):

| | before | after |
|---|---|---|
| empty cache | banner + unanswerable prompt | one line, no prompt, **exit 0** |
| build installed, version supplied | claims `--browser-version` skipped, then asks for it | says it is asked about again, then the real picker |

I confirmed the harness by running it against unfixed code first — it reproduces the issue transcript verbatim. Each half was reverted separately to check both are load-bearing rather than one masking the other; each breaks exactly 7 tests.

The non-interactive path is untouched and still exits 1. `browser install -i`, `list-installed` and `uninstall-all` are unaffected.

**Unit suite: 87 suites, 2272 tests green** — and green at each of the three commits individually (2260 → 2264 → 2272), so bisect works. The 17 integration failures on this machine are `assertEnv` prerequisite guards for missing Qlik credentials; they fire before any test logic and are unrelated.

## Also here

`fix(test): assert missing streams with null, not undefined` — unrelated to #1013 and separable if you would rather it went on its own.

Two tests named "the stream is missing entirely" passed `undefined` to functions declared `stream = process.stdout` / `stdin = process.stdin`. A default fires on `undefined`, so both were handed the real process streams and asserted nothing about a missing one. They passed under CI, where the streams are not TTYs, and **failed for anyone running the suite from a terminal**. `null` skips the default. Verified by mutation: removing the `?.` guards now fails exactly those two tests, where before it failed none.

## Docs

New page staged in `docs/to-doc-site/`. I also corrected the still-pending `interactive-flag-on-commands.md`, whose worked example showed `--browser` as skipped for `browser uninstall` — this change makes that false, since the picker overwrites `browser` too. The old banner was wrong about that case as well.

## Left out deliberately

The issue's third item: three `qseow`/`qscloud` pickers whose fallback says "could not fetch the list" when the list was fetched and was merely empty. It needs a new spec field in `ask-questions.js` to tell empty from failed — the file this PR argues should stay untouched for defect 1 — so it is worth its own change and review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)