### PR TITLE
Stop --forceExit from hiding real test leaks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,11 @@ jobs:
   unit-tests:
     permissions:
       contents: read
+    # Same reason as the integration jobs below, and it matters more here: every one of them
+    # declares `needs: unit-tests`, so an untimed hang in the unit suite would stall the whole
+    # workflow for 6 hours and their own timeouts would never get to fire.
+    # 15 minutes against a job that measures about 2.
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -54,6 +59,12 @@ jobs:
       - unit-tests
     permissions:
       contents: read
+    # The jest scripts no longer pass --forceExit (issue #951), so a suite that genuinely leaks a
+    # handle now hangs instead of exiting - which is the point, it makes the leak visible. Without
+    # an explicit timeout that hang would run to GitHub's 6-hour default, and on the self-hosted
+    # jobs it would hold the runner and its concurrency group for that whole time. 30 minutes is
+    # roughly 3x the slowest of these suites (measured: 1.8-10.3 min).
+    timeout-minutes: 30
     runs-on: macos-15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -87,6 +98,8 @@ jobs:
       - unit-tests
     permissions:
       contents: read
+    # See the note on test-browser-macos: bounds a hung suite now that --forceExit is gone.
+    timeout-minutes: 30
     # No win-code-sign: these jobs sign nothing, and requiring it would pin them to the one
     # runner that holds the signing certificate. Without it they pool across every Windows runner.
     runs-on:
@@ -136,6 +149,8 @@ jobs:
       - unit-tests
     permissions:
       contents: read
+    # See the note on test-browser-macos: bounds a hung suite now that --forceExit is gone.
+    timeout-minutes: 30
     concurrency:
       group: bsi-qscloud-${{ github.repository }}
       cancel-in-progress: false
@@ -185,6 +200,8 @@ jobs:
       - test-qscloud-macos
     permissions:
       contents: read
+    # See the note on test-browser-macos: bounds a hung suite now that --forceExit is gone.
+    timeout-minutes: 30
     concurrency:
       group: bsi-qscloud-${{ github.repository }}
       cancel-in-progress: false
@@ -244,6 +261,8 @@ jobs:
       - unit-tests
     permissions:
       contents: read
+    # See the note on test-browser-macos: bounds a hung suite now that --forceExit is gone.
+    timeout-minutes: 30
     concurrency:
       group: bsi-qseow-${{ github.repository }}
       cancel-in-progress: false
@@ -320,6 +339,8 @@ jobs:
       - test-qseow-macos
     permissions:
       contents: read
+    # See the note on test-browser-macos: bounds a hung suite now that --forceExit is gone.
+    timeout-minutes: 30
     concurrency:
       group: bsi-qseow-${{ github.repository }}
       cancel-in-progress: false

--- a/.github/workflows/insiders-build.yaml
+++ b/.github/workflows/insiders-build.yaml
@@ -14,6 +14,12 @@ jobs:
       contents: read
       actions: write
       security-events: write
+    # The jest scripts no longer pass --forceExit (issue #951), so a unit suite that genuinely
+    # leaks a handle now hangs instead of exiting. The win and mac legs of this matrix are the
+    # self-hosted code-signing runners, so an untimed hang would hold one of them for GitHub's
+    # 6-hour default and queue every later insiders build and signed release behind it.
+    # 20 minutes is roughly 3x the slowest observed run of this job (6m34s, on win).
+    timeout-minutes: 20
     strategy:
       matrix:
         target: [win, mac, linux]

--- a/.github/workflows/pr-unit-tests.yaml
+++ b/.github/workflows/pr-unit-tests.yaml
@@ -35,6 +35,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
+    # The jest scripts no longer pass --forceExit (issue #951), so a unit suite that genuinely
+    # leaks a handle now hangs instead of exiting. This workflow runs on every pull request, which
+    # makes it the likeliest place a newly introduced leak shows up first. Both legs are hosted, so
+    # the cost of an untimed hang is billed minutes rather than a blocked runner - but 6 hours of
+    # them, twice, with no signal. 15 minutes against a job that measures 2-4.
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ This project is indexed by GitNexus as **butler-sheet-icons**. Use the GitNexus 
 - `npm run test:integration` — integration tests only (need real Qlik servers/certs/browsers; long-running)
 - `npm run test` — runs both `test:unit` and `test:integration`
 - `npm run test:watch` — unit tests in watch mode
+- `npm run jest:handles -- --testPathPatterns=<pattern>` — re-run a suite with `--detectOpenHandles`. Only for investigating a suite that does not exit; the flag is deliberately off by default (see `jest.config.mjs`)
 - Single test: `node --experimental-vm-modules node_modules/jest/bin/jest.js src/path/to/file.test.js`
 - `npm run format` — Prettier
 - `npm run build:macos` — produce a macOS SEA binary

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -10,6 +10,21 @@
  * - `*.integration.test.js` → integration tests (`npm run test:integration`)
  *
  * Notes:
+ * - Neither `--detectOpenHandles` nor `--forceExit` is in the `jest` script. They were, and they
+ *   worked against each other: `--forceExit` meant a suite that genuinely leaked a handle finished
+ *   in silence, exactly like one that did not. `npm run jest:handles` turns the detector back on for
+ *   an investigation.
+ *
+ *   Expect false positives when it is on. Measured for issue #951: axios pipes every compressed
+ *   response through `stream.pipeline([res, unzip])`, and Node registers a `STREAM_END_OF_STREAM`
+ *   async resource per stream in that pipeline. Some of those are never destroyed, and they carry no
+ *   `hasRef`, so Jest's collectHandles treats them as permanently active and reports them - even
+ *   though `process._getActiveHandles()` is empty and the process exits on its own. Because Jest
+ *   substitutes the *triggering* resource's stack, the report blames the `await axios(config)` call
+ *   in `src/lib/cloud/cloud-repo-request.js`, which is a red herring: the Qlik Cloud calls there are
+ *   fine, and gzip is the only reason those handles exist. Every response from a server that
+ *   compresses will do this. A hung suite is the signal worth chasing, not this report.
+ *
  * - `transform: {}` and `transformIgnorePatterns: []` are kept empty to allow
  *   the one legacy test (`butler-sheet-icons.test.js`) that still uses
  *   CJS-style `jest.mock(...)` to work. New tests should use the ESM-native

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -67,6 +67,10 @@ const config = {
         'src/lib/util/import-meta-url\\.js$',
     ],
     coverageProvider: 'v8',
+    // Restores `process.exitCode` around every test. Command handlers set it to 1 on failure and
+    // do not rethrow, so a test covering a failure path would otherwise leave the runner's own
+    // exit status at 1 with every suite reported green. See the file for the full account.
+    setupFilesAfterEnv: ['<rootDir>/src/lib/test-helpers/preserve-exit-code.js'],
     testEnvironment: 'node',
     roots: ['<rootDir>/src'],
     transform: {},

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "type": "module",
     "main": "src/butler-sheet-icons.js",
     "scripts": {
-        "jest": "node --experimental-vm-modules --no-warnings node_modules/jest/bin/jest.js --runInBand --detectOpenHandles --forceExit",
+        "jest": "node --experimental-vm-modules --no-warnings node_modules/jest/bin/jest.js --runInBand",
+        "jest:handles": "npm run jest -- --detectOpenHandles",
         "jest:watch": "node --experimental-vm-modules --no-warnings node_modules/jest/bin/jest.js --runInBand",
         "test": "npm run test:unit && npm run test:integration",
         "test:unit": "npm run jest -- --testPathIgnorePatterns=\\.integration\\.test\\.js$ --coverage",

--- a/src/lib/test-helpers/preserve-exit-code.js
+++ b/src/lib/test-helpers/preserve-exit-code.js
@@ -1,0 +1,30 @@
+/**
+ * Keeps a test's `process.exitCode` out of Jest's own exit status.
+ *
+ * `runCommand` (src/lib/commands/run-command.js) sets `process.exitCode = 1` whenever a command
+ * reports failure or throws, and deliberately does not rethrow - an operational failure such as an
+ * unreachable server should not reach the `unhandledRejection` handler. That is right for the CLI
+ * and a trap for the test suite: a test that exercises a failure path passes its assertions while
+ * leaving `process.exitCode` set to 1 on the runner process. With `--runInBand` the tests share
+ * that process, so Jest then exits 1 having reported every suite green.
+ *
+ * That is not hypothetical. Three describe blocks in `commands.test.js` did exactly this; the
+ * `--forceExit` flag hid it for as long as it was set, because force-exiting calls
+ * `process.exit(code)` with Jest's own status and overrides whatever a test left behind. Removing
+ * the flag (issue #951) surfaced it immediately.
+ *
+ * Snapshotting around every test isolates that side effect the same way a restored mock isolates
+ * any other global. The runner's exit status then comes from Jest's results, which is the only
+ * thing that should decide it.
+ */
+import { beforeEach, afterEach } from '@jest/globals';
+
+let savedExitCode;
+
+beforeEach(() => {
+    savedExitCode = process.exitCode;
+});
+
+afterEach(() => {
+    process.exitCode = savedExitCode;
+});


### PR DESCRIPTION
Closes #951.

The `jest` script passed `--detectOpenHandles` and `--forceExit` together, and the two worked against each other: `--forceExit` meant a suite that genuinely leaked a handle finished in exactly the same silence as one that did not.

### The handles in #951 are a false positive

Reproduced offline against a localhost server, no tenant involved:

- a plain JSON response leaves **zero** `STREAM_END_OF_STREAM` handles; a **gzip** one leaves them, via `pipelineImpl -> destroyer -> eos -> new AsyncResource(...)` — Node's bookkeeping for the `stream.pipeline([res, unzip])` axios runs on every compressed response. Qlik Cloud compresses its JSON.
- three requests created 12 such resources; six survived a forced GC and were still there 6s later, while `process._getActiveHandles().length === 0`. The process exited on its own.
- Jest 30's `collectHandles` skips `TCPWRAP` and `TLSWRAP`, so the socket was never what was being reported. `STREAM_END_OF_STREAM` has no `hasRef`, so Jest falls back to `alwaysActive`. It then substitutes the *triggering* resource's stack, which is why the report blamed `await axios(config)` in `cloud-repo-request.js` — a red herring.

So nothing in `src/` changes, and the `keepAlive: false` fix suggested in the issue would not have removed a single handle: they come from gzip decompression, not from sockets.

### What changes

- `jest` drops both flags; new `npm run jest:handles` turns the detector back on for an investigation
- every job that runs jest gets a `timeout-minutes`, because without `--forceExit` a real leak now hangs rather than passing quietly:

| job | slowest observed | timeout |
| --- | --- | --- |
| six integration jobs | 10.3 min | 30 |
| `insiders-build` | 6m34s | 20 |
| `unit-tests` (ci + pr-unit-tests) | 2-4 min | 15 |

  Untimed, a hang runs to GitHub's 6-hour default. Four integration jobs and both signing legs of `insiders-build` are self-hosted inside concurrency groups, so that would hold a runner — and the code-signing runner — for the whole six hours.
- the rationale is recorded in `jest.config.mjs` so the gzip false positive is not chased a second time

### Verification

| run | jest time | wall clock | exits unaided |
| --- | --- | --- | --- |
| `test:unit` | 41.1s | 42s | yes |
| full integration, 12 suites / 51 tests | 149.6s | 150s | yes |

Before/after on the file named in the issue: old flags reported 3 open handles; new flags report none and exit by themselves. A programmatic sweep of every workflow confirms no jest-running job is left unbounded.

Two integration tests currently fail on the `_success` paths with `Browser build 151.0.7922.138 started but stopped responding immediately`. That is pre-existing and unrelated — it reproduces identically with the old flags, and `test-qscloud-macos` failed the same way on main in run 31614550058. Being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
