### PR TITLE
Fix browsers that cannot be driven on recent Chrome builds

### DIFF
--- a/docs/to-doc-site/browser-build-stops-responding-immediately.md
+++ b/docs/to-doc-site/browser-build-stops-responding-immediately.md
@@ -1,0 +1,101 @@
+# "Browser build … started but stopped responding immediately"
+
+Suggested target pages: `/guide/troubleshooting` (symptom → cause → fix) and
+`/guide/concepts/browser-management` (the `recommended` / `stable` explanation).
+
+::: warning Requires BSI 4.2.0 or later
+In earlier versions the only remedy was to pin `--browser-version recommended`.
+:::
+
+## The symptom
+
+A run that used to work starts failing for every app, with no configuration change on your side:
+
+```
+error: CLOUD APP: Browser build 151.0.7922.138 started but stopped responding immediately. This build cannot be driven by Butler Sheet Icons.
+error: Use a different browser build: "--browser-version recommended" selects the build Butler Sheet Icons is tested with. The same value can be set via the command's BSI_*_BROWSER_VERSION environment variable.
+error: CLOUD APP: Protocol error (Emulation.setTouchEmulationEnabled): Session closed. Most likely the page has been closed.
+```
+
+The prefix is `QSEOW:` instead of `CLOUD APP:` on a Qlik Sense Enterprise on Windows run, and the
+build id changes over time — but the shape is the same: the browser starts, then stops answering
+before the first sheet is captured.
+
+## Who this affected
+
+Only runs that let the browser build float ahead of the one Butler Sheet Icons is tested with:
+
+| `--browser-version` (or `BSI_*_BROWSER_VERSION`)   | Affected?                                                |
+| -------------------------------------------------- | -------------------------------------------------------- |
+| `recommended` — the default                        | No                                                       |
+| `stable`, or its old alias `latest`                | Yes, once Chrome's stable channel moved far enough ahead |
+| A release channel: `beta`, `dev`, `canary`         | Yes                                                      |
+| An explicit recent build id, e.g. `151.0.7922.138` | Yes                                                      |
+
+If you never set `--browser-version` and never set a `BSI_*_BROWSER_VERSION` environment variable,
+you were not affected — the default has always been `recommended`.
+
+Because `stable` means "whatever Chrome publishes as stable today", this could appear overnight on
+a machine whose configuration had not been touched for months. That is the nature of the setting,
+not a fault in your environment.
+
+## The cause
+
+Butler Sheet Icons drives Chrome through a browser automation library, and that library is only
+tested against the Chrome builds current when it was released. Chrome's stable channel moves faster
+than the library does. When Chrome moved far enough ahead, the library could no longer establish a
+working session with it — Chrome launched normally, then the very first instruction sent to it
+failed.
+
+Nothing was wrong with Chrome, and nothing was wrong with your Qlik Sense environment.
+
+## The fix
+
+Upgrade to Butler Sheet Icons 4.2.0 or later. It ships a newer browser automation library that
+drives the current Chrome stable builds again. No configuration change is needed.
+
+If you cannot upgrade yet, pin the tested build instead:
+
+::: code-group
+
+```bash [Bash]
+butler-sheet-icons qseow create-sheet-thumbnails \
+  --browser-version recommended \
+  ...
+```
+
+```powershell [PowerShell]
+butler-sheet-icons qseow create-sheet-thumbnails `
+  --browser-version recommended `
+  ...
+```
+
+:::
+
+`recommended` needs no internet lookup and always names one exact build, so it is also the right
+choice for air-gapped and tightly firewalled environments.
+
+## What `recommended` now points at
+
+The build behind `recommended` moves whenever Butler Sheet Icons upgrades its browser automation
+library. In 4.2.0 it is Chrome `151.0.7922.71`; in 4.1.0 it was `151.0.7922.47`.
+
+You will see this in the log on every run:
+
+```
+info: Browser version "recommended" resolved to chrome build 151.0.7922.71 (the build this version of Butler Sheet Icons is tested with)
+```
+
+The practical consequence is that the first run after upgrading downloads the new build. The
+previous one stays in the browser cache until you remove it:
+
+```bash
+butler-sheet-icons browser list-installed
+butler-sheet-icons browser uninstall --browser-version 151.0.7922.47
+```
+
+## Should you go back to `stable`?
+
+Only if you have a specific reason to track Chrome's stable channel. `stable` will drift ahead of
+the tested build again — that is what it is for — and the failure above is what that looks like
+when it goes too far. `recommended` is the setting that stays working without attention.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "jimp": "^1.6.1",
                 "os": "^0.1.2",
                 "picocolors": "^1.1.1",
-                "puppeteer-core": "^25.4.0",
+                "puppeteer-core": "^25.5.0",
                 "qrs-interact": "^6.3.1",
                 "table": "^6.9.0",
                 "upath": "^3.0.8",
@@ -2799,9 +2799,9 @@
             }
         },
         "node_modules/@puppeteer/browsers": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.0.6.tgz",
-            "integrity": "sha512-B/gKoqlFkzhvzsI6jo9K1cZz9o5ypviVv/xu8CwA4grZzyVwN+XfkT+tu8T1zrauuEXv6VhS2oGX+6NL95WcKA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.1.0.tgz",
+            "integrity": "sha512-RDLpio3fH/qrj5k4DVY6eyiN8tCS0Zovd/6jW//n605oeqkWcUjn+3k+9ZtZBnbwMpsu0F7xDIiKXvVmG5c5Bw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "modern-tar": "^0.7.6",
@@ -7398,12 +7398,12 @@
             }
         },
         "node_modules/puppeteer-core": {
-            "version": "25.4.0",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.4.0.tgz",
-            "integrity": "sha512-K1plkLOdeoUnGeT1OvdqF3qxl33v+Ra/uH5VyPEhXdMcpvGiEskHzxxEU3fgpccJpJLIipB/rPUsvkZRWeKqOA==",
+            "version": "25.5.0",
+            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.5.0.tgz",
+            "integrity": "sha512-XPNT0dQJtphqQ4I29zxlG4IIPbg1iEHAQKWuQgtMJGXjACV77pZSmJvDi51IIIfd+DTKICcopJwUx4upVQ4XbA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@puppeteer/browsers": "3.0.6",
+                "@puppeteer/browsers": "3.1.0",
                 "chromium-bidi": "17.0.2",
                 "devtools-protocol": "0.0.1653615",
                 "typed-query-selector": "^2.12.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "jimp": "^1.6.1",
         "os": "^0.1.2",
         "picocolors": "^1.1.1",
-        "puppeteer-core": "^25.4.0",
+        "puppeteer-core": "^25.5.0",
         "qrs-interact": "^6.3.1",
         "table": "^6.9.0",
         "upath": "^3.0.8",


### PR DESCRIPTION
Chrome builds newer than roughly `151.0.7922.109` could not be driven at all. The browser launched, then died on the first command sent to it, and every app in a run failed identically:

```
error: CLOUD APP: Browser build 151.0.7922.138 started but stopped responding immediately. This build cannot be driven by Butler Sheet Icons.
error: CLOUD APP: Protocol error (Emulation.setTouchEmulationEnabled): Session closed. Most likely the page has been closed.
```

Anyone running `--browser-version stable`, a release channel, or a recent explicit build was affected. The default, `recommended`, was not.

## Cause

Neither Chrome nor our argument list. Chrome enables a WebUI omnibox popup by default in those builds, and it creates a target that puppeteer-core 25.4.0 mishandles during frame initialisation — the underlying throw is `Requesting main frame too early!`. Puppeteer 25.5.0 fixes it by disabling those two features in its own default arguments.

`--single-process` was the obvious suspect and is **not** involved. It stays in.

## Evidence

A bare `puppeteer.launch()` outside Butler Sheet Icons, using the product's real `BASE_BROWSER_ARGS`:

| puppeteer-core | Chrome 151.0.7922.47 | Chrome 151.0.7922.138 |
|---|---|---|
| **25.4.0** (previous pin) | pass | **fail** — `Requesting main frame too early!` |
| 25.5.0 | pass | pass |
| 25.6.0 | pass | pass |

`--single-process` was A/B'd with `scripts/diag/browser-flag-probe.mjs`: `.138` fails with *and* without it, `.47` passes both ways.

The mechanism was identified rather than correlated with — appending the single argument 25.5.0 adds (`--disable-features=WebUIOmniboxPopup,WebUIOmniboxAimPopup`) makes **25.4.0 pass on `.138`**.

## Verification

Run against a live Qlik Sense Cloud tenant and a live QSEoW server, both driving `151.0.7922.138` — the exact build that was failing:

- Cloud integration suite: **10/10 passed** (previously 9 passed / 1 failed)
- QSEoW integration suite: **7/7 passed**
- Unit tests **2487/2487**, lint clean

In the QSEoW run, the uncovered lines in `browser-launch.js` include `logUnusableBrowser` and the `catch` around the `browser.version()` health check — the "cannot be driven" branches were never entered.

25.5.0 also ships *"do not override the user agent when nothing is emulated"*, which could have changed which auth method a QSEoW virtual proxy selects. Measured: `HeadlessChrome/151.0.0.0` on both versions, byte-identical. No impact.

## Notes

- `recommended` moves from `151.0.7922.47` to `151.0.7922.71`, since it resolves to puppeteer's pinned build. The first run after upgrading downloads the new build.
- 25.6.0 is the newest release but is held out by the seven-day quarantine in `.npmrc` until around 18 Aug 2026.
- `ci.yaml` runs on push to `main` and `workflow_dispatch` only, so this PR does not trigger CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
