### PR TITLE
Generate the doc site's CLI option tables from the Commander definitions

### DIFF
--- a/docs/to-doc-site/README.md
+++ b/docs/to-doc-site/README.md
@@ -40,6 +40,28 @@ When in doubt, err on the side of explaining more rather than less. Use plain la
 
 A draft may name a target page and suggest replacement text, but it is a proposal. The publishing pass below decides what actually ships.
 
+## Option tables are generated, not written
+
+Never hand-write or hand-edit a table of CLI options on the doc site. Flag names, environment variables, accepted values and defaults are all declared once in the Commander definitions under `src/lib/commands/`, and a table typed out beside them is a second copy that drifts silently — issue #849 is one page's worth of exactly that, including a default documented as `latest` that the code had never used.
+
+Generate them instead:
+
+```bash
+npm run docs:cli-tables -- --command "browser install"
+```
+
+That prints a block wrapped in `<!-- generated:cli-options ... -->` markers. Paste it into the page in place of the table. From then on the block is refreshed in place, with the prose around it untouched:
+
+```bash
+npm run docs:cli-tables -- ../butler-sheet-icons-docs/docs/reference/browser.md --write
+```
+
+Use `--check` instead of `--write` to be told whether a page is current without changing it; it exits non-zero when it is not, so it can gate a release. `--list` names every command a table can be generated for.
+
+The `Example` column is the one part not derived from the code: examples are derived only for options with a fixed set of accepted values, since any other example — a host name, a build id — would be invented. Supply the rest through `--examples <file>`, a JSON file of `{ "<command path>": { "--flag": "..." } }`.
+
+If a description reads badly on the site, fix it in the Commander definition rather than in the table. The same text is what `--help` prints, so the page and the terminal improve together.
+
 ## Processing status
 
 - Files **directly in this folder, without a prefix**, are pending review or publication.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "lint:fix": "npx eslint --fix src/",
         "format": "npx prettier --write \"src/**/*.js\"",
         "build:macos": "./build-script/build-macos.sh",
+        "docs:cli-tables": "node scripts/docs-cli-tables.js",
         "gitnexus:install": "node scripts/gitnexus.js install",
         "gitnexus:status": "node scripts/gitnexus.js status",
         "gitnexus:index": "node scripts/gitnexus.js index",

--- a/scripts/docs-cli-tables.js
+++ b/scripts/docs-cli-tables.js
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+// Platform: Cross-platform (macOS, Linux, Windows)
+// Requires: Node.js
+
+/**
+ * Generate the CLI option tables used by the Butler Sheet Icons doc site.
+ *
+ * The tables on the doc site state flag names, environment variables, accepted values and
+ * defaults. Every one of those is already declared once, in the Commander definitions under
+ * `src/lib/commands/`, so a hand-written table is a second copy that drifts silently - issue
+ * #849 is one page's worth of exactly that. This reads the definitions and writes the table.
+ *
+ * The doc site lives in a separate repository (ptarmiganlabs/butler-sheet-icons-docs), so point
+ * this at a local clone of it. Only the regions between the generated-block markers are
+ * rewritten; the prose around them is left alone.
+ *
+ * Usage:
+ *   node scripts/docs-cli-tables.js --list
+ *   node scripts/docs-cli-tables.js --command "browser install"
+ *   node scripts/docs-cli-tables.js <file.md>... --check
+ *   node scripts/docs-cli-tables.js <file.md>... --write
+ *
+ * Options:
+ *   --list              Print every command path a table can be generated for.
+ *   --command <path>    Print a ready-to-paste block for one command.
+ *   --check             Report whether the blocks in the named files are current. Exit 1 if not.
+ *   --write             Rewrite the blocks in the named files.
+ *   --examples <file>   JSON of hand-written examples: { "<command path>": { "--flag": "..." } }.
+ *
+ * With neither --check nor --write, the named files are rendered to stdout and left untouched.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import process from 'node:process';
+
+import {
+    knownCommandPaths,
+    renderBlock,
+    updateGeneratedBlocks,
+} from '../src/lib/docs/cli-option-tables.js';
+
+/**
+ * Parse the command line.
+ *
+ * Hand-rolled rather than using Commander: this script reads the CLI definitions, and building
+ * a second command tree in the same process to do it invites confusion about which tree is
+ * being inspected.
+ *
+ * @param {string[]} argv - Arguments after the script name.
+ *
+ * @returns {{files: string[], list: boolean, command: string|null, check: boolean, write: boolean, examples: string|null}} Parsed arguments.
+ *
+ * @throws {Error} When a flag that takes a value is given none.
+ */
+const parseArgs = (argv) => {
+    const parsed = {
+        files: [],
+        list: false,
+        command: null,
+        check: false,
+        write: false,
+        examples: null,
+    };
+
+    const valueFor = (flag, index) => {
+        const value = argv[index + 1];
+
+        if (value === undefined || value.startsWith('--')) {
+            throw new Error(`${flag} needs a value`);
+        }
+
+        return value;
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const argument = argv[index];
+
+        if (argument === '--list') {
+            parsed.list = true;
+        } else if (argument === '--check') {
+            parsed.check = true;
+        } else if (argument === '--write') {
+            parsed.write = true;
+        } else if (argument === '--command') {
+            parsed.command = valueFor(argument, index);
+            index += 1;
+        } else if (argument === '--examples') {
+            parsed.examples = valueFor(argument, index);
+            index += 1;
+        } else if (argument.startsWith('--')) {
+            throw new Error(`Unknown option ${argument}`);
+        } else {
+            parsed.files.push(argument);
+        }
+    }
+
+    return parsed;
+};
+
+/**
+ * Load the hand-written examples file, if one was named.
+ *
+ * @param {string|null} path - Path to a JSON file, or null.
+ *
+ * @returns {Record<string, Record<string, string>>} Examples keyed by command path, then flag.
+ */
+const loadExamples = (path) => (path ? JSON.parse(readFileSync(path, 'utf8')) : {});
+
+/**
+ * Entry point.
+ *
+ * @returns {number} Process exit code. 1 when `--check` found a stale block, or on error.
+ */
+const main = () => {
+    let args;
+
+    try {
+        args = parseArgs(process.argv.slice(2));
+    } catch (err) {
+        process.stderr.write(`${err.message}\n`);
+
+        return 1;
+    }
+
+    if (args.list) {
+        process.stdout.write(`${knownCommandPaths().join('\n')}\n`);
+
+        return 0;
+    }
+
+    const examples = loadExamples(args.examples);
+
+    if (args.command) {
+        process.stdout.write(renderBlock(args.command, { examples: examples[args.command] }));
+
+        return 0;
+    }
+
+    if (args.files.length === 0) {
+        process.stderr.write(
+            'Nothing to do. Name one or more markdown files, or use --list or --command.\n'
+        );
+
+        return 1;
+    }
+
+    let stale = 0;
+
+    for (const file of args.files) {
+        const original = readFileSync(file, 'utf8');
+        const { content, blocks } = updateGeneratedBlocks(original, { examples });
+
+        if (blocks.length === 0) {
+            process.stderr.write(`${file}: no generated:cli-options blocks found\n`);
+            continue;
+        }
+
+        for (const block of blocks) {
+            if (block.changed) {
+                stale += 1;
+            }
+
+            // Reported per block rather than per file so a page carrying several tables says
+            // which command's table is the stale one.
+            const state = block.changed ? (args.write ? 'updated' : 'STALE') : 'current';
+
+            process.stderr.write(`${file}: ${block.path}: ${state}\n`);
+        }
+
+        if (args.write) {
+            if (content !== original) {
+                writeFileSync(file, content);
+            }
+        } else if (!args.check) {
+            process.stdout.write(content);
+        }
+    }
+
+    if (args.check && stale > 0) {
+        process.stderr.write(
+            `\n${stale} option table(s) out of date. Regenerate with: node scripts/docs-cli-tables.js <file> --write\n`
+        );
+
+        return 1;
+    }
+
+    return 0;
+};
+
+process.exitCode = main();

--- a/src/lib/docs/__tests__/cli-option-tables.test.js
+++ b/src/lib/docs/__tests__/cli-option-tables.test.js
@@ -46,6 +46,18 @@ describe('escapeCell', () => {
         expect(escapeCell('BSI_* variables')).toBe('BSI\\_\\* variables');
     });
 
+    test('escapes a backslash, which would otherwise pair with what follows it', () => {
+        // Checked through VitePress: `C:\Users\.cache` renders as `C:\Users.cache`, because
+        // `\.` reads as an escaped full stop and the backslash is consumed.
+        expect(escapeCell('C:\\Users\\.cache')).toBe('C:\\\\Users\\\\.cache');
+    });
+
+    test('escapes the backslash before escaping anything else', () => {
+        // If the order slipped, the backslash this function writes for the pipe would itself be
+        // escaped on the next pass and the cell would show a stray backslash.
+        expect(escapeCell('a\\|b')).toBe('a\\\\\\|b');
+    });
+
     test('leaves an underscore between word characters alone', () => {
         // CommonMark does not start emphasis inside a word, so `stable_153.0.3` is already
         // literal. Escaping it would put a visible backslash on the page.
@@ -69,6 +81,13 @@ describe('codeCell', () => {
         // the cell splits, the code span is lost, and the row's last value is pushed off the
         // table and never displayed.
         expect(codeCell('--outputformat <table|json>')).toBe('`--outputformat <table\\|json>`');
+    });
+
+    test('leaves a backslash alone, unlike escapeCell', () => {
+        // Inside a code span a backslash is already literal. Checked through VitePress:
+        // `C:\Users` renders as typed, and escaping it to `C:\\Users` renders two backslashes.
+        // This is why CodeQL's incomplete-sanitization alert does not apply to this function.
+        expect(codeCell('C:\\Users')).toBe('`C:\\Users`');
     });
 });
 

--- a/src/lib/docs/__tests__/cli-option-tables.test.js
+++ b/src/lib/docs/__tests__/cli-option-tables.test.js
@@ -1,0 +1,362 @@
+import { test, expect, describe } from '@jest/globals';
+import { Command, Option } from 'commander';
+
+import {
+    BLOCK_CLOSE,
+    BLOCK_OPEN_PREFIX,
+    codeCell,
+    commandAt,
+    deriveExample,
+    escapeCell,
+    formatDefault,
+    formatDescription,
+    knownCommandPaths,
+    optionRowsFor,
+    renderBlock,
+    renderOptionTable,
+    renderTable,
+    updateGeneratedBlocks,
+} from '../cli-option-tables.js';
+
+/**
+ * Split a rendered markdown row into cells the way a markdown parser does: on pipes that are
+ * not escaped.
+ *
+ * @param {string} row - One line of a rendered table.
+ *
+ * @returns {string[]} The cells, without the leading and trailing empties.
+ */
+const cellsOf = (row) =>
+    row
+        .split(/(?<!\\)\|/)
+        .slice(1, -1)
+        .map((cell) => cell.trim());
+
+describe('escapeCell', () => {
+    test('escapes a pipe so it cannot end the cell', () => {
+        expect(escapeCell('a | b')).toBe('a \\| b');
+    });
+
+    test('turns newlines into <br> so a multi-line description stays in one row', () => {
+        expect(escapeCell('first\nsecond')).toBe('first<br>second');
+        expect(escapeCell('first\r\nsecond')).toBe('first<br>second');
+    });
+
+    test('escapes an asterisk, which always opens emphasis', () => {
+        expect(escapeCell('BSI_* variables')).toBe('BSI\\_\\* variables');
+    });
+
+    test('leaves an underscore between word characters alone', () => {
+        // CommonMark does not start emphasis inside a word, so `stable_153.0.3` is already
+        // literal. Escaping it would put a visible backslash on the page.
+        expect(escapeCell('stable_153.0.3')).toBe('stable_153.0.3');
+    });
+
+    test('escapes an underscore that could open emphasis', () => {
+        expect(escapeCell('_leading')).toBe('\\_leading');
+        expect(escapeCell('trailing_')).toBe('trailing\\_');
+        expect(escapeCell('a _ b')).toBe('a \\_ b');
+    });
+});
+
+describe('codeCell', () => {
+    test('wraps the value in backticks', () => {
+        expect(codeCell('--browser')).toBe('`--browser`');
+    });
+
+    test('escapes a pipe even though a code span makes everything else literal', () => {
+        // `qscloud list-collections` really declares this. Rendered unescaped through VitePress,
+        // the cell splits, the code span is lost, and the row's last value is pushed off the
+        // table and never displayed.
+        expect(codeCell('--outputformat <table|json>')).toBe('`--outputformat <table\\|json>`');
+    });
+});
+
+describe('formatDefault', () => {
+    test('reports a mandatory option as required rather than as having no default', () => {
+        expect(formatDefault({ mandatory: true, defaultValue: undefined })).toBe('**Required**');
+    });
+
+    test('renders a missing default as a dash', () => {
+        expect(formatDefault({ mandatory: false, defaultValue: undefined })).toBe('-');
+    });
+
+    test('renders a scalar default as a code span', () => {
+        expect(formatDefault({ mandatory: false, defaultValue: 'info' })).toBe('`info`');
+        expect(formatDefault({ mandatory: false, defaultValue: false })).toBe('`false`');
+    });
+
+    test('joins an array default, and treats an empty array as no default', () => {
+        expect(formatDefault({ mandatory: false, defaultValue: ['a', 'b'] })).toBe('`a, b`');
+        expect(formatDefault({ mandatory: false, defaultValue: [] })).toBe('-');
+    });
+});
+
+describe('formatDescription', () => {
+    test('appends the accepted values in the shape --help prints them', () => {
+        const option = new Option('--browser <browser>', 'Browser to install').choices([
+            'chrome',
+            'firefox',
+        ]);
+
+        expect(formatDescription(option)).toBe('Browser to install (choices: chrome, firefox)');
+    });
+
+    test('leaves a description without choices unchanged', () => {
+        expect(formatDescription(new Option('--host <host>', 'Server host'))).toBe('Server host');
+    });
+});
+
+describe('deriveExample', () => {
+    test('prefers a value other than the default, which would demonstrate nothing', () => {
+        const option = new Option('--browser <browser>', '')
+            .choices(['chrome', 'firefox'])
+            .default('chrome');
+
+        expect(deriveExample(option)).toBe('--browser firefox');
+    });
+
+    test('falls back to the only choice when it is also the default', () => {
+        const option = new Option('--browser <browser>', '').choices(['chrome']).default('chrome');
+
+        expect(deriveExample(option)).toBe('--browser chrome');
+    });
+
+    test('derives nothing for a free-text option, where any example would be invented', () => {
+        expect(deriveExample(new Option('--host <host>', 'Server host'))).toBeNull();
+    });
+});
+
+describe('renderTable', () => {
+    test('pads every cell so the columns line up', () => {
+        const table = renderTable(['Option', 'Default'], [['`-a`', '`1`']]);
+
+        expect(table).toBe(
+            ['| Option | Default |', '| ------ | ------- |', '| `-a`   | `1`     |', ''].join('\n')
+        );
+    });
+
+    test('writes at least three dashes in a narrow column', () => {
+        const table = renderTable(['A'], [['b']]);
+
+        expect(table.split('\n')[1]).toBe('| --- |');
+    });
+});
+
+describe('optionRowsFor', () => {
+    test('includes the help option Commander adds behind the scenes', () => {
+        const command = new Command('demo');
+        const flags = optionRowsFor(command).map((row) => row[0]);
+
+        expect(flags).toContain('`-h, --help`');
+    });
+
+    test('omits hidden options', () => {
+        const command = new Command('demo').addOption(
+            new Option('--secret <value>', 'Internal').hideHelp()
+        );
+        const flags = optionRowsFor(command).map((row) => row[0]);
+
+        expect(flags).not.toContain('`--secret <value>`');
+    });
+
+    test('prefers a hand-written example over a derived one', () => {
+        const command = new Command('demo').addOption(
+            new Option('--browser <browser>', '').choices(['chrome', 'firefox']).default('chrome')
+        );
+
+        const [row] = optionRowsFor(command, {
+            examples: { '--browser': '--browser firefox@151' },
+        });
+
+        expect(row[4]).toBe('`--browser firefox@151`');
+    });
+
+    test('skips the help row for a command that has disabled help', () => {
+        const command = new Command('demo').helpOption(false);
+
+        expect(optionRowsFor(command)).toEqual([]);
+    });
+});
+
+describe('renderOptionTable', () => {
+    test('drops the Example column when nothing can fill it', () => {
+        const command = new Command('demo').helpOption(false).addOption(
+            // Free text, so no example is derivable and the column would be all dashes.
+            new Option('--host <host>', 'Server host')
+        );
+
+        const header = renderOptionTable(command).split('\n')[0];
+
+        expect(cellsOf(header)).toEqual([
+            'Option',
+            'Environment Variable',
+            'Description',
+            'Default',
+        ]);
+    });
+
+    test('keeps the Example column when at least one option can fill it', () => {
+        const command = new Command('demo').addOption(
+            new Option('--browser <browser>', '').choices(['chrome', 'firefox']).default('chrome')
+        );
+
+        const header = renderOptionTable(command).split('\n')[0];
+
+        expect(cellsOf(header)).toContain('Example');
+    });
+});
+
+describe('every real command', () => {
+    // The pipe in `--outputformat <table|json>` produced a table one column wider than its own
+    // header, and it did so silently: the markdown was valid, just wrong. Asserting the shape
+    // for every command catches the next option declared with a character that means something
+    // to markdown, whichever command grows it.
+    test.each(knownCommandPaths())('%s renders a rectangular table', (path) => {
+        const lines = renderOptionTable(commandAt(path)).trim().split('\n');
+        const columns = cellsOf(lines[0]).length;
+
+        expect(columns).toBeGreaterThan(0);
+
+        for (const line of lines) {
+            expect(cellsOf(line)).toHaveLength(columns);
+        }
+    });
+
+    test.each(knownCommandPaths())('%s pads every row to the same width', (path) => {
+        const lines = renderOptionTable(commandAt(path)).trim().split('\n');
+        const widths = new Set(lines.map((line) => line.length));
+
+        expect(widths.size).toBe(1);
+    });
+});
+
+describe('commandAt', () => {
+    test('finds a command by the path a user would type', () => {
+        expect(commandAt('browser install').name()).toBe('install');
+    });
+
+    test('names the known commands when asked for one that does not exist', () => {
+        expect(() => commandAt('browser nope')).toThrow(/No CLI command "browser nope"/);
+        expect(() => commandAt('browser nope')).toThrow(/browser install/);
+    });
+});
+
+describe('updateGeneratedBlocks', () => {
+    const documentWith = (body) =>
+        [
+            '# Page',
+            '',
+            'Hand-written prose that must survive.',
+            '',
+            `${BLOCK_OPEN_PREFIX}browser list-installed -->`,
+            body,
+            BLOCK_CLOSE,
+            '',
+            'More prose.',
+            '',
+        ].join('\n');
+
+    test('replaces a stale block and reports it as changed', () => {
+        const { content, blocks } = updateGeneratedBlocks(documentWith('| old | table |'));
+
+        expect(blocks).toEqual([{ path: 'browser list-installed', changed: true }]);
+        expect(content).toContain('BSI_BROWSER_LI_LOG_LEVEL');
+        expect(content).not.toContain('| old | table |');
+    });
+
+    test('leaves the surrounding prose exactly as it was', () => {
+        const { content } = updateGeneratedBlocks(documentWith('| old | table |'));
+
+        expect(content).toContain('Hand-written prose that must survive.');
+        expect(content).toContain('More prose.');
+        expect(content.startsWith('# Page\n')).toBe(true);
+    });
+
+    test('reports an already-current block as unchanged, and is idempotent', () => {
+        const once = updateGeneratedBlocks(documentWith('| old | table |')).content;
+        const twice = updateGeneratedBlocks(once);
+
+        expect(twice.blocks).toEqual([{ path: 'browser list-installed', changed: false }]);
+        expect(twice.content).toBe(once);
+    });
+
+    test('handles several blocks in one document independently', () => {
+        const document = [
+            `${BLOCK_OPEN_PREFIX}browser install -->`,
+            '| stale |',
+            BLOCK_CLOSE,
+            '',
+            'Between.',
+            '',
+            `${BLOCK_OPEN_PREFIX}browser uninstall -->`,
+            '| also stale |',
+            BLOCK_CLOSE,
+            '',
+        ].join('\n');
+
+        const { content, blocks } = updateGeneratedBlocks(document);
+
+        expect(blocks.map((block) => block.path)).toEqual(['browser install', 'browser uninstall']);
+        expect(content).toContain('Between.');
+        expect(content).toContain('BSI_BROWSER_I_BROWSER_VERSION');
+        expect(content).toContain('BSI_BROWSER_UI_BROWSER_VERSION');
+    });
+
+    test('reports no blocks for a document that has none', () => {
+        const { content, blocks } = updateGeneratedBlocks('# Just prose\n');
+
+        expect(blocks).toEqual([]);
+        expect(content).toBe('# Just prose\n');
+    });
+
+    test('refuses a block naming a command that does not exist', () => {
+        const document = `${BLOCK_OPEN_PREFIX}browser nope -->\n| x |\n${BLOCK_CLOSE}\n`;
+
+        expect(() => updateGeneratedBlocks(document)).toThrow(/No CLI command "browser nope"/);
+    });
+
+    test('passes the examples for the right command through', () => {
+        const document = `${BLOCK_OPEN_PREFIX}browser install -->\n\n${BLOCK_CLOSE}\n`;
+        const { content } = updateGeneratedBlocks(document, {
+            examples: {
+                'browser install': { '--browser-version': '--browser-version 151.0.7922.77' },
+            },
+        });
+
+        expect(content).toContain('`--browser-version 151.0.7922.77`');
+    });
+});
+
+describe('renderBlock', () => {
+    test('wraps the table in markers the updater can find again', () => {
+        const block = renderBlock('browser list-installed');
+
+        expect(block.startsWith(`${BLOCK_OPEN_PREFIX}browser list-installed -->`)).toBe(true);
+        expect(block.trimEnd().endsWith(BLOCK_CLOSE)).toBe(true);
+
+        // Round trip: what renderBlock emits must already be current, or --check would report a
+        // freshly generated page as stale.
+        expect(updateGeneratedBlocks(block).blocks).toEqual([
+            { path: 'browser list-installed', changed: false },
+        ]);
+    });
+
+    test('separates the markers from the table with blank lines', () => {
+        const lines = renderBlock('browser list-installed').split('\n');
+
+        expect(lines[1]).toBe('');
+        expect(lines.at(-2)).toBe(BLOCK_CLOSE);
+        expect(lines.at(-3)).toBe('');
+    });
+});
+
+describe('knownCommandPaths', () => {
+    test('lists the commands the doc site documents', () => {
+        const paths = knownCommandPaths();
+
+        expect(paths).toContain('browser install');
+        expect(paths).toContain('qseow create-sheet-thumbnails');
+        expect(paths).toContain('qscloud create-sheet-thumbnails');
+    });
+});

--- a/src/lib/docs/cli-option-tables.js
+++ b/src/lib/docs/cli-option-tables.js
@@ -49,8 +49,12 @@ const HEADERS = ['Option', 'Environment Variable', 'Description', 'Default', 'Ex
  * Only ever applied to free-text cells. Cells this module wraps in backticks are code spans,
  * where every character is already literal and escaping would show the backslashes.
  *
- * Three things matter:
+ * Four things matter:
  *
+ * - A backslash is itself the escape character, so it has to be escaped first or it will pair
+ *   with whatever follows. A description mentioning a Windows path is enough: rendered through
+ *   VitePress, `C:\Users\.cache` comes out as `C:\Users.cache`, because `\.` is read as an
+ *   escaped full stop and the backslash disappears.
  * - A literal `|` would end the cell, and a description may contain one.
  * - A newline would end the row. Several descriptions are authored as multiple lines for the
  *   terminal's benefit, and those breaks have to survive as `<br>` rather than truncating the
@@ -71,6 +75,9 @@ const HEADERS = ['Option', 'Environment Variable', 'Description', 'Default', 'Ex
  */
 export const escapeCell = (value) =>
     String(value)
+        // Must stay first. Escaping any other character inserts backslashes of its own, and a
+        // later pass over them would double what this pass has already written.
+        .replace(/\\/g, '\\\\')
         .replace(/([*|])/g, '\\$1')
         .replace(/(^|\W)_|_(?=\W|$)/g, (match) => match.replace('_', '\\_'))
         .replace(/\r?\n/g, '<br>')
@@ -86,6 +93,12 @@ export const escapeCell = (value) =>
  * This is not theoretical. `qscloud list-collections` declares `--outputformat <table|json>`,
  * and rendering that unescaped through VitePress splits the cell, drops the code span, and
  * pushes the row's last value off the end of the table where it is not displayed at all.
+ *
+ * A backslash is deliberately not escaped here, which is the one way this differs from
+ * `escapeCell`. Inside a code span a backslash is already literal: checked through VitePress,
+ * `C:\Users` renders as typed, while escaping it to `C:\\Users` renders two backslashes. CodeQL
+ * reads any escaper that leaves the escape character alone as incomplete sanitization, and it
+ * is right about free text - but here escaping it would be the defect.
  *
  * @param {unknown} value - Raw cell content.
  *

--- a/src/lib/docs/cli-option-tables.js
+++ b/src/lib/docs/cli-option-tables.js
@@ -1,0 +1,356 @@
+import { everyLeafCommand } from '../interactive/command-tree.js';
+
+/**
+ * Markers delimiting a generated option table inside a markdown file.
+ *
+ * The tables live in the doc site repository, interleaved with hand-written prose, so the
+ * generator cannot own whole files. Markers let it own a region: everything between them is
+ * replaced on each run, everything around them is left exactly as the author wrote it.
+ *
+ * The opening marker carries the command path, so a file states which table belongs where and
+ * the generator needs no separate mapping to keep in step with it.
+ */
+export const BLOCK_OPEN_PREFIX = '<!-- generated:cli-options ';
+export const BLOCK_CLOSE = '<!-- /generated:cli-options -->';
+
+/**
+ * The body written between the two markers.
+ *
+ * The blank lines are for whoever opens the file: checked against VitePress's own renderer, the
+ * table is recognised with or without them. They also happen to be what Prettier emits around
+ * an HTML comment, so a block stays byte-identical if the page is ever run through a formatter.
+ *
+ * @param {string} table - The rendered table, newline-terminated.
+ *
+ * @returns {string} The block body.
+ */
+const blockBody = (table) => `\n${table}\n`;
+
+/**
+ * Matches one generated block, capturing the command path and the current body.
+ *
+ * Non-greedy so consecutive blocks in one file are matched separately rather than as a single
+ * span running from the first opening marker to the last closing one.
+ */
+const BLOCK_PATTERN =
+    /<!-- generated:cli-options ([^>]+?) -->\r?\n([\s\S]*?)<!-- \/generated:cli-options -->/g;
+
+/**
+ * Columns, in the order the doc site already uses for these tables.
+ *
+ * `Example` is dropped when nothing in the table can fill it, rather than emitting a column of
+ * placeholders.
+ */
+const HEADERS = ['Option', 'Environment Variable', 'Description', 'Default', 'Example'];
+
+/**
+ * Escape a value for use inside a markdown table cell.
+ *
+ * Only ever applied to free-text cells. Cells this module wraps in backticks are code spans,
+ * where every character is already literal and escaping would show the backslashes.
+ *
+ * Three things matter:
+ *
+ * - A literal `|` would end the cell, and a description may contain one.
+ * - A newline would end the row. Several descriptions are authored as multiple lines for the
+ *   terminal's benefit, and those breaks have to survive as `<br>` rather than truncating the
+ *   table.
+ * - `_` and `*` are emphasis markers. Descriptions are free text written for the terminal,
+ *   where they mean nothing, so nothing stops one arriving with a matched pair that would
+ *   silently italicise part of the cell on the site.
+ *
+ * The emphasis escaping is defensive rather than a fix for a live defect: today's descriptions
+ * render the same either way, checked against VitePress's renderer. It is scoped to where
+ * CommonMark would actually act, because escaping more than that puts visible backslashes on
+ * the page - an `_` between two word characters cannot open emphasis, so `stable_153.0.3` is
+ * left exactly as the CLI prints it.
+ *
+ * @param {unknown} value - Raw cell content.
+ *
+ * @returns {string} Content safe to place between two pipes.
+ */
+export const escapeCell = (value) =>
+    String(value)
+        .replace(/([*|])/g, '\\$1')
+        .replace(/(^|\W)_|_(?=\W|$)/g, (match) => match.replace('_', '\\_'))
+        .replace(/\r?\n/g, '<br>')
+        .trim();
+
+/**
+ * Render a value as a markdown code span for a table cell.
+ *
+ * A code span makes every character literal except one: a `|` still ends the cell, because the
+ * row is split into cells before inline spans are parsed. GFM is explicit that a pipe has to be
+ * escaped "even inside other inline spans".
+ *
+ * This is not theoretical. `qscloud list-collections` declares `--outputformat <table|json>`,
+ * and rendering that unescaped through VitePress splits the cell, drops the code span, and
+ * pushes the row's last value off the end of the table where it is not displayed at all.
+ *
+ * @param {unknown} value - Raw cell content.
+ *
+ * @returns {string} A code span safe to place between two pipes.
+ */
+export const codeCell = (value) => `\`${String(value).replace(/\|/g, '\\|')}\``;
+
+/**
+ * Render the `Default` cell for one option.
+ *
+ * A mandatory option has no default by definition, and saying so is more useful to an
+ * administrator than an empty cell: it is the difference between an option they may omit and
+ * one the command refuses to run without.
+ *
+ * @param {import('commander').Option} option - The option to describe.
+ *
+ * @returns {string} Markdown for the cell.
+ */
+export const formatDefault = (option) => {
+    if (option.mandatory) {
+        return '**Required**';
+    }
+
+    if (option.defaultValue === undefined) {
+        return '-';
+    }
+
+    if (Array.isArray(option.defaultValue)) {
+        return option.defaultValue.length > 0 ? codeCell(option.defaultValue.join(', ')) : '-';
+    }
+
+    return codeCell(option.defaultValue);
+};
+
+/**
+ * Render the `Description` cell for one option.
+ *
+ * The accepted values are appended in the same shape Commander prints them in `--help`, so a
+ * reader comparing the doc page against their own terminal sees the same sentence twice rather
+ * than two wordings of it.
+ *
+ * @param {import('commander').Option} option - The option to describe.
+ *
+ * @returns {string} Markdown for the cell.
+ */
+export const formatDescription = (option) => {
+    const parts = [option.description];
+
+    if (option.argChoices?.length > 0) {
+        parts.push(`(choices: ${option.argChoices.join(', ')})`);
+    }
+
+    return escapeCell(parts.filter(Boolean).join(' '));
+};
+
+/**
+ * Derive an example invocation for one option.
+ *
+ * Only options with a fixed set of accepted values can have one derived: any other example is
+ * editorial - a plausible host name, a real build id - and inventing those here would put
+ * unverifiable text into a generated block. Those are supplied through the examples file
+ * instead, or left out.
+ *
+ * A value other than the default is preferred, since an example repeating the default
+ * demonstrates nothing.
+ *
+ * @param {import('commander').Option} option - The option to derive an example for.
+ *
+ * @returns {string|null} The example, or null when none can be derived.
+ */
+export const deriveExample = (option) => {
+    if (!(option.argChoices?.length > 0)) {
+        return null;
+    }
+
+    const alternative =
+        option.argChoices.find((choice) => choice !== option.defaultValue) ?? option.argChoices[0];
+
+    return `${option.long ?? option.short} ${alternative}`;
+};
+
+/**
+ * The rows of the option table for one command.
+ *
+ * @param {import('commander').Command} command - The command to tabulate.
+ * @param {object} [context] - Rendering context.
+ * @param {Record<string, string>} [context.examples] - Hand-written examples, keyed by long flag.
+ *
+ * @returns {string[][]} One array of cells per row, in `HEADERS` order.
+ */
+export const optionRowsFor = (command, { examples = {} } = {}) => {
+    const rows = command.options
+        .filter((option) => !option.hidden)
+        .map((option) => {
+            const example = examples[option.long] ?? deriveExample(option);
+
+            return [
+                codeCell(option.flags),
+                option.envVar ? codeCell(option.envVar) : '-',
+                formatDescription(option),
+                formatDefault(option),
+                example ? codeCell(example) : '-',
+            ];
+        });
+
+    // Commander adds the help option itself, so it is absent from `command.options` even though
+    // every command accepts it and the doc tables list it. Read it back rather than hardcoding
+    // the flags: `_getHelpOption()` is private, so fall back to omitting the row instead of
+    // guessing, and skip it entirely for a command that has disabled help.
+    const helpOption = command._getHelpOption?.();
+
+    if (helpOption) {
+        rows.push([
+            codeCell(helpOption.flags),
+            '-',
+            escapeCell(helpOption.description),
+            '-',
+            codeCell(helpOption.short ?? helpOption.long),
+        ]);
+    }
+
+    return rows;
+};
+
+/**
+ * Render a markdown table, padding every cell to its column width.
+ *
+ * Markdown does not need the padding, and the rendered page is identical without it. It is here
+ * so a generated table reads like the hand-written ones already on the doc site, and so a diff
+ * against one shows the cells that changed rather than every row reflowing.
+ *
+ * The layout matches Prettier's byte for byte - verified against it for all nine commands - so
+ * the blocks survive a formatter unchanged if the doc site ever gains one.
+ *
+ * @param {string[]} headers - Header cells.
+ * @param {string[][]} rows - Body rows.
+ *
+ * @returns {string} The table, newline-terminated.
+ */
+export const renderTable = (headers, rows) => {
+    const widths = headers.map((header, column) =>
+        Math.max(header.length, ...rows.map((row) => row[column].length))
+    );
+
+    // Measured against Prettier: it lays these columns out by source length, counting an
+    // escaping backslash as a character like any other, so the raw string is what to pad.
+    const line = (cells) =>
+        `| ${cells.map((text, column) => text.padEnd(widths[column])).join(' | ')} |`;
+
+    // Prettier writes at least three dashes per column, even when the column is narrower.
+    const separator = `| ${widths.map((width) => '-'.repeat(Math.max(width, 3))).join(' | ')} |`;
+
+    return [line(headers), separator, ...rows.map(line)].join('\n') + '\n';
+};
+
+/**
+ * The complete option table for one command.
+ *
+ * @param {import('commander').Command} command - The command to tabulate.
+ * @param {object} [context] - Rendering context.
+ * @param {Record<string, string>} [context.examples] - Hand-written examples, keyed by long flag.
+ *
+ * @returns {string} Markdown table, newline-terminated.
+ */
+export const renderOptionTable = (command, context = {}) => {
+    const rows = optionRowsFor(command, context);
+    const exampleColumn = HEADERS.indexOf('Example');
+    const hasExamples = rows.some((row) => row[exampleColumn] !== '-');
+
+    if (hasExamples) {
+        return renderTable(HEADERS, rows);
+    }
+
+    const trimmed = HEADERS.slice(0, exampleColumn);
+
+    return renderTable(
+        trimmed,
+        rows.map((row) => row.slice(0, exampleColumn))
+    );
+};
+
+/**
+ * Look up a command by the path a user would type.
+ *
+ * Reads the same enumeration the interactive wizards and their registry guard read, so a
+ * command added to the CLI is available to the docs from the moment it is registered.
+ *
+ * @param {string} path - Space-separated command path, e.g. `browser install`.
+ *
+ * @returns {import('commander').Command} The command.
+ *
+ * @throws {Error} When no command has that path.
+ */
+export const commandAt = (path) => {
+    const leaves = everyLeafCommand();
+    const match = leaves.find((leaf) => leaf.path === path);
+
+    if (!match) {
+        throw new Error(
+            `No CLI command "${path}". Known commands: ${leaves.map((leaf) => leaf.path).join(', ')}.`
+        );
+    }
+
+    return match.command;
+};
+
+/**
+ * @typedef {object} BlockUpdate
+ * @property {string} path - Command path named by the block.
+ * @property {boolean} changed - Whether the rendered table differs from what the file held.
+ */
+
+/**
+ * @typedef {object} UpdateResult
+ * @property {string} content - The markdown, with every generated block re-rendered.
+ * @property {BlockUpdate[]} blocks - One entry per block found, in document order.
+ */
+
+/**
+ * Re-render every generated option table in a markdown document.
+ *
+ * Content outside the markers is untouched, so this is safe to run against a page that is
+ * mostly hand-written prose.
+ *
+ * @param {string} markdown - The document.
+ * @param {object} [context] - Rendering context.
+ * @param {Record<string, Record<string, string>>} [context.examples] - Hand-written examples,
+ *   keyed by command path and then by long flag.
+ *
+ * @returns {UpdateResult} The updated document and a report of what each block did.
+ *
+ * @throws {Error} When a block names a command that does not exist.
+ */
+export const updateGeneratedBlocks = (markdown, { examples = {} } = {}) => {
+    const blocks = [];
+
+    const content = markdown.replace(BLOCK_PATTERN, (match, rawPath, body) => {
+        const path = rawPath.trim();
+        const rendered = blockBody(
+            renderOptionTable(commandAt(path), { examples: examples[path] })
+        );
+
+        blocks.push({ path, changed: body !== rendered });
+
+        return `${BLOCK_OPEN_PREFIX}${path} -->\n${rendered}${BLOCK_CLOSE}`;
+    });
+
+    return { content, blocks };
+};
+
+/**
+ * A generated block ready to paste into a page that does not have one yet.
+ *
+ * @param {string} path - Space-separated command path, e.g. `browser install`.
+ * @param {object} [context] - Rendering context.
+ * @param {Record<string, string>} [context.examples] - Hand-written examples, keyed by long flag.
+ *
+ * @returns {string} The markers and the table between them.
+ */
+export const renderBlock = (path, context = {}) =>
+    `${BLOCK_OPEN_PREFIX}${path} -->\n${blockBody(renderOptionTable(commandAt(path), context))}${BLOCK_CLOSE}\n`;
+
+/**
+ * Every command path the generator can render a table for.
+ *
+ * @returns {string[]} Command paths, in registration order.
+ */
+export const knownCommandPaths = () => everyLeafCommand().map((leaf) => leaf.path);


### PR DESCRIPTION
The doc site states flag names, environment variables, accepted values and defaults for every command. All of those are already declared once, in the Commander definitions under `src/lib/commands/`, so the tables beside them are a second copy with nothing holding it in step. They drift silently — #849 is one page's worth of exactly that, including a `--browser-version` default documented as `latest` that no code path has ever produced.

This reads the definitions and writes the table.

## Using it

```bash
npm run docs:cli-tables -- --command "browser install"
```

prints a block wrapped in `<!-- generated:cli-options ... -->` markers. Once that block is in a page, it is refreshed in place and the prose around it is untouched:

```bash
npm run docs:cli-tables -- ../butler-sheet-icons-docs/docs/reference/browser.md --write
```

`--check` reports staleness without changing anything and exits non-zero, so a release can be gated on it. `--list` names every command a table can be generated for.

The command tree comes from `everyLeafCommand()`, the same enumeration the interactive wizards and their registry guard read, so a newly registered command reaches the docs immediately rather than when someone remembers a second list.

## A rendering bug found on the way

Checked against VitePress's own renderer, not assumed:

- A pipe has to be escaped **even inside a code span**, because a row is split into cells before inline spans are parsed. `qscloud list-collections` declares `--outputformat <table|json>`; rendered unescaped, the cell splits, the code span is destroyed, and the row's last value is pushed off the table and never displayed. The live page dodges this by writing `--outputformat` without its argument placeholder, so it is a hazard the generator had to handle rather than a defect on the site today.
- Emphasis is escaped only where CommonMark would act on it. An `_` between two word characters cannot open emphasis, so `stable_153.0.3` is left as the CLI prints it — escaping it anyway would put a visible backslash on the page.

Column padding matches Prettier's layout byte for byte, verified across all nine commands, so blocks read like the hand-written tables already on the site and survive a formatter unchanged if the doc site ever gains one.

## Verification

- 54 unit tests; full suite 2314 tests across 88 suites passing; `eslint src/ --max-warnings 0` clean.
- Mutation-tested both escaping fixes — reverting the pipe escaping fails 4 tests, over-escaping underscores fails 1.
- End-to-end against a copy of the live `docs/reference/browser.md`: `--check` reported STALE and exited 1, `--write` updated it, re-check reported current.
- Generated output rendered through VitePress: a clean 5×5 table with the `--outputformat` cell intact.

Regenerating `browser install` also showed the live table omits `-i, --interactive` entirely — drift beyond what #849 records.

The module sits under `src/` for test and coverage reach. esbuild bundles from the CLI entry point only, so it is not carried into the released binary.

Does not close #849 on its own: that issue is about stale sample *output*, which still needs capturing from a released binary. This removes the option-table half of the same problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**Update:** CodeQL flagged both escapers as incomplete sanitization. Verified against VitePress: it is right about the free-text escaper — a description containing a Windows path loses a backslash, since `C:\Users\.cache` renders as `C:\Users.cache` — and that is now fixed. It is wrong about the code-span escaper, where a backslash is already literal and escaping it would render two backslashes; that one is a false positive, documented at the function and pinned by a test.
