### PR TITLE
Stop the browser integration tests deleting the developer's browsers

### DIFF
--- a/src/lib/browser/__tests__/browser_complex_scenarios.integration.test.js
+++ b/src/lib/browser/__tests__/browser_complex_scenarios.integration.test.js
@@ -1,15 +1,21 @@
-import { test, expect, describe, beforeAll } from '@jest/globals';
+import { test, expect, describe, beforeAll, afterAll } from '@jest/globals';
 import 'dotenv/config';
 
 import { browserInstalled } from '../browser-installed.js';
 import { browserInstall } from '../browser-install.js';
 import { browserUninstallAll } from '../browser-uninstall.js';
 import { assertEnv, getTestTimeout } from '../../util/env-check.js';
+import { makeIsolatedCacheDir, removeIsolatedCacheDir } from '../test-helpers/isolated-cache.js';
 
 const defaultTestTimeout = getTestTimeout(process.env, 1800000);
 
+// Everything below installs and uninstalls real browsers, and ends by emptying the cache
+// directory. Without this the target is the developer's own ~/.cache/puppeteer.
+const browserCacheDir = makeIsolatedCacheDir();
+
 const options = {
     loglevel: process.env.BSI_LOG_LEVEL || 'info',
+    browserCacheDir,
 };
 
 describe('complex scenarios', () => {
@@ -17,6 +23,10 @@ describe('complex scenarios', () => {
     // test log even though no per-test failures depend on it.
     beforeAll(() => {
         assertEnv(process.env, { informational: ['BSI_LOG_LEVEL', 'BSI_TEST_TIMEOUT'] });
+    });
+
+    afterAll(() => {
+        removeIsolatedCacheDir(browserCacheDir);
     });
 
     /**
@@ -48,6 +58,7 @@ describe('complex scenarios', () => {
             const browserInstallRes1 = await browserInstall({
                 browser: 'chrome',
                 browserVersion: 'recommended',
+                browserCacheDir,
             });
             expect(browserInstallRes1).toBeTruthy();
 
@@ -55,6 +66,7 @@ describe('complex scenarios', () => {
             const browserInstallRes2 = await browserInstall({
                 browser: 'chrome',
                 browserVersion: '121.0.6167.16',
+                browserCacheDir,
             });
             expect(browserInstallRes2).toBeTruthy();
 
@@ -62,12 +74,14 @@ describe('complex scenarios', () => {
             const browserInstallRes3 = await browserInstall({
                 browser: 'chrome',
                 browserVersion: '123.0.6286.0',
+                browserCacheDir,
             });
             expect(browserInstallRes3).toBeTruthy();
 
             const browserInstallRes4 = await browserInstall({
                 browser: 'firefox',
                 browserVersion: 'recommended',
+                browserCacheDir,
             });
             expect(browserInstallRes4).toBeTruthy();
 

--- a/src/lib/browser/__tests__/browser_edge_cases.integration.test.js
+++ b/src/lib/browser/__tests__/browser_edge_cases.integration.test.js
@@ -1,15 +1,21 @@
-import { test, expect, describe, beforeAll } from '@jest/globals';
+import { test, expect, describe, beforeAll, afterAll } from '@jest/globals';
 import 'dotenv/config';
 
 import { browserInstalled } from '../browser-installed.js';
 import { browserInstall } from '../browser-install.js';
 import { browserUninstallAll } from '../browser-uninstall.js';
 import { assertEnv, getTestTimeout } from '../../util/env-check.js';
+import { makeIsolatedCacheDir, removeIsolatedCacheDir } from '../test-helpers/isolated-cache.js';
 
 const defaultTestTimeout = getTestTimeout(process.env, 1800000);
 
+// The concurrency test installs two browsers and then cleans up with `browserUninstallAll`,
+// which empties the whole cache directory rather than removing just those two.
+const browserCacheDir = makeIsolatedCacheDir();
+
 const options = {
     loglevel: process.env.BSI_LOG_LEVEL || 'info',
+    browserCacheDir,
 };
 
 describe('edge cases and error handling', () => {
@@ -20,6 +26,10 @@ describe('edge cases and error handling', () => {
     // not cause a hard failure here.
     beforeAll(() => {
         assertEnv(process.env, { informational: ['BSI_LOG_LEVEL', 'BSI_TEST_TIMEOUT'] });
+    });
+
+    afterAll(() => {
+        removeIsolatedCacheDir(browserCacheDir);
     });
 
     /**
@@ -33,7 +43,11 @@ describe('edge cases and error handling', () => {
             // be reported as a version that could not be resolved, which sends the reader after
             // the wrong option entirely.
             await expect(
-                browserInstall({ browser: 'invalid-browser', browserVersion: 'recommended' })
+                browserInstall({
+                    browser: 'invalid-browser',
+                    browserVersion: 'recommended',
+                    browserCacheDir,
+                })
             ).rejects.toThrow(/unsupported browser "invalid-browser"/i);
         },
         defaultTestTimeout
@@ -48,8 +62,16 @@ describe('edge cases and error handling', () => {
     test(
         'the legacy "latest" value still installs, and matches "stable"',
         async () => {
-            const viaLatest = await browserInstall({ browser: 'chrome', browserVersion: 'latest' });
-            const viaStable = await browserInstall({ browser: 'chrome', browserVersion: 'stable' });
+            const viaLatest = await browserInstall({
+                browser: 'chrome',
+                browserVersion: 'latest',
+                browserCacheDir,
+            });
+            const viaStable = await browserInstall({
+                browser: 'chrome',
+                browserVersion: 'stable',
+                browserCacheDir,
+            });
 
             expect(viaLatest.buildId).toEqual(viaStable.buildId);
         },
@@ -66,7 +88,10 @@ describe('edge cases and error handling', () => {
             delete process.env.BSI_TEST_TIMEOUT;
             delete process.env.BSI_LOG_LEVEL;
 
-            const installedBrowsers = await browserInstalled({});
+            // No loglevel, which is what this test is about. The cache directory is not an
+            // environment variable and has to stay set, or the read falls back to the
+            // developer's own cache.
+            const installedBrowsers = await browserInstalled({ browserCacheDir });
             expect(installedBrowsers).toBeDefined();
         },
         defaultTestTimeout
@@ -80,8 +105,16 @@ describe('edge cases and error handling', () => {
         'concurrent browser installations',
         async () => {
             const installPromises = [
-                browserInstall({ browser: 'chrome', browserVersion: 'recommended' }),
-                browserInstall({ browser: 'firefox', browserVersion: 'recommended' }),
+                browserInstall({
+                    browser: 'chrome',
+                    browserVersion: 'recommended',
+                    browserCacheDir,
+                }),
+                browserInstall({
+                    browser: 'firefox',
+                    browserVersion: 'recommended',
+                    browserCacheDir,
+                }),
             ];
 
             const results = await Promise.all(installPromises);

--- a/src/lib/browser/__tests__/browser_install_uninstall.integration.test.js
+++ b/src/lib/browser/__tests__/browser_install_uninstall.integration.test.js
@@ -1,15 +1,22 @@
-import { test, expect, describe, beforeAll } from '@jest/globals';
+import { test, expect, describe, beforeAll, afterAll } from '@jest/globals';
 import 'dotenv/config';
 
 import { browserInstalled } from '../browser-installed.js';
 import { browserInstall } from '../browser-install.js';
 import { browserUninstallAll } from '../browser-uninstall.js';
 import { assertEnv, getTestTimeout } from '../../util/env-check.js';
+import { makeIsolatedCacheDir, removeIsolatedCacheDir } from '../test-helpers/isolated-cache.js';
 
 const defaultTestTimeout = getTestTimeout(process.env, 1800000);
 
+// Every test below opens with `browserUninstallAll` and asserts the cache is then empty. Against
+// the developer's own ~/.cache/puppeteer that assertion only held because the call had just
+// deleted whatever was there.
+const browserCacheDir = makeIsolatedCacheDir();
+
 const options = {
     loglevel: process.env.BSI_LOG_LEVEL || 'info',
+    browserCacheDir,
 };
 
 describe('install/uninstall browser scenarios', () => {
@@ -17,6 +24,10 @@ describe('install/uninstall browser scenarios', () => {
     // test log even though no per-test failures depend on it.
     beforeAll(() => {
         assertEnv(process.env, { informational: ['BSI_LOG_LEVEL', 'BSI_TEST_TIMEOUT'] });
+    });
+
+    afterAll(() => {
+        removeIsolatedCacheDir(browserCacheDir);
     });
 
     /**
@@ -40,6 +51,7 @@ describe('install/uninstall browser scenarios', () => {
             const browserInstallRes1 = await browserInstall({
                 browser: 'chrome',
                 browserVersion: 'recommended',
+                browserCacheDir,
             });
             expect(browserInstallRes1).toBeTruthy();
 
@@ -76,7 +88,11 @@ describe('install/uninstall browser scenarios', () => {
 
             // Install a browser
             await expect(
-                browserInstall({ browser: 'chrome', browserVersion: 'non-existent' })
+                browserInstall({
+                    browser: 'chrome',
+                    browserVersion: 'non-existent',
+                    browserCacheDir,
+                })
             ).rejects.toThrow();
 
             // There should now be zero installed browsers
@@ -105,6 +121,7 @@ describe('install/uninstall browser scenarios', () => {
             const browserInstallRes1 = await browserInstall({
                 browser: 'chrome',
                 browserVersion: '114.0.5735.133',
+                browserCacheDir,
             });
             expect(browserInstallRes1).toBeTruthy();
 
@@ -116,6 +133,7 @@ describe('install/uninstall browser scenarios', () => {
             const uninstallRes2 = await browserUninstallAll({
                 browser: 'chrome',
                 browserVersion: '114.0.5735.133',
+                browserCacheDir,
             });
             expect(uninstallRes2).toEqual(true);
 

--- a/src/lib/browser/__tests__/browser_version_resolution.integration.test.js
+++ b/src/lib/browser/__tests__/browser_version_resolution.integration.test.js
@@ -1,4 +1,4 @@
-import { test, expect, describe, beforeAll, afterEach } from '@jest/globals';
+import { test, expect, describe, beforeAll, afterAll, afterEach } from '@jest/globals';
 import 'dotenv/config';
 
 import { browserInstall } from '../browser-install.js';
@@ -8,6 +8,7 @@ import { detectAvailableBrowser } from '../browser-detect.js';
 import { resolveBrowserExecutablePath } from '../browser-launch.js';
 import { resolveBrowserVersion, getRecommendedBuildId } from '../browser-version.js';
 import { assertEnv, getTestTimeout } from '../../util/env-check.js';
+import { makeIsolatedCacheDir, removeIsolatedCacheDir } from '../test-helpers/isolated-cache.js';
 
 // Version resolution against the real Chrome for Testing and Firefox version services, and
 // against a real browser cache on disk. The unit suite covers the same decisions with mocks;
@@ -20,9 +21,20 @@ import { assertEnv, getTestTimeout } from '../../util/env-check.js';
 
 const defaultTestTimeout = getTestTimeout(process.env, 1800000);
 
+// The "cached browser selection" block installs real browsers and clears the cache after every
+// test, so it has to work somewhere other than the developer's own ~/.cache/puppeteer.
+const browserCacheDir = makeIsolatedCacheDir();
+
 const options = {
     loglevel: process.env.BSI_LOG_LEVEL || 'info',
+    browserCacheDir,
 };
+
+// File level rather than per describe: the last block installs a browser and never uninstalls it,
+// so cleanup has to outlive every describe in the file.
+afterAll(() => {
+    removeIsolatedCacheDir(browserCacheDir);
+});
 
 describe('browser version resolution', () => {
     beforeAll(() => {
@@ -117,9 +129,9 @@ describe('browser version resolution', () => {
     ])(
         'a malformed %s version "%s" is rejected up front',
         async (browser, browserVersion) => {
-            await expect(browserInstall({ browser, browserVersion })).rejects.toThrow(
-                /invalid --browser-version/i
-            );
+            await expect(
+                browserInstall({ browser, browserVersion, browserCacheDir })
+            ).rejects.toThrow(/invalid --browser-version/i);
         },
         defaultTestTimeout
     );
@@ -165,8 +177,13 @@ describe('cached browser selection', () => {
             const recommended = await browserInstall({
                 browser: 'chrome',
                 browserVersion: 'recommended',
+                browserCacheDir,
             });
-            const stable = await browserInstall({ browser: 'chrome', browserVersion: 'stable' });
+            const stable = await browserInstall({
+                browser: 'chrome',
+                browserVersion: 'stable',
+                browserCacheDir,
+            });
 
             // Only meaningful while the two keywords point at different builds. When a puppeteer
             // bump makes them coincide there is nothing to tell apart, and the assertions below
@@ -181,10 +198,13 @@ describe('cached browser selection', () => {
             expect(installed.length).toEqual(2);
 
             const foundRecommended = await detectAvailableBrowser(
-                { browser: 'chrome' },
+                { browser: 'chrome', browserCacheDir },
                 recommended.buildId
             );
-            const foundStable = await detectAvailableBrowser({ browser: 'chrome' }, stable.buildId);
+            const foundStable = await detectAvailableBrowser(
+                { browser: 'chrome', browserCacheDir },
+                stable.buildId
+            );
 
             expect(foundRecommended.buildId).toBe(recommended.buildId);
             expect(foundStable.buildId).toBe(stable.buildId);
@@ -201,9 +221,16 @@ describe('cached browser selection', () => {
         'a build that is not cached is reported as absent',
         async () => {
             await browserUninstallAll(options);
-            await browserInstall({ browser: 'chrome', browserVersion: 'recommended' });
+            await browserInstall({
+                browser: 'chrome',
+                browserVersion: 'recommended',
+                browserCacheDir,
+            });
 
-            const found = await detectAvailableBrowser({ browser: 'chrome' }, '99.0.1234.56');
+            const found = await detectAvailableBrowser(
+                { browser: 'chrome', browserCacheDir },
+                '99.0.1234.56'
+            );
 
             expect(found).toBeNull();
         },
@@ -219,7 +246,11 @@ describe('cached browser selection', () => {
         'a browser can be uninstalled by the recommended keyword',
         async () => {
             await browserUninstallAll(options);
-            await browserInstall({ browser: 'chrome', browserVersion: 'recommended' });
+            await browserInstall({
+                browser: 'chrome',
+                browserVersion: 'recommended',
+                browserCacheDir,
+            });
 
             const removed = await browserUninstall({
                 ...options,
@@ -243,7 +274,11 @@ describe('cached browser selection', () => {
         'uninstall refuses a floating keyword and leaves the cache alone',
         async () => {
             await browserUninstallAll(options);
-            await browserInstall({ browser: 'chrome', browserVersion: 'recommended' });
+            await browserInstall({
+                browser: 'chrome',
+                browserVersion: 'recommended',
+                browserCacheDir,
+            });
 
             const removed = await browserUninstall({
                 ...options,
@@ -267,10 +302,18 @@ describe('cached browser selection', () => {
         'a malformed version fails even when a browser is cached',
         async () => {
             await browserUninstallAll(options);
-            await browserInstall({ browser: 'chrome', browserVersion: 'recommended' });
+            await browserInstall({
+                browser: 'chrome',
+                browserVersion: 'recommended',
+                browserCacheDir,
+            });
 
             await expect(
-                resolveBrowserExecutablePath({ browser: 'chrome', browserVersion: 'garbage' })
+                resolveBrowserExecutablePath({
+                    browser: 'chrome',
+                    browserVersion: 'garbage',
+                    browserCacheDir,
+                })
             ).rejects.toThrow(/invalid --browser-version/i);
         },
         defaultTestTimeout
@@ -305,11 +348,12 @@ describe('system browser override', () => {
             const installed = await browserInstall({
                 browser: 'chrome',
                 browserVersion: 'recommended',
+                browserCacheDir,
             });
             process.env.PUPPETEER_EXECUTABLE_PATH = installed.executablePath;
 
             const found = await detectAvailableBrowser(
-                { browser: 'chrome', browserVersion: '99.0.1234.56' },
+                { browser: 'chrome', browserVersion: '99.0.1234.56', browserCacheDir },
                 '99.0.1234.56'
             );
 

--- a/src/lib/browser/test-helpers/isolated-cache.js
+++ b/src/lib/browser/test-helpers/isolated-cache.js
@@ -1,0 +1,40 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * A private browser cache directory for one integration test file.
+ *
+ * The browser integration tests install and uninstall real browsers against a
+ * real filesystem - that is the point of them, and nothing here mocks any of
+ * it. What they must not do is operate on the developer's own cache. Several of
+ * them call `browserUninstallAll`, which finishes with `fs.emptyDir` on the
+ * cache directory, so a run wipes every browser present, including builds that
+ * were staged by hand and that no test installed. That happened on 2026-08-12
+ * and cost a cache holding chrome 114.0.5735.133, chrome 151.0.7922.47 and
+ * firefox stable_153.0.4.
+ *
+ * Passing the returned path as `browserCacheDir` in the options bag of every
+ * browser call in a test file moves all of that into a throwaway directory:
+ * `resolveBrowserCacheDir` in `browser-paths.js` takes that key ahead of every
+ * other tier, so it reaches workers the tests call directly, where the
+ * `--browser-cache-dir` flag never would.
+ *
+ * These tests already began by emptying the cache, so they never ran against a
+ * warm one; moving to a fresh directory therefore downloads no more than before.
+ *
+ * @returns {string} Absolute path to a new empty directory.
+ */
+export const makeIsolatedCacheDir = () => fs.mkdtempSync(path.join(os.tmpdir(), 'bsi-int-'));
+
+/**
+ * Remove a directory created by {@link makeIsolatedCacheDir}.
+ *
+ * `force` keeps this from throwing when a test failed before anything was
+ * installed, so cleanup never masks the real failure.
+ *
+ * @param {string} dir - The directory to remove.
+ *
+ * @returns {void}
+ */
+export const removeIsolatedCacheDir = (dir) => fs.rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
The browser integration tests install and uninstall real browsers against a real filesystem, which is what makes them worth having. They also did that in the developer's own browser cache.

`browser_edge_cases`, `browser_install_uninstall`, `browser_complex_scenarios` and `browser_version_resolution` all call `browserUninstallAll`, which removes every browser present rather than only the ones the test installed. A run therefore deleted builds staged by hand that no test ever installed. On 2026-08-12 this cost a cache holding chrome 114.0.5735.133, chrome 151.0.7922.47 and firefox stable_153.0.4.

Narrowing `uninstall-all` to the cache's own subdirectories, in the `--browser-cache-dir` work merged in #1029, made that deletion safe for an administrator who points the cache at a directory holding other things. It did not make it safe for the developer: every chrome and firefox build in the resolved cache is still removed.

## What this changes

Test files only. No source changes, so no behaviour change for anyone running Butler Sheet Icons.

Each of the four files resolves a per-run temp directory and passes it as `browserCacheDir` in the options bag of every browser call. `resolveBrowserCacheDir` takes that key ahead of every other tier, so it reaches the workers these tests call directly, where the `--browser-cache-dir` flag never would.

Nothing is mocked. Only the directory moves, so the tests still exercise real installs and real removals. They already opened by emptying the cache, so they never ran warm and this downloads no more than before.

Two integration files needed nothing: `browser_uninstall.integration.test.js` mocks `@puppeteer/browsers` wholesale and never touches disk, and `browser_list_installed.integration.test.js` is read-only.

## Verification

A sentinel build was staged under a fake `HOME`, so a failure would cost a temp directory rather than a real cache:

- **On main, unchanged**: sentinel destroyed. The defect reproduces.
- **With this change**: sentinel survives.
- **All six browser integration files, real downloads**: 35 tests pass, sentinel intact, no `bsi-int-*` temp directories left behind.
- Unit suite 2464 passed / 90 suites; lint clean at `--max-warnings 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)