### PR TITLE
fix: stop unit tests reading the developer's .env (#1014)

### DIFF
--- a/src/__tests__/globals.test.js
+++ b/src/__tests__/globals.test.js
@@ -1,4 +1,7 @@
 import { describe, test, expect, beforeAll, afterAll } from '@jest/globals';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 let logger;
 let originalWarningListeners;
@@ -47,5 +50,67 @@ describe('logger redaction', () => {
         );
 
         expect(transformed[splat]).toEqual([{ logonpwd: '***redacted***' }, '******']);
+    });
+});
+
+describe('library code does not read .env off disk (issue #1014)', () => {
+    // globals.js used to `import 'dotenv/config'`, so importing it — which almost every unit
+    // test does transitively — loaded whatever `.env` the developer had. Option declarations
+    // bind `.env('BSI_…')`, so a variable in that file changes an option's *effective* default,
+    // and a test asserting "this equals the default" then asserted something different locally
+    // than in CI. Three tests were patched one at a time before the cause was found.
+    //
+    // The CLI entry point loads it instead, and integration tests load it themselves.
+
+    /**
+     * Reads a source file relative to the repository's `src` directory.
+     *
+     * @param {string} relativePath - Path under `src`, e.g. `'globals.js'`.
+     *
+     * @returns {string} The file contents.
+     */
+    const readSource = (relativePath) =>
+        readFileSync(join(dirname(fileURLToPath(import.meta.url)), '..', relativePath), 'utf8');
+
+    test('globals.js does not import dotenv', () => {
+        expect(readSource('globals.js')).not.toMatch(/^\s*import\s+['"]dotenv/m);
+    });
+
+    test('no module under src/lib imports dotenv outside its tests', () => {
+        // The same reasoning applies to any library module: reading a dotfile as a side effect
+        // of being imported makes every consumer's behaviour depend on the filesystem.
+        const offenders = [];
+        const walk = (dir) => {
+            for (const entry of readdirSync(dir, { withFileTypes: true })) {
+                const full = join(dir, entry.name);
+                if (entry.isDirectory()) {
+                    if (entry.name !== '__tests__') walk(full);
+                } else if (entry.name.endsWith('.js')) {
+                    if (/^\s*import\s+['"]dotenv/m.test(readFileSync(full, 'utf8'))) {
+                        offenders.push(full);
+                    }
+                }
+            }
+        };
+        walk(join(dirname(fileURLToPath(import.meta.url)), '..', 'lib'));
+
+        expect(offenders).toEqual([]);
+    });
+
+    test('the CLI entry point still loads it, so .env keeps working for users', () => {
+        // The other half of the fix. Without this the change would quietly remove a documented
+        // feature: every option's `.env('BSI_…')` binding depends on `.env` being loaded first.
+        expect(readSource('butler-sheet-icons.js')).toMatch(/^\s*import\s+['"]dotenv\/config['"]/m);
+    });
+
+    test('it is loaded before anything that reads the environment', () => {
+        // Import order decides this: ESM executes imports in source order, so the dotenv import
+        // has to come before the command builders that read process.env while being constructed.
+        const source = readSource('butler-sheet-icons.js');
+        const dotenvAt = source.search(/^\s*import\s+['"]dotenv\/config['"]/m);
+        const firstOther = source.search(/^\s*import\s+(?!['"]dotenv)/m);
+
+        expect(dotenvAt).toBeGreaterThanOrEqual(0);
+        expect(dotenvAt).toBeLessThan(firstOther);
     });
 });

--- a/src/butler-sheet-icons.js
+++ b/src/butler-sheet-icons.js
@@ -1,3 +1,7 @@
+// First, and before anything that reads process.env. Option declarations bind `.env('BSI_…')`,
+// so `.env` has to be in place before the command tree is built. It lives here rather than in
+// globals.js so that importing library code does not read a dotfile off disk - see issue #1014.
+import 'dotenv/config';
 import { Command } from 'commander';
 import { appVersion } from './globals.js';
 import { installFatalHandlers } from './lib/util/fatal-handlers.js';

--- a/src/globals.js
+++ b/src/globals.js
@@ -3,7 +3,13 @@ import { createRequire } from 'node:module';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
-import 'dotenv/config';
+// `dotenv/config` is deliberately NOT imported here. Importing this module used to read `.env`
+// off disk as a side effect, and almost every unit test imports it transitively - so unit runs
+// executed against whatever Qlik Sense settings the developer happened to have. Because option
+// declarations bind `.env('BSI_…')`, a variable in that file changes an option's *effective*
+// default, and a test asserting "this equals the default" then asserts something different
+// locally than in CI. Three tests were patched individually for that before the cause was found.
+// The CLI entry point loads it instead; integration tests load it themselves.
 import { redactSensitivePatterns, redactValue } from './lib/util/redact-secrets.js';
 import { isColourEnabled } from './lib/util/colour.js';
 


### PR DESCRIPTION
Closes #1014.

`globals.js` did `import 'dotenv/config'`, so importing it read `.env` off disk as a side effect — and almost every unit test imports it transitively. Unit runs therefore executed against whatever Qlik Sense settings the developer happened to have.

## Why this is more than untidiness

Option declarations bind `.env('BSI_…')`, so a variable in that file changes an option's **effective default**. A test asserting "this value equals the default, and is therefore omitted" then asserts something different locally than in CI. It cuts both ways: a test can also pass locally *because* of a `.env` value and fail in CI.

Three tests had already been patched one at a time for this — `1a73b3e`, `4739159`, `eab65bb`, all "stop X depending on the host that runs it" — and `40ee32b` was a fourth. Each fixed a symptom.

Demonstrated on `201b20e`, where the browser install wizard test failed on a machine with a `.env` while CI stayed green on the same commit:

```
with .env present      -> 1 failed
with .env moved aside  -> passed
```

## The change

`dotenv/config` moves to the CLI entry point, as its **first** import — option declarations read `process.env` while the command tree is built, so ordering matters.

All twelve integration tests already import `dotenv/config` themselves, so none loses its environment. Checked individually before touching anything.

## Verified, both halves

Removing the import without keeping the CLI working would have quietly deleted a documented feature, so both directions were checked by execution:

| | before | after |
|---|---|---|
| `import('./src/globals.js')` exposes `BSI_HOST` | yes | **no** |
| CLI resolves `--browser-page-timeout` | `120` | **`120`** |

`120` comes from `.env`; the declared default is `90`. So the CLI still honours the file.

And the property the issue is actually about: **the unit suite reports identical results with and without `.env`** — 2,380 either way.

## Guard

Four tests, each mutation-verified to fail when the thing it guards is undone:

| Guard | Mutation that breaks it |
|---|---|
| `globals.js` must not import dotenv | re-adding it → 1 failed |
| No module under `src/lib` may either | adding it to `colour.js` → 1 failed |
| The entry point must import it | removing it → 2 failed |
| It must come first | moving it after `commander` → 1 failed |

The third is the one that matters most: it is what stops a future cleanup from removing `.env` support for users while the other guards stay green.

**2,380 tests, 89 suites, lint and Prettier clean.** Rebased onto `a3069f9`; that range touched all three of my files, so I re-verified the change survived rather than trusting a clean rebase.

## One behaviour change worth naming

Anyone importing Butler Sheet Icons **as a library** and relying on `.env` being auto-loaded will no longer get it. There is no `bin` entry and `main` points at the CLI, so this looks unlikely — but it is the one way the change could surprise someone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)