### PR TITLE
Remove the orphaned Chrome build lookup that made fixed behaviour look live

### DIFF
--- a/src/lib/browser/__tests__/browser_install.test.js
+++ b/src/lib/browser/__tests__/browser_install.test.js
@@ -29,11 +29,6 @@ jest.unstable_mockModule('../../../globals.js', () => ({
 }));
 const { logger, sleep } = await import('../../../globals.js');
 
-jest.unstable_mockModule('../browser-list-available.js', () => ({
-    getMostRecentUsableChromeBuildId: jest.fn(),
-}));
-const { getMostRecentUsableChromeBuildId } = await import('../browser-list-available.js');
-
 // Stub the cli-progress SingleBar so the test does not write to a real TTY.
 /**
  * Inert test double for the cli-progress SingleBar constructor. All methods
@@ -75,7 +70,6 @@ describe('browserInstall — retry logic', () => {
         detectBrowserPlatform.mockResolvedValue('mac_arm');
         canDownload.mockResolvedValue(true);
         resolveBuildId.mockResolvedValue('123.0.0.0');
-        getMostRecentUsableChromeBuildId.mockResolvedValue('123.0.0.0');
     });
 
     test('returns the installed browser on first-attempt success (no retry, no warning)', async () => {

--- a/src/lib/browser/__tests__/browser_version.test.js
+++ b/src/lib/browser/__tests__/browser_version.test.js
@@ -110,9 +110,9 @@ describe('the latest alias', () => {
 
         const result = await resolveBrowserVersion('chrome', 'latest');
 
-        // Guards the actual regression: 'latest' previously reached
-        // getMostRecentUsableChromeBuildId, which returned the newest *published* stable build
-        // (151.0.7922.109), not the vendor's last-known-good stable.
+        // Guards the actual regression: 'latest' previously resolved from the consumer Chrome
+        // channel and returned the newest *published* stable build (151.0.7922.109), not the
+        // vendor's last-known-good stable. The function that did so has since been removed.
         expect(resolveBuildId).toHaveBeenCalledWith('chrome', 'mac_arm', 'stable');
         expect(result.buildId).toBe('151.0.7922.77');
         expect(result.source).toBe(VERSION_STABLE);

--- a/src/lib/browser/browser-install.js
+++ b/src/lib/browser/browser-install.js
@@ -203,10 +203,9 @@ export const browserInstall = async (options, _command, resolvedBuildId) => {
         if (err?.message?.includes('Download failed: server returned code 404.')) {
             logger.error(`Browser version "${options.browserVersion}" not found`);
         } else if (!alreadyReported(err)) {
-            // Only report what nothing else has explained. Resolving "latest" goes through
-            // getMostRecentUsableChromeBuildId, which already describes connectivity failures in
-            // detail; repeating the raw message and a stack trace on top is what made an offline
-            // run unreadable. The stack stays available at debug.
+            // Only report what nothing else has explained. Version resolution already describes
+            // connectivity failures in detail; repeating the raw message and a stack trace on top
+            // is what made an offline run unreadable. The stack stays available at debug.
             logger.error(`Error installing browser: ${err?.message ?? err}`);
             logger.debug(err?.stack ?? String(err));
         }

--- a/src/lib/browser/browser-list-available.js
+++ b/src/lib/browser/browser-list-available.js
@@ -130,10 +130,10 @@ function mapPlatformToChrome(puppeteerPlatform) {
  * version picker, say) previously had to wait for hundreds of round trips it
  * had no use for.
  *
- * The `logPrefix` exists so the two callers keep their debug output exactly as
- * it was. `getMostRecentUsableChromeBuildId` prefixes its lines and
- * `browserListAvailable` does not; sharing the fetch without it would have
- * quietly rewritten one of them.
+ * The `logPrefix` exists because this used to have two callers with different
+ * debug output, and sharing the fetch without it would have quietly rewritten
+ * one of them. The prefixing caller has since been removed, so every current
+ * caller leaves it at the default.
  *
  * @param {object} options - An options object.
  * @param {string} options.browser - Browser to list versions for (`chrome` or `firefox`).
@@ -322,68 +322,6 @@ export async function browserListAvailable(options) {
             logger.error(`Error checking for available browsers: ${err?.message || err}`);
             logger.debug(err?.stack ?? String(err));
         }
-        throw err;
-    }
-}
-
-/**
- * Finds the most recent version of Chrome that Puppeteer can download and use.
- *
- * @param {string} channel - The Chrome release channel. Valid values are `stable`, `beta`, `dev`, `canary`.
- *
- * @returns {Promise<string|false>} A promise that resolves to the most recent usable Chrome build ID, or `false` if no usable version was found.
- */
-export async function getMostRecentUsableChromeBuildId(channel) {
-    try {
-        logger.verbose(`Get most recent usable Chrome build ID: Channel "${channel}"`);
-
-        // Verify release channek is valid
-        if (
-            channel !== 'stable' &&
-            channel !== 'beta' &&
-            channel !== 'dev' &&
-            channel !== 'canary'
-        ) {
-            throw new Error(`Invalid Chrome release channel "${channel}"`);
-        }
-
-        const browserPath = getBrowserCacheDir();
-        logger.debug(`Get most recent usable Chrome build ID: Browser cache path: ${browserPath}`);
-
-        const browsersAvailable = await fetchAvailableVersions({
-            browser: 'chrome',
-            channel,
-            logPrefix: 'Get most recent usable Chrome build ID: ',
-        });
-
-        // Output Chrome versions and names to info log
-        if (browsersAvailable.length > 0) {
-            for (const version of browsersAvailable) {
-                // Can this version be downloaded?
-
-                const canDownloadBrowser = await canDownload({
-                    browser: 'chrome',
-                    buildId: version.version,
-                    cacheDir: browserPath,
-                    unpack: false,
-                });
-
-                if (canDownloadBrowser) {
-                    return version.version;
-                }
-            }
-        }
-        logger.info('No Chrome versions available');
-        return false;
-    } catch (err) {
-        // As above: only report what has not already been explained.
-        if (!alreadyReported(err)) {
-            logger.error(
-                `Error getting most recent usable Chrome build ID: ${err?.message || err}`
-            );
-            logger.debug(err?.stack ?? String(err));
-        }
-
         throw err;
     }
 }

--- a/src/lib/commands/browser/__tests__/browser_wizards.test.js
+++ b/src/lib/commands/browser/__tests__/browser_wizards.test.js
@@ -42,7 +42,6 @@ jest.unstable_mockModule('../../../browser/browser-uninstall.js', () => ({
 jest.unstable_mockModule('../../../browser/browser-list-available.js', () => ({
     fetchAvailableVersions,
     browserListAvailable: jest.fn(),
-    getMostRecentUsableChromeBuildId: jest.fn(),
 }));
 jest.unstable_mockModule('../../../browser/browser-install.js', () => ({ browserInstall }));
 


### PR DESCRIPTION
## What & why

`getMostRecentUsableChromeBuildId` has had no caller since the browser-version rework of 2026-08-08 (`178bb30`, `3627ee9`) moved version resolution onto `resolveBuildId` from `@puppeteer/browsers`. This removes it.

The reason it is worth removing rather than leaving is that it made already-fixed behaviour look live. This function resolved `latest` from the consumer Chrome channel gated only on `canDownload`, which is precisely what #870 filed as a gap. When #870 was reviewed four days later, a search of this repo for the known-good index found nothing and this function was still sitting here querying the consumer channel — so the gap was reported as still open, and it was not. The known-good lookup had moved into `@puppeteer/browsers`, where a grep of `src/` will never find it, and this function had already been orphaned. That cost a full round of investigation and a wrong comment on the issue.

No behaviour changes: nothing called it.

## How it was verified

- `gitnexus_impact` on the symbol: LOW risk, zero callers, zero affected processes — matching a repo-wide grep, which now returns no hits at all.
- What stays and why: `fetchAvailableVersions` is still used by the install wizard (`src/lib/commands/browser/install.interactive.js:1`) and `browserListAvailable` by the `list-available` command, so both remain, along with the `getBrowserCacheDir`, `canDownload` and `alreadyReported` imports they need.
- Full unit suite: 89 suites, **2380** tests, all passing — exactly the count on `main`, which confirms this removed inert mocks rather than real tests. `eslint src/ --max-warnings 0` clean across the tree.
- The mock of `browser-list-available.js` in `browser_install.test.js` is removed because `browser-install.js` does not import that module at all, so the mock could never have taken effect.

## Docs

Internal only — the removed function had no callers, so nothing a user can observe changes.

Closes #1027

🤖 Generated with [Claude Code](https://claude.com/claude-code)
