### PR TITLE
Explain a browser launch that stalls where no timeout reaches

### DIFF
--- a/docs/to-doc-site/browser-slow-to-start.md
+++ b/docs/to-doc-site/browser-slow-to-start.md
@@ -1,0 +1,69 @@
+# When the browser takes a very long time to start
+
+Butler Sheet Icons creates thumbnails by starting a Chrome browser in the background and photographing each sheet. Starting that browser normally takes a second or two.
+
+Occasionally it takes very much longer — minutes rather than seconds — with nothing in the log to say why. This page describes a warning that now explains it, and what to do about it. It belongs with the troubleshooting material.
+
+Nothing here needs configuring. There are no new options.
+
+## What you will see
+
+The last thing in the log is the line saying the browser is being started, and then nothing at all for a long time:
+
+```
+info: Browser setup complete. Launching browser...
+```
+
+If Butler Sheet Icons eventually gets the browser running, it now follows that silence with an explanation:
+
+```
+warning: QSEOW: Browser launch took 1500s, longer than the 30s launch timeout allows for.
+         The extra time went into starting the browser process, which no timeout covers.
+warning: QSEOW: On Windows this is typically antivirus or endpoint protection scanning a
+         browser executable it has not seen before. Excluding the Butler Sheet Icons browser
+         cache directory from real-time scanning avoids it.
+```
+
+(Both lines are shown wrapped here; each is a single line in the log. The prefix at the start names the stage the run was in, and differs between commands.)
+
+The run itself is not damaged by this. The thumbnails are created normally once the browser finally starts — it is the waiting that is the problem, and on a scheduled run it can be long enough that the run appears to have frozen.
+
+## What is actually happening
+
+Butler Sheet Icons asks the operating system to start the browser, and the operating system does not come back. This is not the browser being slow; it is the request to start it being held.
+
+On Windows, the usual reason is security software inspecting the browser program before it is allowed to run. Butler Sheet Icons downloads its own copy of Chrome, so the first run after a browser download presents the scanner with a program it has never seen before. Some products will send such a file away to be analysed and hold it until an answer comes back. If that lookup is slow — or the machine's route to the vendor's service is blocked — the wait can be extremely long.
+
+Two details worth knowing:
+
+- **It typically strikes once, then disappears.** Once the file has been examined and accepted, later runs start normally. A failure that will not reproduce the next morning is characteristic of this, and does not mean it was imagined.
+- **It can affect several machines at the same time**, if they share a security policy and all download the same new browser version around the same time.
+
+## What to do about it
+
+**Exclude the Butler Sheet Icons browser cache directory from real-time scanning.** This is the directory Butler Sheet Icons downloads its browsers into:
+
+| Platform | Directory |
+|---|---|
+| Windows | `C:\Users\<the account running Butler Sheet Icons>\.cache\puppeteer` |
+| macOS and Linux | `~/.cache/puppeteer` |
+
+Your security team will normally be the ones to make this change. It is a routine exclusion — the directory holds only browsers that Butler Sheet Icons downloaded itself from Google's official distribution point.
+
+If an exclusion is not possible in your environment, the alternative is to avoid the first-sight scan happening during a scheduled run: after upgrading Butler Sheet Icons or changing the browser version, start a run by hand once and let it complete. The scan then happens while somebody is watching, rather than in the middle of the night.
+
+## If the browser never starts at all
+
+Where the wait ends in failure rather than success, the log says so directly:
+
+```
+error: QSEOW: The browser did not become ready within 30s. It was started but never reported
+       a debugging endpoint - usually a browser build that cannot run on this machine, or
+       security software holding it at startup.
+```
+
+This is the same family of problem, but with the browser failing rather than merely being slow. If the exclusion above does not resolve it, the browser version in use may be one that cannot run on this machine — see the page on choosing a browser version, and try the recommended version:
+
+```
+--browser-version recommended
+```

--- a/src/lib/browser/__tests__/browser_launch.test.js
+++ b/src/lib/browser/__tests__/browser_launch.test.js
@@ -574,7 +574,21 @@ describe('launchBrowserForApp — slow launch reporting (issue #870)', () => {
     }
 
     /**
-     * Makes `puppeteer.launch` consume a given amount of wall-clock time.
+     * Builds a Puppeteer `TimeoutError`, as thrown when a launch exceeds its budget.
+     *
+     * The real one is a class in puppeteer-core that sets `name` from its constructor; only the
+     * name is load-bearing here, so a plain Error carrying it is enough.
+     *
+     * @returns {Error} An error the launch path will recognise as a timeout.
+     */
+    function timeoutError() {
+        const err = new Error('Timed out after 30000 ms while trying to connect to the browser');
+        err.name = 'TimeoutError';
+        return err;
+    }
+
+    /**
+     * Makes `puppeteer.launch` consume a given amount of time on the monotonic clock.
      *
      * The clock is advanced from inside the launch mock rather than by queueing return values,
      * so the elapsed time is tied to the launch itself and cannot drift if some other caller
@@ -597,7 +611,9 @@ describe('launchBrowserForApp — slow launch reporting (issue #870)', () => {
 
     beforeEach(() => {
         now = 0;
-        nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => now);
+        // performance.now, not Date.now: the code deliberately measures on a monotonic clock so
+        // that an NTP step on a virtualised runner cannot invent or hide a stall.
+        nowSpy = jest.spyOn(performance, 'now').mockImplementation(() => now);
         detectAvailableBrowser.mockResolvedValue({
             executablePath: '/cached/chrome',
             source: 'cache',
@@ -651,19 +667,35 @@ describe('launchBrowserForApp — slow launch reporting (issue #870)', () => {
     });
 
     test('explains a launch timeout instead of leaving it to read as a generic failure', async () => {
-        const timedOut = new Error(
-            'Timed out after 30000 ms while trying to connect to the browser'
-        );
-        timedOut.name = 'TimeoutError';
-        launchTaking(BROWSER_LAUNCH_TIMEOUT_MS + 1, { reject: timedOut });
+        launchTaking(BROWSER_LAUNCH_TIMEOUT_MS + 1, { reject: timeoutError() });
 
         await expect(launchBrowserForApp(OPTIONS, CONTEXT)).rejects.toThrow(TestError);
 
         expect(errorOutput()).toContain('did not become ready within 30s');
         expect(errorOutput()).toContain('never reported a debugging endpoint');
-        // Elapsed time is reported on the failing path too - it is what separates "this build is
-        // broken" from "something held the process at startup".
-        expect(warnOutput()).toContain('Browser launch took');
+    });
+
+    test('does not blame a stall for an ordinary launch timeout', async () => {
+        // The measurement starts before puppeteer.launch() and Puppeteer's own clock starts later
+        // still, so a timeout always elapses slightly over the budget. Treating that as
+        // unexplained time would tell an administrator to go reconfigure endpoint protection for
+        // what is really a browser build that cannot run - advice that is worse than silence.
+        launchTaking(BROWSER_LAUNCH_TIMEOUT_MS + 47, { reject: timeoutError() });
+
+        await expect(launchBrowserForApp(OPTIONS, CONTEXT)).rejects.toThrow(TestError);
+
+        expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    test('does blame a stall when a timeout arrives long after the budget', async () => {
+        // Held at startup for 25 minutes and then failing to report a debugging endpoint. The
+        // budget accounts for 30s of that; the rest is the stall, and worth naming.
+        launchTaking(25 * 60 * 1000 + BROWSER_LAUNCH_TIMEOUT_MS, { reject: timeoutError() });
+
+        await expect(launchBrowserForApp(OPTIONS, CONTEXT)).rejects.toThrow(TestError);
+
+        expect(warnOutput()).toContain('Browser launch took 1530s');
+        expect(warnOutput()).toContain('antivirus');
     });
 
     test('does not offer the timeout explanation for an ordinary launch failure', async () => {

--- a/src/lib/browser/__tests__/browser_launch.test.js
+++ b/src/lib/browser/__tests__/browser_launch.test.js
@@ -1,4 +1,4 @@
-import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+import { jest, describe, test, expect, beforeEach, afterEach } from '@jest/globals';
 
 jest.unstable_mockModule('puppeteer-core', () => ({
     default: { launch: jest.fn() },
@@ -68,8 +68,14 @@ jest.unstable_mockModule('node:fs', () => ({
 }));
 const fs = await import('node:fs');
 
-const { launchBrowserForApp, buildBrowserArgs, resolveBrowserExecutablePath, closeBrowserQuietly } =
-    await import('../browser-launch.js');
+const {
+    launchBrowserForApp,
+    buildBrowserArgs,
+    resolveBrowserExecutablePath,
+    closeBrowserQuietly,
+    BROWSER_LAUNCH_TIMEOUT_MS,
+    BROWSER_PROTOCOL_TIMEOUT_MS,
+} = await import('../browser-launch.js');
 
 /** Stand-in typed error, matching the (message, { cause }) shape of the real ones. */
 class TestError extends Error {
@@ -550,5 +556,123 @@ describe('log prefix shape', () => {
         expect(logged).toContain('TEST: Could not launch virtual browser');
         expect(logged).not.toContain('TEST Could not launch');
         expect(logged).not.toContain('TEST:: Could not launch');
+    });
+});
+
+describe('launchBrowserForApp — slow launch reporting (issue #870)', () => {
+    /** Value returned by the stubbed clock, advanced by the launch mock itself. */
+    let now;
+    let nowSpy;
+
+    /**
+     * Concatenates everything logged at warn level.
+     *
+     * @returns {string} Combined warning output.
+     */
+    function warnOutput() {
+        return logger.warn.mock.calls.map((call) => String(call[0])).join('\n');
+    }
+
+    /**
+     * Makes `puppeteer.launch` consume a given amount of wall-clock time.
+     *
+     * The clock is advanced from inside the launch mock rather than by queueing return values,
+     * so the elapsed time is tied to the launch itself and cannot drift if some other caller
+     * reads the clock in between.
+     *
+     * @param {number} elapsedMs - Time the launch should appear to take.
+     * @param {object} outcome - `{ resolve }` or `{ reject }`, the launch result.
+     *
+     * @returns {void}
+     */
+    function launchTaking(elapsedMs, outcome) {
+        puppeteer.launch.mockImplementation(async () => {
+            now += elapsedMs;
+            if (outcome.reject) {
+                throw outcome.reject;
+            }
+            return outcome.resolve;
+        });
+    }
+
+    beforeEach(() => {
+        now = 0;
+        nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => now);
+        detectAvailableBrowser.mockResolvedValue({
+            executablePath: '/cached/chrome',
+            source: 'cache',
+            browser: 'chrome',
+            buildId: '150.0.7871.24',
+        });
+    });
+
+    afterEach(() => {
+        nowSpy.mockRestore();
+        // clearAllMocks leaves implementations in place, so the clock-advancing launch stub would
+        // otherwise outlive this block.
+        puppeteer.launch.mockReset();
+    });
+
+    test('states both Puppeteer timeouts rather than inheriting them', async () => {
+        // Pinned so a dependency bump cannot change the launch budget without a diff here.
+        launchTaking(1_000, { resolve: fakeBrowser() });
+
+        await launchBrowserForApp(OPTIONS, CONTEXT);
+
+        expect(puppeteer.launch).toHaveBeenCalledWith(
+            expect.objectContaining({
+                timeout: BROWSER_LAUNCH_TIMEOUT_MS,
+                protocolTimeout: BROWSER_PROTOCOL_TIMEOUT_MS,
+            })
+        );
+    });
+
+    test('warns when a launch that succeeded took longer than the timeout allows for', async () => {
+        // The case no timeout catches, and the one the CI hang actually was: process startup is
+        // stalled outside the timed region, the stall clears, and the launch then succeeds.
+        launchTaking(25 * 60 * 1000, { resolve: fakeBrowser() });
+
+        await launchBrowserForApp(OPTIONS, CONTEXT);
+
+        expect(warnOutput()).toContain('TEST: Browser launch took 1500s');
+        expect(warnOutput()).toContain('no timeout covers');
+        expect(warnOutput()).toContain('antivirus');
+    });
+
+    test('stays quiet about a launch that finished inside the budget', async () => {
+        launchTaking(BROWSER_LAUNCH_TIMEOUT_MS, { resolve: fakeBrowser() });
+
+        await launchBrowserForApp(OPTIONS, CONTEXT);
+
+        expect(logger.warn).not.toHaveBeenCalled();
+        expect(logger.verbose).toHaveBeenCalledWith(
+            expect.stringContaining(`Browser launch took ${BROWSER_LAUNCH_TIMEOUT_MS} ms`)
+        );
+    });
+
+    test('explains a launch timeout instead of leaving it to read as a generic failure', async () => {
+        const timedOut = new Error(
+            'Timed out after 30000 ms while trying to connect to the browser'
+        );
+        timedOut.name = 'TimeoutError';
+        launchTaking(BROWSER_LAUNCH_TIMEOUT_MS + 1, { reject: timedOut });
+
+        await expect(launchBrowserForApp(OPTIONS, CONTEXT)).rejects.toThrow(TestError);
+
+        expect(errorOutput()).toContain('did not become ready within 30s');
+        expect(errorOutput()).toContain('never reported a debugging endpoint');
+        // Elapsed time is reported on the failing path too - it is what separates "this build is
+        // broken" from "something held the process at startup".
+        expect(warnOutput()).toContain('Browser launch took');
+    });
+
+    test('does not offer the timeout explanation for an ordinary launch failure', async () => {
+        launchTaking(500, { reject: new Error('no display') });
+
+        await expect(launchBrowserForApp(OPTIONS, CONTEXT)).rejects.toThrow(TestError);
+
+        expect(errorOutput()).toContain('Could not launch virtual browser');
+        expect(errorOutput()).not.toContain('did not become ready within');
+        expect(logger.warn).not.toHaveBeenCalled();
     });
 });

--- a/src/lib/browser/browser-launch.js
+++ b/src/lib/browser/browser-launch.js
@@ -306,14 +306,25 @@ const watchForUnexpectedDisconnect = (browser, buildId, logPrefix) => {
  * Anything over the launch budget is by definition time the launch timeout did not account for,
  * which makes it the natural threshold - no second number to keep in sync.
  *
- * @param {number} elapsedMs - Wall-clock time spent in `puppeteer.launch()`.
+ * That subtraction is why `timedOut` exists. When the launch times out, the budget was spent
+ * waiting exactly as designed, so it is accounted for and has to come off before asking whether
+ * anything is unexplained. Without that, every ordinary launch timeout would report itself as a
+ * stall: the measurement starts before `puppeteer.launch()` and Puppeteer's own clock starts
+ * later still, so a timeout always elapses a little over the budget, and the advice below - go
+ * reconfigure endpoint protection - would be given for a browser build that simply cannot run.
+ *
+ * @param {number} elapsedMs - Time spent in `puppeteer.launch()`, from a monotonic clock.
  * @param {string} logPrefix - Log line prefix, e.g. `'QSEOW'`.
+ * @param {object} [options] - Reporting options.
+ * @param {boolean} [options.timedOut] - Whether the launch ended in Puppeteer's own timeout.
  *
  * @returns {void}
  */
-const reportSlowLaunch = (elapsedMs, logPrefix) => {
-    if (elapsedMs <= BROWSER_LAUNCH_TIMEOUT_MS) {
-        logger.verbose(`Browser launch took ${elapsedMs} ms`);
+const reportSlowLaunch = (elapsedMs, logPrefix, { timedOut = false } = {}) => {
+    const unaccountedMs = timedOut ? elapsedMs - BROWSER_LAUNCH_TIMEOUT_MS : elapsedMs;
+
+    if (unaccountedMs <= BROWSER_LAUNCH_TIMEOUT_MS) {
+        logger.verbose(`Browser launch took ${Math.round(elapsedMs)} ms`);
         return;
     }
 
@@ -364,7 +375,11 @@ export const launchBrowserForApp = async (options, { appId, logPrefix, appLabel,
     const browserArgs = await buildBrowserArgs();
 
     let browser;
-    const launchStartedAt = Date.now();
+    // performance.now() rather than Date.now(): this measures a duration, and the machines the
+    // measurement matters most on are virtualised CI runners, where an NTP step correction after
+    // a guest pause is routine. A wall clock that jumps mid-launch would invent a stall that
+    // never happened, or hide a real one behind a negative elapsed time.
+    const launchStartedAt = performance.now();
     try {
         browser = await puppeteer.launch({
             // Both timeouts match Puppeteer's own defaults; see the constants for why they are
@@ -401,20 +416,21 @@ export const launchBrowserForApp = async (options, { appId, logPrefix, appLabel,
         // A launch timeout reads like any other launch failure in the log, but the remedy is
         // completely different - nothing is wrong with the arguments or the certificate setup,
         // the browser simply never reported itself ready. Say so where the distinction is known.
-        if (err?.name === 'TimeoutError') {
+        const timedOut = err?.name === 'TimeoutError';
+        if (timedOut) {
             logger.error(
                 `${logPrefix}: The browser did not become ready within ${BROWSER_LAUNCH_TIMEOUT_MS / 1000}s. It was started but never reported a debugging endpoint - usually a browser build that cannot run on this machine, or security software holding it at startup.`
             );
         }
 
-        reportSlowLaunch(Date.now() - launchStartedAt, logPrefix);
+        reportSlowLaunch(performance.now() - launchStartedAt, logPrefix, { timedOut });
 
         throw new ErrorClass(`Failed to launch virtual browser for ${appLabel} ${appId}`, {
             cause: err,
         });
     }
 
-    reportSlowLaunch(Date.now() - launchStartedAt, logPrefix);
+    reportSlowLaunch(performance.now() - launchStartedAt, logPrefix);
 
     // A browser build that Puppeteer cannot drive starts perfectly well and then dies on the first
     // command sent to it - after launch() has already resolved. Without this check the failure

--- a/src/lib/browser/browser-launch.js
+++ b/src/lib/browser/browser-launch.js
@@ -37,6 +37,26 @@ export const BASE_BROWSER_ARGS = [
 ];
 
 /**
+ * How long Puppeteer may spend getting a launched browser to announce its debugging endpoint.
+ *
+ * This is Puppeteer's own default, pinned here on purpose. Leaving it implicit means the budget
+ * can change under us on a dependency bump, which is the same failure mode as letting the browser
+ * version float: nothing in this repo changes, and the behaviour does.
+ *
+ * Note what it does *not* cover - see `launchBrowserForApp`.
+ */
+export const BROWSER_LAUNCH_TIMEOUT_MS = 30_000;
+
+/**
+ * How long a single DevTools protocol call may take once the browser is running.
+ *
+ * Also Puppeteer's default, pinned for the same reason. Deliberately generous rather than tight:
+ * it bounds every subsequent CDP call, including screenshots of large sheets on a loaded Qlik
+ * Sense server, and nothing in issue #870 implicated it. Lower it only with evidence.
+ */
+export const BROWSER_PROTOCOL_TIMEOUT_MS = 180_000;
+
+/**
  * Detects whether the process is running inside a container.
  *
  * `--single-process` helps on native Linux and macOS but crashes Chromium both in containers and
@@ -266,6 +286,46 @@ const watchForUnexpectedDisconnect = (browser, buildId, logPrefix) => {
 };
 
 /**
+ * Reports a browser launch that took longer than the timeout supposedly bounding it.
+ *
+ * This is the part of issue #870 that has teeth. `timeout` bounds the wait for the browser to
+ * print its debugging endpoint - it does not bound getting the process off the ground in the
+ * first place. `puppeteer.launch()` spawns the browser before that clock starts, and on Windows
+ * process creation is synchronous inside libuv, so anything that stalls it stalls the Node event
+ * loop with it. No JavaScript timer can fire while that is happening, which is why a 30s launch
+ * timeout produced 30 minutes of silence in CI run 31148836253 rather than a timeout error: the
+ * time was spent somewhere no timeout reaches.
+ *
+ * Two shapes follow from that, and both are worth a line in the log:
+ *
+ * - the stall clears, the launch *succeeds*, and the run is merely inexplicably slow - the case
+ *   no timeout will ever catch, and the one this exists for;
+ * - the stall clears past the 30s budget and Puppeteer then times out, in which case the elapsed
+ *   time is what distinguishes "browser is broken" from "something held the process at startup".
+ *
+ * Anything over the launch budget is by definition time the launch timeout did not account for,
+ * which makes it the natural threshold - no second number to keep in sync.
+ *
+ * @param {number} elapsedMs - Wall-clock time spent in `puppeteer.launch()`.
+ * @param {string} logPrefix - Log line prefix, e.g. `'QSEOW'`.
+ *
+ * @returns {void}
+ */
+const reportSlowLaunch = (elapsedMs, logPrefix) => {
+    if (elapsedMs <= BROWSER_LAUNCH_TIMEOUT_MS) {
+        logger.verbose(`Browser launch took ${elapsedMs} ms`);
+        return;
+    }
+
+    logger.warn(
+        `${logPrefix}: Browser launch took ${Math.round(elapsedMs / 1000)}s, longer than the ${BROWSER_LAUNCH_TIMEOUT_MS / 1000}s launch timeout allows for. The extra time went into starting the browser process, which no timeout covers.`
+    );
+    logger.warn(
+        `${logPrefix}: On Windows this is typically antivirus or endpoint protection scanning a browser executable it has not seen before. Excluding the Butler Sheet Icons browser cache directory from real-time scanning avoids it.`
+    );
+};
+
+/**
  * Resolves a browser and launches it, ready for page work.
  *
  * Extracted from `process-cloud-app.js` and `qseow-process-app.js`, which carried this sequence
@@ -304,8 +364,19 @@ export const launchBrowserForApp = async (options, { appId, logPrefix, appLabel,
     const browserArgs = await buildBrowserArgs();
 
     let browser;
+    const launchStartedAt = Date.now();
     try {
         browser = await puppeteer.launch({
+            // Both timeouts match Puppeteer's own defaults; see the constants for why they are
+            // stated rather than inherited.
+            //
+            // They are NOT what issue #870 asked for. That issue proposed adding a launch timeout
+            // to explain a 30-minute Windows CI hang, on the assumption there was none. There was:
+            // puppeteer-core v25 already defaults `timeout` to 30s and `protocolTimeout` to 180s,
+            // so adding them changes no behaviour and would not have shortened that hang by a
+            // second. The reason is spelled out on `reportSlowLaunch`.
+            timeout: BROWSER_LAUNCH_TIMEOUT_MS,
+            protocolTimeout: BROWSER_PROTOCOL_TIMEOUT_MS,
             // Puppeteer removed `ignoreHTTPSErrors` in v23 and replaced it with
             // `acceptInsecureCerts`. Butler Sheet Icons kept passing the old name through the v25
             // upgrade, and because Puppeteer ignores unknown options in silence, the intent behind
@@ -327,10 +398,23 @@ export const launchBrowserForApp = async (options, { appId, logPrefix, appLabel,
             `${logPrefix}: Could not launch virtual browser: ${err?.stack || err?.message || err}`
         );
 
+        // A launch timeout reads like any other launch failure in the log, but the remedy is
+        // completely different - nothing is wrong with the arguments or the certificate setup,
+        // the browser simply never reported itself ready. Say so where the distinction is known.
+        if (err?.name === 'TimeoutError') {
+            logger.error(
+                `${logPrefix}: The browser did not become ready within ${BROWSER_LAUNCH_TIMEOUT_MS / 1000}s. It was started but never reported a debugging endpoint - usually a browser build that cannot run on this machine, or security software holding it at startup.`
+            );
+        }
+
+        reportSlowLaunch(Date.now() - launchStartedAt, logPrefix);
+
         throw new ErrorClass(`Failed to launch virtual browser for ${appLabel} ${appId}`, {
             cause: err,
         });
     }
+
+    reportSlowLaunch(Date.now() - launchStartedAt, logPrefix);
 
     // A browser build that Puppeteer cannot drive starts perfectly well and then dies on the first
     // command sent to it - after launch() has already resolved. Without this check the failure


### PR DESCRIPTION
## What & why

Issue #870 reported a 30-minute Windows CI hang at browser launch and proposed adding a `timeout` to `puppeteer.launch()`, on the assumption there was none. There is one — puppeteer-core v25 defaults `timeout` to 30s and `protocolTimeout` to 180s — so the fix as specified would have changed nothing.

The reason the existing timeout never fired is that it does not cover the whole launch. It bounds the wait for the browser to announce its debugging endpoint, but the process is spawned *before* that clock starts, and on Windows process creation is synchronous inside libuv — a stall there stalls the Node event loop, so no JavaScript timer can fire at all. That produces silence rather than a timeout error.

So this measures the launch and reports afterwards instead. Time unaccounted for by the launch budget is by definition time no timeout covered, which makes it the natural threshold and leaves no second number to keep in sync. When the launch itself times out the budget was spent as designed, so it comes off before that judgement — otherwise every ordinary timeout would report itself as a stall. It is also the only thing that catches the shape #870 actually had: the stall clears, the launch **succeeds**, and the run is merely inexplicably slow — nothing fails, so no timeout could ever have caught it.

Elapsed time is measured on a monotonic clock, so an NTP step on a virtualised runner cannot invent a stall or hide one.

Also here: a `TimeoutError` is now explained rather than reading as a generic launch failure, and both Puppeteer timeouts are stated rather than inherited so a dependency bump cannot move the launch budget without a diff.

Gap 1 from #870 — `latest` resolving from the consumer Chrome channel instead of Chrome for Testing's known-good index — was already fixed on 2026-08-08 by `178bb30` and `3627ee9`, which this PR does not touch. #870 has been updated accordingly.

## How it was verified

- `src/lib/browser/__tests__/browser_launch.test.js` — 36 pass, 7 of them new.
- Full unit suite: 89 suites, 2387 tests, all passing. `eslint --max-warnings 0` clean.
- Five behaviours were mutation-tested — the pinned timeouts, the success-path duration report, the `TimeoutError` branch, the timeout subtraction, and the monotonic clock. Each failed exactly its intended test, so the tests bite rather than passing alongside the code.
- A review pass over the first commit found two real defects in it, both fixed in `48164ed`: an ordinary launch timeout reported itself as a stall and advised an antivirus exclusion that did not apply, and elapsed time came from a wall clock that a virtualised runner can step mid-launch.
- The premise was checked against the installed package, not from memory: `BrowserLauncher.js:53` (`timeout = 30000`) and `Connection.js:38` (`?? 180_000`).

Not verified against a live QSEoW server, and it does not need to be — no thumbnail, login or selector behaviour changes. The scanner explanation for the original stall stays a hypothesis; what is verified is structural, that the timeouts already existed and the spawn sits outside the region they bound.

## Docs

`docs/to-doc-site/browser-slow-to-start.md` — the new warning tells an administrator to add an antivirus exclusion, so it needs a page. Quoted log lines are checked against the implementation.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
