### PR TITLE
Build releases from the tag that was released, not the commit that triggered the run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1061,9 +1061,13 @@ jobs:
     env:
       DIST_FILE_NAME: butler-sheet-icons
     steps:
-      - name: Checkout repository
+      - name: Checkout the released tag
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # Without this, the default checkout is `github.sha` - the commit that happened to
+          # trigger this run, which is not the commit release-please just tagged. See the note
+          # on the same step in release-macos-arm64 for what that shipped.
+          ref: ${{ needs.release-please.outputs.release_tag_name }}
           fetch-depth: 2
           persist-credentials: false
 
@@ -1072,6 +1076,20 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: ''
+
+      # Runs after setup-node so `node` is certain to be on PATH, and before the install and
+      # build so a mismatch costs seconds rather than a signed, notarized artifact.
+      - name: Verify the checkout is the version being released
+        shell: bash
+        run: |
+          expected="${{ needs.release-please.outputs.release_version }}"
+          actual=$(node -p "require('./package.json').version")
+          echo "release-please version : $expected"
+          echo "package.json version   : $actual"
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::Refusing to build: package.json says $actual, but the release is $expected. The binary embeds package.json and would report the wrong version."
+            exit 1
+          fi
 
       # The npm bundled with Node 24 is 11.x, and 11.x resolves this lockfile differently between
       # patch releases - a second Windows runner picking up a newer Node installed 53 fewer
@@ -1142,15 +1160,36 @@ jobs:
           echo "tag_name   : ${{ needs.release-please.outputs.release_tag_name }}"
           echo "upload_url : ${{ needs.release-please.outputs.release_upload_url }}"
 
-      - name: Checkout repository
+      - name: Checkout the released tag
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # Load-bearing. Without `ref`, checkout takes `github.sha` - the commit that triggered
+          # this run - and release-please cuts the release from main's HEAD, which is a
+          # different commit whenever an unrelated push is what started the run. On 2026-08-10
+          # that shipped all three 4.1.0 binaries built from the commit before the version bump,
+          # so they reported "App version: 4.0.0": the SEA build embeds package.json as an asset
+          # and globals.js reads the version straight out of it.
+          ref: ${{ needs.release-please.outputs.release_tag_name }}
           persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
+      # Runs after setup-node so `node` is certain to be on PATH, and before the install and
+      # build so a mismatch costs seconds rather than a signed, notarized artifact.
+      - name: Verify the checkout is the version being released
+        shell: bash
+        run: |
+          expected="${{ needs.release-please.outputs.release_version }}"
+          actual=$(node -p "require('./package.json').version")
+          echo "release-please version : $expected"
+          echo "package.json version   : $actual"
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::Refusing to build: package.json says $actual, but the release is $expected. The binary embeds package.json and would report the wrong version."
+            exit 1
+          fi
+
       # The npm bundled with Node 24 is 11.x, and 11.x resolves this lockfile differently between
       # patch releases - a second Windows runner picking up a newer Node installed 53 fewer
       # packages and could not resolve jest-circus. Pinning npm here makes the install identical
@@ -1223,9 +1262,16 @@ jobs:
           Write-Output 'tag_name        : ${{ needs.release-please.outputs.release_tag_name }}'
           Write-Output 'upload_url      : ${{ needs.release-please.outputs.release_upload_url }}'
 
-      - name: Checkout repository
+      - name: Checkout the released tag
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # Load-bearing. Without `ref`, checkout takes `github.sha` - the commit that triggered
+          # this run - and release-please cuts the release from main's HEAD, which is a
+          # different commit whenever an unrelated push is what started the run. On 2026-08-10
+          # that shipped all three 4.1.0 binaries built from the commit before the version bump,
+          # so they reported "App version: 4.0.0": the SEA build embeds package.json as an asset
+          # and globals.js reads the version straight out of it.
+          ref: ${{ needs.release-please.outputs.release_tag_name }}
           persist-credentials: false
 
       - name: Setup Node.js
@@ -1241,10 +1287,26 @@ jobs:
           npm install -g npm@12.0.2
           npm --version
 
+      # Same check as the other release jobs, written in powershell because that is the shell
+      # this self-hosted runner is known to have - every other run step in this job uses it,
+      # while bash would depend on Git for Windows being on PATH. A guard that fails spuriously
+      # would block a release, which is worse than the defect it guards against.
+      - name: Verify the checkout is the version being released
+        shell: powershell
+        run: |
+          $expected = "${{ needs.release-please.outputs.release_version }}"
+          $actual = node -p "require('./package.json').version"
+          Write-Host "release-please version : $expected"
+          Write-Host "package.json version   : $actual"
+          if ($actual -ne $expected) {
+            Write-Host "::error::Refusing to build: package.json says $actual, but the release is $expected. The binary embeds package.json and would report the wrong version."
+            exit 1
+          }
+
       - name: Install dependencies
         shell: powershell
         run: |
-          pwd 
+          pwd
           npm ci --include=dev --include=prod
 
       - name: Build binaries
@@ -1286,15 +1348,36 @@ jobs:
           echo "tag_name   : ${{ needs.release-please.outputs.release_tag_name }}"
           echo "upload_url : ${{ needs.release-please.outputs.release_upload_url }}"
 
-      - name: Checkout repository
+      - name: Checkout the released tag
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # Load-bearing. Without `ref`, checkout takes `github.sha` - the commit that triggered
+          # this run - and release-please cuts the release from main's HEAD, which is a
+          # different commit whenever an unrelated push is what started the run. On 2026-08-10
+          # that shipped all three 4.1.0 binaries built from the commit before the version bump,
+          # so they reported "App version: 4.0.0": the SEA build embeds package.json as an asset
+          # and globals.js reads the version straight out of it.
+          ref: ${{ needs.release-please.outputs.release_tag_name }}
           persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
+      # Runs after setup-node so `node` is certain to be on PATH, and before the install and
+      # build so a mismatch costs seconds rather than a signed, notarized artifact.
+      - name: Verify the checkout is the version being released
+        shell: bash
+        run: |
+          expected="${{ needs.release-please.outputs.release_version }}"
+          actual=$(node -p "require('./package.json').version")
+          echo "release-please version : $expected"
+          echo "package.json version   : $actual"
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::Refusing to build: package.json says $actual, but the release is $expected. The binary embeds package.json and would report the wrong version."
+            exit 1
+          fi
+
       # The npm bundled with Node 24 is 11.x, and 11.x resolves this lockfile differently between
       # patch releases - a second Windows runner picking up a newer Node installed 53 fewer
       # packages and could not resolve jest-circus. Pinning npm here makes the install identical


### PR DESCRIPTION
The published 4.1.0 binaries report `App version: 4.0.0`. They are genuinely 4.1.0 code — they contain the multi-platform uninstall fix and multi-tag `--blur-sheet-tag` — but the version stamp is wrong, on all three platforms.

## Cause

The four release jobs checked out with no `ref`:

```yaml
- name: Checkout repository
  uses: actions/checkout@... # v7.0.1
  with:
    persist-credentials: false     # <- no ref
```

So they build `github.sha`, the commit that happened to start the run. release-please cuts the release from **main's HEAD**, which is a different commit whenever an unrelated push is what started the run. `needs.release-please.outputs.release_tag_name` was already available, and already echoed in a logging step, but never used for the checkout.

## What happened on 10 August

| Time (UTC) | Event |
|---|---|
| 19:14 | `778d0fb1` "Merge PR #972 feat/interactive-mode-phase-1" pushed → run 31423122602 starts |
| 19:50 | `fac0e5fd` "chore(main): release butler-sheet-icons 4.1.0 (#926)" merged — bumps package.json to 4.1.0 |
| 19:54 | that run reaches `release-please`, reads main's HEAD, tags `butler-sheet-icons-v4.1.0` |
| 20:01–20:08 | its release jobs check out `github.sha` = `778d0fb1`, where package.json still says 4.0.0, build and upload |

Job end times match the published asset timestamps within seconds on all three platforms: macOS 20:03:07 vs asset 20:03:00, linux 20:02:28 vs 20:02:25, win 20:08:41 vs 20:08:32.

`sea-config.json` embeds `package.json` as a SEA asset and `globals.js` reads `appVersion` straight out of it, so a stale tree becomes the reported version. The artifacts are also missing anything merged between the two commits.

Two aggravating details:

- The run on 4.1.0's **own** release commit had every release job **skipped**, because upstream tests failed. Even the run that would have checked out the right tree produced nothing.
- It is a race, not a constant, which is why it had not been noticed. For 4.0.0 the run that cut the release was triggered by the release PR merge itself, so `github.sha` happened to be the released commit.

## The fix

`ref: ${{ needs.release-please.outputs.release_tag_name }}` on all four checkouts, which also makes the artifacts reproducible from the tag.

Plus a guard that refuses to build when `package.json` disagrees with the version being released, so a mis-stamp cannot ship silently again. It runs after `setup-node` so `node` is certainly on PATH, and before the install and build, so a mismatch costs seconds rather than a signed and notarized artifact.

The Windows guard is written in **powershell**, not bash: every other run step on that self-hosted runner uses powershell, and bash would depend on Git for Windows being on PATH. A guard that fails spuriously would block releases, which is worse than the defect it guards against.

## Verification

- Guard logic tested against the real case: tree at 4.0.0 with release 4.1.0 exits 1 with the error; matching versions exits 0.
- YAML parses; all four `ref` pins and all four guards confirmed to sit in jobs that `needs: release-please`. An earlier revision of this branch had the guard land in three jobs that do not, where the version expression is empty and it would have failed every CI run — caught and removed before commit.
- Diff is confined to the release-job region.

**CI on this PR will not exercise the change.** The release jobs only run when `releases_created == 'true'`, so this is unverified until a real release — which argues for making the next release a small deliberate one and watching the guard's log line.

## Not covered here

The published 4.1.0 assets remain wrong and would need rebuilding from the tag. Worth checking what actually landed between `778d0fb1` and `fac0e5fd` before deciding between re-publishing 4.1.0 assets and rolling to 4.1.1.

This also blocks #849: sample output captured from the current binary is stamped `App version: 4.0.0`, so it should not go on the doc site until a correctly stamped binary exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)