### PR TITLE
Accept a virtual proxy prefix written with slashes

### DIFF
--- a/docs/to-doc-site/windows-run-fails-with-invalid-auth-credentials.md
+++ b/docs/to-doc-site/windows-run-fails-with-invalid-auth-credentials.md
@@ -112,6 +112,17 @@ or as an environment variable:
 BSI_QSEOW_CST_PREFIX=form
 ```
 
+::: tip Slashes around the prefix are ignored
+Write it as `form`, `/form` or `/form/` — all three name the same virtual proxy and all three work.
+
+In releases up to and including 4.1.0 they did not. A prefix written with the leading slash it has
+in the browser address bar produced a doubled separator in the URL
+(`https://sense.example.com//form/sense/app/…`), which logged in perfectly well and then failed
+about ninety seconds later with `Waiting for selector '#qv-page-container' failed` — an error that
+named a page element rather than the prefix that caused it. If you are on an older release, drop
+the slashes.
+:::
+
 ::: warning The prefix is not the fix
 `--prefix form` on its own changes nothing. A virtual proxy called `form` whose **Windows
 authentication pattern** is still `Windows` fails in exactly the same way. The pattern is what

--- a/src/lib/qseow/__tests__/qseow_prefix.test.js
+++ b/src/lib/qseow/__tests__/qseow_prefix.test.js
@@ -1,0 +1,42 @@
+import { describe, test, expect } from '@jest/globals';
+
+import { normalizeVirtualProxyPrefix } from '../qseow-prefix.js';
+
+describe('normalizeVirtualProxyPrefix', () => {
+    // The reported bug: BSI_QSEOW_CST_PREFIX='/form' built https://host//form/sense/app/<id>,
+    // which authenticated fine and then timed out 90s later waiting for #qv-page-container.
+    test('strips the leading slash an admin copies out of a URL', () => {
+        expect(normalizeVirtualProxyPrefix('/form')).toBe('form');
+    });
+
+    test.each([
+        ['already clean', 'form', 'form'],
+        ['trailing slash', 'form/', 'form'],
+        ['both ends', '/form/', 'form'],
+        ['repeated slashes', '//form//', 'form'],
+        ['surrounding whitespace', '  form  ', 'form'],
+        ['whitespace outside slashes', ' /form/ ', 'form'],
+    ])('%s: %j -> %j', (_label, input, expected) => {
+        expect(normalizeVirtualProxyPrefix(input)).toBe(expected);
+    });
+
+    // '' is what the CLI defaults to and what callers read as "no virtual proxy", so every
+    // no-prefix spelling has to collapse to exactly that rather than to a slash or undefined.
+    test.each([
+        ['empty string', ''],
+        ['a lone slash', '/'],
+        ['only slashes', '///'],
+        ['only whitespace', '   '],
+        ['undefined', undefined],
+        ['null', null],
+        ['a non-string', 42],
+    ])('%s yields the empty prefix', (_label, input) => {
+        expect(normalizeVirtualProxyPrefix(input)).toBe('');
+    });
+
+    // Only the ends are touched; a prefix is a single path segment, but if a deployment ever
+    // uses a nested one, the separator inside it must survive.
+    test('leaves interior slashes alone', () => {
+        expect(normalizeVirtualProxyPrefix('/a/b/')).toBe('a/b');
+    });
+});

--- a/src/lib/qseow/qseow-enigma.js
+++ b/src/lib/qseow/qseow-enigma.js
@@ -6,6 +6,7 @@ import { logger, bsiExecutablePath } from '../../globals.js';
 import { getEnigmaSchema } from '../util/enigma-util.js';
 import { getCertFilePaths } from '../util/cert.js';
 import { attachSocketKeepalive } from '../util/socket-keepalive.js';
+import { normalizeVirtualProxyPrefix } from './qseow-prefix.js';
 
 /**
  * Reads a file from disk and returns its bytes.
@@ -58,7 +59,7 @@ export const setupEnigmaConnection = (appId, options, _command) => {
         url: SenseUtilities.buildUrl({
             host: options.host,
             port: options.engineport,
-            prefix: options.prefix,
+            prefix: normalizeVirtualProxyPrefix(options.prefix),
             secure: options.secure === 'true' || options.secure === true,
             appId,
         }),

--- a/src/lib/qseow/qseow-logout.js
+++ b/src/lib/qseow/qseow-logout.js
@@ -1,6 +1,7 @@
 import crypto from 'node:crypto';
 
 import { logger, sleep } from '../../globals.js';
+import { normalizeVirtualProxyPrefix } from './qseow-prefix.js';
 
 /** The stable selector for the Qlik Sense hub logout item. */
 export const QSEOW_LOGOUT_BUTTON_SELECTOR =
@@ -19,7 +20,10 @@ const DEFAULT_PAGE_TIMEOUT = 90000;
  *
  * @returns {string} Relative QPS user-session path.
  */
-const qpsUserPath = (prefix) => (prefix ? `/${prefix}/qps/user` : '/qps/user');
+const qpsUserPath = (prefix) => {
+    const normalized = normalizeVirtualProxyPrefix(prefix);
+    return normalized ? `/${normalized}/qps/user` : '/qps/user';
+};
 
 /**
  * Deletes the authenticated proxy session without depending on the Sense web client's DOM.

--- a/src/lib/qseow/qseow-prefix.js
+++ b/src/lib/qseow/qseow-prefix.js
@@ -1,0 +1,35 @@
+/**
+ * Normalises the Qlik Sense virtual proxy prefix given by `--prefix` / `BSI_QSEOW_CST_PREFIX`.
+ *
+ * The prefix is interpolated into URLs as `` `${origin}/${prefix}/sense/app/${appId}` ``, so a
+ * value written with the slash the user sees in the browser address bar - `/form` rather than
+ * `form` - produced a doubled separator:
+ *
+ *     https://sense.example.com//form/sense/app/<appid>
+ *
+ * That URL is not rejected. The Qlik proxy still redirects it to the right login page and the
+ * login succeeds, so the run gets all the way to the first sheet before anything looks wrong -
+ * and then fails with `Waiting for selector '#qv-page-container' failed` after a full 90 second
+ * page timeout, naming a selector rather than the prefix that caused it. Reproduced on macOS and
+ * Windows alike with `--prefix /form`, and fixed by `--prefix form`; the platform never mattered.
+ *
+ * Normalising rather than rejecting: `/form`, `form`, `form/` and `/form/` all name the same
+ * virtual proxy, and an administrator copying the prefix out of a URL has done nothing wrong.
+ *
+ * @param {string|undefined|null} prefix - The prefix as supplied by the user.
+ *
+ * @returns {string} The prefix with surrounding whitespace and slashes removed. An empty string
+ *   when there is no usable prefix, which is what callers treat as "no virtual proxy".
+ *
+ * @example
+ * normalizeVirtualProxyPrefix('/form');   // 'form'
+ * normalizeVirtualProxyPrefix('form/');   // 'form'
+ * normalizeVirtualProxyPrefix('  ');      // ''
+ */
+export const normalizeVirtualProxyPrefix = (prefix) => {
+    if (typeof prefix !== 'string') return '';
+
+    // Trim whitespace before slashes so ' /form ' is handled, and collapse repeats at both ends
+    // rather than a single character, so '//form//' normalises too.
+    return prefix.trim().replace(/^\/+/, '').replace(/\/+$/, '').trim();
+};

--- a/src/lib/qseow/qseow-process-app.js
+++ b/src/lib/qseow/qseow-process-app.js
@@ -22,6 +22,7 @@ import { QSEOW_SHEET_PART_SELECTORS } from './sheet-parts.js';
 import { qseowLogout } from './qseow-logout.js';
 import { getQseowHubSelectors } from './qseow-selectors.js';
 import { logError } from '../util/log-error.js';
+import { normalizeVirtualProxyPrefix } from './qseow-prefix.js';
 
 /**
  * Looks up the sheets in an app that carry any of the supplied tags.
@@ -271,9 +272,15 @@ export const qseowProcessApp = async (appId, options) => {
                             ? `${scheme}${options.host}:${options.port}`
                             : `${scheme}${options.host}`;
 
-                        if (options.prefix && options.prefix.length > 0) {
-                            appUrl = `${origin}/${options.prefix}/sense/app/${appId}`;
-                            hubUrl = `${origin}/${options.prefix}/hub`;
+                        // Normalised, not used raw: a prefix written as it appears in the browser
+                        // address bar ("/form") produced "https://host//form/sense/app/<id>",
+                        // which authenticates fine and then never renders, failing 90 seconds
+                        // later on a selector that says nothing about the prefix.
+                        const prefix = normalizeVirtualProxyPrefix(options.prefix);
+
+                        if (prefix.length > 0) {
+                            appUrl = `${origin}/${prefix}/sense/app/${appId}`;
+                            hubUrl = `${origin}/${prefix}/hub`;
                         } else {
                             appUrl = `${origin}/sense/app/${appId}`;
                             hubUrl = `${origin}/hub`;


### PR DESCRIPTION
`BSI_QSEOW_CST_PREFIX='/form'` — the prefix written the way it appears in a browser address bar — made a run fail with

```
error: QSEOW: qseowProcessApp: Waiting for selector `#qv-page-container` failed [caused by: Waiting failed: 90000ms exceeded]
```

naming a page element rather than the setting that caused it.

## Cause

The prefix was interpolated raw into `` `${origin}/${options.prefix}/sense/app/${appId}` ``, so a leading slash produced a doubled separator:

```
https://sense.example.com//form/sense/app/<appid>
```

That URL is not rejected anywhere obvious. Checked with curl: the Qlik proxy still redirects it to the correct login page, and the login succeeds. The run therefore gets all the way to the first sheet before anything looks wrong — putting ninety seconds and a successful authentication between the cause and the symptom.

## It was never a Windows fault

It was reported as Windows-only, but the two machines being compared had different `.env` files: one set the prefix, the other set none at all. A/B on one machine with one binary, changing only that flag:

| Command | Result |
| --- | --- |
| `--prefix /form --includesheetpart 4` | fails on `#qv-page-container` after 90s — identical to the Windows report |
| `--prefix form --includesheetpart 4` | succeeds |

## Fix

Normalise rather than reject — `/form`, `form`, `form/` and `/form/` all name the same virtual proxy, and an administrator copying the prefix out of a URL has done nothing wrong.

Applied at all three places the prefix reaches a URL, not only the one that was reported:

- the app and hub URLs in `qseow-process-app.js`
- the logout call in `qseow-logout.js`, which had the same raw interpolation and would have broken the same way
- the engine websocket in `qseow-enigma.js`

## Verification

- Ran the previously failing command from the fixed source against a live QSEoW server: `App URL: https://…/form/sense/app/…` — single slash — and the run completes, uploads and finishes.
- 2491 unit tests pass across 91 suites, 15 of them new for the normaliser. ESLint clean.

## Not fixed here

A genuinely wrong prefix — a typo such as `--prefix frm` — still fails the same cryptic way, ninety seconds later on a selector name. Normalisation cannot help that; checking after login whether the app page actually loaded is the real answer, and belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)