### PR TITLE
Wire the option table generator into the doc publishing steps

### DIFF
--- a/docs/to-doc-site/README.md
+++ b/docs/to-doc-site/README.md
@@ -131,6 +131,8 @@ For each unprefixed file, answer three questions before writing anything:
 
 Correct the draft's technical errors in the published page. If a processed file is left in `done/` with a claim that turned out to be wrong, add a short HTML comment noting the correction so the error does not resurface later.
 
+**Except in an option table.** Do not verify flags, environment variables, accepted values or defaults by hand where they appear in a table between `<!-- generated:cli-options ... -->` markers — those are generated from the Commander definitions, and anything typed inside the markers is overwritten on the next run. Regenerate instead, and see "Option tables are generated, not written" above. If a table is wrong, the declaration in `src/lib/commands/` is wrong, and fixing it there fixes `--help` too.
+
 ### 4. Establish which BSI version the behaviour ships in
 
 This sets the version gate on the page. It does **not** affect which branch the change goes to — that is always `next`.
@@ -185,6 +187,14 @@ grep -o 'id="[^"]*"' docs/.vitepress/dist/guide/concepts/<page>.html | sort -u
 ```
 
 Watch for headings containing typographic characters. Several pages use the non-breaking hyphen `‑` (U+2011) rather than `-`, and it survives into the anchor — so `#strategy-3-use-a-pre-cached-browser-semi-offline` silently misses a heading that reads identically. Normalise the heading to plain ASCII hyphens rather than copying the unicode into the link.
+
+Then confirm no generated option table has gone stale. From **this** repo, naming the doc site pages you touched:
+
+```bash
+npm run docs:cli-tables -- ../butler-sheet-icons-docs/docs/reference/browser.md --check
+```
+
+It exits non-zero and names the command whose table is out of date. A table can go stale without anyone editing the page — a changed flag, default or description in `src/lib/commands/` is enough — so this is worth running even on a pass that did not touch a reference page.
 
 ### 7. Git workflow
 

--- a/scripts/docs-cli-tables.js
+++ b/scripts/docs-cli-tables.js
@@ -104,7 +104,45 @@ const parseArgs = (argv) => {
  *
  * @returns {Record<string, Record<string, string>>} Examples keyed by command path, then flag.
  */
-const loadExamples = (path) => (path ? JSON.parse(readFileSync(path, 'utf8')) : {});
+const loadExamples = (path) => {
+    if (!path) {
+        return {};
+    }
+
+    const text = readText(path);
+
+    try {
+        return JSON.parse(text);
+    } catch (err) {
+        // JSON.parse names neither the file nor what was expected of it.
+        throw new Error(
+            `${path}: not valid JSON (${err.message}). Expected { "<command path>": { "--flag": "example" } }.`,
+            { cause: err }
+        );
+    }
+};
+
+/**
+ * Read a file, reporting a missing or unreadable one in a sentence rather than a stack trace.
+ *
+ * @param {string} path - Path to read.
+ *
+ * @returns {string} File contents.
+ *
+ * @throws {Error} When the file cannot be read.
+ */
+const readText = (path) => {
+    try {
+        return readFileSync(path, 'utf8');
+    } catch (err) {
+        throw new Error(
+            err.code === 'ENOENT'
+                ? `${path}: no such file. Paths are resolved from the current directory; the doc site is a separate repository.`
+                : `${path}: ${err.message}`,
+            { cause: err }
+        );
+    }
+};
 
 /**
  * Entry point.
@@ -112,16 +150,29 @@ const loadExamples = (path) => (path ? JSON.parse(readFileSync(path, 'utf8')) : 
  * @returns {number} Process exit code. 1 when `--check` found a stale block, or on error.
  */
 const main = () => {
-    let args;
-
     try {
-        args = parseArgs(process.argv.slice(2));
+        return run(parseArgs(process.argv.slice(2)));
     } catch (err) {
+        // Everything reaching here is a user-facing mistake with a written message: a path that
+        // does not exist, a malformed examples file, a marker naming a command that was renamed.
+        // A Node stack trace would bury all three, and this is a command the publishing
+        // instructions tell people to run.
         process.stderr.write(`${err.message}\n`);
 
         return 1;
     }
+};
 
+/**
+ * Do the work described by the parsed arguments.
+ *
+ * @param {ReturnType<typeof parseArgs>} args - Parsed arguments.
+ *
+ * @returns {number} Process exit code.
+ *
+ * @throws {Error} With a message written for the person who typed the command.
+ */
+const run = (args) => {
     if (args.list) {
         process.stdout.write(`${knownCommandPaths().join('\n')}\n`);
 
@@ -147,7 +198,7 @@ const main = () => {
     let stale = 0;
 
     for (const file of args.files) {
-        const original = readFileSync(file, 'utf8');
+        const original = readText(file);
         const { content, blocks } = updateGeneratedBlocks(original, { examples });
 
         if (blocks.length === 0) {


### PR DESCRIPTION
The generator from #1017 had a section in `docs/to-doc-site/README.md`, but nothing in that file's numbered publishing procedure pointed at it. A publishing pass runs steps 1–9 and never goes past the reference material above them, so in practice the tool was documented and unreachable.

## Step 3 was working against it

Step 3, "Verify every claim against the implementation", told the publisher to confirm *"Exact CLI flags, defaults, and environment variable names (`src/lib/commands/`)"* by hand. That is precisely the work the generator removes — and worse, it invites hand-editing a table that is regenerated, which looks like it worked until the next run silently undoes it.

It now carves out the exception: don't hand-verify inside `generated:cli-options` markers, regenerate instead, and a wrong table means a wrong declaration in `src/lib/commands/` — where fixing it also fixes `--help`.

## Step 6 now arms the alarm

`--check` sits beside `npm run docs:build`, with the reason it belongs there: a table can go stale with nobody touching the page, since a changed flag, default or description is enough. So it is worth running even on a pass that never opened a reference page.

## A fix the docs exposed

Running the command I had just written into step 6 crashed with an unhandled Node stack trace, because the path did not exist from where I ran it. Three failure modes did this — a missing file, a malformed `--examples` file, and a marker naming a command that has since been renamed. All three now print one sentence naming the file and exit 1:

```
../butler-sheet-icons-docs/docs/reference/browser.md: no such file. Paths are resolved from the current directory; the doc site is a separate repository.
```

That is the least a command in a written procedure should do. The path in the instructions is correct for the documented side-by-side clone layout — verified from the repository root, where it resolves.

## Verification

- All four modes re-smoke-tested after the refactor, including exit codes: `--list` 0, `--check` on a current page 0, missing file 1.
- 2376 tests across 89 suites passing; eslint clean over `src/` **and** the script. Note `npm run lint` only covers `src/`, so `scripts/` is not linted in CI — it was checked explicitly here, and the new throws now attach `cause` for `preserve-caught-error`.

The matching docs-repo change, which explains the markers to anyone working in that repository, is ptarmiganlabs/butler-sheet-icons-docs#73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)