### PR TITLE
Add a short pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+<!--
+Title: a plain sentence, NOT a Conventional Commits subject.
+GitHub copies the PR title into the merge commit body; release-please then
+parses it as a second entry and the changelog ends up with duplicates.
+-->
+
+## What & why
+
+<!-- One or two sentences. What changed, and what problem it solves. -->
+
+## How it was verified
+
+<!-- Name the test file, the command, or the live QSEoW/Cloud check you ran.
+     "Unit tests pass" alone is not enough for browser or thumbnail behaviour. -->
+
+## Docs
+
+<!-- Either the path of the page staged in docs/to-doc-site/, or "internal only". -->


### PR DESCRIPTION
## What & why

Adds `.github/pull_request_template.md`. Three prompts — what/why, how it was verified, and whether a docs page was staged — plus a comment reminding the author that the PR title stays a plain sentence.

The value here is not onboarding strangers; this repo is effectively solo. It is that two conventions from `CLAUDE.md` become visible artifacts in the PR itself rather than instructions someone has to remember: staging a page in `docs/to-doc-site/` for user-facing changes, and keeping Conventional Commits subjects out of PR titles so release-please stops emitting duplicate changelog entries.

## How it was verified

No code, so nothing to execute. What was checked instead:

- No competing template at the repo root or in `docs/` — GitHub's precedence is root → `.github/` → `docs/`, so this file is the one that takes effect.
- `npm run format` is scoped to `src/**/*.js` and no workflow runs prettier as a check; the pre-commit prettier hook skipped the file, confirming markdown is outside its filter.
- The title claim is accurate against this repo's own history: `git log --merges` shows merge subjects of `Merge pull request #N from …` with the PR title in the body.
- `docs/to-doc-site/` exists with the pending/`done/` structure the template's comment describes.

Known limitation: the template only fires for PRs composed in the GitHub web UI. `gh pr create --body …`, `--fill`, and release-please all set the body directly and bypass it.

## Docs

Internal only — no user-observable behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)