### PR TITLE
Remove Firefox from the browser commands

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -243,7 +243,7 @@ npm run test:integration -- --testPathPattern="qseow" --testTimeout=900000
 
 ### Browser Management
 
-The tool can install and manage Chrome/Firefox browsers via `@puppeteer/browsers`. Browser installation is required for thumbnail generation functionality.
+The tool can install and manage Chrome browsers via `@puppeteer/browsers`. Chrome only. Browser installation is required for thumbnail generation functionality.
 
 ### Build Process
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,10 @@ build/**
 coverage/**
 sea-prep.blob
 build.cjs
+
+# Carries a `<!-- gitnexus:start -->` block that `gitnexus analyze` rewrites wholesale, in its
+# own formatting. Letting Prettier reformat it too means the two rewrite the same tables back
+# and forth, once per re-index, for no benefit. CLAUDE.md carries the same block and is left
+# alone for the same reason.
+AGENTS.md
+CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,5 @@
 <!-- gitnexus:start -->
+
 # GitNexus — Code Intelligence
 
 This project is indexed by GitNexus as **butler-sheet-icons**. Use the GitNexus MCP tools to understand code, assess impact, and navigate safely. Read `gitnexus://repo/butler-sheet-icons/context` for live index statistics.
@@ -28,28 +29,28 @@ This project is indexed by GitNexus as **butler-sheet-icons**. Use the GitNexus 
 
 ## Resources
 
-| Resource | Use for |
-|----------|---------|
-| `gitnexus://repo/butler-sheet-icons/context` | Codebase overview, check index freshness |
-| `gitnexus://repo/butler-sheet-icons/clusters` | All functional areas |
-| `gitnexus://repo/butler-sheet-icons/processes` | All execution flows |
-| `gitnexus://repo/butler-sheet-icons/process/{name}` | Step-by-step execution trace |
+| Resource                                            | Use for                                  |
+| --------------------------------------------------- | ---------------------------------------- |
+| `gitnexus://repo/butler-sheet-icons/context`        | Codebase overview, check index freshness |
+| `gitnexus://repo/butler-sheet-icons/clusters`       | All functional areas                     |
+| `gitnexus://repo/butler-sheet-icons/processes`      | All execution flows                      |
+| `gitnexus://repo/butler-sheet-icons/process/{name}` | Step-by-step execution trace             |
 
 ## CLI
 
-| Task | Read this skill file |
-|------|---------------------|
-| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
-| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
-| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
-| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
-| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
-| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
-| Work in the Cloud area | `.claude/skills/generated/cloud/SKILL.md` |
-| Work in the Browser area | `.claude/skills/generated/browser/SKILL.md` |
-| Work in the Qscloud area | `.claude/skills/generated/qscloud/SKILL.md` |
-| Work in the Qseow area | `.claude/skills/generated/qseow/SKILL.md` |
-| Work in the Util area | `.claude/skills/generated/util/SKILL.md` |
+| Task                                         | Read this skill file                                        |
+| -------------------------------------------- | ----------------------------------------------------------- |
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md`       |
+| Blast radius / "What breaks if I change X?"  | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?"             | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md`       |
+| Rename / extract / split / refactor          | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md`     |
+| Tools, resources, schema reference           | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md`           |
+| Index, status, clean, wiki CLI commands      | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md`             |
+| Work in the Cloud area                       | `.claude/skills/generated/cloud/SKILL.md`                   |
+| Work in the Browser area                     | `.claude/skills/generated/browser/SKILL.md`                 |
+| Work in the Qscloud area                     | `.claude/skills/generated/qscloud/SKILL.md`                 |
+| Work in the Qseow area                       | `.claude/skills/generated/qseow/SKILL.md`                   |
+| Work in the Util area                        | `.claude/skills/generated/util/SKILL.md`                    |
 
 <!-- gitnexus:end -->
 
@@ -79,7 +80,7 @@ This project is indexed by GitNexus as **butler-sheet-icons**. Use the GitNexus 
 - **Tests**: `src/__tests__/` for top-level CLI tests; module-specific tests live next to code as `*.test.js`
 - **Test types** — `*.test.js` are unit tests (run by `test:unit`); `*.integration.test.js` are integration tests that need external services (run by `test:integration`). Always use the `.integration.test.js` suffix for tests that require network, credentials, real Qlik servers, or browser downloads.
 - **ESM-friendly Jest imports** — use `import { jest, describe, test, expect } from '@jest/globals';` at the top of test files.
-- **ESM mocking** — use `jest.unstable_mockModule('some-module', () => ({...}))` *before* importing, then `const mod = await import('some-module');`. Plain `jest.mock()` does not work with ESM.
+- **ESM mocking** — use `jest.unstable_mockModule('some-module', () => ({...}))` _before_ importing, then `const mod = await import('some-module');`. Plain `jest.mock()` does not work with ESM.
 - **Dockerfile**: `src/Dockerfile` — multi-stage build with Chromium for Puppeteer
 
 ## Conventions
@@ -97,7 +98,7 @@ This project is indexed by GitNexus as **butler-sheet-icons**. Use the GitNexus 
 
 ## Browser / Puppeteer
 
-- The tool can install/manage Chrome and Firefox via `@puppeteer/browsers`
+- The tool can install/manage Chrome via `@puppeteer/browsers`. Chrome only — the render path speaks the Chrome DevTools Protocol
 - Docker images install Chromium at `/usr/bin/chromium-browser`; set `PUPPETEER_EXECUTABLE_PATH` accordingly
 - Puppeteer launch options are centralized in `src/lib/browser/` — do not create new browser instances ad hoc
 - Long browser sessions can hold files open; always call `browser.close()` (or use the `try/finally` helpers) to avoid hanging tests
@@ -146,6 +147,6 @@ The order is: **branch first, implement, verify, stop and report.** Committing, 
 - Explain **why** in the body, not just what — the diff already says what changed.
 - **MUST NOT give a pull request a Conventional Commits title.** Commit subjects use `type: subject`; PR titles must not. Write the PR title as an ordinary sentence — "Ship the Windows binary again, unsigned until a certificate is available", not `fix: ship the Windows binary unsigned`.
 
-  This is not style. PRs land here as merge commits, and GitHub puts the PR title into the **body** of the merge commit. release-please cannot parse the merge commit's subject (`Merge pull request #924 from …`), so it falls back to the body — finds a second conventional commit there — and emits a **duplicate changelog entry** for every such PR. The 4.0.0 release PR had 154 entries for 128 real changes and had to be de-duplicated by hand; 4.0.1 started doing the same.
+    This is not style. PRs land here as merge commits, and GitHub puts the PR title into the **body** of the merge commit. release-please cannot parse the merge commit's subject (`Merge pull request #924 from …`), so it falls back to the body — finds a second conventional commit there — and emits a **duplicate changelog entry** for every such PR. The 4.0.0 release PR had 154 entries for 128 real changes and had to be de-duplicated by hand; 4.0.1 started doing the same.
 
-  If a PR genuinely needs a conventional title for something else, strip the merge commit body instead: `gh pr merge --merge --body ""`. Do not rely on that as the default — it does not help anyone merging through the GitHub web UI, which is why the title rule is the one that holds.
+    If a PR genuinely needs a conventional title for something else, strip the merge commit body instead: `gh pr merge --merge --body ""`. Do not rely on that as the default — it does not help anyone merging through the GitHub web UI, which is why the title rule is the one that holds.

--- a/docs/browser-detection-environment-variables.md
+++ b/docs/browser-detection-environment-variables.md
@@ -379,7 +379,6 @@ docker run -it --rm \
 
 - ✅ Use latest browser version (embedded version may be older)
 - ✅ Test with specific browser versions
-- ✅ Use Firefox instead of Chrome
 - ✅ Match browser version with production environment
 - ✅ Access newer browser features or bug fixes
 
@@ -716,14 +715,14 @@ PUPPETEER_EXECUTABLE_PATH is set to "/path/to/browser" but file does not exist
 
 ### `--browser <type>`
 
-**Values**: `chrome`, `firefox`  
+**Values**: `chrome`  
 **Default**: `chrome`  
 **Description**: Browser type to use
 
 ### `--browser-version <version>`
 
-**Values**: Version string or `latest`  
-**Default**: `latest`  
+**Values**: `recommended`, `stable`, a release channel (`beta`, `dev`, `canary`), or an exact build id  
+**Default**: `recommended`  
 **Description**: Browser version to download (only used if download is needed)
 
 **Examples**:
@@ -920,8 +919,8 @@ A: Yes, use `-e PUPPETEER_EXECUTABLE_PATH=/your/browser` when running the contai
 **Q: What happens if the browser at `PUPPETEER_EXECUTABLE_PATH` doesn't exist?**  
 A: BSI logs a warning and falls back to checking cached browsers.
 
-**Q: Can I use Firefox instead of Chrome?**  
-A: Yes, but Docker image includes only Chromium. For standalone, use `--browser firefox`.
+**Q: Can I use a browser other than Chrome?**  
+A: No. Thumbnails are produced by driving the browser over the Chrome DevTools Protocol, so only Chrome and Chromium builds can be used.
 
 **Q: How much disk space do cached browsers use?**  
 A: Approximately 200-300 MB per browser version.

--- a/docs/to-doc-site/browser-uninstall-when-nothing-is-installed.md
+++ b/docs/to-doc-site/browser-uninstall-when-nothing-is-installed.md
@@ -4,8 +4,8 @@ If you ran `butler-sheet-icons browser uninstall -i` on a server with no browser
 you which build to remove anyway — and the question it asked was the help text for `--browser-version`:
 
 ```
-? Browser build to uninstall: an exact build id (for Chrome e.g. "151.0.7922.77", for Firefox e.g.
-"stable_153.0.3"), or "recommended" for the build Butler Sheet Icons is tested with.
+? Browser build to uninstall: an exact build id (e.g. "151.0.7922.77"), or "recommended" for the
+build Butler Sheet Icons is tested with.
 ```
 
 There was no answer to that question that could work. Whatever you typed, the run ended with

--- a/docs/to-doc-site/firefox-support-removed.md
+++ b/docs/to-doc-site/firefox-support-removed.md
@@ -1,0 +1,157 @@
+# Firefox is no longer a browser Butler Sheet Icons knows about
+
+Butler Sheet Icons no longer accepts `--browser firefox` anywhere. `chrome` is the only value the
+`--browser` option takes, on every command that has it.
+
+> [!IMPORTANT]
+> **Confirm the version number before publishing.** This ships as a breaking change, so
+> release-please cuts the next major — **5.0.0**, from the current 4.1.0. If anything else lands
+> first, use whatever version actually contains the change and update every mention below.
+
+Target pages: `guide/concepts/browser-management` (the main one),
+`guide/concepts/browser-detection-and-environment-variables`, `reference/browser`,
+`examples/browser-management`, and `guide/troubleshooting`. Note that the last two are **not** in
+the list issue #934 gave — they also carry Firefox instructions and were found by grepping the
+whole site.
+
+None of the option tables on those pages are generated: `npm run docs:cli-tables --check` reports
+no `generated:cli-options` blocks in `reference/browser.md`, so every table row below has to be
+edited by hand.
+
+## What changed
+
+Three commands used to accept `--browser firefox`:
+
+- `butler-sheet-icons browser install`
+- `butler-sheet-icons browser uninstall`
+- `butler-sheet-icons browser list-available`
+
+They no longer do. Each rejects the value while reading the command line:
+
+```
+error: option '--browser <browser>' argument 'firefox' is invalid. Allowed choices are chrome.
+```
+
+Environment values are checked against the same list, so these now fail the run before anything
+else happens:
+
+| Command | Environment variable |
+| --- | --- |
+| `browser install` | `BSI_BROWSER_I_BROWSER` |
+| `browser uninstall` | `BSI_BROWSER_UI_BROWSER` |
+| `browser list-available` | `BSI_BROWSER_LA_BROWSER` |
+
+```
+error: option '--browser <browser>' value 'firefox' from env 'BSI_BROWSER_LA_BROWSER' is invalid. Allowed choices are chrome.
+```
+
+`browser list-installed` and `browser uninstall-all` have no `--browser` option and are unchanged.
+
+Three Firefox release channel names — `nightly`, `devedition` and `esr` — are also no longer
+accepted as a `--browser-version` value, and neither are Firefox's channel-prefixed build ids such
+as `stable_153.0.3`. Chrome's channels are `beta`, `dev` and `canary`:
+
+```
+error: "esr" is not a valid --browser-version for chrome.
+error: Use a keyword - "recommended" (the build Butler Sheet Icons is tested against) or "stable" (the newest stable release) - or a release channel ("beta", "dev", "canary"), a milestone such as "151", a build prefix such as "151.0.7922", or a full build id such as "151.0.7922.77".
+```
+
+## Why
+
+Thumbnails are produced by driving the browser over the **Chrome DevTools Protocol**, with a list
+of startup switches only Chromium-based browsers understand. A Firefox binary cannot be driven that
+way.
+
+4.0.0 removed `firefox` from the two `create-sheet-thumbnails` commands for that reason. What it
+left behind was a browser that could be installed and removed but never used: a successful
+`browser install --browser firefox` put a real Firefox in the cache that no Butler Sheet Icons
+command would ever launch, and nothing said so. Removing the option states plainly what was already
+true.
+
+## A note on tone for these edits
+
+The site is single-version, so it describes the current release. Prefer "Chrome is the browser
+Butler Sheet Icons uses" over "Firefox support was removed" wherever the reader does not need the
+history. Keep one short historical note — the version callout on `browser-management` — for
+administrators who have `--browser firefox` in a script and need to know what happened. Everywhere
+else, the Firefox text should simply go.
+
+## Page-by-page
+
+Line numbers are from the doc site's `main` at the time of writing; confirm before editing.
+
+### `guide/concepts/browser-management` — 16 mentions
+
+The main page, and the only one that should keep any history.
+
+- **Line 20** — "**Firefox**: can be installed, listed and removed with the `browser` commands, but
+  **cannot be used to create thumbnails**." Delete this bullet.
+- **Lines 22–37** — the "Firefox is not available for thumbnails — BSI 4.0.0 or later" warning
+  block. Replace with a version callout for the new release, saying `--browser firefox` is no
+  longer accepted by any command, listing the three environment variables, and giving the parse
+  error above. Line 37 currently says the `browser` commands "still accept `--browser firefox`" —
+  that sentence is now false and is the single most important correction on the site.
+- **Lines 85–86 and 96–97** — the two "Install Firefox" examples. Delete both.
+- **Line 139** — "Both work for Chrome and Firefox, so you do not need to know what each vendor
+  calls its channels." Reword: the keywords work for Chrome.
+- **Line 150** — drop the Firefox half of the channel list, leaving `beta`, `dev` and `canary`.
+- **Line 168** — the Firefox channel-prefixed build id paragraph. Delete.
+- **Lines 233–235** — the whole "Firefox Versions" section. Delete, and check the page's table of
+  contents and any anchor links to `#firefox-versions`.
+
+### `reference/browser` — 18 mentions
+
+The command reference. Every table row and every sample transcript needs attention.
+
+- **Lines 75, 123, 184** — the `--browser` rows for `list-available`, `install` and `uninstall`.
+  Change the description from `Browser to … (chrome, firefox)` to Chrome only, and replace the
+  `--browser firefox` example in the Example column.
+- **Line 105** — "For Firefox the command makes no network call at all …". Delete; the command now
+  always queries Google's version history service.
+- **Lines 139–146** — the "Install latest Firefox (macOS)" transcript. Delete the whole example.
+  Note it also uses `--browser-version latest`, which has been a deprecated alias for `stable`
+  since 4.0.0, so it was doubly out of date.
+- **Line 153** — the "**Firefox:** a channel-prefixed build id …" paragraph. Delete.
+- **Lines 196, 209, 269, 277, 280** — sample `list-installed` and `uninstall-all` output showing a
+  cached `firefox` build. Re-run the commands and paste real current output, or hand-edit the
+  firefox lines out so the transcripts show Chrome builds only.
+- **Lines 298–299 and 340** — two more `browser install --browser firefox` examples. Delete.
+
+### `examples/browser-management` — 11 mentions
+
+Not named in issue #934, but it is entirely worked examples, so every Firefox one is now a command
+that fails.
+
+- **Line 34** — sample output with a cached firefox build.
+- **Lines 60–69** — the "Install Firefox (latest)" section, both the macOS/Linux and Windows
+  variants. Delete.
+- **Line 186** — "Firefox can be installed and removed with the `browser` commands, but cannot
+  render thumbnails." Now false; replace with Chrome being the only browser.
+- **Lines 339–351** — the "Available Firefox builds" examples for `list-available`. Delete both.
+- **Lines 366 and 378** — two more `browser install --browser firefox` examples. Delete.
+
+### `guide/troubleshooting` — 4 mentions
+
+- **Line 646** — "Firefox is not an alternative here — it cannot render thumbnails." The advice is
+  still right but the framing is stale; simplify to "Chrome is the only browser Butler Sheet Icons
+  can use", keeping the link to Supported Browsers.
+- **Line 752** — "# For Firefox dependencies:" in a Linux shared-library snippet. Delete the
+  Firefox package list.
+- **Lines 769 and 777** — `list-available --browser firefox` and `install --browser firefox`.
+  Delete or change to `chrome`.
+
+### `guide/concepts/browser-detection-and-environment-variables` — 2 mentions
+
+- **Line 59** — "The thumbnail commands accept `chrome` only; the `browser` commands also accept
+  `firefox`". Now false: every command accepts `chrome` only.
+- **Line 96** — the `browser list-available` network-access row, "(For Firefox the command …)".
+  Delete the parenthetical.
+
+## Checks before publishing
+
+- `grep -ri firefox docs/` over the doc site should return nothing outside `.vitepress/dist` and
+  `.vitepress/cache`, which are build artifacts.
+- `npm run docs:build` — it fails on dead links, which is what catches an anchor still pointing at
+  the deleted `#firefox-versions` section.
+- Everything goes to the `next` branch. The clone at `/Users/goran/code/butler-sheet-icons-docs`
+  was on `main` when this was written.

--- a/docs/to-doc-site/interactive-flag-on-commands.md
+++ b/docs/to-doc-site/interactive-flag-on-commands.md
@@ -21,7 +21,7 @@ This is the part worth knowing about. Options you have already given are treated
 about again. So you can supply the parts you know and let Butler Sheet Icons ask for the rest:
 
 ```bash
-butler-sheet-icons browser install --browser firefox -i
+butler-sheet-icons browser install --browser chrome -i
 ```
 
 ```

--- a/docs/todo/airgap-browser-phase-1.md
+++ b/docs/todo/airgap-browser-phase-1.md
@@ -440,8 +440,8 @@ The worker returns data rather than only logging, so tests assert on values inst
 | Option | Env var | Default |
 | --- | --- | --- |
 | `--loglevel, --log-level <level>` | `BSI_BROWSER_C_LOG_LEVEL` | `info` |
-| `--browser <browser>` (`chrome`, `firefox`) | `BSI_BROWSER_C_BROWSER` | `chrome` |
-| `--browser-version <version>` | `BSI_BROWSER_C_BROWSER_VERSION` | `latest` |
+| `--browser <browser>` (`chrome`) | `BSI_BROWSER_C_BROWSER` | `chrome` |
+| `--browser-version <version>` | `BSI_BROWSER_C_BROWSER_VERSION` | `recommended` |
 | `--browser-cache-dir <directory>` | `BSI_BROWSER_CACHE_DIR` | — (resolver decides) |
 | `--browser-executable-path <path>` | `BSI_BROWSER_EXECUTABLE_PATH` | — |
 | `--headless <true\|false>` | `BSI_BROWSER_C_HEADLESS` | `true` |

--- a/src/lib/browser/__tests__/browser_complex_scenarios.integration.test.js
+++ b/src/lib/browser/__tests__/browser_complex_scenarios.integration.test.js
@@ -33,8 +33,8 @@ describe('complex scenarios', () => {
      * Remove all installed browsers
      * Should return true.
      *
-     * Install four differenct browsers (3 chrome versions, 1 firefox).
-     * There should now be four installed browsers
+     * Install three different Chrome builds.
+     * There should now be three installed browsers.
      *
      * Remove all installed browsers.
      * Should return true.
@@ -42,7 +42,7 @@ describe('complex scenarios', () => {
      * There should then be zero installed browsers.
      */
     test(
-        'install and uninstall several browsers',
+        'install and uninstall several browser builds',
         async () => {
             // Remove all installed browsers
             const uninstallRes1 = await browserUninstallAll(options);
@@ -52,7 +52,7 @@ describe('complex scenarios', () => {
             const installedBrowsers1 = await browserInstalled(options);
             expect(installedBrowsers1.length).toEqual(0);
 
-            // Install four different browsers
+            // Install three different Chrome builds
 
             // The Chrome build this Butler Sheet Icons release is tested with
             const browserInstallRes1 = await browserInstall({
@@ -78,16 +78,9 @@ describe('complex scenarios', () => {
             });
             expect(browserInstallRes3).toBeTruthy();
 
-            const browserInstallRes4 = await browserInstall({
-                browser: 'firefox',
-                browserVersion: 'recommended',
-                browserCacheDir,
-            });
-            expect(browserInstallRes4).toBeTruthy();
-
-            // There should now be four installed browsers
+            // There should now be three installed browsers
             const installedBrowsers2 = await browserInstalled(options);
-            expect(installedBrowsers2.length).toEqual(4);
+            expect(installedBrowsers2.length).toEqual(3);
 
             // Remove all installed browsers
             const uninstallRes2 = await browserUninstallAll(options);

--- a/src/lib/browser/__tests__/browser_detect.test.js
+++ b/src/lib/browser/__tests__/browser_detect.test.js
@@ -103,7 +103,9 @@ describe('detectAvailableBrowser — cached browsers', () => {
     });
 
     test('ignores cached browsers of a different type', async () => {
-        getInstalledBrowsers.mockResolvedValue([cachedBrowser('firefox', '130.0')]);
+        getInstalledBrowsers.mockResolvedValue([
+            cachedBrowser('chrome-headless-shell', '130.0.6099.109'),
+        ]);
 
         expect(await detectAvailableBrowser({ browser: 'chrome' })).toBeNull();
     });

--- a/src/lib/browser/__tests__/browser_edge_cases.integration.test.js
+++ b/src/lib/browser/__tests__/browser_edge_cases.integration.test.js
@@ -104,6 +104,9 @@ describe('edge cases and error handling', () => {
     test(
         'concurrent browser installations',
         async () => {
+            // Two different Chrome builds. Chrome is the only browser there is, and two
+            // builds exercise the same concurrent-download path. The archive path under
+            // `<cacheDir>/chrome/` is prefixed with the build id, so these do not collide.
             const installPromises = [
                 browserInstall({
                     browser: 'chrome',
@@ -111,8 +114,8 @@ describe('edge cases and error handling', () => {
                     browserCacheDir,
                 }),
                 browserInstall({
-                    browser: 'firefox',
-                    browserVersion: 'recommended',
+                    browser: 'chrome',
+                    browserVersion: '121.0.6167.16',
                     browserCacheDir,
                 }),
             ];

--- a/src/lib/browser/__tests__/browser_fetch_available_versions.test.js
+++ b/src/lib/browser/__tests__/browser_fetch_available_versions.test.js
@@ -82,25 +82,6 @@ describe('fetchAvailableVersions', () => {
         );
     });
 
-    describe('Firefox', () => {
-        test('returns the same shape as the Chrome branch', async () => {
-            // Previously this was `{ version: 'latest' }` with no `name`, so
-            // every consumer had to special-case a missing field.
-            const versions = await fetchAvailableVersions({
-                browser: 'firefox',
-                channel: 'stable',
-            });
-
-            expect(versions).toEqual([{ version: 'latest', name: 'firefox/latest' }]);
-        });
-
-        test('needs no network call', async () => {
-            await fetchAvailableVersions({ browser: 'firefox', channel: 'stable' });
-
-            expect(axios).not.toHaveBeenCalled();
-        });
-    });
-
     describe('failures', () => {
         test('explains an unreachable host before rethrowing', async () => {
             axios.mockRejectedValue(Object.assign(new Error('getaddrinfo ENOTFOUND'), {}));
@@ -186,9 +167,13 @@ describe('browserListAvailable still behaves as before', () => {
         expect(axios).not.toHaveBeenCalled();
     });
 
-    test('rejects an unknown browser', async () => {
+    // Rejected before any request, so an unknown browser is reported as an unknown browser
+    // rather than as a version lookup that returned nothing.
+    test.each(['safari', 'edge'])('rejects the unknown browser "%s"', async (browser) => {
         await expect(
-            browserListAvailable({ browser: 'safari', channel: 'stable', loglevel: 'info' })
+            browserListAvailable({ browser, channel: 'stable', loglevel: 'info' })
         ).rejects.toThrow('Invalid browser');
+
+        expect(axios).not.toHaveBeenCalled();
     });
 });

--- a/src/lib/browser/__tests__/browser_install_offline.test.js
+++ b/src/lib/browser/__tests__/browser_install_offline.test.js
@@ -17,7 +17,6 @@ const { resolveBuildId } = await import('@puppeteer/browsers');
 jest.unstable_mockModule('puppeteer-core/internal/revisions.js', () => ({
     PUPPETEER_REVISIONS: Object.freeze({
         chrome: '150.0.7871.24',
-        firefox: 'stable_152.0.1',
     }),
 }));
 

--- a/src/lib/browser/__tests__/browser_uninstall.integration.test.js
+++ b/src/lib/browser/__tests__/browser_uninstall.integration.test.js
@@ -81,10 +81,10 @@ describe('browserUninstall function', () => {
         // Mock no installed browsers
         getInstalledBrowsers.mockResolvedValue([
             {
-                browser: 'firefox',
+                browser: 'chrome-headless-shell',
                 buildId: '100.0.0.0',
                 platform: 'linux',
-                path: '/path/to/firefox',
+                path: '/path/to/chrome-headless-shell',
             },
         ]);
 
@@ -191,10 +191,10 @@ describe('browserUninstallAll function', () => {
                 path: '/path/to/chrome',
             },
             {
-                browser: 'firefox',
+                browser: 'chrome-headless-shell',
                 buildId: '100.0.0.0',
                 platform: 'linux',
-                path: '/path/to/firefox',
+                path: '/path/to/chrome-headless-shell',
             },
         ]);
 
@@ -240,10 +240,10 @@ describe('browserUninstallAll function', () => {
                 path: '/path/to/chrome',
             },
             {
-                browser: 'firefox',
+                browser: 'chrome-headless-shell',
                 buildId: '100.0.0.0',
                 platform: 'linux',
-                path: '/path/to/firefox',
+                path: '/path/to/chrome-headless-shell',
             },
         ]);
 

--- a/src/lib/browser/__tests__/browser_uninstall.test.js
+++ b/src/lib/browser/__tests__/browser_uninstall.test.js
@@ -266,7 +266,12 @@ describe('browserUninstallAll — race fix', () => {
     test('awaits every uninstall() before cleaning up', async () => {
         getInstalledBrowsers.mockResolvedValue([
             { browser: 'chrome', buildId: '123.0.0.0', platform: 'mac', path: '/p/1' },
-            { browser: 'firefox', buildId: '100.0.0.0', platform: 'mac', path: '/p/2' },
+            {
+                browser: 'chrome-headless-shell',
+                buildId: '100.0.0.0',
+                platform: 'mac',
+                path: '/p/2',
+            },
         ]);
 
         uninstall.mockImplementation(async () => {
@@ -285,7 +290,12 @@ describe('browserUninstallAll — race fix', () => {
     test('continues uninstalling remaining browsers when one throws', async () => {
         getInstalledBrowsers.mockResolvedValue([
             { browser: 'chrome', buildId: '123.0.0.0', platform: 'mac', path: '/p/1' },
-            { browser: 'firefox', buildId: '100.0.0.0', platform: 'mac', path: '/p/2' },
+            {
+                browser: 'chrome-headless-shell',
+                buildId: '100.0.0.0',
+                platform: 'mac',
+                path: '/p/2',
+            },
             { browser: 'chrome', buildId: '124.0.0.0', platform: 'mac', path: '/p/3' },
         ]);
 

--- a/src/lib/browser/__tests__/browser_version.test.js
+++ b/src/lib/browser/__tests__/browser_version.test.js
@@ -9,6 +9,10 @@ const { detectBrowserPlatform, resolveBuildId } = await import('@puppeteer/brows
 // The real constant is mocked so these tests assert the wiring - "the default comes from
 // puppeteer's pin" - rather than the specific build a given puppeteer-core happens to carry.
 // A separate test below asserts against the genuine module.
+//
+// The firefox entry mirrors the real constant, which pins every browser puppeteer supports
+// rather than every browser Butler Sheet Icons drives. It is here to be *refused*: without it,
+// the guard on getRecommendedBuildId would appear to work simply because no pin existed.
 jest.unstable_mockModule('puppeteer-core/internal/revisions.js', () => ({
     PUPPETEER_REVISIONS: Object.freeze({
         chrome: '150.0.7871.24',
@@ -46,14 +50,11 @@ beforeEach(() => {
 });
 
 describe('the recommended keyword', () => {
-    test.each([
-        ['chrome', '150.0.7871.24'],
-        ['firefox', 'stable_152.0.1'],
-    ])("resolves %s to puppeteer's pinned build", async (browser, expected) => {
-        const result = await resolveBrowserVersion(browser, VERSION_RECOMMENDED);
+    test("resolves chrome to puppeteer's pinned build", async () => {
+        const result = await resolveBrowserVersion('chrome', VERSION_RECOMMENDED);
 
         expect(result).toEqual({
-            buildId: expected,
+            buildId: '150.0.7871.24',
             source: VERSION_RECOMMENDED,
             requested: VERSION_RECOMMENDED,
             usedNetwork: false,
@@ -70,25 +71,30 @@ describe('the recommended keyword', () => {
         expect(detectBrowserPlatform).not.toHaveBeenCalled();
     });
 
-    test('fails clearly if puppeteer-core stops publishing a pin', () => {
-        // PUPPETEER_REVISIONS carries an @internal tag, so a future major could drop it. That
-        // must surface as a named failure rather than defaulting the product to undefined.
-        expect(() => getRecommendedBuildId('opera')).toThrow(/recommended "opera" build/i);
-    });
+    // PUPPETEER_REVISIONS pins every browser *puppeteer* supports, which is a wider set than the
+    // one Butler Sheet Icons can drive - it still carries a firefox pin, for instance. Reading it
+    // without checking the browser first meant this function answered for names that
+    // resolveBrowserVersion rejects, so the two disagreed about which browsers exist.
+    // browser_version_no_pin.test.js covers the other failure: a supported browser with no pin.
+    test.each(['opera', 'firefox'])(
+        'refuses "%s", which puppeteer may pin but Butler Sheet Icons cannot drive',
+        (browser) => {
+            expect(() => getRecommendedBuildId(browser)).toThrow(
+                new RegExp(`unsupported browser "${browser}"`, 'i')
+            );
+        }
+    );
 });
 
 describe('the stable keyword', () => {
-    test.each([
-        ['chrome', '151.0.7922.77'],
-        ['firefox', 'stable_153.0.3'],
-    ])('resolves %s via the browser vendor stable channel', async (browser, expected) => {
-        resolveBuildId.mockResolvedValue(expected);
+    test('resolves chrome via the browser vendor stable channel', async () => {
+        resolveBuildId.mockResolvedValue('151.0.7922.77');
 
-        const result = await resolveBrowserVersion(browser, VERSION_STABLE);
+        const result = await resolveBrowserVersion('chrome', VERSION_STABLE);
 
-        expect(resolveBuildId).toHaveBeenCalledWith(browser, 'mac_arm', 'stable');
+        expect(resolveBuildId).toHaveBeenCalledWith('chrome', 'mac_arm', 'stable');
         expect(result).toEqual({
-            buildId: expected,
+            buildId: '151.0.7922.77',
             source: VERSION_STABLE,
             requested: VERSION_STABLE,
             usedNetwork: true,
@@ -143,40 +149,33 @@ describe('release channels', () => {
     // These worked before the recommended/stable vocabulary existed - every value was handed to
     // resolveBuildId verbatim, which recognises channel tags - so administrators have them in
     // scheduled jobs. The first cut of the vocabulary rejected them (issue #878 review).
-    test.each([
-        ['chrome', 'beta'],
-        ['chrome', 'dev'],
-        ['chrome', 'canary'],
-        ['firefox', 'beta'],
-        ['firefox', 'nightly'],
-        ['firefox', 'devedition'],
-        ['firefox', 'esr'],
-    ])('resolves %s %s through the vendor', async (browser, channel) => {
-        resolveBuildId.mockResolvedValue('resolved-build');
+    test.each(['beta', 'dev', 'canary'])(
+        'resolves chrome %s through the vendor',
+        async (channel) => {
+            resolveBuildId.mockResolvedValue('resolved-build');
 
-        const result = await resolveBrowserVersion(browser, channel);
+            const result = await resolveBrowserVersion('chrome', channel);
 
-        expect(resolveBuildId).toHaveBeenCalledWith(browser, 'mac_arm', channel);
-        expect(result.buildId).toBe('resolved-build');
-        expect(result.source).toBe('channel');
-        expect(result.usedNetwork).toBe(true);
-    });
+            expect(resolveBuildId).toHaveBeenCalledWith('chrome', 'mac_arm', channel);
+            expect(result.buildId).toBe('resolved-build');
+            expect(result.source).toBe('channel');
+            expect(result.usedNetwork).toBe(true);
+        }
+    );
 
-    // The vendors' channels differ; a channel the browser does not have must be rejected up
-    // front, not passed to a lookup that would throw a less helpful error.
-    test.each([
-        ['chrome', 'nightly'],
-        ['chrome', 'devedition'],
-        ['chrome', 'esr'],
-        ['firefox', 'dev'],
-        ['firefox', 'canary'],
-    ])('rejects %s "%s", a channel that browser does not have', async (browser, channel) => {
-        await expect(resolveBrowserVersion(browser, channel)).rejects.toThrow(
-            /invalid --browser-version/i
-        );
+    // A channel name Chrome does not have must be rejected up front, not passed to a lookup
+    // that would throw a less helpful error. These are other vendors' channel names, which is
+    // what a reader reaching for a channel is most likely to guess wrong with.
+    test.each(['nightly', 'devedition', 'esr'])(
+        'rejects "%s", which Chrome does not have',
+        async (channel) => {
+            await expect(resolveBrowserVersion('chrome', channel)).rejects.toThrow(
+                /invalid --browser-version/i
+            );
 
-        expect(resolveBuildId).not.toHaveBeenCalled();
-    });
+            expect(resolveBuildId).not.toHaveBeenCalled();
+        }
+    );
 });
 
 describe('lookup-failure marking', () => {
@@ -226,26 +225,29 @@ describe('lookup-failure marking', () => {
 });
 
 describe('isVersionKeyword', () => {
+    test.each(['recommended', 'stable', 'latest', 'beta', 'dev', 'canary'])(
+        'recognises the floating "%s"',
+        (value) => {
+            expect(isVersionKeyword(value)).toBe(true);
+        }
+    );
+
+    // A keyword is allowed to degrade to a cached build when a lookup fails, so anything that
+    // cannot name a build must not be treated as floating - including other vendors' channel
+    // names, which look like keywords but resolve to nothing here.
     test.each([
-        'recommended',
-        'stable',
-        'latest',
-        'beta',
-        'dev',
-        'canary',
+        '151.0.7922.77',
+        '151',
+        'stable_153.0.3',
         'nightly',
         'devedition',
         'esr',
-    ])('recognises the floating "%s"', (value) => {
-        expect(isVersionKeyword(value)).toBe(true);
+        'garbage',
+        '',
+        undefined,
+    ])('does not treat %s as a keyword', (value) => {
+        expect(isVersionKeyword(value)).toBe(false);
     });
-
-    test.each(['151.0.7922.77', '151', 'stable_153.0.3', 'garbage', '', undefined])(
-        'does not treat %s as a keyword',
-        (value) => {
-            expect(isVersionKeyword(value)).toBe(false);
-        }
-    );
 });
 
 describe('parseBrowserVersionValue', () => {
@@ -265,17 +267,15 @@ describe('parseBrowserVersionValue', () => {
 
 describe('explicit versions', () => {
     test.each([
-        ['chrome', '151', 'milestone'],
-        ['chrome', '151.0.7922', 'build prefix'],
-        ['chrome', '151.0.7922.77', 'full build id'],
-        ['firefox', 'stable_153.0.3', 'channel-prefixed build id'],
-        ['firefox', 'esr_128.4.0', 'esr build id'],
-    ])('accepts %s %s (%s)', async (browser, version) => {
+        ['151', 'milestone'],
+        ['151.0.7922', 'build prefix'],
+        ['151.0.7922.77', 'full build id'],
+    ])('accepts chrome %s (%s)', async (version) => {
         resolveBuildId.mockResolvedValue('resolved-build');
 
-        const result = await resolveBrowserVersion(browser, version);
+        const result = await resolveBrowserVersion('chrome', version);
 
-        expect(resolveBuildId).toHaveBeenCalledWith(browser, 'mac_arm', version);
+        expect(resolveBuildId).toHaveBeenCalledWith('chrome', 'mac_arm', version);
         expect(result.source).toBe('explicit');
         expect(result.requested).toBe(version);
     });
@@ -283,20 +283,16 @@ describe('explicit versions', () => {
     // resolveBuildId returns unrecognised input verbatim rather than failing, so without this
     // check a typo travelled all the way to canDownload and surfaced as "cannot be downloaded"
     // - which reads like a network problem.
-    test.each([
-        ['chrome', 'garbage'],
-        ['chrome', '151.0'],
-        ['chrome', 'v151.0.7922.77'],
-        ['chrome', 'stable_153.0.3'],
-        ['firefox', '152.0.1'],
-        ['firefox', 'garbage'],
-    ])('rejects %s "%s" before any network call', async (browser, version) => {
-        await expect(resolveBrowserVersion(browser, version)).rejects.toThrow(
-            /invalid --browser-version/i
-        );
+    test.each(['garbage', '151.0', 'v151.0.7922.77', 'stable_153.0.3', 'esr_128.4.0'])(
+        'rejects chrome "%s" before any network call',
+        async (version) => {
+            await expect(resolveBrowserVersion('chrome', version)).rejects.toThrow(
+                /invalid --browser-version/i
+            );
 
-        expect(resolveBuildId).not.toHaveBeenCalled();
-    });
+            expect(resolveBuildId).not.toHaveBeenCalled();
+        }
+    );
 
     test('tells the user what a valid chrome version looks like', async () => {
         await expect(resolveBrowserVersion('chrome', 'garbage')).rejects.toThrow();
@@ -305,16 +301,6 @@ describe('explicit versions', () => {
         expect(advice).toContain(VERSION_RECOMMENDED);
         expect(advice).toContain(VERSION_STABLE);
         expect(advice).toContain('151.0.7922.77');
-    });
-
-    // A bare Firefox version is not merely unsupported - @puppeteer/browsers reads an
-    // unprefixed build id as FirefoxChannel.NIGHTLY, so passing it through would quietly
-    // install a nightly build.
-    test('tells firefox users to prefix the channel', async () => {
-        await expect(resolveBrowserVersion('firefox', '152.0.1')).rejects.toThrow();
-
-        const advice = logger.error.mock.calls.map(([msg]) => msg).join('\n');
-        expect(advice).toContain('stable_153.0.3');
     });
 });
 
@@ -328,11 +314,21 @@ describe('unsupported browsers', () => {
         );
     });
 
+    // Commander's .choices() already refuses an unknown browser on the command line, but the
+    // workers are called directly too - by the integration tests and by the interactive path -
+    // so the refusal has to live here as well.
+    test('is refused before any version work happens', async () => {
+        await expect(resolveBrowserVersion('safari', VERSION_RECOMMENDED)).rejects.toThrow(
+            /unsupported browser "safari"/i
+        );
+
+        expect(resolveBuildId).not.toHaveBeenCalled();
+    });
+
     test('lists what is supported', async () => {
         const err = await resolveBrowserVersion('opera', VERSION_STABLE).catch((e) => e);
 
         expect(err.message).toContain('chrome');
-        expect(err.message).toContain('firefox');
     });
 
     test('is rejected before any network call', async () => {
@@ -363,7 +359,7 @@ describe('resolveLocalBrowserBuildId (uninstall)', () => {
     // A floating keyword resolves to whatever the vendor currently publishes - almost never a
     // build in the local cache - so for a destructive, offline-capable command it is refused
     // with guidance instead of resolved over the network.
-    test.each(['stable', 'latest', 'beta', 'esr'])(
+    test.each(['stable', 'latest', 'beta', 'dev', 'canary'])(
         'refuses the floating "%s" and points at list-installed',
         (value) => {
             expect(resolveLocalBrowserBuildId('chrome', value)).toBeNull();
@@ -376,7 +372,12 @@ describe('resolveLocalBrowserBuildId (uninstall)', () => {
 
     test('passes an exact build id through unchanged', () => {
         expect(resolveLocalBrowserBuildId('chrome', '151.0.7922.77')).toBe('151.0.7922.77');
-        expect(resolveLocalBrowserBuildId('firefox', 'stable_153.0.3')).toBe('stable_153.0.3');
+    });
+
+    // Anything that is not a Chrome keyword is passed through unvalidated: it simply will not
+    // match a cache entry, and "not found in cache" is the honest outcome for it.
+    test('passes an unrecognised value through to fail the cache lookup', () => {
+        expect(resolveLocalBrowserBuildId('chrome', 'esr')).toBe('esr');
     });
 
     test('refuses an empty value', () => {

--- a/src/lib/browser/__tests__/browser_version_no_pin.test.js
+++ b/src/lib/browser/__tests__/browser_version_no_pin.test.js
@@ -1,0 +1,52 @@
+import { jest, test, expect, describe } from '@jest/globals';
+
+// Its own file because the failure it covers is a *shape* of `PUPPETEER_REVISIONS`, and a module
+// mock is per-file: the sibling browser_version.test.js needs a constant that carries a chrome
+// pin, and this one needs a constant that does not. Same reason browser_install_offline.test.js
+// is separate.
+jest.unstable_mockModule('puppeteer-core/internal/revisions.js', () => ({
+    PUPPETEER_REVISIONS: Object.freeze({}),
+}));
+
+jest.unstable_mockModule('@puppeteer/browsers', () => ({
+    detectBrowserPlatform: jest.fn().mockResolvedValue('mac_arm'),
+    resolveBuildId: jest.fn(),
+}));
+
+jest.unstable_mockModule('../../../globals.js', () => ({
+    logger: {
+        info: jest.fn(),
+        verbose: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+    },
+}));
+
+const { getRecommendedBuildId, resolveLocalBrowserBuildId, VERSION_RECOMMENDED } =
+    await import('../browser-version.js');
+
+describe('a supported browser that puppeteer-core no longer pins', () => {
+    // PUPPETEER_REVISIONS carries an `@internal` tag, so a future major could drop or rename it.
+    // That must surface as a named failure rather than defaulting the whole product to
+    // `undefined` - which is what would reach the cache lookup and the installer.
+    //
+    // browser_version_pin.test.js is the other half: it asserts against the *real* puppeteer-core
+    // that the pin is still there, so a dependency bump fails in CI rather than in the field.
+    // This half asserts what happens on the day that canary goes off.
+    test('fails by name rather than resolving to undefined', () => {
+        expect(() => getRecommendedBuildId('chrome')).toThrow(/recommended "chrome" build/i);
+    });
+
+    test('names a way forward, since the default is the thing that broke', () => {
+        expect(() => getRecommendedBuildId('chrome')).toThrow(/--browser-version/);
+    });
+
+    // The uninstall path reaches the same constant through resolveLocalBrowserBuildId, and must
+    // not turn a missing pin into a silent "no cache entry matched".
+    test('propagates through the offline uninstall path', () => {
+        expect(() => resolveLocalBrowserBuildId('chrome', VERSION_RECOMMENDED)).toThrow(
+            /recommended "chrome" build/i
+        );
+    });
+});

--- a/src/lib/browser/__tests__/browser_version_pin.test.js
+++ b/src/lib/browser/__tests__/browser_version_pin.test.js
@@ -15,15 +15,11 @@ describe('the puppeteer-core browser pin', () => {
         expect(PUPPETEER_REVISIONS).toBeDefined();
     });
 
-    test('carries build-id-shaped pins for both supported browsers', async () => {
+    test('carries a build-id-shaped pin for chrome', async () => {
         const { PUPPETEER_REVISIONS } = await import('puppeteer-core/internal/revisions.js');
 
         // Chrome build ids are four dot-separated numbers, e.g. 150.0.7871.24.
         expect(PUPPETEER_REVISIONS.chrome).toMatch(/^\d+\.\d+\.\d+\.\d+$/);
-
-        // Firefox build ids are channel-prefixed, e.g. stable_152.0.1. A pin that ever arrived
-        // unprefixed would be read as a nightly build by @puppeteer/browsers.
-        expect(PUPPETEER_REVISIONS.firefox).toMatch(/^(stable|beta|nightly|devedition|esr)_\S+$/);
     });
 
     test('agrees between the package root and the leaf module the resolver imports', async () => {
@@ -31,6 +27,5 @@ describe('the puppeteer-core browser pin', () => {
         const leaf = (await import('puppeteer-core/internal/revisions.js')).PUPPETEER_REVISIONS;
 
         expect(leaf.chrome).toBe(root.chrome);
-        expect(leaf.firefox).toBe(root.firefox);
     });
 });

--- a/src/lib/browser/__tests__/browser_version_resolution.integration.test.js
+++ b/src/lib/browser/__tests__/browser_version_resolution.integration.test.js
@@ -10,7 +10,7 @@ import { resolveBrowserVersion, getRecommendedBuildId } from '../browser-version
 import { assertEnv, getTestTimeout } from '../../util/env-check.js';
 import { makeIsolatedCacheDir, removeIsolatedCacheDir } from '../test-helpers/isolated-cache.js';
 
-// Version resolution against the real Chrome for Testing and Firefox version services, and
+// Version resolution against the real Chrome for Testing version service, and
 // against a real browser cache on disk. The unit suite covers the same decisions with mocks;
 // what only an integration test can show is that the vendor services still answer in the shape
 // Butler Sheet Icons expects, and that a build resolved from one of them is actually installable.
@@ -62,16 +62,13 @@ describe('browser version resolution', () => {
      * `stable` has to reach the vendor. Guards against the service changing shape - a silent
      * change there would take out every run that does not use `recommended`.
      */
-    test.each([
-        ['chrome', /^\d+\.\d+\.\d+\.\d+$/],
-        ['firefox', /^stable_\S+$/],
-    ])(
-        'the stable %s build is resolvable from the vendor',
-        async (browser, shape) => {
-            const resolved = await resolveBrowserVersion(browser, 'stable');
+    test(
+        'the stable chrome build is resolvable from the vendor',
+        async () => {
+            const resolved = await resolveBrowserVersion('chrome', 'stable');
 
             expect(resolved.usedNetwork).toBe(true);
-            expect(resolved.buildId).toMatch(shape);
+            expect(resolved.buildId).toMatch(/^\d+\.\d+\.\d+\.\d+$/);
         },
         defaultTestTimeout
     );
@@ -122,15 +119,11 @@ describe('browser version resolution', () => {
      * reached `canDownload` and surfaced as "cannot be downloaded" - which reads like a network
      * problem and sends the reader after the wrong thing entirely.
      */
-    test.each([
-        ['chrome', 'garbage'],
-        ['chrome', '151.0'],
-        ['firefox', '152.0.1'],
-    ])(
-        'a malformed %s version "%s" is rejected up front',
-        async (browser, browserVersion) => {
+    test.each(['garbage', '151.0', 'stable_153.0.3'])(
+        'a malformed chrome version "%s" is rejected up front',
+        async (browserVersion) => {
             await expect(
-                browserInstall({ browser, browserVersion, browserCacheDir })
+                browserInstall({ browser: 'chrome', browserVersion, browserCacheDir })
             ).rejects.toThrow(/invalid --browser-version/i);
         },
         defaultTestTimeout

--- a/src/lib/browser/browser-detect.js
+++ b/src/lib/browser/browser-detect.js
@@ -49,7 +49,8 @@ const sortNewestFirst = (browsers, browser) => {
  * how a broken build survived unnoticed on one CI runner while another passed (issue #878).
  *
  * @param {object} options - Options object.
- * @param {string} options.browser - Browser type (e.g. `chrome`, `firefox`).
+ * @param {string} options.browser - Browser type. `chrome` is the only supported value; a cache
+ * entry of any other type is ignored.
  * @param {string} [options.browserCacheDir] - Cache directory to search. Resolved here rather
  * than by the caller, so a worker called directly with a bare options bag still works.
  * @param {string} [options.browserVersion] - The raw value the user asked for. Used only to decide

--- a/src/lib/browser/browser-install.js
+++ b/src/lib/browser/browser-install.js
@@ -24,7 +24,7 @@ import { alreadyReported } from '../util/reported-error.js';
  * must therefore wrap the call in try/catch rather than test the result.
  *
  * @param {object} options - Options object.
- * @param {string} options.browser - Browser to install (`chrome` or `firefox`).
+ * @param {string} options.browser - Browser to install. `chrome` is the only supported value.
  * @param {string} options.browserVersion - Browser version to install: the keyword `recommended` or
  * `stable`, or an explicit build id.
  * @param {string} [options.browserCacheDir] - Directory to install into. Defaults to the resolver's

--- a/src/lib/browser/browser-list-available.js
+++ b/src/lib/browser/browser-list-available.js
@@ -121,7 +121,7 @@ function mapPlatformToChrome(puppeteerPlatform) {
 }
 
 /**
- * Fetch the browser versions the vendor currently publishes.
+ * Fetch the Chrome versions Google currently publishes.
  *
  * Fetching only: no availability checking, no per-version logging. That
  * separation is the point. The availability check is one HTTP request per
@@ -136,22 +136,14 @@ function mapPlatformToChrome(puppeteerPlatform) {
  * caller leaves it at the default.
  *
  * @param {object} options - An options object.
- * @param {string} options.browser - Browser to list versions for (`chrome` or `firefox`).
- * @param {string} options.channel - Chrome release channel. Ignored for Firefox.
+ * @param {string} options.channel - Chrome release channel.
  * @param {string} [options.logPrefix] - Prefix for this function's debug lines.
  *
  * @returns {Promise<Array<{version: string, name: string}>>} Published versions, newest first, as the API returns them.
  *
  * @throws {Error} If the version history API cannot be reached or returns something unusable.
  */
-export async function fetchAvailableVersions({ browser, channel, logPrefix = '' }) {
-    // Firefox has no version history lookup yet. Returning the same shape as
-    // the Chrome branch - rather than an object with no `name` - means no
-    // consumer has to special-case a missing field.
-    if (browser === 'firefox') {
-        return [{ version: 'latest', name: 'firefox/latest' }];
-    }
-
+export async function fetchAvailableVersions({ channel, logPrefix = '' }) {
     // The real detectBrowserPlatform is synchronous, so this await does nothing
     // - but it is what the code did before this function was extracted, and
     // dropping it would change what a promise-returning stub does. Left as-is
@@ -184,12 +176,13 @@ export async function fetchAvailableVersions({ browser, channel, logPrefix = '' 
 /**
  * List all available browser versions.
  *
- * For Chrome, the available versions are fetched from the Chrome version history API and filtered
- * to those that Puppeteer can actually download. For Firefox, only `latest` is supported at this time.
+ * The available versions are fetched from the Chrome version history API and filtered to those
+ * that Puppeteer can actually download.
  *
  * @param {object} options - An options object.
- * @param {string} options.browser - Browser to list available versions for (`chrome` or `firefox`).
- * @param {string} options.channel - Which Chrome release channel to list (`stable`, `beta`, `dev`, or `canary`). Ignored for Firefox.
+ * @param {string} options.browser - Browser to list available versions for. `chrome` is the only
+ * supported value.
+ * @param {string} options.channel - Which Chrome release channel to list (`stable`, `beta`, `dev`, or `canary`).
  * @param {string} [options.loglevel] - The log level. Can be one of "error", "warn", "info", "verbose", "debug", or "silly".
  *
  * @returns {Promise<Array<object>>} A promise that resolves to an array of available browsers.
@@ -204,22 +197,22 @@ export async function browserListAvailable(options) {
         logger.debug(`BSI executable path: ${bsiExecutablePath}`);
         logger.debug(`Options: ${JSON.stringify(redactOptions(options), null, 2)}`);
 
-        // Verify release channek is valid for the selected browser
-        if (options.browser === 'chrome') {
-            if (
-                options.channel !== 'stable' &&
-                options.channel !== 'beta' &&
-                options.channel !== 'dev' &&
-                options.channel !== 'canary'
-            ) {
-                throw new Error(
-                    `Invalid release channel "${options.channel}" for browser "${options.browser}"`
-                );
-            }
-        } else if (options.browser === 'firefox') {
-            // Nothing to do here
-        } else {
+        // Reported as a bad browser rather than a bad channel: the two are separate mistakes
+        // and the messages must not be swapped.
+        if (options.browser !== 'chrome') {
             throw new Error(`Invalid browser "${options.browser}"`);
+        }
+
+        // Verify the release channel is one the version history API publishes
+        if (
+            options.channel !== 'stable' &&
+            options.channel !== 'beta' &&
+            options.channel !== 'dev' &&
+            options.channel !== 'canary'
+        ) {
+            throw new Error(
+                `Invalid release channel "${options.channel}" for browser "${options.browser}"`
+            );
         }
 
         // No --browser-cache-dir on this command: this value is only ever handed to
@@ -228,94 +221,63 @@ export async function browserListAvailable(options) {
         // so there is one answer to "where is the cache" rather than two.
         const browserPath = resolveBrowserCacheDir(options);
 
-        // Get versions for the selected browser
-        let browsersAvailable = [];
-        if (options.browser === 'chrome') {
-            // https://developer.chrome.com/docs/web-platform/versionhistory/guide
-            //
-            // Chome version history API:
-            // https://developer.chrome.com/docs/versionhistory/guide/
-            //
-            // Get chrome versions from this URL:
-            // https://versionhistory.googleapis.com/v1/chrome/platforms/<platform>/channels/<channel>/versions
-            //
-            // Example:
-            // https://versionhistory.googleapis.com/v1/chrome/platforms/win/channels/stable/versions
-            //
-            // Response:
-            // {
-            //     "versions": [
-            //         {
-            //             "name": "chrome/platforms/win/channels/stable/versions/115.0.5790.90",
-            //             "version": "115.0.5790.90"
-            //         },
-            //         {
-            //             "name": "chrome/platforms/win/channels/stable/versions/114.0.5735.200"
-            //             ""version": "114.0.5735.200"
-            //         }
-            //     ],
-            //     "nextPageToken": ""
-            // }
+        // https://developer.chrome.com/docs/web-platform/versionhistory/guide
+        //
+        // Chome version history API:
+        // https://developer.chrome.com/docs/versionhistory/guide/
+        //
+        // Get chrome versions from this URL:
+        // https://versionhistory.googleapis.com/v1/chrome/platforms/<platform>/channels/<channel>/versions
+        //
+        // Example:
+        // https://versionhistory.googleapis.com/v1/chrome/platforms/win/channels/stable/versions
+        //
+        // Response:
+        // {
+        //     "versions": [
+        //         {
+        //             "name": "chrome/platforms/win/channels/stable/versions/115.0.5790.90",
+        //             "version": "115.0.5790.90"
+        //         },
+        //         {
+        //             "name": "chrome/platforms/win/channels/stable/versions/114.0.5735.200"
+        //             ""version": "114.0.5735.200"
+        //         }
+        //     ],
+        //     "nextPageToken": ""
+        // }
 
-            browsersAvailable = await fetchAvailableVersions({
-                browser: options.browser,
-                channel: options.channel,
-            });
+        const browsersAvailable = await fetchAvailableVersions({
+            channel: options.channel,
+        });
 
-            // Output Chrome versions and names to info log
-            if (browsersAvailable.length > 0) {
-                logger.info(`Chrome versions from "${options.channel}" channel:`);
-                logger.verbose(
-                    'Note that not all versions may be available for use with Butler Sheet Icons.'
-                );
-
-                for (const version of browsersAvailable) {
-                    // Can this version be downloaded?
-
-                    const canDownloadBrowser = await canDownload({
-                        browser: options.browser,
-                        buildId: version.version,
-                        cacheDir: browserPath,
-                        unpack: true,
-                    });
-
-                    if (canDownloadBrowser) {
-                        logger.info(`    ${version.version}, "${version.name}"`);
-                    } else {
-                        logger.verbose(`    ${version.version}, "${version.name}" (not available)`);
-                    }
-                }
-            } else {
-                logger.info('No Chrome versions available');
-            }
-        } else if (options.browser === 'firefox') {
-            // For now support for older Firefox versions is not implemented
-            logger.warn(
-                'Firefox support is not implemented yet. Only latest version is supported, i.e. "browser install --browser firefox --browser-version latest", or simply "browser install --browser firefox".'
+        // Output Chrome versions and names to info log
+        if (browsersAvailable.length > 0) {
+            logger.info(`Chrome versions from "${options.channel}" channel:`);
+            logger.verbose(
+                'Note that not all versions may be available for use with Butler Sheet Icons.'
             );
-            browsersAvailable.push({ version: 'latest' });
 
-            // Firefox version history API:
-            // https://wiki.mozilla.org/Release_Management/Product_details#firefox.json
-            //
-            // Get Firefox versions from this URL:
-            // https://product-details.mozilla.org/1.0/firefox.json
-            //
-            // Response:
-            // {
-            //     "releases": [
-            //         "firefox-114.0b7": {
-            //             "build_number": 1,
-            //             "category": "dev",
-            //             "date": "2023-05-22",
-            //             "description": null,
-            //             "is_security_driven": false,
-            //             "product": "firefox",
-            //             "version": "114.0b7"
-            //         }
-            //     ]
-            // }
+            for (const version of browsersAvailable) {
+                // Can this version be downloaded?
+
+                const canDownloadBrowser = await canDownload({
+                    browser: options.browser,
+                    buildId: version.version,
+                    cacheDir: browserPath,
+                    unpack: true,
+                });
+
+                if (canDownloadBrowser) {
+                    logger.info(`    ${version.version}, "${version.name}"`);
+                } else {
+                    logger.verbose(`    ${version.version}, "${version.name}" (not available)`);
+                }
+            }
+        } else {
+            logger.info('No Chrome versions available');
         }
+
         return browsersAvailable;
     } catch (err) {
         // Only report failures nothing else has explained. Request and response problems are

--- a/src/lib/browser/browser-version.js
+++ b/src/lib/browser/browser-version.js
@@ -28,27 +28,14 @@ export const VERSION_STABLE = 'stable';
 export const VERSION_LATEST = 'latest';
 
 /**
- * Every keyword Butler Sheet Icons understands, for help text and error messages.
- */
-export const VERSION_KEYWORDS = [VERSION_RECOMMENDED, VERSION_STABLE];
-
-/**
- * Browser release channels accepted per browser.
+ * Chrome release channels accepted as a `--browser-version` value.
  *
  * Resolved live through the same `@puppeteer/browsers` tag handling that resolves `stable`.
  * These worked before the `recommended`/`stable` vocabulary existed - every value used to be
  * handed to `resolveBuildId` verbatim, which recognises them as tags - and administrators use
- * them to track a vendor channel, so they must keep working. The sets differ per browser
- * because the vendors' channels differ: Chrome has no nightly/devedition/esr, Firefox has no
- * dev/canary.
+ * them to track a vendor channel, so they must keep working.
  */
-const CHANNEL_KEYWORDS = {
-    chrome: ['beta', 'dev', 'canary'],
-    firefox: ['beta', 'nightly', 'devedition', 'esr'],
-};
-
-/** Every channel name accepted for at least one browser. */
-const ALL_CHANNEL_KEYWORDS = new Set(Object.values(CHANNEL_KEYWORDS).flat());
+const CHANNEL_KEYWORDS = ['beta', 'dev', 'canary'];
 
 /**
  * Builds the help text for a `--browser-version` option.
@@ -64,7 +51,7 @@ const ALL_CHANNEL_KEYWORDS = new Set(Object.values(CHANNEL_KEYWORDS).flat());
  * @returns {string} Description for Commander.
  */
 export const describeBrowserVersionOption = (action) =>
-    `Browser build to ${action}. Either a keyword - "${VERSION_RECOMMENDED}" for the build Butler Sheet Icons is tested with, "${VERSION_STABLE}" for the newest stable release, or a release channel such as "beta" - or an exact version. For Chrome that is a milestone ("151"), a build prefix ("151.0.7922") or a full build id ("151.0.7922.77"); for Firefox a channel-prefixed build id ("stable_153.0.3"). Use "butler-sheet-icons browser list-available" to see what is available.`;
+    `Browser build to ${action}. Either a keyword - "${VERSION_RECOMMENDED}" for the build Butler Sheet Icons is tested with, "${VERSION_STABLE}" for the newest stable release, or a release channel such as "beta" - or an exact version: a milestone ("151"), a build prefix ("151.0.7922") or a full build id ("151.0.7922.77"). Use "butler-sheet-icons browser list-available" to see what is available.`;
 
 /**
  * Commander argument parser for `--browser-version` options that default to `recommended`.
@@ -98,39 +85,59 @@ export const isVersionKeyword = (browserVersion) =>
     browserVersion === VERSION_RECOMMENDED ||
     browserVersion === VERSION_STABLE ||
     browserVersion === VERSION_LATEST ||
-    ALL_CHANNEL_KEYWORDS.has(browserVersion);
+    CHANNEL_KEYWORDS.includes(browserVersion);
 
 /**
- * Explicit version forms accepted per browser.
+ * Explicit version forms accepted for Chrome.
  *
- * Chrome accepts three shapes, all of which `@puppeteer/browsers` resolves against the
- * Chrome for Testing "known good versions" data:
+ * Three shapes, all of which `@puppeteer/browsers` resolves against the Chrome for Testing
+ * "known good versions" data:
  *
  * - a milestone, `151`
  * - a build prefix without the patch component, `151.0.7922`
  * - a full build id, `151.0.7922.77`
- *
- * Firefox build ids are channel-prefixed, `stable_153.0.3`. A bare Firefox version is
- * deliberately **not** accepted: `@puppeteer/browsers` treats an unprefixed build id as
- * `FirefoxChannel.NIGHTLY`, so `--browser-version 152.0.1` would quietly install a nightly
- * build. Rejecting it and naming the correct form is the whole point of this validation.
  */
-const EXPLICIT_VERSION_PATTERNS = {
-    chrome: [/^\d+$/, /^\d+\.\d+\.\d+$/, /^\d+\.\d+\.\d+\.\d+$/],
-    firefox: [/^(stable|beta|nightly|devedition|esr)_\S+$/],
-};
+const EXPLICIT_VERSION_PATTERNS = [/^\d+$/, /^\d+\.\d+\.\d+$/, /^\d+\.\d+\.\d+\.\d+$/];
 
-/** Browsers Butler Sheet Icons knows how to resolve a version for. */
-const SUPPORTED_BROWSERS = Object.keys(EXPLICIT_VERSION_PATTERNS);
+/**
+ * Browsers Butler Sheet Icons knows how to resolve a version for.
+ *
+ * Chrome, and only Chrome: the render path speaks the Chrome DevTools Protocol and passes a
+ * Chromium-only argument list, so no other browser could be driven. Kept as a list, and checked
+ * by name, so a bad `browser` value from a directly-called worker is reported as a bad browser
+ * rather than failing later as a version that cannot be resolved.
+ */
+const SUPPORTED_BROWSERS = ['chrome'];
+
+/**
+ * Refuses a browser Butler Sheet Icons cannot drive.
+ *
+ * One helper rather than a check per entry point, so every path answers the same way. The two
+ * that matter are `resolveBrowserVersion` (the network path) and `getRecommendedBuildId` (the
+ * offline one, reached by `resolveLocalBrowserBuildId` on the uninstall path): before this was
+ * shared, the second read straight from `PUPPETEER_REVISIONS` and returned a build id for
+ * browsers the first rejected by name.
+ *
+ * @param {string} browser - Browser name from the CLI, the environment, or a directly-called
+ * worker.
+ *
+ * @returns {void}
+ *
+ * @throws {Error} If the browser is not one Butler Sheet Icons supports.
+ */
+const assertBrowserIsSupported = (browser) => {
+    if (!SUPPORTED_BROWSERS.includes(browser)) {
+        throw new Error(
+            `Unsupported browser "${browser}". Butler Sheet Icons can install ${SUPPORTED_BROWSERS.join(' and ')}.`
+        );
+    }
+};
 
 /**
  * Human-readable description of the accepted explicit forms, used in error text.
  */
-const EXPLICIT_VERSION_HELP = {
-    chrome: 'a release channel ("beta", "dev", "canary"), a milestone such as "151", a build prefix such as "151.0.7922", or a full build id such as "151.0.7922.77"',
-    firefox:
-        'a release channel ("beta", "nightly", "devedition", "esr"), or a channel-prefixed build id such as "stable_153.0.3"',
-};
+const EXPLICIT_VERSION_HELP =
+    'a release channel ("beta", "dev", "canary"), a milestone such as "151", a build prefix such as "151.0.7922", or a full build id such as "151.0.7922.77"';
 
 /**
  * Whether the deprecation warning for `latest` has already been emitted in this process.
@@ -149,13 +156,23 @@ let latestDeprecationWarned = false;
  * failure path: if a future puppeteer-core drops or renames it, this throws with a clear cause
  * instead of silently yielding `undefined` and defaulting the whole product to nothing.
  *
- * @param {string} browser - Browser to look up (`chrome` or `firefox`).
+ * The browser is checked against {@link SUPPORTED_BROWSERS} first, and that check is
+ * load-bearing rather than defensive: `PUPPETEER_REVISIONS` carries a pin for every browser
+ * puppeteer itself supports, which is a wider set than the one Butler Sheet Icons can drive.
+ * Without it this function answers happily for a browser nothing else accepts - so
+ * `resolveBrowserVersion` would reject a name that `resolveLocalBrowserBuildId` resolved, and the
+ * product would hold two contradictory opinions about which browsers exist.
+ *
+ * @param {string} browser - Browser to look up. `chrome` is the only supported value.
  *
  * @returns {string} The pinned build id, e.g. `150.0.7871.24`.
  *
- * @throws {Error} If puppeteer-core does not publish a pinned build for this browser.
+ * @throws {Error} If the browser is not one Butler Sheet Icons supports, or if puppeteer-core
+ * does not publish a pinned build for it.
  */
 export const getRecommendedBuildId = (browser) => {
+    assertBrowserIsSupported(browser);
+
     const buildId = PUPPETEER_REVISIONS?.[browser];
 
     if (typeof buildId !== 'string' || buildId.length === 0) {
@@ -225,16 +242,13 @@ const normalizeVersionKeyword = (browserVersion) => {
  * @throws {Error} If the value is neither a keyword nor a plausible build id.
  */
 const assertExplicitVersionIsWellFormed = (browser, browserVersion) => {
-    // The browser is known to be supported: resolveBrowserVersion checks that first.
-    const patterns = EXPLICIT_VERSION_PATTERNS[browser];
-
-    if (patterns.some((pattern) => pattern.test(browserVersion))) {
+    if (EXPLICIT_VERSION_PATTERNS.some((pattern) => pattern.test(browserVersion))) {
         return;
     }
 
     logger.error(`"${browserVersion}" is not a valid --browser-version for ${browser}.`);
     logger.error(
-        `Use a keyword - "${VERSION_RECOMMENDED}" (the build Butler Sheet Icons is tested against) or "${VERSION_STABLE}" (the newest stable release) - or ${EXPLICIT_VERSION_HELP[browser]}.`
+        `Use a keyword - "${VERSION_RECOMMENDED}" (the build Butler Sheet Icons is tested against) or "${VERSION_STABLE}" (the newest stable release) - or ${EXPLICIT_VERSION_HELP}.`
     );
     logger.error(
         `Run "butler-sheet-icons browser list-available --browser ${browser}" to see the versions that can be installed.`
@@ -340,7 +354,8 @@ const logVersionLookupFailure = (browser, browserVersion, err) => {
  * keyword means exactly one build within a run, and two machines running the same Butler Sheet
  * Icons release with the same options select the same build.
  *
- * @param {string} browser - Browser to resolve for (`chrome` or `firefox`).
+ * @param {string} browser - Browser to resolve for. `chrome` is the only supported value;
+ * anything else is rejected by name.
  * @param {string} browserVersion - Keyword, release channel, or explicit version from the CLI or
  * environment.
  *
@@ -364,11 +379,7 @@ export const resolveBrowserVersion = async (browser, browserVersion) => {
     // Checked before anything else so an unknown browser is reported as an unknown browser.
     // Without this the run failed further down with "Could not resolve --browser-version ... to a
     // <name> build", which blames the version for a problem with the browser.
-    if (!SUPPORTED_BROWSERS.includes(browser)) {
-        throw new Error(
-            `Unsupported browser "${browser}". Butler Sheet Icons can install ${SUPPORTED_BROWSERS.join(' and ')}.`
-        );
-    }
+    assertBrowserIsSupported(browser);
 
     const keyword = normalizeVersionKeyword(browserVersion);
 
@@ -392,7 +403,7 @@ export const resolveBrowserVersion = async (browser, browserVersion) => {
 
     // A release channel is validated by name, not by shape - "beta" is a real Chrome channel
     // but matches none of the explicit build-id patterns.
-    const isChannel = !keyword && CHANNEL_KEYWORDS[browser].includes(browserVersion);
+    const isChannel = !keyword && CHANNEL_KEYWORDS.includes(browserVersion);
 
     if (!keyword && !isChannel) {
         assertExplicitVersionIsWellFormed(browser, browserVersion);
@@ -401,10 +412,8 @@ export const resolveBrowserVersion = async (browser, browserVersion) => {
     const platform = await detectBrowserPlatform();
     logger.debug(`Detected browser platform: ${platform}`);
 
-    // `stable` and the release channels are tags @puppeteer/browsers understands for both
-    // browsers, which is why one Butler Sheet Icons vocabulary can serve both. Note that its
-    // `latest` tag is NOT the equivalent of `stable` - for Chrome it means the canary channel,
-    // and for Firefox nightly.
+    // `stable` and the release channels are tags @puppeteer/browsers understands. Note that its
+    // `latest` tag is NOT the equivalent of `stable` - for Chrome it means the canary channel.
     const tag = keyword === VERSION_STABLE ? VERSION_STABLE : browserVersion;
 
     let buildId;
@@ -449,13 +458,21 @@ export const resolveBrowserVersion = async (browser, browserVersion) => {
  * network.
  *
  * A value that matches no accepted form is passed through unvalidated: it simply will not match
- * any cache entry, and "not found in cache" is the honest outcome for it.
+ * any cache entry, and "not found in cache" is the honest outcome for it. Note what that means
+ * for `browser`: only the `recommended` path consults it, through `getRecommendedBuildId`, so an
+ * exact build id is matched against the cache without regard to which browser it belongs to.
+ * That is deliberate - this function's job is to name a build, and the caller filters the
+ * inventory by browser itself - but it does mean an unsupported browser is refused here only
+ * when the version is `recommended`.
  *
- * @param {string} browser - Browser the version belongs to (`chrome` or `firefox`).
+ * @param {string} browser - Browser the version belongs to. `chrome` is the only supported value.
  * @param {string} browserVersion - Raw `--browser-version` value.
  *
  * @returns {string|null} The build id to match against the cache, or `null` when the value
  * cannot name a local build - in which case the reason has already been logged.
+ *
+ * @throws {Error} If `browserVersion` is `recommended` and the browser is not supported, or
+ * puppeteer-core publishes no pin for it.
  */
 export const resolveLocalBrowserBuildId = (browser, browserVersion) => {
     if (!browserVersion) {

--- a/src/lib/browser/test-helpers/isolated-cache.js
+++ b/src/lib/browser/test-helpers/isolated-cache.js
@@ -11,8 +11,8 @@ import path from 'node:path';
  * them call `browserUninstallAll`, which finishes with `fs.emptyDir` on the
  * cache directory, so a run wipes every browser present, including builds that
  * were staged by hand and that no test installed. That happened on 2026-08-12
- * and cost a cache holding chrome 114.0.5735.133, chrome 151.0.7922.47 and
- * firefox stable_153.0.4.
+ * and cost a cache holding chrome 114.0.5735.133, chrome 151.0.7922.47 and a
+ * third hand-staged build.
  *
  * Passing the returned path as `browserCacheDir` in the options bag of every
  * browser call in a test file moves all of that into a throwaway directory:

--- a/src/lib/commands/__tests__/commands.test.js
+++ b/src/lib/commands/__tests__/commands.test.js
@@ -104,6 +104,7 @@ let handleBrowserInstall;
 let handleBrowserListAvailable;
 let buildBrowserInstallCommand;
 let buildBrowserUninstallCommand;
+let buildBrowserListAvailableCommand;
 
 beforeAll(async () => {
     await Promise.all([
@@ -140,7 +141,8 @@ beforeAll(async () => {
         await import('../browser/uninstall.js'));
     ({ handleBrowserUninstallAll } = await import('../browser/uninstall-all.js'));
     ({ handleBrowserInstall, buildBrowserInstallCommand } = await import('../browser/install.js'));
-    ({ handleBrowserListAvailable } = await import('../browser/list-available.js'));
+    ({ handleBrowserListAvailable, buildBrowserListAvailableCommand } =
+        await import('../browser/list-available.js'));
 });
 
 describe('parsePositiveInteger', () => {
@@ -460,25 +462,19 @@ describe('--sense-version choices', () => {
 });
 
 describe('--browser choices', () => {
-    // Firefox can be installed, but cannot render thumbnails: the launch path speaks the Chrome
-    // DevTools Protocol and passes a Chromium-only argument list. Offering it here only moved
-    // the failure somewhere the operator could not interpret it.
+    // Chrome is the only value any command accepts, on every command that has the option.
+    // The launch path speaks the Chrome DevTools Protocol and passes a Chromium-only argument
+    // list, so anything else would fail somewhere the operator could not interpret it.
     test.each([
-        ['qseow', () => buildQseowCommand()],
-        ['qscloud', () => buildQscloudCommand()],
-    ])('%s create-sheet-thumbnails offers chrome only', (_name, build) => {
-        const option = thumbnailCommand(build()).options.find((opt) => opt.long === '--browser');
-
-        expect(option.argChoices).toEqual(['chrome']);
-    });
-
-    test.each([
+        ['qseow', () => thumbnailCommand(buildQseowCommand())],
+        ['qscloud', () => thumbnailCommand(buildQscloudCommand())],
         ['browser install', () => buildBrowserInstallCommand()],
         ['browser uninstall', () => buildBrowserUninstallCommand()],
-    ])('%s still offers both browsers', (_name, build) => {
+        ['browser list-available', () => buildBrowserListAvailableCommand()],
+    ])('%s offers chrome only', (_name, build) => {
         const option = build().options.find((opt) => opt.long === '--browser');
 
-        expect(option.argChoices).toEqual(['chrome', 'firefox']);
+        expect(option.argChoices).toEqual(['chrome']);
     });
 });
 
@@ -959,7 +955,7 @@ describe('browser commands', () => {
 
     test.each([
         ['chrome', 'recommended'],
-        ['firefox', 'stable'],
+        ['chrome', 'stable'],
         ['chrome', '114.0.5735.133'],
     ])('install delegates %s %s to browserInstall unchanged', async (browser, browserVersion) => {
         // The handler used to rewrite browserVersion when it was empty. That could not happen
@@ -997,7 +993,7 @@ describe('browser commands', () => {
     });
 
     test('install delegates with command parameter', async () => {
-        const options = { browser: 'firefox', browserVersion: 'latest', loglevel: 'debug' };
+        const options = { browser: 'chrome', browserVersion: 'latest', loglevel: 'debug' };
         /**
          * Stub of a Commander command whose `name()` always returns `'browser'`.
          *

--- a/src/lib/commands/browser/__tests__/browser_wizards.test.js
+++ b/src/lib/commands/browser/__tests__/browser_wizards.test.js
@@ -327,7 +327,7 @@ describe('an option a synthetic question stands in for', () => {
 
         await runInteractive({
             path: 'browser install',
-            presetOptions: { browser: 'firefox' },
+            presetOptions: { browser: 'chrome' },
             runtime,
         });
 
@@ -339,34 +339,22 @@ describe('an option a synthetic question stands in for', () => {
 
 describe('options already supplied on the command line', () => {
     // What makes `-i` compose rather than merely exist:
-    // `bsi browser install --browser firefox -i` should ask which build, not
+    // `bsi browser install --browser chrome -i` should ask which build, not
     // which browser.
+    //
+    // A preset answer also has to stay visible to the questions that follow. The install
+    // wizard's version picker does not read earlier answers, so that property is covered by
+    // the uninstall wizard's cache-dir test above.
     test('are not asked about again', async () => {
         const runtime = scriptedRuntime({ browserVersion: '151.0.7922.47', _review: 'cancel' });
 
         await runInteractive({
             path: 'browser install',
-            presetOptions: { browser: 'firefox' },
+            presetOptions: { browser: 'chrome' },
             runtime,
         });
 
         expect(runtime.asked.map((a) => a.key)).toEqual(['browserVersion', '_review']);
-    });
-
-    test('are still visible to the questions that follow', async () => {
-        // The pre-filled answer has to reach `choices`, or the version list
-        // would be fetched for the wrong browser.
-        const runtime = scriptedRuntime({ browserVersion: '151.0.7922.47', _review: 'cancel' });
-
-        await runInteractive({
-            path: 'browser install',
-            presetOptions: { browser: 'firefox' },
-            runtime,
-        });
-
-        expect(fetchAvailableVersions).toHaveBeenCalledWith(
-            expect.objectContaining({ browser: 'firefox' })
-        );
     });
 
     test('and reach the command that finally runs', async () => {
@@ -374,12 +362,12 @@ describe('options already supplied on the command line', () => {
 
         await runInteractive({
             path: 'browser install',
-            presetOptions: { browser: 'firefox' },
+            presetOptions: { browser: 'chrome' },
             runtime,
         });
 
         expect(browserInstall).toHaveBeenCalledWith(
-            expect.objectContaining({ browser: 'firefox', browserVersion: '151.0.7922.47' })
+            expect.objectContaining({ browser: 'chrome', browserVersion: '151.0.7922.47' })
         );
     });
 
@@ -388,7 +376,7 @@ describe('options already supplied on the command line', () => {
 
         await runInteractive({
             path: 'browser install',
-            presetOptions: { browser: 'firefox' },
+            presetOptions: { browser: 'chrome' },
             runtime,
         });
 
@@ -411,9 +399,9 @@ describe('the install wizard', () => {
         expect(fetchAvailableVersions).toHaveBeenCalledTimes(1);
     });
 
-    test('fetches versions for the browser that was chosen', async () => {
+    test('fetches the stable channel, which is what the picker lists', async () => {
         const runtime = scriptedRuntime({
-            browser: 'firefox',
+            browser: 'chrome',
             browserVersion: 'latest',
             _review: 'cancel',
         });
@@ -421,7 +409,7 @@ describe('the install wizard', () => {
         await runInteractive({ path: 'browser install', runtime });
 
         expect(fetchAvailableVersions).toHaveBeenCalledWith(
-            expect.objectContaining({ browser: 'firefox' })
+            expect.objectContaining({ channel: 'stable' })
         );
     });
 

--- a/src/lib/commands/browser/install.interactive.js
+++ b/src/lib/commands/browser/install.interactive.js
@@ -48,10 +48,8 @@ export default {
                 // user would have to type. The picker makes all of that moot:
                 // the choices are the answer to what it was explaining.
                 hint: 'Type to filter, or take one of the first two entries.',
-                needs: ['browser'],
-                choices: async ({ answers }) => {
+                choices: async () => {
                     const published = await fetchAvailableVersions({
-                        browser: answers.browser,
                         channel: 'stable',
                     });
 

--- a/src/lib/commands/browser/install.js
+++ b/src/lib/commands/browser/install.js
@@ -55,11 +55,14 @@ const buildBrowserInstallCommand = () => {
                 .env('BSI_BROWSER_I_LOG_LEVEL')
         )
         .addOption(
+            // Chrome is the only browser Butler Sheet Icons drives: the render path speaks the
+            // Chrome DevTools Protocol and passes a Chromium-only argument list. The option is
+            // kept rather than dropped so that scripts passing "--browser chrome" keep working.
             new Option(
                 '--browser <browser>',
-                'Browser to install (e.g. "chrome" or "firefox"). Use "butler-sheet-icons browser list-installed" to see which browsers are currently installed.'
+                'Browser to install. Only "chrome" is supported. Use "butler-sheet-icons browser list-installed" to see which browsers are currently installed.'
             )
-                .choices(['chrome', 'firefox'])
+                .choices(['chrome'])
                 .default('chrome')
                 .env('BSI_BROWSER_I_BROWSER')
         )

--- a/src/lib/commands/browser/list-available.js
+++ b/src/lib/commands/browser/list-available.js
@@ -48,18 +48,19 @@ const buildBrowserListAvailableCommand = () => {
                 .env('BSI_BROWSER_LA_LOG_LEVEL')
         )
         .addOption(
+            // Chrome only; see the note on the same option in install.js.
             new Option(
                 '--browser <browser>',
-                'Browser to list available versions for (e.g. "chrome" or "firefox"). Use "butler-sheet-icons browser install" to install one of them.'
+                'Browser to list available versions for. Only "chrome" is supported. Use "butler-sheet-icons browser install" to install one of the listed builds.'
             )
-                .choices(['chrome', 'firefox'])
+                .choices(['chrome'])
                 .default('chrome')
                 .env('BSI_BROWSER_LA_BROWSER')
         )
         .addOption(
             new Option(
                 '--channel <channel>',
-                "Which of the browser's release channel versions should be listed? This option is only used for Chrome."
+                "Which of the browser's release channel versions should be listed?"
             )
                 .choices(['stable', 'beta', 'dev', 'canary'])
                 .default('stable')

--- a/src/lib/commands/browser/uninstall.js
+++ b/src/lib/commands/browser/uninstall.js
@@ -53,11 +53,12 @@ const buildBrowserUninstallCommand = () => {
                 .env('BSI_BROWSER_UI_LOG_LEVEL')
         )
         .addOption(
+            // Chrome only; see the note on the same option in install.js.
             new Option(
                 '--browser <browser>',
-                'Browser to uninstall (e.g. "chrome" or "firefox"). Use "butler-sheet-icons browser list-installed" to see which browsers are currently installed.'
+                'Browser to uninstall. Only "chrome" is supported. Use "butler-sheet-icons browser list-installed" to see which browsers are currently installed.'
             )
-                .choices(['chrome', 'firefox'])
+                .choices(['chrome'])
                 .default('chrome')
                 .makeOptionMandatory()
                 .env('BSI_BROWSER_UI_BROWSER')
@@ -70,7 +71,7 @@ const buildBrowserUninstallCommand = () => {
             // build on this machine.
             new Option(
                 '--browser-version <version>',
-                'Browser build to uninstall: an exact build id (for Chrome e.g. "151.0.7922.77", for Firefox e.g. "stable_153.0.3"), or "recommended" for the build Butler Sheet Icons is tested with. Use "butler-sheet-icons browser list-installed" to see which builds are installed.'
+                'Browser build to uninstall: an exact build id (e.g. "151.0.7922.77"), or "recommended" for the build Butler Sheet Icons is tested with. Use "butler-sheet-icons browser list-installed" to see which builds are installed.'
             )
                 .makeOptionMandatory()
                 .env('BSI_BROWSER_UI_BROWSER_VERSION')

--- a/src/lib/commands/qscloud/create-sheet-thumbnails.js
+++ b/src/lib/commands/qscloud/create-sheet-thumbnails.js
@@ -247,10 +247,9 @@ const buildCloudCreateSheetThumbnailsCommand = () => {
                 .env('BSI_QSCLOUD_CST_BLUR_FACTOR')
         )
         .addOption(
-            // Chrome only, unlike "browser install": thumbnails are produced by driving the
-            // browser over the Chrome DevTools Protocol with a Chromium-only argument list, so a
-            // Firefox binary cannot be used here. Offering it in .choices() only moved the
-            // failure to a confusing place further along.
+            // Chrome only: thumbnails are produced by driving the browser over the Chrome
+            // DevTools Protocol with a Chromium-only argument list, so no other browser could be
+            // driven here. The option is kept so that scripts naming the browser keep working.
             new Option('--browser <browser>', 'Browser used to render sheets. Chrome only.')
                 .choices(['chrome'])
                 .default('chrome')

--- a/src/lib/commands/qseow/index.js
+++ b/src/lib/commands/qseow/index.js
@@ -342,10 +342,9 @@ const buildQseowCommand = () => {
                 .env('BSI_QSEOW_CST_SENSE_VERSION')
         )
         .addOption(
-            // Chrome only, unlike "browser install": thumbnails are produced by driving the
-            // browser over the Chrome DevTools Protocol with a Chromium-only argument list, so a
-            // Firefox binary cannot be used here. Offering it in .choices() only moved the
-            // failure to a confusing place further along.
+            // Chrome only: thumbnails are produced by driving the browser over the Chrome
+            // DevTools Protocol with a Chromium-only argument list, so no other browser could be
+            // driven here. The option is kept so that scripts naming the browser keep working.
             new Option('--browser <browser>', 'Browser used to render sheets. Chrome only.')
                 .choices(['chrome'])
                 .default('chrome')

--- a/src/lib/docs/__tests__/cli-option-tables.test.js
+++ b/src/lib/docs/__tests__/cli-option-tables.test.js
@@ -113,12 +113,12 @@ describe('formatDefault', () => {
 
 describe('formatDescription', () => {
     test('appends the accepted values in the shape --help prints them', () => {
-        const option = new Option('--browser <browser>', 'Browser to install').choices([
-            'chrome',
-            'firefox',
+        const option = new Option('--channel <channel>', 'Release channel to list').choices([
+            'stable',
+            'beta',
         ]);
 
-        expect(formatDescription(option)).toBe('Browser to install (choices: chrome, firefox)');
+        expect(formatDescription(option)).toBe('Release channel to list (choices: stable, beta)');
     });
 
     test('leaves a description without choices unchanged', () => {
@@ -128,11 +128,11 @@ describe('formatDescription', () => {
 
 describe('deriveExample', () => {
     test('prefers a value other than the default, which would demonstrate nothing', () => {
-        const option = new Option('--browser <browser>', '')
-            .choices(['chrome', 'firefox'])
-            .default('chrome');
+        const option = new Option('--channel <channel>', '')
+            .choices(['stable', 'beta'])
+            .default('stable');
 
-        expect(deriveExample(option)).toBe('--browser firefox');
+        expect(deriveExample(option)).toBe('--channel beta');
     });
 
     test('falls back to the only choice when it is also the default', () => {
@@ -181,14 +181,14 @@ describe('optionRowsFor', () => {
 
     test('prefers a hand-written example over a derived one', () => {
         const command = new Command('demo').addOption(
-            new Option('--browser <browser>', '').choices(['chrome', 'firefox']).default('chrome')
+            new Option('--channel <channel>', '').choices(['stable', 'beta']).default('stable')
         );
 
         const [row] = optionRowsFor(command, {
-            examples: { '--browser': '--browser firefox@151' },
+            examples: { '--channel': '--channel beta@151' },
         });
 
-        expect(row[4]).toBe('`--browser firefox@151`');
+        expect(row[4]).toBe('`--channel beta@151`');
     });
 
     test('skips the help row for a command that has disabled help', () => {
@@ -217,7 +217,7 @@ describe('renderOptionTable', () => {
 
     test('keeps the Example column when at least one option can fill it', () => {
         const command = new Command('demo').addOption(
-            new Option('--browser <browser>', '').choices(['chrome', 'firefox']).default('chrome')
+            new Option('--channel <channel>', '').choices(['stable', 'beta']).default('stable')
         );
 
         const header = renderOptionTable(command).split('\n')[0];

--- a/src/lib/interactive/__tests__/ask-questions.test.js
+++ b/src/lib/interactive/__tests__/ask-questions.test.js
@@ -73,7 +73,7 @@ describe('askQuestions', () => {
     });
 
     test('skips a question whose `when` says it does not apply', async () => {
-        const runtime = scriptedRuntime({ browser: 'firefox', channel: 'stable' });
+        const runtime = scriptedRuntime({ browser: 'safari', channel: 'stable' });
         const answers = await askQuestions(
             [
                 spec({ key: 'browser' }),
@@ -275,7 +275,7 @@ describe('the needs guard', () => {
     });
 
     test('accepts a dependency that was supplied rather than asked', () => {
-        // `bsi browser install --browser firefox -i` drops the browser question
+        // `bsi browser install --browser chrome -i` drops the browser question
         // because it is already answered. The dependency is satisfied by the
         // answer, so requiring an earlier *question* would reject exactly the
         // command line that supplied it.

--- a/src/lib/interactive/__tests__/option-introspect.test.js
+++ b/src/lib/interactive/__tests__/option-introspect.test.js
@@ -266,13 +266,15 @@ describe('splitDescription', () => {
     });
 
     test('does not mistake an abbreviation for the end of the question', () => {
-        // Taking the first full stop turned this into the question "Browser to
-        // install (e.g.", which is worse than not splitting at all.
+        // Taking the first full stop would cut this at "an exact build id (e.g.",
+        // which is worse than not splitting at all.
         const { message, hint } = splitDescription(
-            'Browser to install (e.g. "chrome" or "firefox"). Use list-installed to see them.'
+            'Browser build to uninstall: an exact build id (e.g. "151.0.7922.77"). Use list-installed to see them.'
         );
 
-        expect(message).toBe('Browser to install (e.g. "chrome" or "firefox").');
+        expect(message).toBe(
+            'Browser build to uninstall: an exact build id (e.g. "151.0.7922.77").'
+        );
         expect(hint).toBe('Use list-installed to see them.');
     });
 

--- a/src/lib/interactive/__tests__/render-command-line.test.js
+++ b/src/lib/interactive/__tests__/render-command-line.test.js
@@ -52,11 +52,11 @@ describe('formatCommandLine', () => {
 
     test('includes an answer that differs from the default', () => {
         const line = formatCommandLine(UNINSTALL, specsFor(UNINSTALL), {
-            browser: 'firefox',
-            browserVersion: 'stable_153.0.3',
+            browserVersion: '151.0.7922.77',
+            loglevel: 'debug',
         });
 
-        expect(line).toContain('--browser firefox');
+        expect(line).toContain('--loglevel debug');
     });
 
     test('shows defaulted answers when asked, for the full picture', () => {

--- a/src/lib/interactive/ask-questions.js
+++ b/src/lib/interactive/ask-questions.js
@@ -10,15 +10,14 @@ import { withQuietLogging } from './quiet.js';
  *
  * `needs` is a developer-facing guarantee, not a user-facing one: a wizard that
  * asks which apps to update before asking for the credentials that list them is
- * broken in a way no answer can fix. Phase 1 has one such edge, so the ordering
- * is simply declaration order and this asserts the declaration is coherent -
- * five lines that make the property real now, and a graph to sort when phase 2
- * has enough edges to need one.
+ * broken in a way no answer can fix. No phase 1 question declares an edge today -
+ * ordering is simply declaration order - so this guards the declarations a later
+ * phase adds, and becomes a graph to sort when there are enough edges to need one.
  *
  * A need is satisfied by an answer, not by a question. Anything supplied on the
  * command line or through a BSI_* environment variable is dropped from the
  * questions but is still an answer, so those keys count as already seen -
- * otherwise `bsi browser install --browser firefox -i` would fail this check for
+ * otherwise `bsi browser install --browser chrome -i` would fail this check for
  * having satisfied it.
  *
  * @param {import('./option-introspect.js').QuestionSpec[]} specs - The questions.

--- a/src/lib/interactive/option-introspect.js
+++ b/src/lib/interactive/option-introspect.js
@@ -57,9 +57,9 @@ export const splitDescription = (description = '') => {
 
     // A sentence ends at .?! only when what follows starts a new sentence, and
     // when the full stop is not part of an abbreviation. Both halves are
-    // needed: taking the first full stop turned "Browser to install (e.g.
-    // "chrome" or "firefox")." into the question "Browser to install (e.g.",
-    // which is worse than not splitting at all.
+    // needed: taking the first full stop turns "Browser build to uninstall: an
+    // exact build id (e.g. "151.0.7922.77"), or ..." into a question ending at
+    // "(e.g.", which is worse than not splitting at all.
     const sentenceEnd = /[.?!](?=\s+["(A-Z]|$)/g;
     let end = -1;
     let match;

--- a/src/lib/interactive/self-test.js
+++ b/src/lib/interactive/self-test.js
@@ -308,9 +308,13 @@ export const renderStaticReport = (deps = {}) => {
  * @returns {Promise<void>} Resolves when every prompt has been answered.
  */
 const runPromptGallery = async (runtime, theme) => {
+    // Demo data only - nothing here is applied. Log levels rather than browsers: they are a real
+    // multi-value option, and the gallery needs more than one entry for the cursor, the toggle
+    // and the filter to have anything to do.
     const choices = [
-        { name: 'Chrome', value: 'chrome', description: 'The browser BSI is tested with' },
-        { name: 'Firefox', value: 'firefox', description: 'Partial support' },
+        { name: 'info', value: 'info', description: 'The default log level' },
+        { name: 'verbose', value: 'verbose', description: 'Adds progress detail' },
+        { name: 'debug', value: 'debug', description: 'Adds internal diagnostics' },
     ];
 
     await runtime.ask(


### PR DESCRIPTION
Closes #934.

Since 4.0.0 removed `firefox` from the thumbnail commands, a Firefox installed through Butler Sheet Icons could never be used for anything: `browser install`, `browser uninstall` and `browser list-available` still managed it, but no command would ever launch the result. Thumbnails are produced by driving the browser over the Chrome DevTools Protocol with a Chromium-only argument list, so no other browser can be driven.

This removes the surface entirely, along with the machinery that existed only for Firefox — its release channel keywords, its channel-prefixed build id pattern, and the Firefox half of every `--browser-version` help string, which was being carried onto the thumbnail commands where Firefox was never accepted.

**This is a breaking change and will make release-please cut a major.**

## What breaks

- `--browser firefox` is rejected by `browser install`, `browser uninstall` and `browser list-available`
- `BSI_BROWSER_I_BROWSER`, `BSI_BROWSER_UI_BROWSER` and `BSI_BROWSER_LA_BROWSER` set to `firefox` fail at argument parsing, since Commander validates environment values against an option's choices
- `nightly`, `devedition` and `esr`, and channel-prefixed build ids such as `stable_153.0.3`, are no longer valid `--browser-version` values
- A Firefox left in the cache by an earlier release is removed by `browser uninstall-all`

`--browser` itself is kept on every command that had it, so scripts passing `--browser chrome` keep working. It stays because a second Chromium variant — `chrome-headless-shell`, say — would reuse the same option and the same version vocabulary, sharing Chrome's build ids and channels.

## Deliberately not removed

`BROWSER_CACHE_SUBDIRS` keeps its `firefox` entry. It mirrors the `Browser` enum from `@puppeteer/browsers` so `uninstall-all` never leaves a directory behind, and `browser_paths.test.js` asserts the two lists match. It is cache hygiene driven by the dependency, not Firefox support.

## A bug found in review

`getRecommendedBuildId` read a pin straight from `PUPPETEER_REVISIONS`, which still publishes one for every browser puppeteer supports. It therefore answered `stable_152.0.5` for Firefox while `resolveBrowserVersion` rejected the same input — two contradictory opinions about which browsers exist, reachable through the uninstall path. Both now go through one shared `assertBrowserIsSupported`.

## Verification

- `npm run lint` clean; **2487 unit tests across 92 suites**; browser integration suite 34/34
- The render path exercised end to end with `scripts/diag/browser-flag-probe.mjs`, which launches real Chrome through the product's own resolution and argument list and screenshots successfully
- Every command's `--help` parses with no Firefox mentions; `firefox` rejected on all five `--browser` surfaces and all five `BSI_*_BROWSER` variables; full install → list-installed → uninstall → uninstall-all lifecycle against a real cache; all fourteen `--browser-version` forms checked

## Docs

`docs/to-doc-site/firefox-support-removed.md` stages the doc site update. It lists 51 Firefox mentions across five published pages — two of which, `examples/browser-management` and `guide/troubleshooting`, were not in the set #934 named — and records that none of the option tables there are generated, so every affected row is a hand edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)