### PR TITLE
Piping output to head or less no longer leaves a crash report behind

### DIFF
--- a/docs/to-doc-site/piping-output-to-head-or-less.md
+++ b/docs/to-doc-site/piping-output-to-head-or-less.md
@@ -1,0 +1,86 @@
+# Piping output to `head` or `less` no longer leaves a crash report behind
+
+Looking at the first few lines of a long list is an everyday thing to do:
+
+```bash
+butler-sheet-icons browser list-available --browser chrome --channel stable | head -12
+```
+
+Until now, that left two files in a `crash_dumps` folder in whatever directory you happened to be
+standing in — a `.json` and a `.txt` crash report, saying that Butler Sheet Icons had crashed:
+
+```
+=== CRASH INFO ===
+Error Type: Error
+Source: uncaughtException
+Exit Code: 1
+
+=== ERROR MESSAGE ===
+write EPIPE
+```
+
+Nothing had gone wrong. `head` stops reading once it has the twelve lines you asked for, and the next
+line Butler Sheet Icons tried to print had nowhere to go. That is what `write EPIPE` means: *the thing
+reading my output has gone away*.
+
+The same thing happened with `less` when you quit before the end, with `grep -m1`, and with any other
+command that stops reading early.
+
+## What changed
+
+Butler Sheet Icons now treats a closed output pipe as an ordinary end to the run. No crash report is
+written, and nothing is printed about it. The command above now leaves your working directory exactly
+as it found it.
+
+Nothing about the output itself has changed — you still get the same twelve lines.
+
+## The exit code
+
+A run that ends because its output pipe closed exits with code **141**.
+
+That is the standard convention on Linux and macOS for a program stopped by a closed pipe — `128 + 13`,
+where 13 is the `SIGPIPE` signal number. `ls | head`, `yes | head` and most other tools report the same.
+Butler Sheet Icons uses 141 on Windows too, for consistency.
+
+**It is deliberately not 0.** Piping to `head` usually cuts a run short rather than letting it finish,
+and Butler Sheet Icons' exit code is meant to tell a scheduler whether the run did its job. Reporting
+success for work that was abandoned halfway would be misleading.
+
+In practice this affects almost nobody:
+
+- **Running a command by hand** — you will never see it. The shell reports the exit code of the *last*
+  command in the pipeline, which is `head`, not Butler Sheet Icons.
+- **In a script using `set -o pipefail`** — the pipeline is reported as failed, exactly as it would be
+  for `ls | head` in the same script. If you are piping Butler Sheet Icons into something that stops
+  reading early and you want the script to carry on, check for 141 specifically, or do not use
+  `pipefail` for that line.
+- **In a scheduled task** — no change. A scheduled run writes to a log file or to the console, not into
+  a pipe that closes early.
+
+## What has not changed
+
+Real failures are still reported exactly as before. This is worth being clear about, because the two
+can happen together:
+
+- A genuine error still writes one `.json` and one `.txt` crash report and exits with code **1**, with
+  its `FATAL:` line in the log.
+- That remains true **even when the output pipe has already closed**. If a run crashes for a real
+  reason while you happen to be piping it through `head`, you still get the crash report you need.
+- A failure to write output for any *other* reason — a full disk, a permission problem — is still a
+  genuine error and still produces a crash report.
+
+The `BSI_CRASH_DUMP_*` environment variables are unchanged, and so is the limit of one crash dump per
+run.
+
+## Notes for the publishing pass
+
+- Not released at the time of writing. Gate with a `::: warning Requires BSI X.Y.Z or later` callout
+  using the version from the open release-please pull request.
+- Best placed as a short section on the **existing crash dump page**, next to the one-dump-per-run
+  material, rather than as a page of its own — the reader who needs it arrives asking "why is there a
+  crash_dumps folder here?".
+- The **troubleshooting page** is the natural home for the symptom itself: *"I piped output to `head`
+  and got a crash report."* Cross-link to the crash dump page.
+- If the reference pages list exit codes anywhere, 141 belongs there alongside 0 and 1.
+- Verified on macOS against `browser list-available` piped to `head`, and in the test suite on both
+  Linux and Windows runners.

--- a/src/__tests__/butler-sheet-icons.test.js
+++ b/src/__tests__/butler-sheet-icons.test.js
@@ -1,5 +1,14 @@
 // filepath: /Users/goran/code/butler-sheet-icons/src/__tests__/butler-sheet-icons.test.js
-import { test, expect, describe, jest, beforeEach, afterEach } from '@jest/globals';
+import {
+    test,
+    expect,
+    describe,
+    jest,
+    beforeAll,
+    afterAll,
+    beforeEach,
+    afterEach,
+} from '@jest/globals';
 import 'dotenv/config';
 import {} from 'commander';
 import {} from '../globals.js';
@@ -8,6 +17,8 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
+
+import { BROKEN_PIPE_EXIT_CODE } from '../lib/util/fatal-handlers.js';
 
 // Mock all the imported modules that are used in the main file
 jest.mock('../globals.js', () => ({
@@ -253,6 +264,121 @@ describe('fatal error safety net, end to end (issue #946)', () => {
 
         expect(fatalLines).toHaveLength(1);
         expect(fatalLines[0]).toContain('boom 0');
+    });
+});
+
+describe('a closed output pipe leaves nothing behind, end to end (issue #1019)', () => {
+    // `butler-sheet-icons browser list-available ... | head -12` used to leave a
+    // crash report in the working directory, because `head` closing the pipe
+    // raised EPIPE and nothing was listening for it.
+    //
+    // The read end is closed from this side rather than by a real `head`, so
+    // there is no shell and no `head` binary involved and the test runs
+    // identically on the Windows runner.
+    let dumpDir;
+    let result;
+
+    /** Exit code the child uses if it is still writing long after the pipe closed. */
+    const CHILD_GAVE_UP = 20;
+
+    /**
+     * Runs a child that installs the real handlers and writes steadily to
+     * stdout, then closes the read end as soon as the first output arrives.
+     *
+     * @returns {Promise<{status: number|null, signal: string|null, stdout: string, stderr: string}>}
+     *   The child's exit status and the output seen before the pipe was closed.
+     */
+    const runUntilPipeCloses = () =>
+        new Promise((resolve, reject) => {
+            const __dirname = path.dirname(fileURLToPath(import.meta.url));
+            const handlersPath = path.resolve(__dirname, '../lib/util/fatal-handlers.js');
+            const handlersUrl = pathToFileURL(handlersPath).href;
+            const source = [
+                `import { installFatalHandlers } from ${JSON.stringify(handlersUrl)};`,
+                'installFatalHandlers();',
+                `console.log(${JSON.stringify(HANDLERS_READY)});`,
+                // Keep writing, so a write is guaranteed to land after the pipe
+                // has gone. The counter is a safety valve: a child that is
+                // somehow still writing has failed the test, and should say so
+                // by exiting rather than by hanging.
+                'let ticks = 0;',
+                'const tick = () => {',
+                `    if (ticks > 200) process.exit(${CHILD_GAVE_UP});`,
+                '    ticks += 1;',
+                '    for (let i = 0; i < 200; i += 1) process.stdout.write(`line ${ticks}:${i}\\n`);',
+                '    setTimeout(tick, 5);',
+                '};',
+                'tick();',
+            ].join('\n');
+
+            const child = childProcess.spawn('node', ['--input-type=module', '-e', source], {
+                stdio: ['ignore', 'pipe', 'pipe'],
+                timeout: 20000,
+                env: {
+                    ...process.env,
+                    BSI_CRASH_DUMP_DIR: dumpDir,
+                    BSI_CRASH_DUMP_ENABLE: '1',
+                    BSI_CRASH_DUMP_CREATE_JSON: '1',
+                    BSI_CRASH_DUMP_CREATE_TEXT: '1',
+                },
+            });
+
+            let stdout = '';
+            let stderr = '';
+            child.stderr.setEncoding('utf-8');
+            child.stderr.on('data', (chunk) => {
+                stderr += chunk;
+            });
+
+            // This is the `head` moment: enough output has been read, so the
+            // reader goes away.
+            child.stdout.setEncoding('utf-8');
+            child.stdout.once('data', (chunk) => {
+                stdout += chunk;
+                child.stdout.destroy();
+            });
+
+            child.on('error', reject);
+            child.on('close', (status, signal) => resolve({ status, signal, stdout, stderr }));
+        });
+
+    beforeAll(async () => {
+        dumpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bsi-epipe-e2e-'));
+        result = await runUntilPipeCloses();
+
+        // A child that never installed the handlers would pass "no crash dumps
+        // written" while proving nothing at all.
+        if (!result.stdout.includes(HANDLERS_READY)) {
+            throw new Error(
+                [
+                    'The child process did not reach installFatalHandlers().',
+                    `status: ${result.status}, signal: ${result.signal}`,
+                    `stdout: ${result.stdout}`,
+                    `stderr: ${result.stderr}`,
+                ].join('\n')
+            );
+        }
+    }, 30000);
+
+    afterAll(() => {
+        fs.rmSync(dumpDir, { recursive: true, force: true });
+    });
+
+    test('no crash dump is written', () => {
+        // The whole point of the issue: an operator piping to `head` should not
+        // accumulate crash reports in the working directory.
+        expect(fs.readdirSync(dumpDir)).toEqual([]);
+    });
+
+    test('the run ends on its own, with the shell convention for a closed pipe', () => {
+        expect(result.signal).toBeNull();
+        expect(result.status).toBe(BROKEN_PIPE_EXIT_CODE);
+    });
+
+    test('nothing is printed about it', () => {
+        // Not even a FATAL line: the pipe closing is what the operator asked
+        // for, and any message would be going into the stream that just closed.
+        expect(result.stderr).toBe('');
     });
 });
 

--- a/src/lib/util/__tests__/fatal-handlers.test.js
+++ b/src/lib/util/__tests__/fatal-handlers.test.js
@@ -5,22 +5,29 @@ import {
     installFatalHandlers,
     resetFatalHandlerState,
     FATAL_EXIT_WATCHDOG_MS,
+    BROKEN_PIPE_EXIT_CODE,
 } from '../fatal-handlers.js';
 
 /**
  * Every test installs the handlers onto a throwaway emitter with an injected
  * `exit` spy, so nothing here can register a listener on the real `process` or
- * take the Jest worker down with it.
+ * take the Jest worker down with it. The output streams are stand-ins for the
+ * same reason: attaching to the real `process.stdout` would leave a listener on
+ * the stream Jest reports through.
  */
 let target;
 let exit;
 let logger;
+let stdout;
+let stderr;
 
 beforeEach(() => {
     resetFatalHandlerState();
     target = new EventEmitter();
     exit = jest.fn();
     logger = { error: jest.fn() };
+    stdout = new EventEmitter();
+    stderr = new EventEmitter();
 });
 
 afterEach(() => {
@@ -35,7 +42,29 @@ afterEach(() => {
  *
  * @returns {void}
  */
-const install = (overrides = {}) => installFatalHandlers({ logger, exit, target, ...overrides });
+const install = (overrides = {}) =>
+    installFatalHandlers({
+        logger,
+        exit,
+        target,
+        outputStreams: [stdout, stderr],
+        ...overrides,
+    });
+
+/**
+ * Builds an error carrying a broken-pipe code, shaped like the one Node raises
+ * when the reader of a pipe closes it.
+ *
+ * @param {string} [code] - The error code. Defaults to `EPIPE`.
+ *
+ * @returns {Error} The error, with `code` and `syscall` set.
+ */
+const brokenPipeError = (code = 'EPIPE') => {
+    const err = new Error(code === 'EPIPE' ? 'write EPIPE' : 'Cannot call write after destroy');
+    err.code = code;
+    err.syscall = 'write';
+    return err;
+};
 
 /**
  * Yields to the microtask queue so the promise chain inside the handler can
@@ -320,6 +349,190 @@ describe('rejection reasons that are not Errors', () => {
         expect(err).toBeInstanceOf(Error);
         expect(err.message).toBe('Unhandled promise rejection with an uncoercible reason');
         expect(exit).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('output pipe closing is not a crash (issue #1019)', () => {
+    // `butler-sheet-icons browser list-available ... | head -12`. `head` closes
+    // the pipe once it has its lines, the next write raises EPIPE, and that
+    // used to leave a crash report behind for an operator who did nothing
+    // wrong.
+
+    describe('caught at the stream, which is where the pipe is known', () => {
+        test.each([
+            ['stdout', () => stdout],
+            ['stderr', () => stderr],
+        ])('an EPIPE on %s exits quietly without a dump', async (_name, streamOf) => {
+            const writeCrashDump = jest.fn().mockResolvedValue(undefined);
+            install({ writeCrashDump });
+
+            streamOf().emit('error', brokenPipeError());
+            await flush();
+
+            expect(writeCrashDump).not.toHaveBeenCalled();
+            expect(exit).toHaveBeenCalledTimes(1);
+            expect(exit).toHaveBeenCalledWith(BROKEN_PIPE_EXIT_CODE);
+        });
+
+        test('nothing is logged, since the stream to log to is the one that closed', async () => {
+            const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+            install({ writeCrashDump: jest.fn().mockResolvedValue(undefined) });
+
+            stdout.emit('error', brokenPipeError());
+            await flush();
+
+            expect(logger.error).not.toHaveBeenCalled();
+            expect(consoleError).not.toHaveBeenCalled();
+
+            consoleError.mockRestore();
+        });
+
+        test('ERR_STREAM_DESTROYED — a write after Node tore the stream down — counts too', async () => {
+            const writeCrashDump = jest.fn().mockResolvedValue(undefined);
+            install({ writeCrashDump });
+
+            stdout.emit('error', brokenPipeError('ERR_STREAM_DESTROYED'));
+            await flush();
+
+            expect(writeCrashDump).not.toHaveBeenCalled();
+            expect(exit).toHaveBeenCalledWith(BROKEN_PIPE_EXIT_CODE);
+        });
+
+        test('a stream error that is not a broken pipe is still a crash', async () => {
+            // Registering the listener took these errors away from Node's
+            // uncaughtException path, so the fatal handling has to be preserved
+            // here rather than assumed.
+            const writeCrashDump = jest.fn().mockResolvedValue(undefined);
+            install({ writeCrashDump });
+
+            const err = new Error('EACCES: permission denied, write');
+            err.code = 'EACCES';
+            stdout.emit('error', err);
+            await flush();
+
+            expect(writeCrashDump).toHaveBeenCalledTimes(1);
+            expect(writeCrashDump).toHaveBeenCalledWith(err, 'uncaughtException');
+            expect(exit).toHaveBeenCalledWith(1);
+        });
+
+        test('the stream listeners are removed on reset, and not doubled up on re-install', () => {
+            install();
+            install();
+
+            expect(stdout.listenerCount('error')).toBe(1);
+            expect(stderr.listenerCount('error')).toBe(1);
+
+            resetFatalHandlerState();
+
+            expect(stdout.listenerCount('error')).toBe(0);
+            expect(stderr.listenerCount('error')).toBe(0);
+        });
+
+        test('a stream that will not take a listener does not stop installation', () => {
+            const hostile = {
+                /**
+                 * Stands in for a stream stub, or a stripped-down SEA runtime,
+                 * that cannot register listeners.
+                 *
+                 * @returns {never} Never returns; always throws.
+                 */
+                on() {
+                    throw new Error('no listeners here');
+                },
+            };
+
+            expect(() => install({ outputStreams: [hostile, stdout] })).not.toThrow();
+            expect(stdout.listenerCount('error')).toBe(1);
+            expect(target.listenerCount('uncaughtException')).toBe(1);
+        });
+    });
+
+    describe('backstop on the uncaughtException path', () => {
+        test.each([['EPIPE'], ['ERR_STREAM_DESTROYED']])(
+            'an uncaught %s exits quietly without a dump',
+            async (code) => {
+                const writeCrashDump = jest.fn().mockResolvedValue(undefined);
+                install({ writeCrashDump });
+
+                target.emit('uncaughtException', brokenPipeError(code));
+                await flush();
+
+                expect(writeCrashDump).not.toHaveBeenCalled();
+                expect(logger.error).not.toHaveBeenCalled();
+                expect(exit).toHaveBeenCalledTimes(1);
+                expect(exit).toHaveBeenCalledWith(BROKEN_PIPE_EXIT_CODE);
+            }
+        );
+
+        test('an EPIPE-coded rejection is still a crash', async () => {
+            // Every network call in BSI is promise-based, and a wrapper such as
+            // an AxiosError copies `code` across from the socket error it came
+            // from. Quietly swallowing those would hide real Qlik Sense
+            // failures, so the backstop stops at uncaught exceptions.
+            const writeCrashDump = jest.fn().mockResolvedValue(undefined);
+            install({ writeCrashDump });
+
+            const err = brokenPipeError();
+            target.emit('unhandledRejection', err);
+            await flush();
+
+            expect(writeCrashDump).toHaveBeenCalledTimes(1);
+            expect(writeCrashDump).toHaveBeenCalledWith(err, 'unhandledRejection');
+            expect(exit).toHaveBeenCalledWith(1);
+        });
+    });
+
+    describe('interaction with a crash already being handled', () => {
+        test('a pipe breaking mid-dump does not truncate that dump', async () => {
+            // The order that matters: a real crash starts a dump, and logging it
+            // is itself what breaks the pipe. Exiting on that would leave the
+            // zero-byte dump of issue #946.
+            let releaseDump;
+            const dumpPromise = new Promise((resolve) => {
+                releaseDump = resolve;
+            });
+            const writeCrashDump = jest.fn(() => dumpPromise);
+            install({ writeCrashDump });
+
+            target.emit('uncaughtException', new Error('the real failure'));
+            await flush();
+
+            stdout.emit('error', brokenPipeError());
+            await flush();
+
+            expect(exit).not.toHaveBeenCalled();
+
+            releaseDump();
+            await flush();
+
+            expect(writeCrashDump).toHaveBeenCalledTimes(1);
+            expect(exit).toHaveBeenCalledTimes(1);
+            expect(exit).toHaveBeenCalledWith(1);
+        });
+
+        test('a crash arriving after the pipe broke cannot exit a second time', async () => {
+            const writeCrashDump = jest.fn().mockResolvedValue(undefined);
+            install({ writeCrashDump });
+
+            stdout.emit('error', brokenPipeError());
+            target.emit('uncaughtException', new Error('too late'));
+            await flush();
+
+            expect(writeCrashDump).not.toHaveBeenCalled();
+            expect(exit).toHaveBeenCalledTimes(1);
+            expect(exit).toHaveBeenCalledWith(BROKEN_PIPE_EXIT_CODE);
+        });
+
+        test('no watchdog is armed, so the quiet exit needs no timer to complete', () => {
+            jest.useFakeTimers();
+            install({ writeCrashDump: jest.fn().mockResolvedValue(undefined) });
+
+            stdout.emit('error', brokenPipeError());
+            expect(exit).toHaveBeenCalledTimes(1);
+
+            jest.advanceTimersByTime(FATAL_EXIT_WATCHDOG_MS * 2);
+            expect(exit).toHaveBeenCalledTimes(1);
+        });
     });
 });
 

--- a/src/lib/util/fatal-handlers.js
+++ b/src/lib/util/fatal-handlers.js
@@ -41,6 +41,32 @@
  * written is dropped rather than exiting immediately. Exiting there would
  * truncate the one dump the operator actually needs, leaving the zero-byte file
  * that #946 is about; the watchdog bounds how long the wait can be instead.
+ *
+ * ## Output going away is not a crash (issue #1019)
+ *
+ * `butler-sheet-icons browser list-available ... | head -12` used to leave a
+ * crash dump behind. `head` closes the pipe once it has its lines, the next
+ * write to stdout fails with `EPIPE`, and with nothing listening for it that
+ * became an uncaught exception — a crash report for an operator doing something
+ * completely ordinary. `less`, `grep -m1` and a quit pager do the same.
+ *
+ * So a broken output pipe is handled separately from a crash: no log line (the
+ * stream it would go to is the one that just died), no crash dump, and an
+ * immediate exit with {@link BROKEN_PIPE_EXIT_CODE}.
+ *
+ * It is caught in two places, because certainty differs between them:
+ *
+ *   - An `error` listener on stdout and stderr. This is the path that fires in
+ *     practice, and it is exact: the event names the stream, so there is no
+ *     guessing about which pipe broke.
+ *   - The `uncaughtException` path, as a backstop for anything that writes to
+ *     fd 1 or 2 without going through those stream objects. Attribution there
+ *     is a judgement call — a raw socket write can raise `EPIPE` too — so the
+ *     backstop is deliberately narrow: `unhandledRejection` never takes it (all
+ *     of BSI's network I/O is promise-based, and an `AxiosError` can carry
+ *     `code: 'EPIPE'` across), and the exit code stays non-zero, so a
+ *     misattributed socket failure still fails a scheduled task. What it would
+ *     cost is the crash dump for that one rare case.
  */
 
 import { logger as defaultLogger } from '../../globals.js';
@@ -58,6 +84,27 @@ import { writeCrashDump as defaultWriteCrashDump } from './crash-dump.js';
  */
 export const FATAL_EXIT_WATCHDOG_MS = 10000;
 
+/**
+ * Exit code used when the output stream goes away: 128 + `SIGPIPE` (13), the
+ * status a shell reports for any other tool killed by a closed pipe.
+ *
+ * Non-zero on purpose. Piping to `head` usually cuts a run short rather than
+ * letting it finish, and BSI's exit code is documented as telling a scheduler
+ * whether the run did its job — claiming success for output that was thrown
+ * away would be the same lie the exit code work removed. It also bounds the
+ * cost of the `uncaughtException` backstop misreading a socket failure as this:
+ * the dump is lost, but the run is still reported as failed.
+ */
+export const BROKEN_PIPE_EXIT_CODE = 141;
+
+/**
+ * Error codes a stream raises once whatever it writes into has gone away.
+ *
+ * `EPIPE` is the pipe being closed by the reader; `ERR_STREAM_DESTROYED` is a
+ * later write to the stream Node then tore down in response.
+ */
+const BROKEN_PIPE_CODES = new Set(['EPIPE', 'ERR_STREAM_DESTROYED']);
+
 /** True once a fatal event is being handled. Later fatal events are dropped. */
 let handlingFatal = false;
 
@@ -68,12 +115,13 @@ let exited = false;
 let watchdogTimer = null;
 
 /**
- * The listeners currently registered, so a re-install can remove them first.
- * `null` when nothing is installed.
+ * Every listener the current installation registered, so a re-install or a
+ * reset removes exactly what it added — on `process` and on the output streams
+ * alike.
  *
- * @type {{target: import('node:events').EventEmitter, listeners: Array<[string, Function]>}|null}
+ * @type {Array<{emitter: import('node:events').EventEmitter, event: string, listener: Function}>}
  */
-let installation = null;
+let installedListeners = [];
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -99,6 +147,17 @@ function toError(reason) {
     } catch {
         return new Error('Unhandled promise rejection with an uncoercible reason');
     }
+}
+
+/**
+ * Reports whether an error says the stream being written to has gone away.
+ *
+ * @param {Error|unknown} err - The error to classify.
+ *
+ * @returns {boolean} `true` for a broken-pipe error code.
+ */
+function isBrokenPipeError(err) {
+    return BROKEN_PIPE_CODES.has(err?.code);
 }
 
 /**
@@ -174,6 +233,28 @@ function armWatchdog(deps) {
 }
 
 /**
+ * Ends the run because there is nowhere left to write: quietly, and without a
+ * crash dump.
+ *
+ * Nothing is logged. The stream a message would go to is the one that just
+ * closed, so the line would either vanish or raise the same error again.
+ *
+ * Takes the re-entry guard for the same reason the fatal path does, and
+ * respects it: a pipe breaking while a real crash dump is being written must
+ * not exit early and truncate that dump. The watchdog already bounds the wait.
+ *
+ * @param {object} deps - Resolved dependencies for this installation.
+ *
+ * @returns {void}
+ */
+function handleBrokenOutputPipe(deps) {
+    if (handlingFatal) return;
+    handlingFatal = true;
+
+    exitOnce(BROKEN_PIPE_EXIT_CODE, deps.exit);
+}
+
+/**
  * Handles one fatal event: log it, write a crash dump, exit.
  *
  * The first fatal event to arrive wins; every later one returns immediately
@@ -188,6 +269,15 @@ function armWatchdog(deps) {
 function handleFatal(err, source, deps) {
     // A fatal error raised while already handling a fatal error is dropped.
     if (handlingFatal) return;
+
+    // Output going away is an ordinary end to a piped run, not a crash. Only
+    // from `uncaughtException`, and only as a backstop to the stream listeners
+    // below — see the header for why a rejection never qualifies.
+    if (source === 'uncaughtException' && isBrokenPipeError(err)) {
+        handleBrokenOutputPipe(deps);
+        return;
+    }
+
     handlingFatal = true;
 
     armWatchdog(deps);
@@ -213,17 +303,29 @@ function handleFatal(err, source, deps) {
  * @returns {void}
  */
 function removeInstalledListeners() {
-    if (installation === null) return;
-
-    for (const [event, listener] of installation.listeners) {
+    for (const { emitter, event, listener } of installedListeners) {
         try {
-            installation.target.removeListener(event, listener);
+            emitter.removeListener(event, listener);
         } catch {
-            // Best effort: a target that cannot remove listeners is replaced
+            // Best effort: an emitter that cannot remove listeners is replaced
             // wholesale by the new installation anyway.
         }
     }
-    installation = null;
+    installedListeners = [];
+}
+
+/**
+ * Registers one listener and records it so it can be removed again.
+ *
+ * @param {import('node:events').EventEmitter} emitter - Emitter to listen on.
+ * @param {string} event - Event name.
+ * @param {Function} listener - The listener to register.
+ *
+ * @returns {void}
+ */
+function registerListener(emitter, event, listener) {
+    emitter.on(event, listener);
+    installedListeners.push({ emitter, event, listener });
 }
 
 // ---------------------------------------------------------------------------
@@ -247,6 +349,8 @@ function removeInstalledListeners() {
  * @param {Function} [options.exit] - Exit function. Defaults to `process.exit`.
  * @param {import('node:events').EventEmitter} [options.target] - Emitter to listen on. Defaults to `process`.
  * @param {number} [options.watchdogMs] - Watchdog delay in ms. Defaults to {@link FATAL_EXIT_WATCHDOG_MS}.
+ * @param {Array<import('node:stream').Writable>} [options.outputStreams] - Streams to watch for a
+ *   broken pipe. Defaults to `process.stdout` and `process.stderr`.
  *
  * @returns {void}
  */
@@ -263,6 +367,7 @@ export function installFatalHandlers({
     exit = (code) => process.exit(code),
     target = process,
     watchdogMs = FATAL_EXIT_WATCHDOG_MS,
+    outputStreams = [process.stdout, process.stderr],
 } = {}) {
     removeInstalledListeners();
 
@@ -292,16 +397,43 @@ export function installFatalHandlers({
     const onUnhandledRejection = (reason) =>
         handleFatal(toError(reason), 'unhandledRejection', deps);
 
-    target.on('uncaughtException', onUncaughtException);
-    target.on('unhandledRejection', onUnhandledRejection);
+    /**
+     * Listener for errors on stdout and stderr.
+     *
+     * Without it a broken pipe has no listener, and Node turns an unlistened
+     * stream `error` into an uncaught exception — which is how `| head` came to
+     * write a crash dump. Registering it also means these errors are attributed
+     * with certainty rather than guessed at from an error code.
+     *
+     * Anything that is not a broken pipe is passed on to the fatal path, so a
+     * genuine failure to write output still produces a dump and exit 1, exactly
+     * as it did when it arrived as an uncaught exception.
+     *
+     * @param {Error} err - The stream error.
+     *
+     * @returns {void}
+     */
+    const onOutputStreamError = (err) => {
+        if (isBrokenPipeError(err)) {
+            handleBrokenOutputPipe(deps);
+            return;
+        }
 
-    installation = {
-        target,
-        listeners: [
-            ['uncaughtException', onUncaughtException],
-            ['unhandledRejection', onUnhandledRejection],
-        ],
+        handleFatal(toError(err), 'uncaughtException', deps);
     };
+
+    registerListener(target, 'uncaughtException', onUncaughtException);
+    registerListener(target, 'unhandledRejection', onUnhandledRejection);
+
+    for (const stream of outputStreams) {
+        try {
+            registerListener(stream, 'error', onOutputStreamError);
+        } catch {
+            // A stream that cannot take a listener — a stub in a test, a
+            // stripped-down SEA environment — leaves the `uncaughtException`
+            // backstop to cover it.
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
Closes #1019.

`butler-sheet-icons browser list-available --browser chrome --channel stable | head -12` wrote a `.json` and a `.txt` crash report into `crash_dumps/` in the working directory. `head` closes the pipe once it has its lines, the next write fails with `write EPIPE`, nothing listened for it, and it reached the `uncaughtException` handler — a crash report for an administrator doing something completely ordinary. The same happened with `less` quit early and with `grep -m1`.

## What changed

A broken output pipe is now handled separately from a crash: no log line, no crash dump, and an immediate exit with **141** (`128 + SIGPIPE`).

Non-zero on purpose. Piping to `head` usually cuts a run short rather than letting it finish, and the exit code is meant to tell a scheduler whether the run did its job — the same reasoning as the earlier exit-code work. `yes | head` under `pipefail` reports 141 too, so this matches every other tool. It also bounds the downside of the backstop below: a misread socket error loses its dump, but the run is still reported as failed.

It is caught in two places, because certainty differs between them:

- **An `error` listener on stdout and stderr.** This is the path that fires in practice, and it is exact — the event names the stream. Stream state is no help here: when the `uncaughtException` handler runs, `stdout.destroyed` is still `false`, so any state-based check would have been dead code.
- **The `uncaughtException` path, as a narrow backstop** for anything writing to fd 1 or 2 without going through those stream objects. `unhandledRejection` deliberately never takes it: all of BSI's network I/O is promise-based, and an `AxiosError` can carry `code: 'EPIPE'` across from a socket, so swallowing those would hide real Qlik Sense failures.

## Real failures are untouched

- A stream error that is **not** a broken pipe still writes a dump and exits 1. Registering the listener took those errors away from Node's `uncaughtException` path, so this is asserted rather than assumed.
- A genuine crash that happens **after** the pipe closed still writes both dump files and exits 1. This is the interaction most likely to break, since the `FATAL:` log line is itself what meets the dead stdout.

## Verification

Against the real path, not only mocks:

- `browser list-available ... | head -12` now leaves **no `crash_dumps/` directory at all**; producer exits 141. Before the fix: two files and exit 1.
- A full run redirected to a file still exits 0 with all 461 lines — the added listener changes nothing off-pipe.
- A genuine crash after the pipe closed still writes both dump files, non-zero size, exit 1.
- **The tests were mutation-checked**: disabling just the broken-pipe predicate fails 10 of them, including the end-to-end one, which reports the actual `crash_dump_*.json`/`.txt` filenames appearing. They fail for the right reason.
- 2288 tests / 87 suites pass; eslint and prettier clean.

13 unit tests and 3 end-to-end tests. The end-to-end test closes the read end from the parent process rather than shelling out to `head`, so it needs no shell and runs identically on the Windows runner.

## Docs

`docs/to-doc-site/piping-output-to-head-or-less.md` is staged for the doc site, with the before/after quoted verbatim from a real dump regenerated against the old code. It suggests folding into the existing crash dump page rather than adding a new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)