### PR TITLE
Stop dumping stack traces on ordinary failures, and document the Windows-only auth error

### DIFF
--- a/docs/to-doc-site/windows-run-fails-with-invalid-auth-credentials.md
+++ b/docs/to-doc-site/windows-run-fails-with-invalid-auth-credentials.md
@@ -1,0 +1,210 @@
+# QSEoW run fails on Windows with `ERR_INVALID_AUTH_CREDENTIALS`
+
+A run that works from macOS or Linux can fail from Windows with an authentication error, using the
+same command, the same credentials and the same Qlik Sense server. The cause is a Qlik Sense
+virtual proxy setting, not a problem with Butler Sheet Icons, the network, or the credentials.
+
+This is a troubleshooting topic for existing behaviour. There is no new option and nothing to
+upgrade.
+
+## What you see
+
+```
+error: QSEOW: qseowProcessApp: net::ERR_INVALID_AUTH_CREDENTIALS at https://sense.example.com/sense/app/ded8d27d-…
+error: QSEOW PROCESS APP: Failed to process app ded8d27d-…: net::ERR_INVALID_AUTH_CREDENTIALS at https://sense.example.com/sense/app/ded8d27d-…
+error: Failed to process 1 of 1 app(s)
+```
+
+The part to search for is `ERR_INVALID_AUTH_CREDENTIALS`.
+
+::: tip Older versions print more
+Up to and including 4.1.0, the first line reads
+`QSEOW: qseowProcessApp (stack): Error: net::ERR_INVALID_AUTH_CREDENTIALS …` and is followed by a
+stack trace — a long list of lines beginning `at`. That is the same failure, reported more noisily;
+the stack moved to `--loglevel debug` in a later release.
+:::
+
+Everything before this point succeeds, which is what makes the failure confusing. The log will
+already have shown that Butler Sheet Icons connected to the server, opened the app, read its name
+and counted its sheets:
+
+```
+info: Created session to server sense.example.com, engine version is 12.2759.8
+info: Opened app ded8d27d-…
+info: App name: "Employee salaries"
+info: Number of sheets in app: 1
+info: Browser setup complete. Launching browser...
+```
+
+Those steps use the certificates supplied with `--certfile` and `--certkeyfile`, and they are
+working. It is only the **browser** that cannot get in.
+
+::: tip A line that is not the cause
+A `warning` about the engine session being *"closed from the other end, code 1000"* usually appears
+just before the error. It appears in successful runs too. It is a side effect of the run ending,
+not the reason it failed.
+:::
+
+## Why it happens on Windows and not on macOS
+
+Butler Sheet Icons signs in to Qlik Sense the same way a person does: it opens a browser, waits for
+the login page, and types the user name and password from `--logonuserdir`, `--logonuserid` and
+`--logonpwd`.
+
+A Qlik Sense virtual proxy does not always serve that login page. Each virtual proxy has a setting
+called **Windows authentication pattern**, and Qlik Sense matches it against the **User-Agent** that
+the browser sends — the piece of text in which a browser states what it is and which operating
+system it runs on. The default value of that setting is the word `Windows`.
+
+A browser running on Windows announces itself with a User-Agent containing `Windows NT`. That
+matches the default pattern, so Qlik Sense decides this visitor should use Windows authentication
+and sends the browser to an NTLM login instead of the login page:
+
+| Butler Sheet Icons runs on | User-Agent contains | Qlik Sense sends the browser to |
+| --- | --- | --- |
+| macOS | `Macintosh; Intel Mac OS X` | `/internal_forms_authentication/` — the login page |
+| Linux | `X11; Linux x86_64` | `/internal_forms_authentication/` — the login page |
+| Windows | `Windows NT 10.0; Win64; x64` | `/internal_windows_authentication` — NTLM |
+
+Butler Sheet Icons cannot complete an NTLM login. The browser it runs has no window and no way to
+ask anyone for credentials, so Windows quietly offers whatever account the machine is signed in as.
+On a machine that is not domain-joined — or is signed in as the wrong user — Qlik Sense rejects
+that account, the browser has nothing else to offer, and it gives up with
+`ERR_INVALID_AUTH_CREDENTIALS`.
+
+The same command from macOS never matches the pattern, gets the login page, and works.
+
+## The fix
+
+Run Butler Sheet Icons against a virtual proxy whose **Windows authentication pattern** cannot match
+a browser. The convention is to set it to `Form`, because no browser's User-Agent contains that
+word, so every visitor is given the login page.
+
+::: warning Use a separate virtual proxy — do not change your existing one
+Changing the pattern on the virtual proxy your users log in through will **turn off Windows
+single sign-on for all of them**. They will get a login page instead of being signed in
+automatically.
+
+Create a virtual proxy for Butler Sheet Icons instead, and leave the one your users rely on alone.
+:::
+
+In the QMC:
+
+1. Go to **Virtual proxies** and create a new virtual proxy, or select an existing one used only for
+   this purpose.
+2. Under **IDENTIFICATION**, give it a **Prefix**. Any valid prefix will do — the name has no
+   meaning to Butler Sheet Icons. The examples below use `form`.
+3. Under **AUTHENTICATION**, set **Windows authentication pattern** to `Form`.
+4. Leave **Authentication method** as `Ticket`. This is not the setting that needs changing, and a
+   proxy that already says `Ticket` can still send Windows users to NTLM — the pattern is what
+   decides.
+5. Link the virtual proxy to your proxy service, and apply the changes.
+
+Then tell Butler Sheet Icons to use it, with the prefix you chose:
+
+```
+--prefix form
+```
+
+or as an environment variable:
+
+```
+BSI_QSEOW_CST_PREFIX=form
+```
+
+::: warning The prefix is not the fix
+`--prefix form` on its own changes nothing. A virtual proxy called `form` whose **Windows
+authentication pattern** is still `Windows` fails in exactly the same way. The pattern is what
+matters; the prefix just tells Butler Sheet Icons which proxy to use.
+:::
+
+## Checking a virtual proxy without running Butler Sheet Icons
+
+You can ask the server directly which login it would offer. The important part is to send a Windows
+User-Agent — otherwise the tool you test with gets the login page regardless, and the test tells you
+nothing.
+
+Replace the host, the prefix and the app ID with your own. Omit the `/form` part to test the default
+virtual proxy.
+
+```powershell
+curl.exe -sk -o NUL -D - -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64)" `
+  "https://sense.example.com/form/sense/app/ded8d27d-…"
+```
+
+```bash
+curl -sk -o /dev/null -D - -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64)" \
+  "https://sense.example.com/form/sense/app/ded8d27d-…"
+```
+
+Read the `Location:` line in the reply:
+
+| `Location` contains | Meaning |
+| --- | --- |
+| `internal_forms_authentication` | The login page. Butler Sheet Icons will work through this proxy. |
+| `internal_windows_authentication` | NTLM. Butler Sheet Icons will fail with `ERR_INVALID_AUTH_CREDENTIALS`. |
+
+On Windows, use `curl.exe` rather than `curl` — in PowerShell, `curl` is a built-in alias for
+something else and does not accept these options.
+
+## What this means in general
+
+Butler Sheet Icons always expects the Qlik Sense login page. It cannot use Windows authentication at
+all — not from a domain-joined machine, and not with a correct domain account. On a virtual proxy
+that serves NTLM, a run either fails as described above or, if Windows single sign-on happens to
+succeed, fails while waiting for a login page that never appears.
+
+A virtual proxy that serves the login page to every visitor is therefore a requirement for
+Butler Sheet Icons, on every platform. It only becomes visible on Windows, because that is the only
+platform where the default pattern matches.
+
+---
+
+<!-- Notes for the publishing pass — not for the site -->
+
+## For the publisher
+
+**Version gate:** none for the cause and the fix — the Qlik Sense behaviour described here has
+always been the case.
+
+**But the quoted log output is version-dependent**, so check it before publishing. The stack-trace
+cleanup that ships alongside this page changes the first line: through 4.1.0 it is
+`QSEOW: qseowProcessApp (stack): Error: net::ERR_…` followed by the full stack, and after that
+release it is `QSEOW: qseowProcessApp: net::ERR_…` with the stack moved to `--loglevel debug`. The
+page shows the newer form with a callout for the older one, since readers will arrive from a
+console search. Confirm which release the cleanup landed in and name it in the callout rather than
+leaving "a later release".
+
+**Verified against the implementation** and against a live QSEoW 12.2759.8 server:
+
+- The redirect difference was confirmed by requesting the same app URL twice, changing only the
+  User-Agent. `/internal_windows_authentication/` answers `401 WWW-Authenticate: NTLM`.
+- The QRS API confirms the two proxies involved. Both have `authenticationMethod: 0` (Ticket); they
+  differ only in `windowsAuthenticationEnabledDevicePattern`, which is `Windows` on the default
+  proxy and `Form` on the working one. This is why step 4 above tells the reader not to touch
+  **Authentication method**.
+- `--prefix <prefix>` / `BSI_QSEOW_CST_PREFIX`, default `''`, confirmed in
+  `src/lib/commands/qseow/index.js`.
+- The quoted error lines are verbatim from a real failing run.
+
+**Suggested placement.** Prefer editing `docs/guide/troubleshooting.md` over adding a page:
+
+- Add this as a symptom-keyed subsection under **QSEoW Authentication Problems**, and add
+  `net::ERR_INVALID_AUTH_CREDENTIALS` to that section's **Symptoms** list — today it lists only
+  "Certificate errors / Access denied / Connection timeouts", none of which an admin hitting this
+  would match on.
+- That section already carries a `--prefix form` snippet under *Virtual Proxy Configuration*,
+  commented `# Ensure you're using form-based authentication`. It is correct but unexplained, and
+  reads as though a proxy named `form` is a Sense built-in. Replace it with a pointer to the new
+  subsection.
+- Cross-link from **Browser Login and Navigation Issues**, whose listed symptom "Login page loads
+  but credentials aren't entered" is what an admin may well match on first.
+
+**Screenshot.** A QMC screenshot of the field is available from the investigation — *Edit virtual
+proxy* showing description `Central node, Windows form auth`, prefix `form`, **Authentication
+method** `Ticket` and **Windows authentication pattern** `Form`. Worth including at step 3; the
+field is easy to miss among the other AUTHENTICATION settings.
+
+**Known limitation worth an issue.** The failure message names neither the virtual proxy nor the
+pattern, so nothing in the output points an admin here. Making Butler Sheet Icons recognise
+`ERR_INVALID_AUTH_CREDENTIALS` and say so is tracked separately.

--- a/src/lib/browser/browser-launch.js
+++ b/src/lib/browser/browser-launch.js
@@ -13,6 +13,7 @@ import {
 } from './browser-version.js';
 import { parseHeadlessOption } from '../util/headless-option.js';
 import { markReported } from '../util/reported-error.js';
+import { logError } from '../util/log-error.js';
 
 /**
  * Chromium flags used for every Butler Sheet Icons browser launch.
@@ -409,11 +410,7 @@ export const launchBrowserForApp = async (options, { appId, logPrefix, appLabel,
             args: browserArgs,
         });
     } catch (err) {
-        // Falls back to the value itself so a non-Error throw still logs something useful
-        // rather than "undefined".
-        logger.error(
-            `${logPrefix}: Could not launch virtual browser: ${err?.stack || err?.message || err}`
-        );
+        logError(`${logPrefix}: Could not launch virtual browser`, err);
 
         // A launch timeout reads like any other launch failure in the log, but the remedy is
         // completely different - nothing is wrong with the arguments or the certificate setup,
@@ -496,8 +493,6 @@ export const closeBrowserQuietly = async (browser, logPrefix) => {
         await browser.close();
         logger.verbose('Closed virtual browser');
     } catch (err) {
-        logger.error(
-            `${logPrefix}: Could not close virtual browser: ${err?.stack || err?.message || err}`
-        );
+        logError(`${logPrefix}: Could not close virtual browser`, err);
     }
 };

--- a/src/lib/cloud/cloud-collections.js
+++ b/src/lib/cloud/cloud-collections.js
@@ -4,6 +4,7 @@ import { redactOptions } from '../util/redact-secrets.js';
 import QlikSaas from './cloud-repo.js';
 import { qscloudTestConnection } from './cloud-test-connection.js';
 import { listCollections } from './cloud-apps.js';
+import { logError } from '../util/log-error.js';
 
 /**
  * Lists all available collections in the Qlik Sense Cloud tenant.
@@ -37,13 +38,7 @@ export const qscloudListCollections = async (options) => {
         try {
             saasInstance = new QlikSaas(cloudConfig);
         } catch (err) {
-            if (err.stack) {
-                logger.error(`LIST COLLECTIONS 1 (stack): ${err.stack}`);
-            } else if (err.message) {
-                logger.error(`LIST COLLECTIONS 1 (message): ${err.message}`);
-            } else {
-                logger.error(`LIST COLLECTIONS 1: ${err}`);
-            }
+            logError('LIST COLLECTIONS 1', err);
 
             return false;
         }
@@ -55,13 +50,12 @@ export const qscloudListCollections = async (options) => {
                 `Connection to tenant ${options.tenanturl} successful: ${JSON.stringify(res)}`
             );
         } catch (err) {
-            if (err.stack) {
-                logger.error(`LIST COLLECTIONS 1 (stack): ${err.stack}`);
-            } else if (err.message) {
-                logger.error(`LIST COLLECTIONS 1 (message): ${err.message}`);
+            logError('LIST COLLECTIONS 1', err);
+            // Both halves required: this line used to sit in a branch that a real Error never
+            // reached, so it never printed. Now that it does, a status without a statusText
+            // would render as 401="undefined".
+            if (err?.status && err?.statusText) {
                 logger.error(`LIST COLLECTIONS 1 (error code): ${err.status}="${err.statusText}"`);
-            } else {
-                logger.error(`LIST COLLECTIONS 1: ${err}`);
             }
 
             return false;
@@ -72,13 +66,7 @@ export const qscloudListCollections = async (options) => {
         try {
             allCollections = await listCollections(saasInstance);
         } catch (err) {
-            if (err.stack) {
-                logger.error(`LIST COLLECTIONS 2 (stack): ${err.stack}`);
-            } else if (err.message) {
-                logger.error(`LIST COLLECTIONS 2 (message): ${err.message}`);
-            } else {
-                logger.error(`LIST COLLECTIONS 2: ${err}`);
-            }
+            logError('LIST COLLECTIONS 2', err);
             return false;
         }
 
@@ -125,13 +113,7 @@ export const qscloudListCollections = async (options) => {
 
         return true;
     } catch (err) {
-        if (err.stack) {
-            logger.error(`LIST COLLECTIONS 3 (stack): ${err.stack}`);
-        } else if (err.message) {
-            logger.error(`LIST COLLECTIONS 3 (message): ${err.message}`);
-        } else {
-            logger.error(`LIST COLLECTIONS 3: ${err}`);
-        }
+        logError('LIST COLLECTIONS 3', err);
 
         return false;
     }
@@ -175,13 +157,7 @@ export const qscloudVerifyCollectionExists = async (options) => {
             return true;
         }
     } catch (err) {
-        if (err.stack) {
-            logger.error(`CLOUD COLLECTION EXISTS 1 (stack): ${err.stack}`);
-        } else if (err.message) {
-            logger.error(`CLOUD COLLECTION EXISTS 1 (message): ${err.message}`);
-        } else {
-            logger.error(`CLOUD COLLECTION EXISTS 1: ${err}`);
-        }
+        logError('CLOUD COLLECTION EXISTS 1', err);
 
         throw new Error(`COLLECTION EXISTS 1: ${err}`, { cause: err });
     }

--- a/src/lib/cloud/cloud-create-thumbnails.js
+++ b/src/lib/cloud/cloud-create-thumbnails.js
@@ -7,6 +7,7 @@ import { runOverApps } from '../util/run-over-apps.js';
 import { listAppsByCollection } from './cloud-apps.js';
 import { toAppIdList } from '../util/app-ids.js';
 import { CLOUD_SHEET_PARTS } from './sheet-parts.js';
+import { logError } from '../util/log-error.js';
 
 /**
  * Create thumbnails for Qlik Sense Cloud (QSC).
@@ -94,17 +95,9 @@ export const qscloudCreateThumbnails = async (options) => {
                 `Connection to tenant ${options.tenanturl} successful: ${JSON.stringify(res)}`
             );
         } catch (err) {
-            if (err.stack) {
-                logger.error(`TEST CONNECTIVITY 1 (stack): ${err.stack}`);
-            } else if (err.message) {
-                logger.error(`TEST CONNECTIVITY 1 (message): ${err.message}`);
-                if (err.status && err.statusText) {
-                    logger.error(
-                        `TEST CONNECTIVITY 1 (error code): ${err.status}="${err.statusText}"`
-                    );
-                }
-            } else {
-                logger.error(`TEST CONNECTIVITY 1: ${err}`);
+            logError('TEST CONNECTIVITY 1', err);
+            if (err?.status && err?.statusText) {
+                logger.error(`TEST CONNECTIVITY 1 (error code): ${err.status}="${err.statusText}"`);
             }
 
             return false;
@@ -131,13 +124,7 @@ export const qscloudCreateThumbnails = async (options) => {
             (appId) => processCloudApp(appId, saasInstance, options)
         );
     } catch (err) {
-        if (err.stack) {
-            logger.error(`CLOUD CREATE THUMBNAILS 2 (stack): ${err.stack}`);
-        } else if (err.message) {
-            logger.error(`CLOUD CREATE THUMBNAILS 2 (message): ${err.message}`);
-        } else {
-            logger.error(`CLOUD CREATE THUMBNAILS 2: ${JSON.stringify(err, null, 2)}`);
-        }
+        logError('CLOUD CREATE THUMBNAILS 2', err);
 
         return false;
     }

--- a/src/lib/cloud/cloud-delete-thumbnails.js
+++ b/src/lib/cloud/cloud-delete-thumbnails.js
@@ -20,12 +20,14 @@ export async function deleteCloudAppThumbnail(thumbnailImg, appId, saasInstance,
             `Deleted existing file ${thumbnailImg.name}, result=${JSON.stringify(result)}`
         );
     } catch (err) {
-        if (err.stack) {
-            logger.error(`CREATE THUMBNAILS 3 (stack): ${err.stack}`);
-        } else if (err.message) {
-            logger.error(`CREATE THUMBNAILS 3 (message): ${err.message}`);
-        } else {
-            logger.error(`CREATE THUMBNAILS 3: Error deleting existing thumbnail: ${err}`);
+        // Applies the same split as `logError` in ../util/log-error.js, but through the logger
+        // this function is given rather than the global one. The injected logger is this
+        // function's contract with its caller, so the shared helper is deliberately not used.
+        logger.error(
+            `CREATE THUMBNAILS 3: Error deleting existing thumbnail: ${err?.message ?? err}`
+        );
+        if (err?.stack) {
+            logger.debug(err.stack);
         }
         throw new Error('Error deleting existing thumbnail', { cause: err });
     }

--- a/src/lib/cloud/cloud-remove-sheet-icons.js
+++ b/src/lib/cloud/cloud-remove-sheet-icons.js
@@ -15,6 +15,7 @@ import {
 import { withEngineSession } from '../util/engine-session.js';
 import { listAppsByCollection } from './cloud-apps.js';
 import { toAppIdList } from '../util/app-ids.js';
+import { logError } from '../util/log-error.js';
 
 /**
  * Removes all sheet icons from a Qlik Sense Cloud app.
@@ -141,13 +142,7 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
 
         logger.info(`Done processing app ${appId}`);
     } catch (err) {
-        if (err.stack) {
-            logger.error(`CLOUD REMOVE SHEET ICONS 1 (stack): ${err.stack}`);
-        } else if (err.message) {
-            logger.error(`CLOUD REMOVE SHEET ICONS 1 (message): ${err.message}`);
-        } else {
-            logger.error(`CLOUD REMOVE SHEET ICONS 1: ${err}`);
-        }
+        logError('CLOUD REMOVE SHEET ICONS 1', err);
         // Rethrow so the app loop can count this app as failed. Logging and returning
         // normally made a run in which every app failed look exactly like a clean run.
         throw err;
@@ -195,15 +190,14 @@ export const qscloudRemoveSheetIcons = async (options) => {
                 `Connection to tenant ${options.tenanturl} successful: ${JSON.stringify(res)}`
             );
         } catch (err) {
-            if (err.stack) {
-                logger.error(`CLOUD REMOVE SHEET ICONS: connection test (stack): ${err.stack}`);
-            } else if (err.message) {
-                logger.error(`CLOUD REMOVE SHEET ICONS: connection test (message): ${err.message}`);
+            logError('CLOUD REMOVE SHEET ICONS: connection test', err);
+            // Both halves required: this line used to sit in a branch that a real Error never
+            // reached, so it never printed. Now that it does, a status without a statusText
+            // would render as 401="undefined".
+            if (err?.status && err?.statusText) {
                 logger.error(
                     `CLOUD REMOVE SHEET ICONS: connection test (error code): ${err.status}="${err.statusText}"`
                 );
-            } else {
-                logger.error(`CLOUD REMOVE SHEET ICONS: connection test: ${err}`);
             }
 
             return false;
@@ -230,13 +224,7 @@ export const qscloudRemoveSheetIcons = async (options) => {
             (appId) => removeSheetIconsCloudApp(appId, saasInstance, options)
         );
     } catch (err) {
-        if (err.stack) {
-            logger.error(`CLOUD REMOVE THUMBNAILS 3 (stack): ${err.stack}`);
-        } else if (err.message) {
-            logger.error(`CLOUD REMOVE THUMBNAILS 3 (message): ${err.message}`);
-        } else {
-            logger.error(`CLOUD REMOVE THUMBNAILS 3: ${JSON.stringify(err, null, 2)}`);
-        }
+        logError('CLOUD REMOVE THUMBNAILS 3', err);
 
         return false;
     }

--- a/src/lib/cloud/cloud-updatesheets.js
+++ b/src/lib/cloud/cloud-updatesheets.js
@@ -2,6 +2,7 @@ import { setupEnigmaConnection } from './cloud-enigma.js';
 import { logger } from '../../globals.js';
 import { CloudError } from '../util/errors.js';
 import { withEngineSession } from '../util/engine-session.js';
+import { logError } from '../util/log-error.js';
 import {
     runOverSheets,
     SHEET_SKIPPED,
@@ -209,13 +210,7 @@ export const qscloudUpdateSheetThumbnails = async (createdFiles, appId, options)
             `Closed session after updating sheet thumbnail images in QS Cloud app ${appId} on tenant ${options.tenanturl}`
         );
     } catch (err) {
-        if (err.stack) {
-            logger.error(`CLOUD UPDATE SHEETS (stack): ${err.stack}`);
-        } else if (err.message) {
-            logger.error(`CLOUD UPDATE SHEETS (stack): ${err.message}`);
-        } else {
-            logger.error(`CLOUD UPDATE SHEETS: ${JSON.stringify(err, null, 2)}`);
-        }
+        logError('CLOUD UPDATE SHEETS', err);
 
         throw new CloudError(`Failed to update sheet thumbnails in app ${appId}`, { cause: err });
     }

--- a/src/lib/cloud/cloud-upload.js
+++ b/src/lib/cloud/cloud-upload.js
@@ -4,6 +4,7 @@ import path from 'path';
 import { logger, setLoggingLevel } from '../../globals.js';
 import { CloudError } from '../util/errors.js';
 import QlikSaas from './cloud-repo.js';
+import { logError } from '../util/log-error.js';
 
 /**
  * Uploads image files to a Qlik Sense Cloud app.
@@ -112,23 +113,11 @@ export const qscloudUploadToApp = async (filesToUpload, appId, options) => {
                 }
             } catch (err) {
                 failedCount += 1;
-                logger.error(`CLOUD UPLOAD 1: ${JSON.stringify(err, null, 2)}`);
-                if (err.message) {
-                    logger.error(`CLOUD UPLOAD 1 (message): ${err.message}`);
-                }
-                if (err.stack) {
-                    logger.error(`CLOUD UPLOAD 1 (stack): ${err.stack}`);
-                }
+                logError('CLOUD UPLOAD 1', err);
             }
         }
     } catch (err) {
-        if (err.stack) {
-            logger.error(`CLOUD UPLOAD 2 (stack): ${err.stack}`);
-        } else if (err.message) {
-            logger.error(`CLOUD UPLOAD 2 (message): ${err.message}`);
-        } else {
-            logger.error(`CLOUD UPLOAD 2: ${JSON.stringify(err, null, 2)}`);
-        }
+        logError('CLOUD UPLOAD 2', err);
 
         // Rethrow: returning normally here told the caller every image was in place, and
         // it went on to point every sheet at files that had never been uploaded.

--- a/src/lib/cloud/process-cloud-app.js
+++ b/src/lib/cloud/process-cloud-app.js
@@ -16,6 +16,7 @@ import {
 import { withEngineSession } from '../util/engine-session.js';
 import { createAppImageDir } from '../util/image-dir.js';
 import { determineSheetExcludeStatus } from './determine-sheet-exclude-status.js';
+import { logError } from '../util/log-error.js';
 
 // Selector paths to elements on login page
 const selectorLoginPageUserName = '[id="\u0031-email"]';
@@ -71,13 +72,7 @@ export const processCloudApp = async (appId, saasInstance, options) => {
                 );
                 existingThumbnails = await saasInstance.Get(`apps/${appId}/media/list/thumbnails`);
             } catch (err) {
-                if (err.stack) {
-                    logger.error(`CREATE THUMBNAILS 2 (stack): ${err.stack}`);
-                } else if (err.message) {
-                    logger.error(`CREATE THUMBNAILS 2 (message): ${err.message}`);
-                } else {
-                    logger.error(`CREATE THUMBNAILS 2: Error getting existing thumbnails: ${err}`);
-                }
+                logError('CREATE THUMBNAILS 2: Error getting existing thumbnails', err);
                 throw new Error('Error getting existing thumbnails', { cause: err });
             }
 
@@ -270,13 +265,7 @@ export const processCloudApp = async (appId, saasInstance, options) => {
         await qscloudUpdateSheetThumbnails(createdFiles, appId, options);
         logger.info(`Done processing app ${appId}`);
     } catch (err) {
-        if (err.stack) {
-            logger.error(`CLOUD APP (stack): ${err.stack}`);
-        } else if (err.message) {
-            logger.error(`CLOUD APP (message): ${err.message}`);
-        } else {
-            logger.error(`CLOUD APP: ${err.stack}`);
-        }
+        logError('CLOUD APP', err);
         // Rethrow so the app loop can count this app as failed. Logging and returning
         // normally made a run in which every app failed look exactly like a clean run.
         throw err;

--- a/src/lib/cloud/sheet-screenshot.js
+++ b/src/lib/cloud/sheet-screenshot.js
@@ -70,12 +70,14 @@ export async function takeSheetScreenshot(
             fileNameShortBlurred,
         };
     } catch (err) {
-        logger.error(`Failed to create blurred image: ${err}`);
-        if (err.message) {
-            logger.error(`CREATE BLURRED IMAGE (message): ${err.message}`);
-        }
-        if (err.stack) {
-            logger.error(`CREATE BLURRED IMAGE (stack): ${err.stack}`);
+        // Applies the same split as `logError` in ../util/log-error.js, but through the logger
+        // this function is given rather than the global one. The injected logger is this
+        // function's contract with its caller, so the shared helper is deliberately not used.
+        logger.error(
+            `CREATE BLURRED IMAGE: Failed to create blurred image: ${err?.message ?? err}`
+        );
+        if (err?.stack) {
+            logger.debug(err.stack);
         }
 
         // Fail the sheet rather than fall back to the unblurred screenshot. --blur-sheet-*

--- a/src/lib/commands/run-command.js
+++ b/src/lib/commands/run-command.js
@@ -1,4 +1,5 @@
 import { logger } from '../../globals.js';
+import { logError } from '../util/log-error.js';
 
 /**
  * Runs a command implementation on behalf of a Commander action handler, and makes its
@@ -43,13 +44,7 @@ export const runCommand = async (logPrefix, run, onError) => {
             return false;
         }
 
-        logger.error(`${logPrefix}: ${err}`);
-        if (err?.message) {
-            logger.error(`${logPrefix} (message): ${err.message}`);
-        }
-        if (err?.stack) {
-            logger.error(`${logPrefix} (stack): ${err.stack}`);
-        }
+        logError(logPrefix, err);
 
         return false;
     }

--- a/src/lib/qseow/qseow-certificates.js
+++ b/src/lib/qseow/qseow-certificates.js
@@ -3,6 +3,7 @@ import { promises as Fs, constants as FsConstants } from 'fs';
 
 import { logger, bsiExecutablePath } from '../../globals.js';
 import { CertError } from '../util/errors.js';
+import { logError } from '../util/log-error.js';
 
 /**
  * Checks that a file exists and can actually be read.
@@ -83,9 +84,7 @@ export const qseowVerifyCertificatesExist = async (options) => {
         // Rethrown rather than folded into `false`: the caller reports `false` as a missing
         // file, which would send the operator looking for a certificate that is present and
         // merely unreadable.
-        logger.error(
-            `QSEOW CERT CHECK: Could not check the certificate files: ${err?.stack || err?.message || err}`
-        );
+        logError('QSEOW CERT CHECK: Could not check the certificate files', err);
 
         throw new CertError('Could not read the Qlik Sense certificate files', { cause: err });
     }

--- a/src/lib/qseow/qseow-contentlibrary.js
+++ b/src/lib/qseow/qseow-contentlibrary.js
@@ -4,6 +4,7 @@ import { logger } from '../../globals.js';
 import { setupQseowQrsConnection } from './qseow-qrs.js';
 import { qrsGetList } from './qrs-response.js';
 import { qrsFilterAnyOf, qrsPathWithFilter } from './qrs-filter.js';
+import { logError } from '../util/log-error.js';
 
 /**
  * Verifies if a specified content library exists in Qlik Sense Enterprise on Windows (QSEoW).
@@ -43,13 +44,7 @@ export const qseowVerifyContentLibraryExists = async (options) => {
         logger.debug(`Content library '${contentlibrary}' does not exist`);
         return false;
     } catch (err) {
-        if (err.stack) {
-            logger.error(`QSEOW CONTENT LIBRARY 1 (stack): ${err.stack}`);
-        } else if (err.message) {
-            logger.error(`QSEOW CONTENT LIBRARY 1 (message): ${err.message}`);
-        } else {
-            logger.error(`QSEOW CONTENT LIBRARY 1: ${err}`);
-        }
+        logError('QSEOW CONTENT LIBRARY 1', err);
 
         throw new Error(`CONTENT LIBRARY 1: ${err}`, { cause: err });
     }

--- a/src/lib/qseow/qseow-create-thumbnails.js
+++ b/src/lib/qseow/qseow-create-thumbnails.js
@@ -7,6 +7,7 @@ import { runOverApps } from '../util/run-over-apps.js';
 import { listAppsByTag } from './qseow-app-lookup.js';
 import { toAppIdList } from '../util/app-ids.js';
 import { QSEOW_SHEET_PARTS } from './sheet-parts.js';
+import { logError } from '../util/log-error.js';
 
 /**
  * Create thumbnails for Qlik Sense Enterprise on Windows (QSEoW).
@@ -95,13 +96,7 @@ export const qseowCreateThumbnails = async (options) => {
             (appId) => qseowProcessApp(appId, options)
         );
     } catch (err) {
-        if (err.stack) {
-            logger.error(`QSEOW CREATE THUMBNAILS 2 (stack): ${err.stack}`);
-        } else if (err.message) {
-            logger.error(`QSEOW CREATE THUMBNAILS 2 (message): ${err.message}`);
-        } else {
-            logger.error(`QSEOW CREATE THUMBNAILS 2: ${err}`);
-        }
+        logError('QSEOW CREATE THUMBNAILS 2', err);
 
         return false;
     }

--- a/src/lib/qseow/qseow-process-app.js
+++ b/src/lib/qseow/qseow-process-app.js
@@ -21,6 +21,7 @@ import { qrsGetList } from './qrs-response.js';
 import { QSEOW_SHEET_PART_SELECTORS } from './sheet-parts.js';
 import { qseowLogout } from './qseow-logout.js';
 import { getQseowHubSelectors } from './qseow-selectors.js';
+import { logError } from '../util/log-error.js';
 
 /**
  * Looks up the sheets in an app that carry any of the supplied tags.
@@ -421,17 +422,10 @@ export const qseowProcessApp = async (appId, options) => {
                                     });
                                     logger.verbose(`Created blurred image: ${fileNameBlurred}`);
                                 } catch (err) {
-                                    logger.error(`Failed to create blurred image: ${err}`);
-                                    if (err.message) {
-                                        logger.error(
-                                            `QSEOW CREATE BLURRED IMAGE (message): ${err.message}`
-                                        );
-                                    }
-                                    if (err.stack) {
-                                        logger.error(
-                                            `QSEOW CREATE BLURRED IMAGE (stack): ${err.stack}`
-                                        );
-                                    }
+                                    logError(
+                                        'QSEOW CREATE BLURRED IMAGE: Failed to create blurred image',
+                                        err
+                                    );
 
                                     // Drop this sheet entirely rather than leave the unblurred entry
                                     // behind. The blur decision is made later, in updatesheets, from
@@ -496,13 +490,7 @@ export const qseowProcessApp = async (appId, options) => {
 
         logger.info(`Done processing app ${appId}`);
     } catch (err) {
-        if (err.stack) {
-            logger.error(`QSEOW: qseowProcessApp (stack): ${err.stack}`);
-        } else if (err.message) {
-            logger.error(`QSEOW: qseowProcessApp (message): ${err.message}`);
-        } else {
-            logger.error(`QSEOW: qseowProcessApp: ${err}`);
-        }
+        logError('QSEOW: qseowProcessApp', err);
         // Rethrow so the app loop can count this app as failed. Logging and returning
         // normally made a run in which every app failed look exactly like a clean run.
         throw err;

--- a/src/lib/qseow/qseow-remove-sheet-icons.js
+++ b/src/lib/qseow/qseow-remove-sheet-icons.js
@@ -14,6 +14,7 @@ import { runOverApps } from '../util/run-over-apps.js';
 import { listAppsByTag } from './qseow-app-lookup.js';
 import { toAppIdList } from '../util/app-ids.js';
 import { withEngineSession } from '../util/engine-session.js';
+import { logError } from '../util/log-error.js';
 
 /**
  * Removes all sheet icons from a Qlik Sense Enterprise on Windows (QSEoW) application.
@@ -108,13 +109,7 @@ const removeSheetIconsQSEoWApp = async (appId, g, options) => {
 
         logger.info(`Done processing app ${appId}`);
     } catch (err) {
-        if (err.stack) {
-            logger.error(`QSEOW: removeSheetIconsQSEoWApp (stack): ${err.stack}`);
-        } else if (err.message) {
-            logger.error(`QSEOW: removeSheetIconsQSEoWApp (message): ${err.message}`);
-        } else {
-            logger.error(`QSEOW: removeSheetIconsQSEoWApp: ${err}`);
-        }
+        logError('QSEOW: removeSheetIconsQSEoWApp', err);
         // Rethrow so the app loop can count this app as failed. Logging and returning
         // normally made a run in which every app failed look exactly like a clean run.
         throw err;
@@ -180,13 +175,7 @@ export const qseowRemoveSheetIcons = async (options) => {
             (appId) => removeSheetIconsQSEoWApp(appId, global, options)
         );
     } catch (err) {
-        logger.error(`QSEOW REMOVE THUMBNAILS 2: ${err}`);
-        if (err.message) {
-            logger.error(`QSEOW REMOVE THUMBNAILS 2 (message): ${err.message}`);
-        }
-        if (err.stack) {
-            logger.error(`QSEOW REMOVE THUMBNAILS 2 (stack): ${err.stack}`);
-        }
+        logError('QSEOW REMOVE THUMBNAILS 2', err);
 
         return false;
     }

--- a/src/lib/qseow/qseow-updatesheets.js
+++ b/src/lib/qseow/qseow-updatesheets.js
@@ -2,6 +2,7 @@ import { setupEnigmaConnection } from './qseow-enigma.js';
 import { logger } from '../../globals.js';
 import { QseowError } from '../util/errors.js';
 import { withEngineSession } from '../util/engine-session.js';
+import { logError } from '../util/log-error.js';
 import {
     isSheetTagged,
     runOverSheets,
@@ -207,13 +208,7 @@ export const qseowUpdateSheetThumbnails = async (
             `Closed session after updating sheet thumbnail images in QSEoW app ${appId} on host ${options.host}`
         );
     } catch (err) {
-        if (err.stack) {
-            logger.error(`QSEOW UPDATE SHEETS (stack): ${err.stack}`);
-        } else if (err.message) {
-            logger.error(`QSEOW UPDATE SHEETS (message): ${err.message}`);
-        } else {
-            logger.error(`QSEOW UPDATE SHEETS: ${JSON.stringify(err, null, 2)}`);
-        }
+        logError('QSEOW UPDATE SHEETS', err);
 
         throw new QseowError(`Failed to update sheet thumbnails in app ${appId}`, { cause: err });
     }

--- a/src/lib/qseow/qseow-upload.js
+++ b/src/lib/qseow/qseow-upload.js
@@ -5,6 +5,7 @@ import qrsInteract from 'qrs-interact';
 import { logger, setLoggingLevel } from '../../globals.js';
 import { QseowError } from '../util/errors.js';
 import { setupQseowQrsConnection } from './qseow-qrs.js';
+import { logError } from '../util/log-error.js';
 
 /**
  * Upload files to a Qlik Sense Enterprise on Windows (QSEoW) content library.
@@ -94,23 +95,11 @@ export const qseowUploadToContentLibrary = async (filesToUpload, appId, options)
                 }
             } catch (err) {
                 failedCount += 1;
-                if (err.stack) {
-                    logger.error(`QSEOW UPLOAD 1 (stack): ${err.stack}`);
-                } else if (err.message) {
-                    logger.error(`QSEOW UPLOAD 1 (message): ${err.message}`);
-                } else {
-                    logger.error(`QSEOW UPLOAD 1: ${JSON.stringify(err, null, 2)}`);
-                }
+                logError('QSEOW UPLOAD 1', err);
             }
         }
     } catch (err) {
-        if (err.stack) {
-            logger.error(`QSEOW UPLOAD 2 (stack): ${err.stack}`);
-        } else if (err.message) {
-            logger.error(`QSEOW UPLOAD 2 (message): ${err.message}`);
-        } else {
-            logger.error(`QSEOW UPLOAD 2: ${JSON.stringify(err, null, 2)}`);
-        }
+        logError('QSEOW UPLOAD 2', err);
 
         // Rethrow: returning normally here told the caller every image was in place, and
         // it went on to point every sheet at files that had never been uploaded.

--- a/src/lib/util/__tests__/log-error.test.js
+++ b/src/lib/util/__tests__/log-error.test.js
@@ -98,6 +98,110 @@ describe('logError', () => {
         expect(() => logError('CTX', err)).not.toThrow();
     });
 
+    // The typed errors in ../errors.js are thrown with { cause } throughout, so the reason a
+    // reader actually needs is usually one level down from the message.
+    describe('cause chain', () => {
+        test('appends the underlying cause', () => {
+            const err = new Error('Failed to update sheet thumbnails in app abc', {
+                cause: new Error('Not connected'),
+            });
+
+            logError('QSEOW UPDATE SHEETS', err);
+
+            expect(logger.error).toHaveBeenCalledWith(
+                'QSEOW UPDATE SHEETS: Failed to update sheet thumbnails in app abc [caused by: Not connected]'
+            );
+        });
+
+        test('walks more than one level', () => {
+            const err = new Error('outer', {
+                cause: new Error('middle', { cause: new Error('root') }),
+            });
+
+            logError('CTX', err);
+
+            expect(logger.error).toHaveBeenCalledWith('CTX: outer [caused by: middle: root]');
+        });
+
+        // Several call sites throw `new Error(\`PREFIX: ${err}\`, { cause: err })`.
+        test('does not repeat a cause already quoted in the outer message', () => {
+            const cause = new Error('Not connected');
+            const err = new Error(`CONTENT LIBRARY 1: ${cause}`, { cause });
+
+            logError('CTX', err);
+
+            expect(logger.error).toHaveBeenCalledWith(
+                'CTX: CONTENT LIBRARY 1: Error: Not connected'
+            );
+        });
+
+        test('terminates on a cyclic cause chain', () => {
+            const a = new Error('a');
+            const b = new Error('b', { cause: a });
+            a.cause = b;
+
+            expect(() => logError('CTX', b)).not.toThrow();
+            expect(logger.error).toHaveBeenCalledWith('CTX: b [caused by: a]');
+        });
+
+        // Regression: `.message` need not be a string. A non-string reaching the dedup's
+        // substring match threw `TypeError: part.includes is not a function` out of the logger,
+        // from inside a catch block - so the real error was lost and replaced by a crash.
+        test('survives a non-string message alongside a cause', () => {
+            const err = { message: { code: 401 }, cause: new Error('root reason') };
+
+            expect(() => logError('CTX', err)).not.toThrow();
+            expect(logger.error).toHaveBeenCalledWith('CTX: {"code":401} [caused by: root reason]');
+        });
+
+        test('survives a cause accessor that throws', () => {
+            const err = new Error('outer');
+            Object.defineProperty(err, 'cause', {
+                get: () => {
+                    throw new Error('cause getter exploded');
+                },
+            });
+
+            expect(() => logError('CTX', err)).not.toThrow();
+            expect(logger.error).toHaveBeenCalledWith('CTX: outer');
+        });
+
+        // Regression: the bound used to count kept entries, so causes collapsed by the dedup
+        // advanced no counter and the chain was walked in full.
+        test('follows at most MAX_CAUSE_DEPTH links when every cause reads the same', () => {
+            let reads = 0;
+            const make = (depth) => {
+                const e = new Error('same');
+                Object.defineProperty(e, 'cause', {
+                    get: () => {
+                        reads += 1;
+                        return depth > 0 ? make(depth - 1) : undefined;
+                    },
+                });
+                return e;
+            };
+
+            logError('CTX', make(1000));
+
+            // One read per link followed, plus the read that ends the loop.
+            expect(reads).toBeLessThanOrEqual(6);
+            expect(logger.error).toHaveBeenCalledWith('CTX: same');
+        });
+
+        test('stops at the depth limit', () => {
+            let err = new Error('root');
+            for (let i = 0; i < 20; i += 1) {
+                err = new Error(`level${i}`, { cause: err });
+            }
+
+            logError('CTX', err);
+
+            const line = logger.error.mock.calls[0][0];
+            expect(line).toContain('level19');
+            expect(line).not.toContain('root');
+        });
+    });
+
     test.each([
         ['undefined', undefined],
         ['null', null],

--- a/src/lib/util/__tests__/log-error.test.js
+++ b/src/lib/util/__tests__/log-error.test.js
@@ -11,93 +11,101 @@ jest.unstable_mockModule('../../../globals.js', () => ({
     isSea: false,
 }));
 
-const { logError, logWarn, logInfo, logVerbose, logDebug } = await import('../log-error.js');
+const { logError } = await import('../log-error.js');
 const { logger } = await import('../../../globals.js');
 
-describe('log-error (non-SEA)', () => {
+describe('logError', () => {
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    test('logError: logs message + stack separately', () => {
+    // The point of the helper: a user at the default log level sees the reason, not the stack.
+    test('logs the reason at error level and the stack at debug level', () => {
         const err = new Error('boom');
-        logError('CTX', err);
-
-        expect(logger.error).toHaveBeenCalledTimes(2);
-        expect(logger.error).toHaveBeenNthCalledWith(1, 'CTX: boom');
-        expect(logger.error).toHaveBeenNthCalledWith(2, expect.stringContaining('Stack trace:'));
-        expect(logger.error.mock.calls[1][0]).toContain('Error: boom');
-    });
-
-    test('logError: skips stack when error has no stack', () => {
-        const err = new Error('boom');
-        err.stack = undefined;
         logError('CTX', err);
 
         expect(logger.error).toHaveBeenCalledTimes(1);
         expect(logger.error).toHaveBeenCalledWith('CTX: boom');
+
+        expect(logger.debug).toHaveBeenCalledTimes(1);
+        expect(logger.debug.mock.calls[0][0]).toContain('Error: boom');
     });
 
-    test('logError: handles non-Error throwables via toString()', () => {
+    // Guards the actual regression: no stack frame may reach `error` level, whatever else changes.
+    test('never puts a stack frame on the error-level line', () => {
+        logError('CTX', new Error('boom'));
+
+        expect(logger.error.mock.calls[0][0]).not.toContain('    at ');
+    });
+
+    test('skips the debug line when the error carries no stack', () => {
+        const err = new Error('boom');
+        err.stack = undefined;
+        logError('CTX', err);
+
+        expect(logger.error).toHaveBeenCalledWith('CTX: boom');
+        expect(logger.debug).not.toHaveBeenCalled();
+    });
+
+    test('handles a thrown string', () => {
         logError('CTX', 'just a string');
 
-        expect(logger.error).toHaveBeenCalledTimes(1);
         expect(logger.error).toHaveBeenCalledWith('CTX: just a string');
+        expect(logger.debug).not.toHaveBeenCalled();
     });
 
-    test('logError: forwards plain message when no error provided', () => {
-        logError('just a message');
+    // Several of the catch blocks this helper replaced had their own JSON.stringify fallback,
+    // because '[object Object]' names nothing.
+    test('JSON-encodes a thrown plain object', () => {
+        logError('CTX', { code: 42, detail: 'nope' });
+
+        expect(logger.error).toHaveBeenCalledWith('CTX: {"code":42,"detail":"nope"}');
+    });
+
+    test('falls back to String() for an object JSON cannot encode', () => {
+        const circular = {};
+        circular.self = circular;
+
+        logError('CTX', circular);
+
+        expect(logger.error).toHaveBeenCalledWith('CTX: [object Object]');
+    });
+
+    test('falls back to String() for an object with no enumerable properties', () => {
+        logError('CTX', Object.create({}, { hidden: { value: 1, enumerable: false } }));
+
+        expect(logger.error).toHaveBeenCalledWith('CTX: [object Object]');
+    });
+
+    // A null-prototype object has no toString(), so String() throws on it. The helper runs inside
+    // catch blocks, so it must degrade rather than turn a reported error into a crash.
+    test('does not throw on a value that cannot be stringified at all', () => {
+        const noPrototype = Object.create(null);
+        noPrototype.self = noPrototype; // also defeats JSON.stringify
+
+        expect(() => logError('CTX', noPrototype)).not.toThrow();
+        expect(logger.error).toHaveBeenCalledWith('CTX: [object Object]');
+    });
+
+    test('does not throw when reading .message throws', () => {
+        const err = {};
+        Object.defineProperty(err, 'message', {
+            get: () => {
+                throw new Error('message getter exploded');
+            },
+        });
+
+        expect(() => logError('CTX', err)).not.toThrow();
+    });
+
+    test.each([
+        ['undefined', undefined],
+        ['null', null],
+    ])('logs the message alone when the error is %s', (_label, value) => {
+        logError('just a message', value);
 
         expect(logger.error).toHaveBeenCalledTimes(1);
         expect(logger.error).toHaveBeenCalledWith('just a message');
-    });
-
-    test('logWarn: logs at warn level', () => {
-        const err = new Error('warn-me');
-        logWarn('CTX', err);
-
-        expect(logger.warn).toHaveBeenCalledTimes(2);
-        expect(logger.warn.mock.calls[0][0]).toBe('CTX: warn-me');
-    });
-
-    test('logInfo / logVerbose / logDebug: route to the correct level', () => {
-        const err = new Error('x');
-
-        logInfo('CTX', err);
-        logVerbose('CTX', err);
-        logDebug('CTX', err);
-
-        expect(logger.info).toHaveBeenCalledTimes(2);
-        expect(logger.verbose).toHaveBeenCalledTimes(2);
-        expect(logger.debug).toHaveBeenCalledTimes(2);
-    });
-});
-
-describe('log-error (SEA mode)', () => {
-    let seaLogger;
-    let seaLogError;
-
-    beforeEach(async () => {
-        jest.resetModules();
-        jest.unstable_mockModule('../../../globals.js', () => ({
-            logger: {
-                error: jest.fn(),
-                warn: jest.fn(),
-                info: jest.fn(),
-                verbose: jest.fn(),
-                debug: jest.fn(),
-            },
-            isSea: true,
-        }));
-        seaLogger = (await import('../../../globals.js')).logger;
-        seaLogError = (await import('../log-error.js')).logError;
-    });
-
-    test('SEA mode: only the message is logged (no stack)', () => {
-        const err = new Error('boom');
-        seaLogError('CTX', err);
-
-        expect(seaLogger.error).toHaveBeenCalledTimes(1);
-        expect(seaLogger.error).toHaveBeenCalledWith('CTX: boom');
+        expect(logger.debug).not.toHaveBeenCalled();
     });
 });

--- a/src/lib/util/log-error.js
+++ b/src/lib/util/log-error.js
@@ -90,13 +90,58 @@ const describeValue = (value) => {
 const describeError = (error) => {
     if (typeof error === 'string') return error;
 
-    // `.message` is whatever was thrown and need not be a string, and reading it can itself
-    // throw when it is an accessor. Neither may escape: this runs inside `catch` blocks, where a
-    // failing log call would replace a reported error with an unreported crash.
+    // `.message` is whatever was thrown and need not be a string. It must become one here:
+    // describeWithCauses does substring matching over these values, and a non-string reaching
+    // that comparison threw `TypeError: part.includes is not a function` out of the logger -
+    // from inside a `catch` block, so the real error was lost and replaced by a crash.
     const message = safeRead(error, 'message');
     if (message !== undefined && message !== null && message !== '') return describeValue(message);
 
     return describeValue(error);
+};
+
+/** How many `cause` links to follow, so a cyclic or absurdly deep chain cannot run away. */
+const MAX_CAUSE_DEPTH = 5;
+
+/**
+ * Renders an error together with its `cause` chain.
+ *
+ * The typed errors in `./errors.js` are thrown with `{ cause }` throughout, so the outermost
+ * message is usually the general one ("Failed to update sheet thumbnails in app X") and the
+ * specific reason ("Not connected") is one or more levels down. Reporting only the outer message
+ * tells the user which step failed but not why.
+ *
+ * A cause already quoted in an enclosing message is skipped: several call sites throw
+ * ``new Error(`PREFIX: ${err}`, { cause: err })``, and repeating it would say the same thing twice.
+ *
+ * @param {Error|unknown} error - The caught value.
+ * @returns {string} e.g. `Failed to update sheet thumbnails in app X [caused by: Not connected]`.
+ */
+const describeWithCauses = (error) => {
+    const parts = [describeError(error)];
+    const seen = new Set([error]);
+
+    // Counts links followed, not entries kept. Bounding `parts.length` instead looked equivalent
+    // but was not: a cause skipped by the dedup below never grows `parts`, so a chain whose links
+    // share one message advanced no counter at all. That walked a 50 000-link chain in full, and
+    // against a `cause` accessor returning a fresh object each read - which also defeats `seen` -
+    // it never terminated.
+    let steps = 0;
+    let current = safeRead(error, 'cause');
+    while (current && steps < MAX_CAUSE_DEPTH && !seen.has(current)) {
+        steps += 1;
+        seen.add(current);
+
+        const description = describeError(current);
+        if (!parts.some((part) => part.includes(description))) {
+            parts.push(description);
+        }
+
+        current = safeRead(current, 'cause');
+    }
+
+    const [outermost, ...causes] = parts;
+    return causes.length > 0 ? `${outermost} [caused by: ${causes.join(': ')}]` : outermost;
 };
 
 /**
@@ -119,7 +164,7 @@ export function logError(message, error) {
         return;
     }
 
-    logger.error(`${message}: ${describeError(error)}`);
+    logger.error(`${message}: ${describeWithCauses(error)}`);
 
     if (error.stack) {
         logger.debug(error.stack);

--- a/src/lib/util/log-error.js
+++ b/src/lib/util/log-error.js
@@ -1,124 +1,127 @@
 /**
- * Enhanced error logging utility for Butler Sheet Icons.
+ * Shared error logging for Butler Sheet Icons.
  *
- * Provides consistent error logging across the application with different
- * behavior for SEA (Single Executable Application) vs non-SEA environments.
+ * Every caught error is reported the same way: what went wrong at `error` level, and the stack
+ * trace at `debug` level.
  *
- * In SEA mode: Only the error message is logged (cleaner output for end users).
- * In non-SEA mode: Both error message and stack trace are logged as separate
- *                  entries (better debugging for developers).
+ * The split matters because the default log level is `info`. Before this helper was used, roughly
+ * thirty `catch` blocks each carried their own copy of
+ *
+ * ```js
+ * if (err.stack) logger.error(`SOMETHING (stack): ${err.stack}`);
+ * else if (err.message) ...
+ * ```
+ *
+ * and since a real `Error` always has a `.stack`, the second branch was unreachable and every
+ * ordinary failure printed a full JavaScript stack trace to a Qlik Sense administrator running a
+ * packaged binary. Sixteen frames of `at async ./build/build.cjs:131375:17` tell that reader
+ * nothing and bury the one line that does. The same reasoning produced the message/stack split in
+ * `src/lib/browser/` for issue #785; this is that convention made shared.
+ *
+ * The stack is not discarded, only moved: `--loglevel debug` still prints it, from a packaged
+ * binary as well as from source.
  */
 
-import { isSea, logger } from '../../globals.js';
+import { logger } from '../../globals.js';
 
 /**
- * Log an error with appropriate formatting based on execution environment.
+ * `String(value)` that cannot throw.
  *
- * This function wraps the global logger and provides enhanced error logging:
- * - In SEA apps: logs only the error message (cleaner for production).
- * - In non-SEA apps: logs error message and stack trace separately (better for debugging).
+ * @param {unknown} value - The value to stringify.
+ * @returns {string} The string form, or the object tag if even `String()` fails.
+ */
+const safeString = (value) => {
+    try {
+        return String(value);
+    } catch {
+        // A null-prototype object has no toString(), so even String() throws on it. Nothing may
+        // throw from here: this helper runs inside `catch` blocks, and a logging call that fails
+        // would replace a reported error with an unreported crash.
+        return Object.prototype.toString.call(value);
+    }
+};
+
+/**
+ * Reads a property that may be an accessor written by whoever threw the value.
  *
- * The function accepts the same parameters as winston logger methods.
+ * @param {unknown} source - The value to read from.
+ * @param {string} property - Property name.
+ * @returns {unknown} The value, or `undefined` if reading it threw.
+ */
+const safeRead = (source, property) => {
+    try {
+        return source?.[property];
+    } catch {
+        return undefined;
+    }
+};
+
+/**
+ * Renders any single value as a string, preferring JSON over `[object Object]`.
  *
- * @param {string} level - The log level (`error`, `warn`, `info`, `verbose`, `debug`).
- * @param {string} message - The log message (prefix/context for the error).
- * @param {Error|unknown} error - The error object to log. May be omitted, in which
- *   case the call is forwarded to the logger as a plain message.
- * @param {...unknown} args - Additional arguments to pass to the logger.
+ * @param {unknown} value - The value to render.
+ * @returns {string} Always a string; never throws.
+ */
+const describeValue = (value) => {
+    if (typeof value === 'string') return value;
+
+    try {
+        const json = JSON.stringify(value);
+        // `undefined` for a function or symbol, `{}` for an object with no enumerable properties -
+        // in both cases String() is more informative than the JSON.
+        if (json && json !== '{}') return json;
+    } catch {
+        // Circular references, or a throwing toJSON(). Fall through to String().
+    }
+
+    return safeString(value);
+};
+
+/**
+ * Renders a caught value as a single human-readable line.
+ *
+ * Anything can be thrown, so this deliberately handles more than `Error`. Plain objects are
+ * JSON-encoded rather than stringified, since `[object Object]` names nothing — several of the
+ * `catch` blocks this replaced had their own `JSON.stringify` fallback for exactly that reason.
+ *
+ * @param {Error|unknown} error - The caught value.
+ * @returns {string} A description suitable for the end of a log line.
+ */
+const describeError = (error) => {
+    if (typeof error === 'string') return error;
+
+    // `.message` is whatever was thrown and need not be a string, and reading it can itself
+    // throw when it is an accessor. Neither may escape: this runs inside `catch` blocks, where a
+    // failing log call would replace a reported error with an unreported crash.
+    const message = safeRead(error, 'message');
+    if (message !== undefined && message !== null && message !== '') return describeValue(message);
+
+    return describeValue(error);
+};
+
+/**
+ * Logs a caught error: the reason at `error` level, the stack trace at `debug` level.
+ *
+ * @param {string} message - Context for the error, used as a prefix. Written as a statement of
+ *   what failed rather than a bare symbol name, since it is what the user reads first.
+ * @param {Error|unknown} [error] - The caught value. When omitted, `message` is logged on its own.
  *
  * @example
- * // Basic error logging
  * try {
- *   // some code
+ *     await uploadThumbnail(sheet);
  * } catch (err) {
- *   logError('HEALTH: Error when calling health check API', err);
+ *     logError('QSEOW UPLOAD: Failed to upload thumbnail', err);
  * }
  */
-function logErrorWithLevel(level, message, error, ...args) {
-    if (!error) {
-        // If no error object provided, just log the message normally
-        logger[level](message, ...args);
+export function logError(message, error) {
+    if (error === undefined || error === null) {
+        logger.error(message);
         return;
     }
 
-    // Get error message - prefer error.message, fallback to toString()
-    const errorMessage = error.message || error.toString();
+    logger.error(`${message}: ${describeError(error)}`);
 
-    if (isSea) {
-        // SEA mode: Only log the error message (cleaner output)
-        logger[level](`${message}: ${errorMessage}`, ...args);
-    } else {
-        // Non-SEA mode: Log error message first, then stack trace separately
-        // This provides better readability and debugging information
-
-        // Log 1: The error message with context
-        logger[level](`${message}: ${errorMessage}`, ...args);
-
-        // Log 2: The stack trace (if available)
-        if (error.stack) {
-            logger[level](`Stack trace: ${error.stack}`, ...args);
-        }
+    if (error.stack) {
+        logger.debug(error.stack);
     }
-}
-
-/**
- * Convenience function for logging errors at `error` level.
- *
- * @param {string} message - The log message (prefix/context for the error).
- * @param {Error|unknown} [error] - The error object to log.
- * @param {...unknown} args - Additional arguments to pass to the logger.
- *
- * @example
- * try {
- *   // some code
- * } catch (err) {
- *   logError('HEALTH: Error when calling health check API', err);
- * }
- */
-export function logError(message, error, ...args) {
-    logErrorWithLevel('error', message, error, ...args);
-}
-
-/**
- * Convenience function for logging errors at `warn` level.
- *
- * @param {string} message - The log message (prefix/context for the error).
- * @param {Error|unknown} [error] - The error object to log.
- * @param {...unknown} args - Additional arguments to pass to the logger.
- */
-export function logWarn(message, error, ...args) {
-    logErrorWithLevel('warn', message, error, ...args);
-}
-
-/**
- * Convenience function for logging errors at `info` level.
- *
- * @param {string} message - The log message (prefix/context for the error).
- * @param {Error|unknown} [error] - The error object to log.
- * @param {...unknown} args - Additional arguments to pass to the logger.
- */
-export function logInfo(message, error, ...args) {
-    logErrorWithLevel('info', message, error, ...args);
-}
-
-/**
- * Convenience function for logging errors at `verbose` level.
- *
- * @param {string} message - The log message (prefix/context for the error).
- * @param {Error|unknown} [error] - The error object to log.
- * @param {...unknown} args - Additional arguments to pass to the logger.
- */
-export function logVerbose(message, error, ...args) {
-    logErrorWithLevel('verbose', message, error, ...args);
-}
-
-/**
- * Convenience function for logging errors at `debug` level.
- *
- * @param {string} message - The log message (prefix/context for the error).
- * @param {Error|unknown} [error] - The error object to log.
- * @param {...unknown} args - Additional arguments to pass to the logger.
- */
-export function logDebug(message, error, ...args) {
-    logErrorWithLevel('debug', message, error, ...args);
 }


### PR DESCRIPTION
Two findings from testing the 4.1.0 binaries against the lab server: creating QSEoW thumbnails worked from macOS and failed from Windows, and the failure output contained a raw JavaScript stack trace.

## Why the Windows run failed — no code change

Not a network fault and not a Butler Sheet Icons bug. A Qlik Sense virtual proxy picks its login method by regex-matching **Windows authentication pattern** (default `Windows`) against the browser's **User-Agent**. Confirmed against the lab server — same URL, same moment, only the UA differing:

| Request User-Agent | Server responds `302` to |
| --- | --- |
| `…(Macintosh; Intel Mac OS X…)…` | `/internal_forms_authentication/` |
| `…(Windows NT 10.0; Win64; x64)…` | `/internal_windows_authentication` |

and that endpoint answers `401 WWW-Authenticate: NTLM`. Headless Chromium on Windows replies with the machine's ambient credentials, the server rejects them, it cannot prompt, and `page.goto` fails with `net::ERR_INVALID_AUTH_CREDENTIALS`.

The QRS API confirms both proxies use `authenticationMethod: 0` (Ticket) and differ **only** in `windowsAuthenticationEnabledDevicePattern` — `Windows` on the default, `Form` on the working one. The prefix name is irrelevant; the pattern is the lever.

The fix is configuration, so this PR only documents it: a draft staged in `docs/to-doc-site/`, to be published through the per-file approval pass in that folder's README.

## Why the stack trace appeared

Around thirty `catch` blocks each carried:

```js
if (err.stack) logger.error(`PREFIX (stack): ${err.stack}`);
else if (err.message) ...
```

A real `Error` always has a `.stack`, so the second branch was unreachable and every ordinary, already-handled failure printed a full stack trace at `error` level — above the default `info`.

This adopts `src/lib/util/log-error.js`, which existed with zero callers, resolving **#906**. The stack is moved, not discarded: `--loglevel debug` still prints it.

## Commits

| Commit | What |
| --- | --- |
| `docs:` | The staged draft for the Windows auth failure |
| `fix:` | Level split, 32 call sites, and the robustness gaps #906 listed as prerequisites |
| `feat:` | Cause chaining, so the reason appears alongside the step that failed |

Each commit builds and tests green on its own.

## Verification

- 2476 unit tests pass across 90 suites; ESLint and Prettier clean.
- Ran a genuinely failing QSEoW path against the live lab server: **zero stack frames** at the default level, stack still present with `--loglevel debug`.
- Log prefixes are carried across unchanged, so existing output stays greppable.
- Integration tests were **not** run — they need `BSI_*` credentials this worktree has no `.env` for, and they mutate lab apps.

## Known limitation, not addressed here

Butler Sheet Icons clicks `#username-input` unconditionally, so it cannot use a Windows-authentication virtual proxy at all — even a successful NTLM SSO from a domain-joined machine fails, just with a selector timeout instead. Worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)