### PR TITLE
Stop reporting our own engine session close as a dropped connection

### DIFF
--- a/src/lib/util/__tests__/engine-session.test.js
+++ b/src/lib/util/__tests__/engine-session.test.js
@@ -210,16 +210,34 @@ describe('withEngineSession', () => {
 
     describe('an unexpected close', () => {
         /**
-         * Runs a session and hands back the handler registered for enigma's `closed` event.
+         * Reads back the handler enigma's `closed` event was registered with.
          *
+         * @param {object} session - The mock session.
          * @returns {Function} The registered handler.
          */
-        const closeHandler = async () => {
+        const closedHandlerOf = (session) =>
+            session.on.mock.calls.find(([event]) => event === 'closed')[1];
+
+        /**
+         * Runs a session and fires `closed` from **inside** the callback.
+         *
+         * The event has to arrive while the session is still in use, because that is when a real
+         * unexpected close arrives - and because firing it after the helper has returned now
+         * means something different: by then the session has been released deliberately, and the
+         * warning is correctly suppressed.
+         *
+         * @param {object} evt - The close event to deliver.
+         * @returns {Promise<Function>} The handler that was fired.
+         */
+        const closeHandler = async (evt) => {
             const { session } = wireSession();
 
-            await withEngineSession({}, CTX, async () => true);
+            await withEngineSession({}, CTX, async () => {
+                closedHandlerOf(session)(evt);
+                return true;
+            });
 
-            return session.on.mock.calls.find(([event]) => event === 'closed')[1];
+            return closedHandlerOf(session);
         };
 
         test('is listened for at every log level', async () => {
@@ -233,7 +251,7 @@ describe('withEngineSession', () => {
         test('reports the close code and reason', async () => {
             // The whole point of the listener: `Not connected` on the next engine call says
             // the session was gone, and only the close event says what closed it.
-            (await closeHandler())({ code: 1006, reason: 'connection reset' });
+            await closeHandler({ code: 1006, reason: 'connection reset' });
 
             const line = String(logger.warn.mock.calls.at(-1)[0]);
             expect(line).toContain('server sense.example.com');
@@ -243,11 +261,47 @@ describe('withEngineSession', () => {
 
         test('still names the code when the far end gave no reason', async () => {
             // 1006 arrives with an empty reason - there was no close frame to carry one.
-            (await closeHandler())({ code: 1006, reason: '' });
+            await closeHandler({ code: 1006, reason: '' });
 
             const line = String(logger.warn.mock.calls.at(-1)[0]);
             expect(line).toContain('code 1006');
             expect(line).not.toContain('reason');
+        });
+
+        // Regression: enigma's own close() ends in an unconditional
+        // `this.rpc.close(code, reason).then((evt) => this.emit('closed', evt))`, with the
+        // default code 1000 - so releasing the session fired this warning. Every successful run
+        // claimed the session had been closed from the other end and that whatever used it would
+        // now fail, once per session and twice per app on the screenshot paths.
+        test('stays silent when the close is the one we asked for', async () => {
+            const { session } = wireSession();
+            session.close.mockImplementation(async () => {
+                closedHandlerOf(session)({ code: 1000, reason: '' });
+                return true;
+            });
+
+            await withEngineSession({}, CTX, async () => true);
+
+            expect(session.close).toHaveBeenCalled();
+            expect(logger.warn).not.toHaveBeenCalled();
+        });
+
+        // The suppression must be scoped to our own close, not a blanket mute: a session that
+        // died mid-run still has to be reported, even though the teardown close follows it.
+        test('still reports a mid-run close even though teardown follows', async () => {
+            const { session } = wireSession();
+            session.close.mockImplementation(async () => {
+                closedHandlerOf(session)({ code: 1000, reason: '' });
+                return true;
+            });
+
+            await withEngineSession({}, CTX, async () => {
+                closedHandlerOf(session)({ code: 1006, reason: 'connection reset' });
+                return true;
+            });
+
+            expect(logger.warn).toHaveBeenCalledTimes(1);
+            expect(String(logger.warn.mock.calls[0][0])).toContain('code 1006');
         });
     });
 

--- a/src/lib/util/engine-session.js
+++ b/src/lib/util/engine-session.js
@@ -64,6 +64,11 @@ export const withEngineSession = async (configEnigma, ctx, fn) => {
     let bodyFailed = false;
     let bodyError;
 
+    // Set immediately before the close below, so the `closed` handler can tell a session we
+    // released from one that went away underneath us. See the handler for why enigma cannot
+    // tell us that itself.
+    let closeRequested = false;
+
     try {
         // Inside the try, so that nothing between create and close can leak the session -
         // attaching a handler is not expected to throw, but the point of this helper is that
@@ -75,19 +80,30 @@ export const withEngineSession = async (configEnigma, ctx, fn) => {
             );
         }
 
-        // enigma emits this only for a close nobody here asked for: it returns early on a
-        // normal close and on a manual suspend, so a healthy run never logs this line.
+        // Only for a close nobody here asked for. `closeRequested` is what makes that true:
+        // enigma has two paths to this event and only one of them filters.
         //
-        // It is worth a line of its own because it fires when the socket dies, whereas the
-        // error surfaces later - up to 40 s later in the screenshot paths, which use the
+        //   - `onRpcClosed`, the socket-died path, returns early on code 1000 and on a manual
+        //     suspend. This is the path the guard below was once thought to be unnecessary for.
+        //   - `session.close()` ends `this.rpc.close(...).then((evt) => this.emit('closed', evt))`
+        //     - unconditional, with the default code 1000. Every deliberate release therefore
+        //     emitted this warning, and every healthy run said the session had been closed from
+        //     the other end and that whatever used it would now fail. Neither was true: one
+        //     warning per session, two per app on the screenshot paths, on runs that worked.
+        //
+        // Worth a line of its own when it is real, because it fires when the socket dies whereas
+        // the error surfaces later - up to 40 s later in the screenshot paths, which use the
         // engine once per sheet and spend the rest of the time in the browser. Issue #975 is
-        // that gap: the log showed sheets failing with `Not connected` long after the event,
-        // and nothing recorded the close code that would say what closed the connection.
-        session.on('closed', (evt) =>
+        // that gap: the log showed sheets failing with `Not connected` long after the event, and
+        // nothing recorded the close code that would say what closed the connection. A warning
+        // that also fires on every success is no use for that.
+        session.on('closed', (evt) => {
+            if (closeRequested) return;
+
             logger.warn(
                 `${logPrefix}: The engine session to ${connectionLabel} was closed from the other end, code ${evt?.code}${evt?.reason ? `, reason "${evt.reason}"` : ''}. Whatever is still using this session will fail from here on.`
-            )
-        );
+            );
+        });
 
         const global = await session.open();
 
@@ -108,6 +124,7 @@ export const withEngineSession = async (configEnigma, ctx, fn) => {
 
     try {
         // enigma.js always resolves close() truthy; a real failure rejects.
+        closeRequested = true;
         await session.close();
     } catch (closeErr) {
         if (!bodyFailed) {


### PR DESCRIPTION
Every successful run warned, once per engine session and twice per app on the screenshot paths:

```
warn: QSEOW PROCESS APP: The engine session to server 192.168.100.109 was closed from the other end, code 1000. Whatever is still using this session will fail from here on.
```

Nothing was wrong with those runs — the thumbnails were created and applied. Code 1000 is a normal WebSocket closure, and the close was ours: `withEngineSession` releases the session once the work is done.

## Cause

The comment above the handler claimed enigma emits `closed` only for a close nobody asked for, because it returns early on a normal close. That is true of one of enigma's two paths to the event and false of the other:

- `onRpcClosed`, the socket-died path, **does** return early on code 1000 and on a manual suspend. This is the path the comment described.
- `session.close()` ends in an unconditional `this.rpc.close(code, reason).then((evt) => this.emit('closed', evt))`, with the default code 1000.

So deliberate teardown fired the warning — which also hollowed it out for the case it exists for. #975 added it to catch a session dying mid-run, where the failure only surfaces up to 40s later as `Not connected`. A warning printed on every success cannot serve that purpose.

## Fix

Track intent rather than filtering on the close code. Filtering on 1000 would have worked only by accident — a server-initiated 1000 never reaches the handler, because `onRpcClosed` swallows it — and would have broken silently if enigma changed.

## Both platforms

Fixed by this change, with no Cloud-side edit:

| Cloud call site | Prefix |
| --- | --- |
| `process-cloud-app.js:100` | `CLOUD PROCESS APP` |
| `cloud-updatesheets.js:47` | `CLOUD UPDATE SHEETS` |
| `cloud-remove-sheet-icons.js:43` | `CLOUD REMOVE SHEET ICONS` |

All six callers share this helper, there is exactly one `session.close()` in the tree, and neither platform sets `suspendOnClose` — the only config that would change which branch a close takes. Cloud had the same two-sessions-per-app shape and so the same two false warnings per app.

## Verification

- Live QSEoW run against a real server with the fix: **both warnings gone**, thumbnails still uploaded and applied.
- Two tests added, one modelling enigma's real `close()` behaviour and one checking the suppression is scoped to our own close rather than a blanket mute — a 1006 mid-run close is still reported even though teardown follows it. Confirmed genuine by disabling the guard: exactly those two fail, 18 pass.
- The existing tests fired `closed` after `withEngineSession` had returned, which is not when a real unexpected close arrives. They now fire it from inside the callback.
- 2493 unit tests pass across 91 suites. ESLint and Prettier clean.

The Cloud claim is established by construction — same helper, no platform-specific close config — not by observation; no Cloud tenant was available to run against.

## Deliberate narrowing

A close that genuinely fails *during* our own `session.close()` is now also suppressed. That seems right — we asked to close, and a failing close already has its own error path immediately below — but it is a decision, not an oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)