### PR TITLE
Correct the option help text on browser list-available

### DIFF
--- a/src/lib/commands/__tests__/commands.test.js
+++ b/src/lib/commands/__tests__/commands.test.js
@@ -1179,4 +1179,88 @@ describe('option keys match the property names the code reads (issue #890)', () 
             expect(declaredNames().size).toBeGreaterThan(30);
         });
     });
+
+    describe('option argument placeholders', () => {
+        // `browser list-available` declared `--channel <browser>` for a long time. Commander
+        // takes the stored name from the long flag, so nothing broke and no test failed - it
+        // only ever showed up as a confusing `--help` line, which is exactly the kind of defect
+        // nobody reads closely enough to catch. Generating the doc site's option tables from
+        // these declarations put it on a page, where it was obvious.
+        //
+        // A placeholder naming a *different* option of the same command is the signature of an
+        // option block copy-pasted and not fully edited - but only when it has nothing to do
+        // with its own option. `--engineport <port>` and `--qrsport <port>` sit beside a
+        // `--port` on the qseow command and are perfectly clear, because each placeholder
+        // describes the value that option takes. `--channel <browser>` does not.
+        // Walked here rather than through command-tree.js: importing that statically would pull
+        // the real worker modules in before this file's mocks are installed.
+        const everyLeaf = () => {
+            const leaves = [];
+
+            const walk = (command, path) => {
+                if (command.commands.length === 0) {
+                    leaves.push({ path: path.join(' '), command });
+
+                    return;
+                }
+
+                for (const child of command.commands) {
+                    walk(child, [...path, child.name()]);
+                }
+            };
+
+            for (const namespace of [
+                buildQseowCommand(),
+                buildQscloudCommand(),
+                buildBrowserCommand(),
+            ]) {
+                walk(namespace, [namespace.name()]);
+            }
+
+            return leaves;
+        };
+
+        test('no placeholder is named after a different option on the same command', () => {
+            const offenders = [];
+
+            for (const { path, command } of everyLeaf()) {
+                const names = new Set(
+                    command.options
+                        .filter((option) => option.long)
+                        .map((option) => option.long.replace(/^--/, ''))
+                );
+
+                for (const option of command.options) {
+                    const placeholder = option.flags
+                        .match(/[<[]([^>\]]+)[>\]]/)?.[1]
+                        ?.replace(/\.\.\.$/, '');
+                    const own = option.long?.replace(/^--/, '');
+
+                    // `own.includes(placeholder)` is the "describes its own option" test:
+                    // `port` is part of `engineport`, `browser` is no part of `channel`.
+                    if (
+                        placeholder &&
+                        placeholder !== own &&
+                        names.has(placeholder) &&
+                        !own?.includes(placeholder)
+                    ) {
+                        offenders.push(
+                            `${path}: ${option.flags} (placeholder names --${placeholder})`
+                        );
+                    }
+                }
+            }
+
+            expect(offenders).toEqual([]);
+        });
+
+        test('the scan actually walked some options, so an empty pass is not a false negative', () => {
+            const optionCount = everyLeaf().reduce(
+                (total, { command }) => total + command.options.length,
+                0
+            );
+
+            expect(optionCount).toBeGreaterThan(30);
+        });
+    });
 });

--- a/src/lib/commands/browser/list-available.js
+++ b/src/lib/commands/browser/list-available.js
@@ -50,7 +50,7 @@ const buildBrowserListAvailableCommand = () => {
         .addOption(
             new Option(
                 '--browser <browser>',
-                'Browser to install (e.g. "chrome" or "firefox"). Use "butler-sheet-icons browser list-installed" to see which browsers are currently installed.'
+                'Browser to list available versions for (e.g. "chrome" or "firefox"). Use "butler-sheet-icons browser install" to install one of them.'
             )
                 .choices(['chrome', 'firefox'])
                 .default('chrome')
@@ -58,8 +58,8 @@ const buildBrowserListAvailableCommand = () => {
         )
         .addOption(
             new Option(
-                '--channel <browser>',
-                "Which of the browser's release channel versions should be listed?\n This option is only used for Chrome."
+                '--channel <channel>',
+                "Which of the browser's release channel versions should be listed? This option is only used for Chrome."
             )
                 .choices(['stable', 'beta', 'dev', 'canary'])
                 .default('stable')


### PR DESCRIPTION
Three defects in one option block, all visible in `butler-sheet-icons browser list-available --help`.

- **`--browser` was described as installing.** Its description read "Browser to install … Use `list-installed` to see which browsers are currently installed", copied from the `install` command. This command installs nothing — it lists what is available to download. The interactive wizard derives its prompt from the same string, so it asked the wrong question too.
- **`--channel` declared its argument as `<browser>`.** Commander takes the stored property name from the long flag, so nothing malfunctioned and no test failed. It only ever showed as a confusing help line, which is why it survived.
- **The `--channel` description carried a hard newline** that broke the help layout, leaving its second sentence unindented and running past the right margin.

## How it surfaced

Generating the doc site's option tables from these declarations (#1017) put the wrong text on a page, where it was obvious in a way it never was in a terminal.

## The guard

Rather than pin these three strings, there is now a test for the class: a placeholder that names a *different* option of the same command, and has nothing to do with its own option, is the signature of an option block copy-pasted and not finished. `--engineport <port>` beside a `--port` stays legal, because the placeholder describes what that option takes.

Mutation-checked: restoring `--channel <browser>` fails the guard with `browser list-available: --channel <browser> (placeholder names --browser)`.

## Verification

- `--help` output inspected before and after.
- Confirmed `--channel`'s stored property, choices, default and env var are all unchanged, and that `--channel beta` still parses to `{ channel: 'beta' }`. The placeholder is help text only.
- Full suite: 2360 tests across 89 suites passing; `eslint src/ --max-warnings 0` clean.
- `gitnexus impact` on the command builder: risk LOW, one direct caller, no affected execution flows.

No staged page under `docs/to-doc-site/`: the user-visible surface of this change *is* the doc site's option table for this command, which is regenerated from these declarations in the corresponding docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)