### PR TITLE
Report unreadable Qlik Sense Cloud replies instead of throwing a TypeError

### DIFF
--- a/docs/to-doc-site/unreadable-replies-from-qlik-sense-cloud.md
+++ b/docs/to-doc-site/unreadable-replies-from-qlik-sense-cloud.md
@@ -1,0 +1,88 @@
+# An unreadable reply from Qlik Sense Cloud now says so
+
+When Butler Sheet Icons asked your tenant for a list — your collections, the apps in a
+collection, or the apps on the tenant — it assumed the answer would be a list. If it was
+anything else, the run stopped with a message like this:
+
+```
+TypeError: allCollections.map is not a function
+```
+
+That names a variable inside Butler Sheet Icons. It does not tell you which request failed,
+which tenant answered, or what the tenant actually sent — and nothing in it suggests what to
+check. This is the Qlik Sense Cloud counterpart to the QRS fix described in _Options and error
+messages that told you the wrong thing_; the two platforms now behave the same way.
+
+Nothing changes for a run that already works.
+
+## What you will see instead
+
+```
+Qlik Sense Cloud returned an unusable response for "collections": expected a list, got string
+```
+
+The last word is what arrived instead of a list — `string` for an HTML page, `object` for an
+error document. If the tenant answered successfully but sent nothing at all, you get this
+instead:
+
+```
+Qlik Sense Cloud returned status 200 and an empty body for "collections", expected a list
+```
+
+The quoted part is the request that failed, which tells you what to look at:
+
+| Request                  | What Butler Sheet Icons was asking for |
+| ------------------------ | -------------------------------------- |
+| `collections`            | The collections on your tenant         |
+| `collections/<id>/items` | The contents of one collection         |
+| `items?resourceType=app` | Every app on the tenant                |
+
+## What to check
+
+This message means the request **succeeded** — Qlik Cloud, or something standing in for it,
+answered with a normal success code — but what came back was not a list of anything. That
+narrows the cause considerably:
+
+- **Something is answering instead of your tenant.** A proxy, gateway, or corporate network
+  that intercepts outbound traffic will happily return its own page with a 200. `got string`
+  almost always means HTML arrived where JSON was expected. Try the same URL from the machine
+  running Butler Sheet Icons and look at what comes back.
+- **The tenant URL points somewhere that is not a Qlik Cloud tenant.** A typo in
+  `--tenanturl` that still resolves to a real web server produces exactly this.
+- **An empty body** usually means a gateway timed out and closed the response without content.
+
+**A rejected API key does not produce this message.** Expired keys, missing scopes and wrong
+tenant names return proper HTTP error codes, and those are reported separately, as a failed
+request naming the status. If you are chasing a permissions problem, that is the message to
+look for — not this one.
+
+## An empty result is still an empty result
+
+A tenant with no collections, or a collection with no apps, is a normal answer and is treated
+as one. Only a reply Butler Sheet Icons cannot read is reported as a failure. This matters for
+scheduled jobs: a broken tenant can no longer look like a successful run that happened to have
+nothing to do.
+
+## One more case
+
+An entry in an otherwise valid list that claims to be an app but carries no app id is now
+skipped with a warning, instead of stopping the run:
+
+```
+Skipping collection item <item id> as it claims to be an app but carries no app id
+```
+
+The other apps in the list are processed as normal. If you see this, that one app is missing
+from the run — the warning names the item so you can find it in the tenant. Previously such an
+entry either stopped the run outright or, worse, was carried forward as an app with no id and
+reported later as a failure that named nothing.
+
+## Commands affected
+
+Any command that resolves apps through a collection, or lists collections:
+
+- `butler-sheet-icons qscloud create-sheet-thumbnails --collectionid ...`
+- `butler-sheet-icons qscloud remove-sheet-icons --collectionid ...`
+- `butler-sheet-icons qscloud list-collections`
+
+Runs that name apps directly with `--appid` do not query collections and are unaffected.

--- a/src/lib/cloud/__tests__/cloud_apps.test.js
+++ b/src/lib/cloud/__tests__/cloud_apps.test.js
@@ -371,3 +371,133 @@ describe('both app sources agree on shape', () => {
         expect(fromCollection).toEqual(fromTenant);
     });
 });
+
+describe('a tenant that does not answer with a list (issue #935)', () => {
+    // A 200 whose body is not the paginated envelope resolves rather than rejecting, so every
+    // one of these used to reach a `.map()` and surface as
+    // `TypeError: allCollections.map is not a function` - an internal error naming a local
+    // variable, with no endpoint or tenant in it. HTTP error statuses are deliberately absent:
+    // axios rejects on those, so they never take this path.
+    test('listCollections reports the tenant instead of throwing a TypeError', async () => {
+        Get.mockResolvedValue('<html>502 Bad Gateway</html>');
+
+        await expect(listCollections(saasInstance)).rejects.toThrow(/expected a list, got string/);
+    });
+
+    test('the failure never surfaces as a TypeError about .map', async () => {
+        Get.mockResolvedValue({ errors: [{ code: 'x' }] });
+
+        await expect(listCollections(saasInstance)).rejects.not.toThrow(TypeError);
+    });
+
+    test('listAppsByCollection fails on an unusable collections response', async () => {
+        Get.mockResolvedValue({ errors: [{ code: 'x' }] });
+
+        await expect(listAppsByCollection(saasInstance, COLLECTION_ID)).rejects.toThrow(
+            /expected a list, got object/
+        );
+    });
+
+    test('listAppsByCollection fails on an unusable items response', async () => {
+        // The collection resolves fine; the second request is the bad one. Naming the path is
+        // what tells those two apart.
+        Get.mockImplementation(async (path) => {
+            if (path === 'collections') return [{ id: COLLECTION_ID }];
+            return { errors: [{ code: 'x' }] };
+        });
+
+        await expect(listAppsByCollection(saasInstance, COLLECTION_ID)).rejects.toThrow(
+            new RegExp(`collections/${COLLECTION_ID}/items`)
+        );
+    });
+
+    test('listApps fails on an unusable items response', async () => {
+        Get.mockResolvedValue('<html>');
+
+        await expect(listApps(saasInstance)).rejects.toThrow(/items\?resourceType=app/);
+    });
+
+    test('an empty body reports the status rather than a shape', async () => {
+        // The one shape that keeps its status through request()'s unwrap.
+        Get.mockResolvedValue({ data: '', status: 200 });
+
+        await expect(listCollections(saasInstance)).rejects.toThrow(/status 200 and an empty body/);
+    });
+
+    test('a missing collection still reads as missing, not as a broken tenant', async () => {
+        // The guard must not swallow the ordinary case it sits next to.
+        Get.mockResolvedValue([{ id: 'some-other-collection' }]);
+
+        await expect(listAppsByCollection(saasInstance, COLLECTION_ID)).rejects.toThrow(
+            /does not exist/
+        );
+    });
+});
+
+describe('malformed entries inside a well-formed list', () => {
+    test('an app entry with no attributes is skipped rather than crashing the run', async () => {
+        Get.mockResolvedValue([
+            { id: 'item-a', resourceType: 'app' },
+            {
+                id: 'item-b',
+                resourceType: 'app',
+                resourceAttributes: { id: 'app-b', name: 'Beta' },
+            },
+        ]);
+
+        await expect(listApps(saasInstance)).resolves.toEqual([{ id: 'app-b', name: 'Beta' }]);
+    });
+
+    test('the skipped entry is warned about, not whispered at verbose', async () => {
+        // An app that should be in the list is now absent from it. That is worth a warning.
+        Get.mockResolvedValue([{ id: 'item-a', resourceType: 'app' }]);
+
+        await listApps(saasInstance);
+
+        expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('item-a'));
+    });
+
+    test('an entry with attributes but no app id is skipped too', async () => {
+        // `resourceAttributes: {}` passes an existence check. Left unguarded it contributed
+        // `{ id: undefined }`, which survives dedupe in runOverApps and makes the run try to
+        // process an app called `undefined`.
+        Get.mockResolvedValue([
+            { id: 'item-a', resourceType: 'app', resourceAttributes: {} },
+            {
+                id: 'item-b',
+                resourceType: 'app',
+                resourceAttributes: { id: 'app-b', name: 'Beta' },
+            },
+        ]);
+
+        await expect(listApps(saasInstance)).resolves.toEqual([{ id: 'app-b', name: 'Beta' }]);
+    });
+
+    test('no app is ever returned without an id', async () => {
+        Get.mockResolvedValue([
+            { id: 'item-a', resourceType: 'app', resourceAttributes: {} },
+            { id: 'item-b', resourceType: 'app', resourceAttributes: { name: 'no id' } },
+        ]);
+
+        const apps = await listApps(saasInstance);
+
+        expect(apps.every((app) => app.id !== undefined)).toBe(true);
+    });
+
+    test('an entry with no id of its own is described, not called "undefined"', async () => {
+        // The warning exists so an administrator can find the dropped app. Interpolating an
+        // absent id defeats that.
+        Get.mockResolvedValue([{ resourceType: 'app' }]);
+
+        await listApps(saasInstance);
+
+        expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('no id of its own'));
+        expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining('undefined'));
+    });
+
+    test('a null entry does not crash the line that logs the skip', async () => {
+        Get.mockResolvedValue([null, { id: 'item-b', resourceType: 'sheet' }]);
+
+        await expect(listApps(saasInstance)).resolves.toEqual([]);
+    });
+});

--- a/src/lib/cloud/__tests__/cloud_repo_request.test.js
+++ b/src/lib/cloud/__tests__/cloud_repo_request.test.js
@@ -102,6 +102,25 @@ describe('cloud-repo-request pagination', () => {
 
         await expect(get()).rejects.toBe(boom);
     });
+
+    test('a truthy but non-iterable data field does not throw from the spread', async () => {
+        // `{ data: <object> }` is how some gateways answer 200. The page accumulator used to
+        // test `body.data` for truthiness and then spread it, so this threw
+        // `TypeError: body.data is not iterable` from inside this module - before any caller
+        // could say which endpoint or tenant produced it (issue #935). It is not a page of
+        // results, so it now travels as an ordinary unrecognised body.
+        axios.mockResolvedValueOnce({ status: 200, data: { data: { message: 'unavailable' } } });
+
+        await expect(get()).resolves.toEqual({ data: { message: 'unavailable' } });
+    });
+
+    test('a data field that is a string is not spread into characters', async () => {
+        // Strings are iterable, so a truthiness check would have spread `'oops'` into
+        // ['o','o','p','s'] and returned it as four results.
+        axios.mockResolvedValueOnce({ status: 200, data: { data: 'oops' } });
+
+        await expect(get()).resolves.toEqual({ data: 'oops' });
+    });
 });
 
 describe('axios error interceptor (root cause of issue #785)', () => {

--- a/src/lib/cloud/__tests__/saas_response.test.js
+++ b/src/lib/cloud/__tests__/saas_response.test.js
@@ -1,0 +1,117 @@
+import { jest, describe, test, expect } from '@jest/globals';
+
+import { saasGetList } from '../saas-response.js';
+import { CloudError } from '../../util/errors.js';
+
+/**
+ * Builds a QlikSaas stand-in whose `Get` resolves to the supplied response.
+ *
+ * @param {Array<object>|object|string|null|undefined} response - What `Get` should resolve to.
+ *
+ * @returns {object} An object with a `Get` method.
+ */
+const respondingWith = (response) => ({ Get: jest.fn().mockResolvedValue(response) });
+
+describe('saasGetList', () => {
+    test('returns the response when the tenant answers with a list', async () => {
+        const rows = [{ id: 'a' }, { id: 'b' }];
+
+        await expect(saasGetList(respondingWith(rows), 'collections')).resolves.toBe(rows);
+    });
+
+    test('an empty list is a real answer, not a failure', async () => {
+        // The distinction the whole helper exists for: a tenant with no collections, which is
+        // ordinary, versus a response this code cannot read, which is not.
+        await expect(saasGetList(respondingWith([]), 'collections')).resolves.toEqual([]);
+    });
+
+    test('passes the path through to Get unchanged', async () => {
+        const saasInstance = respondingWith([]);
+
+        await saasGetList(saasInstance, 'collections/abc-123/items');
+
+        expect(saasInstance.Get).toHaveBeenCalledWith('collections/abc-123/items');
+    });
+
+    // The shapes below are the ones `request()` in cloud-repo-request.js can actually hand back
+    // for a 200, traced through its unwrap rather than assumed. An earlier version of this suite
+    // fed in `{ data: {}, status: 403 }` and similar, which reads plausibly but cannot occur:
+    // axios rejects on 4xx and 5xx, and `request()` unwraps the envelope for any truthy body.
+    describe('a 200 whose body is not a list', () => {
+        test('an HTML page from a proxy is reported as a string', async () => {
+            await expect(
+                saasGetList(respondingWith('<html>502 Bad Gateway</html>'), 'collections')
+            ).rejects.toThrow(/expected a list, got string/);
+        });
+
+        test('an error document is reported as an object', async () => {
+            await expect(
+                saasGetList(respondingWith({ errors: [{ code: 'x' }] }), 'collections')
+            ).rejects.toThrow(/expected a list, got object/);
+        });
+
+        test('throws a typed CloudError, not a bare Error', async () => {
+            await expect(saasGetList(respondingWith({}), 'collections')).rejects.toThrow(
+                CloudError
+            );
+        });
+
+        test('names the path, so the operator knows which call failed', async () => {
+            await expect(
+                saasGetList(respondingWith('<html>'), 'items?resourceType=app')
+            ).rejects.toThrow(/items\?resourceType=app/);
+        });
+    });
+
+    describe('a success response with no body at all', () => {
+        // The only shape where the status survives request()'s unwrap: a falsy body leaves the
+        // `{ data, status }` envelope intact.
+        test('says the tenant answered with an empty body, and gives the status', async () => {
+            await expect(
+                saasGetList(respondingWith({ data: '', status: 200 }), 'collections')
+            ).rejects.toThrow(/status 200 and an empty body/);
+        });
+
+        test('does not claim the body was an object', async () => {
+            // "got object" would be true of the envelope and useless about the response.
+            await expect(
+                saasGetList(respondingWith({ data: '', status: 204 }), 'collections')
+            ).rejects.not.toThrow(/got object/);
+        });
+    });
+
+    describe('a response that is not a list and carries no status', () => {
+        test('names the shape when it is a bare object', async () => {
+            await expect(
+                saasGetList(respondingWith({ collections: [] }), 'collections')
+            ).rejects.toThrow(/expected a list, got object/);
+        });
+
+        test('distinguishes null from object', async () => {
+            // typeof null is 'object', which would be actively misleading in the message.
+            await expect(saasGetList(respondingWith(null), 'collections')).rejects.toThrow(
+                /expected a list, got null/
+            );
+        });
+
+        test('names the shape when it is a string', async () => {
+            await expect(saasGetList(respondingWith('nope'), 'collections')).rejects.toThrow(
+                /expected a list, got string/
+            );
+        });
+
+        test('throws a typed CloudError, not a bare Error', async () => {
+            await expect(saasGetList(respondingWith(undefined), 'collections')).rejects.toThrow(
+                CloudError
+            );
+        });
+    });
+
+    test('a rejecting Get is left alone rather than wrapped', async () => {
+        // Transport failures already carry their own diagnosis from cloud-repo-request.js.
+        // Rewrapping them here would bury the status and code that interceptor preserved.
+        const saasInstance = { Get: jest.fn().mockRejectedValue(new Error('401 Unauthorized')) };
+
+        await expect(saasGetList(saasInstance, 'collections')).rejects.toThrow('401 Unauthorized');
+    });
+});

--- a/src/lib/cloud/cloud-apps.js
+++ b/src/lib/cloud/cloud-apps.js
@@ -1,4 +1,5 @@
 import { logger } from '../../globals.js';
+import { saasGetList } from './saas-response.js';
 
 /**
  * Turn a batch of items-API entries into apps.
@@ -23,14 +24,35 @@ const appsFromItems = (items, source) => {
     const apps = [];
 
     for (const item of items) {
-        if (item.resourceType === 'app') {
+        if (item?.resourceType === 'app') {
+            // The test is for the app id, not merely for `resourceAttributes`: an entry carrying
+            // `resourceAttributes: {}` passes an existence check and then contributes
+            // `{ id: undefined }` to the list. That id survives dedupe in runOverApps as a
+            // distinct entry, so the run ends up trying to process an app called `undefined` and
+            // reporting it as a failure - the same anonymous failure saasGetList exists to
+            // prevent, one level further in. Skipping keeps the rest of the list usable, and
+            // warns rather than whispers because an app that should be here is now missing.
+            if (!item.resourceAttributes?.id) {
+                // The item id is what an administrator would search the tenant for, so it is
+                // worth saying when there is one - and worth being explicit when there is not,
+                // rather than interpolating `undefined` into the sentence.
+                const label = item.id ? `item ${item.id}` : 'an item with no id of its own';
+
+                logger.warn(
+                    `Skipping ${source} ${label} as it claims to be an app but carries no app id`
+                );
+                continue;
+            }
+
             apps.push({
                 id: item.resourceAttributes.id,
                 name: item.resourceAttributes.name ?? item.resourceAttributes.id,
             });
         } else {
+            // Optional chaining throughout: the guard above admits a null or non-object entry to
+            // this branch, and logging the skip must not itself be what crashes the run.
             logger.verbose(
-                `Skipping ${source} item ${item.id} as it is not an app: ${item.resourceType}`
+                `Skipping ${source} item ${item?.id} as it is not an app: ${item?.resourceType}`
             );
         }
     }
@@ -57,9 +79,17 @@ const appsFromItems = (items, source) => {
  *
  * @returns {Promise<Array<object>>} Collections on the tenant, as the API returned them. Each
  *     carries at least `id`, `name` and `itemCount`; `description` may be absent.
+ *
+ * @throws {import('../util/errors.js').CloudError} If the tenant did not answer with a list. See `saas-response.js` - an
+ *     empty tenant returns `[]`, an unusable response says so.
  */
 export const listCollections = async (saasInstance) => {
-    const allCollections = await saasInstance.Get('collections');
+    // Through saasGetList, so a tenant that answers with an error document or an HTML page fails
+    // as itself rather than as `TypeError: allCollections.map is not a function` in whichever
+    // caller reached for `.map` first. Checking that the response *is* a list is not the same as
+    // narrowing it - the objects inside are still passed through exactly as the API sent them,
+    // which is what the paragraph above is about.
+    const allCollections = await saasGetList(saasInstance, 'collections');
     logger.debug(`Collections:\n${JSON.stringify(allCollections, null, 2)}`);
 
     return allCollections;
@@ -77,9 +107,11 @@ export const listCollections = async (saasInstance) => {
  *
  * @returns {Promise<Array<{id: string, name: string}>>} Apps on the tenant. `name` falls back
  *     to `id` when the API does not supply one.
+ *
+ * @throws {import('../util/errors.js').CloudError} If the tenant did not answer with a list.
  */
 export const listApps = async (saasInstance) => {
-    const items = await saasInstance.Get('items?resourceType=app');
+    const items = await saasGetList(saasInstance, 'items?resourceType=app');
 
     return appsFromItems(items, 'tenant');
 };
@@ -101,6 +133,9 @@ export const listApps = async (saasInstance) => {
  *
  * @throws {Error} If the collection does not exist on the tenant. The message includes the
  *     requested collection ID so the caller can report it without re-extracting it.
+ * @throws {import('../util/errors.js').CloudError} If the tenant did not answer either request with a list. Distinct from
+ *     the above on purpose: "this collection is not here" and "the tenant is not answering
+ *     usefully" send the operator to different places.
  */
 export const listAppsByCollection = async (saasInstance, collectionId) => {
     const allCollections = await listCollections(saasInstance);
@@ -111,7 +146,7 @@ export const listAppsByCollection = async (saasInstance, collectionId) => {
         throw new Error(`Collection '${collectionId}' does not exist`);
     }
 
-    const collectionItems = await saasInstance.Get(`collections/${collectionId}/items`);
+    const collectionItems = await saasGetList(saasInstance, `collections/${collectionId}/items`);
 
     return appsFromItems(collectionItems, 'collection');
 };

--- a/src/lib/cloud/cloud-repo-request.js
+++ b/src/lib/cloud/cloud-repo-request.js
@@ -93,7 +93,13 @@ async function makeRequest(config, data = []) {
         // reading `.data` off it unguarded would throw on a response with no body.
         const body = response.data;
 
-        if (body?.data) {
+        // `Array.isArray`, not a truthiness check: a truthy `body.data` that is not iterable -
+        // `{ data: { message: 'unavailable' } }`, which is how some gateways answer 200 - made
+        // this spread throw `TypeError: body.data is not iterable` from inside the request
+        // helper, before any caller could describe what went wrong. Such a body is not a page of
+        // results, so it takes the same route as any other unrecognised response and is reported
+        // by saas-response.js instead (issue #935).
+        if (Array.isArray(body?.data)) {
             returnData = [...returnData, ...body.data];
         } else {
             returnData = { data: body, status: response.status };

--- a/src/lib/cloud/saas-response.js
+++ b/src/lib/cloud/saas-response.js
@@ -1,0 +1,62 @@
+import { CloudError } from '../util/errors.js';
+
+/**
+ * Reads a list-shaped response from Qlik Sense Cloud and returns it as an array.
+ *
+ * The Cloud twin of `qseow/qrs-response.js`, and the single place that interprets what the
+ * repository client resolved with.
+ *
+ * Only a `{ data: [...] }` envelope reaches a caller as an array. Everything else arrives as
+ * whatever the tenant sent, because `request()` in `cloud-repo-request.js` unwraps the
+ * `{ data, status }` envelope `makeRequest` built and hands back the body itself. Traced
+ * against that code, a 200 response reaches this helper as:
+ *
+ * | Body sent by the tenant     | What arrives here            |
+ * | --------------------------- | ---------------------------- |
+ * | `{ data: [...] }`           | the array - the expected case |
+ * | an HTML page from a proxy   | a string                     |
+ * | `{}` or an error document   | an object                    |
+ * | nothing at all              | `{ data: '', status }`       |
+ *
+ * All of these resolve. None reject. So call sites that went straight to `.map()` threw
+ * `TypeError: allCollections.map is not a function` from inside Butler Sheet Icons, naming a
+ * local variable and nothing an operator can act on (issue #935).
+ *
+ * **HTTP error statuses do not come through here at all.** Axios rejects on 4xx and 5xx - no
+ * `validateStatus` override exists - so 401, 403, 404 and 502 take the rejection path and keep
+ * the diagnosis the interceptor in `cloud-repo-request.js` attached to them. The status check
+ * below therefore only ever describes a *successful* response that carried no body, which is
+ * the one shape where the status survives the unwrap.
+ *
+ * @param {object} saasInstance - Configured QlikSaas client.
+ * @param {string} apiPath - Cloud API path, e.g. `collections` or `items?resourceType=app`.
+ *
+ * @returns {Promise<Array<object>>} The response, when it is a list. Empty when nothing matched.
+ *
+ * @throws {CloudError} When the response is not a list. An empty list and an unusable response
+ *   are different answers: `[]` is returned, anything else throws, so a broken tenant cannot
+ *   look like a successful run that simply had no work to do.
+ */
+export const saasGetList = async (saasInstance, apiPath) => {
+    const result = await saasInstance.Get(apiPath);
+
+    if (Array.isArray(result)) {
+        return result;
+    }
+
+    // The one shape that keeps its status through the unwrap in `request()`: a success response
+    // with an empty body. Saying "answered with no content" is more use than "got object", which
+    // is all the shape check below could say about it.
+    const status = result?.status;
+    if (status !== undefined) {
+        throw new CloudError(
+            `Qlik Sense Cloud returned status ${status} and an empty body for "${apiPath}", expected a list`
+        );
+    }
+
+    const shape = result === null ? 'null' : typeof result;
+
+    throw new CloudError(
+        `Qlik Sense Cloud returned an unusable response for "${apiPath}": expected a list, got ${shape}`
+    );
+};


### PR DESCRIPTION
## What & why

Closes #935 — the Qlik Sense Cloud half; the QSEoW half landed in `40064ba`. Call sites read a Cloud response and went straight to `.map()`, so a tenant answering with anything other than a list produced `TypeError: allCollections.map is not a function` — a message naming a local variable, with no endpoint, tenant or remedy in it.

`saas-response.js` adds `saasGetList`, adopted at the three list reads in `cloud-apps.js`. What actually arrives there was traced through `request()`, which unwraps the `{ data, status }` envelope `makeRequest` builds, rather than assumed:

| Body sent by the tenant   | Arrives as             |
| ------------------------- | ---------------------- |
| `{ data: [...] }`         | the array              |
| an HTML page from a proxy | a string               |
| `{}` or an error document | an object              |
| nothing at all            | `{ data: '', status }` |

HTTP error statuses never reach it — axios rejects on 4xx/5xx, so those keep the diagnosis the interceptor already attached. The status branch describes only a *successful* response with no body, the one shape where the status survives the unwrap.

Two further defects found on the way:

- `cloud-repo-request.js` tested `body.data` for truthiness and then spread it. `{ data: {...} }` threw `TypeError: body.data is not iterable` from inside the request helper, and `{ data: 'oops' }` was spread into `['o','o','p','s']` and returned as four results. Now `Array.isArray`.
- `appsFromItems` checked that `resourceAttributes` existed, not that it carried an id. An entry with `resourceAttributes: {}` contributed `{ id: undefined }`, which survives dedupe in `runOverApps`, so the run tried to process an app called `undefined`.

## How it was verified

- `npm run test:unit` — 2289 tests / 88 suites pass. New: `src/lib/cloud/__tests__/saas_response.test.js`; extended: `cloud_apps.test.js`, `cloud_repo_request.test.js`
- `npm run lint` clean at `--max-warnings 0`; prettier clean
- 100% statement/branch/function/line coverage on `saas-response.js` and `cloud-apps.js`
- Mutation-tested every guard: reverting the `Array.isArray` check fails 2 tests, the `?.id` check 2, the item label 1, and removing the list check in `saasGetList` fails 13
- Executed `saasGetList` against all four real response shapes to confirm the emitted strings match the doc page verbatim, rather than transcribing them
- Each of the three commits is independently green — checked out and tested in turn, which matters because `cloud-repo-request.js` sits on every Cloud request path

No live tenant check: this path is reached only by a malformed reply, which a healthy tenant does not produce.

## Docs

`docs/to-doc-site/unreadable-replies-from-qlik-sense-cloud.md`