### PR TITLE
Restore Windows code signing with the new Certum certificate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1238,23 +1238,24 @@ jobs:
       - windows
       - sp53
       - win-code-sign
-    # timeout-minutes: 15
+    # Not optional. A lapsed SimplySign session can leave signtool waiting on a graphical prompt
+    # that nothing on a runner will answer; the scripts kill signtool themselves, and this is the
+    # backstop if anything else wedges. Without it the default is six hours.
+    timeout-minutes: 30
     if: needs.release-please.outputs.releases_created == 'true'
     permissions:
       contents: write
     env:
       DIST_FILE_NAME: butler-sheet-icons
       GITHUB_TOKEN: ${{ secrets.PAT }}
-      # Windows code signing is OFF: the certificate expired, and signtool cannot sign with it
-      # whatever else is configured. scripts/release-win.ps1 skips signing when this variable is
-      # empty and ships an unsigned binary instead of failing, which is why 4.0.0 went out with no
-      # Windows binary at all.
+      # The certificate is a Certum cloud certificate, reached through SimplySign Desktop on the
+      # win-code-sign runner. It only exists in that machine's certificate store while a SimplySign
+      # session is open, and a session lasts about two hours - so somebody has to log in to
+      # SimplySign Desktop before merging a release-please PR.
       #
-      # TO RE-ENABLE: uncomment the line below, once WIN_CODESIGN_THUMBPRINT holds the thumbprint
-      # of a valid certificate. Nothing else needs changing here. Note that Certum SimplySign is a
-      # cloud signing service, so the signtool invocation in release-win.ps1 will probably need
-      # reworking for it rather than simply being switched back on - see the comment there.
-      # CODESIGN_WIN_THUMBPRINT: ${{ secrets.WIN_CODESIGN_THUMBPRINT}}
+      # Forgetting is not a disaster: the preflight step below fails this job in seconds, and
+      # re-running it after logging in is all that is needed. See scripts/lib/win-signing.ps1.
+      CODESIGN_WIN_THUMBPRINT: ${{ secrets.WIN_CODESIGN_THUMBPRINT }}
     steps:
       - name: Release tag and upload url from previous job
         shell: powershell
@@ -1273,6 +1274,26 @@ jobs:
           # and globals.js reads the version straight out of it.
           ref: ${{ needs.release-please.outputs.release_tag_name }}
           persist-credentials: false
+
+      # Fail before spending ten minutes on a build that cannot be signed.
+      #
+      # The Certum certificate is only in this machine's store while a SimplySign session is open,
+      # and a session lasts about two hours - so "no certificate" is a routine state, not an exotic
+      # one. Checking here means the answer arrives in seconds and the fix is to log in to
+      # SimplySign Desktop on the runner and re-run this job.
+      #
+      # -ProveSigning actually signs a few-kilobyte scratch file rather than trusting the
+      # certificate store. That is not belt and braces: SimplySign leaves certificates registered
+      # after a session ends, so a store lookup would pass with an expired session and this step
+      # would wave through a build that cannot possibly be signed - which is the whole thing it
+      # exists to prevent.
+      #
+      # Written for `shell: powershell` for the same reason as the version check below - it is the
+      # shell this self-hosted runner is known to have - which also keeps the signing scripts
+      # working under Windows PowerShell 5.1, not just the pwsh that runs the build step.
+      - name: Preflight the Windows signing certificate
+        shell: powershell
+        run: ./scripts/diag/win-signing-check.ps1 -RequireSigning -ProveSigning
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/insiders-build.yaml
+++ b/.github/workflows/insiders-build.yaml
@@ -39,6 +39,10 @@ jobs:
               - ubuntu-latest
             artifact_insider: butler-sheet-icons--linux-x64--${{ github.sha }}.tgz
     runs-on: ${{ matrix.runs_on }}
+    # The win leg signs when a SimplySign session happens to be open on the runner, so it can in
+    # principle sit on a graphical prompt nobody will answer. scripts/lib/win-signing.ps1 kills
+    # signtool itself; this is the backstop, because the default is six hours per leg.
+    timeout-minutes: 45
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/windows-signing-canary.yaml
+++ b/.github/workflows/windows-signing-canary.yaml
@@ -61,12 +61,17 @@ jobs:
         with:
           persist-credentials: false
 
-      # Read-only, and identical to the step release-win64 runs. It reports the Windows account,
-      # the session, and whether the runner is a service - which is what distinguishes "the session
-      # expired" from "this runner can never see the certificate at all".
-      - name: Report the signing environment
+      # Byte-for-byte the step release-win64 runs, flags included. A rehearsal that invokes a
+      # different command than the thing it rehearses cannot vouch for it - and -ProveSigning is
+      # exactly the flag worth exercising, since it is the one that actually signs rather than
+      # trusting the certificate store.
+      #
+      # It also reports the Windows account, the session, and whether the runner is a service,
+      # which is what distinguishes "the session expired" from "this runner cannot see the
+      # certificate at all".
+      - name: Preflight the Windows signing certificate
         shell: powershell
-        run: ./scripts/diag/win-signing-check.ps1 -RequireSigning
+        run: ./scripts/diag/win-signing-check.ps1 -RequireSigning -ProveSigning
 
       - name: Sign a throwaway file
         if: inputs.mode == 'smoke'

--- a/.github/workflows/windows-signing-canary.yaml
+++ b/.github/workflows/windows-signing-canary.yaml
@@ -1,0 +1,147 @@
+name: windows-signing-canary
+
+# Manually-run smoke test for the Windows signing path.
+#
+# release-win64 in ci.yaml only runs when release-please actually cuts a release, so signing is
+# otherwise exercised for the first time during a live release. That is not theoretical: the
+# timestamp URL was changed from http to https in May 2026 and nothing noticed until the 4.0.0
+# release failed in August. This job is the counterpart to macos-signing-canary.yaml.
+#
+# Two modes, because they answer different questions:
+#
+#   smoke (default) - signs a throwaway copy of node.exe and checks the result. Seconds, no npm
+#                     install, no esbuild, no postject. This is the one to run after touching
+#                     scripts/lib/win-signing.ps1, after a certificate renewal, or to find out
+#                     whether the SimplySign session on the runner is still alive.
+#
+#   full            - runs the real scripts/release-win.ps1 end to end, publishing nothing. Use it
+#                     before a release, or after changing the build itself.
+#
+# Both run on the win-code-sign runner, and that is half the point: signing works only for the
+# Windows account SimplySign Desktop is connected as, so proving it by hand on the machine proves
+# less than it appears to. Only a run through the runner exercises the account the release uses.
+#
+# Note the certificate is a Certum cloud certificate whose session lasts about two hours. If this
+# job fails at the preflight step, that is very likely all it is - log in to SimplySign Desktop on
+# the runner and run it again.
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'smoke = sign one throwaway file; full = run the whole release build'
+        required: true
+        default: smoke
+        type: choice
+        options:
+          - smoke
+          - full
+
+permissions: {}
+
+jobs:
+  sign:
+    name: sign (${{ inputs.mode }})
+    # MUST stay in sync with release-win64 in ci.yaml - proving that runner is the point.
+    runs-on:
+      - self-hosted
+      - x64
+      - windows
+      - sp53
+      - win-code-sign
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      DIST_FILE_NAME: butler-sheet-icons
+      CODESIGN_WIN_THUMBPRINT: ${{ secrets.WIN_CODESIGN_THUMBPRINT }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Read-only, and identical to the step release-win64 runs. It reports the Windows account,
+      # the session, and whether the runner is a service - which is what distinguishes "the session
+      # expired" from "this runner can never see the certificate at all".
+      - name: Report the signing environment
+        shell: powershell
+        run: ./scripts/diag/win-signing-check.ps1 -RequireSigning
+
+      - name: Sign a throwaway file
+        if: inputs.mode == 'smoke'
+        id: smoke
+        shell: powershell
+        run: ./scripts/diag/win-signing-smoke.ps1 -KeepOutput
+
+      - name: Upload the signed test file
+        if: inputs.mode == 'smoke'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-signing-canary-smoke-${{ github.run_id }}
+          path: ${{ steps.smoke.outputs.signed_file }}
+          retention-days: 3
+
+      # ---------------------------------------------------------------------------------------
+      # full mode: everything below only runs for a complete release rehearsal.
+      # ---------------------------------------------------------------------------------------
+      - name: Setup Node.js
+        if: inputs.mode == 'full'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+      # See the note in ci.yaml: pins npm so the install is identical on every runner.
+      - name: Pin npm
+        if: inputs.mode == 'full'
+        shell: powershell
+        # zizmor: ignore[adhoc-packages] - setup-node has no npm-version input, so npm 12
+        # cannot arrive any other way. Pinned to an exact version rather than a range.
+        run: | # zizmor: ignore[adhoc-packages]
+          npm install -g npm@12.0.2
+          npm --version
+
+      - name: Install dependencies
+        if: inputs.mode == 'full'
+        shell: powershell
+        run: npm ci --include=dev --include=prod
+
+      - name: Build and sign
+        if: inputs.mode == 'full'
+        env:
+          RELEASE_VERSION: canary-${{ github.run_id }}
+        run: ./scripts/release-win.ps1
+
+      # release-win.ps1 verifies its own output, so this is a second opinion taken from the PE
+      # itself rather than from signtool's console text - the same assertions the macOS canary
+      # makes about codesign. A wrong signing identity or a missing timestamp would pass every
+      # string check and still be wrong.
+      - name: Verify the signature
+        if: inputs.mode == 'full'
+        shell: powershell
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $signature = Get-AuthenticodeSignature -LiteralPath "./${env:DIST_FILE_NAME}.exe"
+
+          Write-Host "status     : $($signature.Status)"
+          Write-Host "signer     : $($signature.SignerCertificate.Subject)"
+          Write-Host "thumbprint : $($signature.SignerCertificate.Thumbprint)"
+
+          if ($signature.Status -ne 'Valid') {
+            Write-Host "::error::signature status is '$($signature.Status)', expected 'Valid'. $($signature.StatusMessage)"
+            exit 1
+          }
+
+          if ($null -eq $signature.TimeStamperCertificate) {
+            Write-Host '::error::the signature carries no RFC 3161 timestamp, so it stops validating when the certificate expires'
+            exit 1
+          }
+
+          Write-Host "timestamped by: $($signature.TimeStamperCertificate.Subject)"
+
+      - name: Upload the signed archive for inspection
+        if: inputs.mode == 'full'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-signing-canary-full-${{ github.run_id }}
+          path: ./*-win.zip
+          retention-days: 3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,9 +118,18 @@ The section above is about the browser BSI drives. This one is about the browser
 
 - SEA config: `build-script/sea-config.json` — bundles `build.cjs` and enigma.js JSON schemas as assets
 - `scripts/release-*.sh` / `scripts/release-*.ps1` produce signed/notarized binaries for macOS, Linux, Windows
-- `scripts/insider-build-*.sh` / `scripts/insider-build-*.ps1` produce unsigned insider builds
+- `scripts/insider-build-*.sh` / `scripts/insider-build-*.ps1` produce insider builds — unsigned on Linux, signed on macOS, and signed on Windows only when a certificate happens to be available
 - In SEA binaries, `__dirname`/`__filename` are unavailable; use the helpers in `src/lib/util/import-meta-url.js` (injected at build time)
 - Always clean up `build.cjs` and `sea-prep.blob` after builds
+
+### Windows code signing
+
+**A SimplySign session must be open on the `win-code-sign` runner before a release-please PR is merged.** The Windows certificate is a Certum *cloud* certificate: it exists in that machine's certificate store only while SimplySign Desktop holds a session, and a session lasts about two hours before it needs a fresh token from the SimplySign mobile app. Nothing in CI can renew it.
+
+- Forgetting is cheap. `release-win64` preflights the certificate before it builds anything and fails in seconds; log in and re-run the job.
+- `scripts/lib/win-signing.ps1` holds the signing logic shared by the release build, the insider build and the diagnostics — including why the timestamp URL is `http` and must stay that way.
+- To check a machine, or to test signing without waiting for a release build, run `scripts/diag/win-signing-check.ps1` and `scripts/diag/win-signing-smoke.ps1` on the runner. The `windows-signing-canary` workflow runs both through the runner's own account, which is the part running them by hand cannot prove.
+- signtool only sees certificates belonging to the Windows account it runs as. A runner running as a service, or as a different account than the one SimplySign is connected as, cannot sign at all — and the symptom looks exactly like an expired session.
 
 ## Security
 

--- a/docs/to-doc-site/done/done_windows-binary-temporarily-unsigned.md
+++ b/docs/to-doc-site/done/done_windows-binary-temporarily-unsigned.md
@@ -55,10 +55,25 @@ A replacement certificate is being obtained. When it is in place, Windows releas
 The macOS binary continues to be signed and notarized by Apple throughout, and Linux releases are distributed as archives, where code signing is not customary.
 
 <!--
-NOT PUBLISHED - stale.
+NOT PUBLISHED.
 
 Retired without publishing on 2026-08-10. scripts/release-win.ps1 has two live
 `signtool sign` calls and none commented out, so the Windows release binary is
 signed again and this draft would have told users the opposite. The live doc
 site never carried the claim, so there was nothing to correct.
+
+CORRECTION, 2026-08-12: the reasoning above was wrong, though retiring the page
+was still the right call.
+
+The two `signtool sign` calls were live but *guarded* - release-win.ps1 skipped
+signing whenever CODESIGN_WIN_THUMBPRINT was empty, and ci.yaml had that variable
+commented out. So Windows releases were still shipping unsigned when this note
+claimed they were signed again, and 4.1.0 went out unsigned after it was written.
+Reading a script for commented-out lines says nothing about whether the code runs;
+what decided it was the workflow that supplies the variable.
+
+The page stayed unpublished throughout, so no reader was ever misled. Signing was
+restored with a new Certum certificate; the successor draft is
+docs/to-doc-site/windows-binary-signed-again.md, which covers 4.0.0 and 4.1.0
+having been unsigned and so replaces the need for this one.
 -->

--- a/docs/to-doc-site/windows-binary-signed-again.md
+++ b/docs/to-doc-site/windows-binary-signed-again.md
@@ -1,0 +1,91 @@
+# The Windows download is digitally signed again
+
+**Applies to:** the Windows download of Butler Sheet Icons. The macOS and Linux downloads, and the Docker image, are unaffected.
+
+**Suggested target pages:** the troubleshooting page (a "Windows warns about the publisher" symptom), and wherever the site covers downloading and installing the Windows binary. This is a short addition to existing pages rather than a page of its own.
+
+::: warning Version gate to be filled in at publication
+The version that first carries the restored signature is not yet decided — it is whatever release ships after this change. Set the gate before publishing; do not guess it.
+:::
+
+## What changed
+
+Butler Sheet Icons' Windows executable carries a digital signature again. The certificate is issued by Certum to the project's maintainer as an open source developer, so the publisher shown by Windows is:
+
+> **Open Source Developer Karl Göran Sander**
+
+That is the name on the certificate rather than a company name, which is normal for open source projects and does not affect what the signature guarantees.
+
+The previous certificate expired shortly before version 4.0.0, and the versions released in between — **4.0.0 and 4.1.0** — shipped without any signature at all.
+
+Nothing about how Butler Sheet Icons works has changed. This affects only how Windows treats the file.
+
+## What the signature does for you
+
+**It proves where the file came from.** A valid signature confirms the executable was published by the holder of that certificate and has not been altered since — by a mirror, a proxy, or anything else between the release page and your server.
+
+**Publisher rules work again.** Many organisations enforce application control through AppLocker or Windows Defender Application Control, commonly allowing programs by publisher certificate. Those rules can match the signed release, where they could not match the unsigned 4.0.0 and 4.1.0 downloads at all — an unsigned executable cannot be permitted by a publisher rule under any configuration.
+
+If your Windows administrator created a file hash rule to allow an unsigned version, it is worth asking them to replace it with a publisher rule. A hash rule has to be updated for every new release; a publisher rule does not.
+
+**Antivirus false positives become less likely.** Butler Sheet Icons is a single-file executable built from the Node.js runtime, and that construction is a common source of false positives. A valid signature helps, though it does not guarantee anything — if your antivirus still quarantines the file and you obtained it from the official release page, add an exclusion.
+
+## What the signature does not do
+
+**It does not immediately silence Microsoft Defender SmartScreen.**
+
+SmartScreen decides whether to warn based on the *reputation* it has accumulated for a file and its signing certificate, not merely on whether a signature exists. Only Extended Validation certificates receive reputation immediately; this is a standard code signing certificate, so reputation builds as more people download the release.
+
+In practice that means you may still see:
+
+> **Windows protected your PC**
+> Microsoft Defender SmartScreen prevented an unrecognised app from starting.
+
+especially in the first weeks after a new certificate is put into use. Choose **More info**, then **Run anyway**. The warning should become less frequent over time, and unlike an unsigned file, you can now confirm who published it before you proceed.
+
+## Checking the signature yourself
+
+Worth doing if you are deploying into a controlled environment, or confirming a download before distributing it internally. In PowerShell, in the folder holding the executable:
+
+```powershell
+Get-AuthenticodeSignature -LiteralPath .\butler-sheet-icons.exe | Format-List Status, StatusMessage, SignerCertificate
+```
+
+`Status` reads `Valid` for a correctly signed file, and the signer certificate names the publisher above, issued by `Certum Code Signing 2021 CA`.
+
+You can also right-click the file, choose **Properties**, and look at the **Digital Signatures** tab.
+
+One point worth understanding: **the signature is timestamped**. It therefore stays valid after the signing certificate itself expires, so a release downloaded years from now still verifies. Without a timestamp, every previously released binary would stop validating the day the certificate lapsed.
+
+A valid signature proves the publisher, not the download source. Always download from the official release page:
+
+<https://github.com/ptarmiganlabs/butler-sheet-icons/releases>
+
+## Still on an unsigned version
+
+If you are running 4.0.0 or 4.1.0, upgrading to the current release is the fix. No configuration change is needed on your side — download the newer release as usual.
+
+<!--
+DRAFT - do not publish until a signed release actually exists.
+
+Verified against the signing host on 2026-08-12 (scripts/diag/win-signing-check.ps1):
+
+  - Publisher name is "Open Source Developer Karl Göran Sander", NOT "Ptarmigan Labs".
+    An earlier draft of this page said Ptarmigan Labs throughout and was wrong. The
+    certificate is an individual open source developer certificate, subject
+    CN=Open Source Developer Karl Göran Sander, O=Open Source Developer,
+    L=Saltsjö-Duvnäs, S=Stockholm, C=SE.
+  - Issuer is CN=Certum Code Signing 2021 CA, valid 2026-08-12 to 2027-08-12.
+
+Still to confirm before publishing:
+
+  - The list of unsigned versions. 4.0.0 and 4.1.0 are unsigned. Whether any later
+    release is also unsigned depends on when this change ships - check the releases
+    page and update.
+  - Set the version gate at the top.
+
+The SmartScreen section deliberately does NOT promise the warning disappears. This is a
+standard certificate, not EV, so it earns reputation over time rather than receiving it
+on day one. Telling admins the warning is gone and having it appear anyway would cost
+more trust than saying nothing.
+-->

--- a/scripts/diag/win-signing-check.ps1
+++ b/scripts/diag/win-signing-check.ps1
@@ -1,0 +1,309 @@
+# Read-only audit of the Windows code signing setup on a build host.
+#
+# The macOS side has scripts/diag/macos-keychain-check.sh for the same purpose and with the same
+# contract: it changes nothing, and exits 0 when the host can sign and 1 when it cannot. Keeping it
+# read-only means it can be run on any machine without consequences, and means a CI failure here
+# reports a real state rather than one the checker just repaired.
+#
+# It answers the question that decides whether Windows signing works at all: is a usable certificate
+# visible *to this Windows account, in this session*? A Certum cloud certificate reaches the store
+# through SimplySign Desktop's Key Storage Provider, which serves the account SimplySign is logged
+# in as. A runner running as a service, or as a different account, sees nothing - and the symptom is
+# indistinguishable from an expired session unless something reports the account.
+#
+# Usage:
+#   pwsh -File scripts/diag/win-signing-check.ps1
+#   pwsh -File scripts/diag/win-signing-check.ps1 -Thumbprint <hex> -RequireSigning
+#
+# Without -RequireSigning it reports and exits 0 - useful for looking at a machine.
+#
+# -RequireSigning means "if signing is configured, it has to work": a thumbprint that does not
+# resolve to a usable certificate becomes a failure, which is how the release job fails fast
+# instead of building for ten minutes and then discovering it cannot sign. An *empty* thumbprint is
+# still not a failure, because that is the deliberate kill switch - scripts/release-win.ps1 then
+# ships an unsigned binary with a warning, which is a decision somebody made rather than a fault.
+
+#
+# -ProveSigning goes further and actually signs a few-kilobyte scratch file. Use it wherever the
+# answer needs to be trustworthy, because the store listing on its own is not: SimplySign leaves
+# certificates registered after a session ends, so a present certificate proves only that a session
+# existed once. Costs about a second.
+
+[CmdletBinding()]
+param(
+    [string] $Thumbprint = $env:CODESIGN_WIN_THUMBPRINT,
+    [switch] $RequireSigning,
+    [switch] $ProveSigning
+)
+
+$ErrorActionPreference = 'Stop'
+
+# $IsWindows only exists on PowerShell Core; on Windows PowerShell 5.1 it is undefined and the
+# edition is the tell.
+$onWindows = if ($PSVersionTable.PSEdition -eq 'Core') { [bool]$IsWindows } else { $true }
+if (-not $onWindows) {
+    Write-Host 'FAIL: this script inspects the Windows certificate store and only runs on Windows.'
+    exit 1
+}
+
+. "$PSScriptRoot/../lib/win-signing.ps1"
+
+$failures = 0
+function Add-Failure {
+    param([string] $Message)
+    Write-Host "FAIL: $Message"
+    $script:failures++
+}
+
+$codeSigningOid = '1.3.6.1.5.5.7.3.3'
+
+function Test-CodeSigningEku {
+    param($Certificate)
+    foreach ($extension in $Certificate.Extensions) {
+        if ($extension -is [System.Security.Cryptography.X509Certificates.X509EnhancedKeyUsageExtension]) {
+            foreach ($usage in $extension.EnhancedKeyUsages) {
+                if ($usage.Value -eq $codeSigningOid) { return $true }
+            }
+        }
+    }
+    return $false
+}
+
+# ---------------------------------------------------------------------------------------------
+# Host and identity. The account and session are the part people forget, and the part that makes
+# an otherwise perfect setup produce "No certificates were found".
+# ---------------------------------------------------------------------------------------------
+Write-Host '--- host ---'
+Write-Host "computer          : $env:COMPUTERNAME"
+Write-Host "os                : $([System.Environment]::OSVersion.VersionString)"
+Write-Host "powershell        : $($PSVersionTable.PSVersion) ($($PSVersionTable.PSEdition))"
+Write-Host "running as        : $([System.Security.Principal.WindowsIdentity]::GetCurrent().Name)"
+Write-Host "user interactive  : $([System.Environment]::UserInteractive)"
+Write-Host "session id        : $((Get-Process -Id $PID).SessionId)"
+
+if (-not [System.Environment]::UserInteractive) {
+    Write-Host 'NOTE: this process is not interactive. A SimplySign PIN or login prompt raised here'
+    Write-Host '      would be invisible and unanswerable - signtool would simply hang.'
+}
+
+# ---------------------------------------------------------------------------------------------
+# The GitHub Actions runner. Reported rather than judged: what matters is whether its account
+# matches the account SimplySign is connected as, and only a human knows the intended answer.
+# ---------------------------------------------------------------------------------------------
+Write-Host ''
+Write-Host '--- github actions runner ---'
+try {
+    $runnerServices = @(Get-CimInstance -ClassName Win32_Service -Filter "Name LIKE 'actions.runner%'" -ErrorAction Stop)
+    if ($runnerServices.Count -eq 0) {
+        Write-Host 'no runner service registered (the runner may be started interactively, which is'
+        Write-Host 'the arrangement signing needs)'
+    }
+    foreach ($service in $runnerServices) {
+        Write-Host "service           : $($service.Name)"
+        Write-Host "  state           : $($service.State)"
+        Write-Host "  start mode      : $($service.StartMode)"
+        Write-Host "  runs as         : $($service.StartName)"
+        Write-Host '  NOTE: a runner running as a Windows service gets its own session, separate from'
+        Write-Host '        the desktop session SimplySign Desktop runs in. If signing fails here but'
+        Write-Host '        works when run by hand, this is why.'
+    }
+}
+catch {
+    Write-Host "could not query services: $($_.Exception.Message)"
+}
+
+# ---------------------------------------------------------------------------------------------
+# SimplySign Desktop. Its session is what puts the certificate in the store, and it lasts about
+# two hours.
+# ---------------------------------------------------------------------------------------------
+Write-Host ''
+Write-Host '--- simplysign desktop ---'
+$simplySign = @(Get-Process -Name 'SimplySignDesktop' -ErrorAction SilentlyContinue)
+if ($simplySign.Count -eq 0) {
+    Write-Host 'SimplySignDesktop is not running on this machine.'
+}
+else {
+    foreach ($process in $simplySign) {
+        $owner = 'unknown'
+        try {
+            $cimProcess = Get-CimInstance -ClassName Win32_Process -Filter "ProcessId = $($process.Id)" -ErrorAction Stop
+            $ownerInfo = Invoke-CimMethod -InputObject $cimProcess -MethodName GetOwner -ErrorAction Stop
+            if ($ownerInfo.ReturnValue -eq 0) { $owner = "$($ownerInfo.Domain)\$($ownerInfo.User)" }
+        }
+        catch { }
+        Write-Host "running           : pid $($process.Id), session $($process.SessionId), as $owner"
+    }
+    Write-Host 'NOTE: running is not the same as connected. A SimplySign session lasts about two'
+    Write-Host '      hours; the certificate listing below is the real test.'
+}
+
+# ---------------------------------------------------------------------------------------------
+# signtool.
+# ---------------------------------------------------------------------------------------------
+Write-Host ''
+Write-Host '--- signtool ---'
+$signtool = $null
+try {
+    $signtool = Get-BsiSigntoolPath
+    Write-Host "path              : $signtool"
+    $signtoolVersion = (Get-Item -LiteralPath $signtool).VersionInfo.ProductVersion
+    Write-Host "version           : $signtoolVersion"
+}
+catch {
+    Add-Failure $_.Exception.Message
+}
+
+# ---------------------------------------------------------------------------------------------
+# Every code signing certificate this account can see. When a thumbprint goes stale after a
+# renewal, this listing is where the new one comes from.
+# ---------------------------------------------------------------------------------------------
+Write-Host ''
+Write-Host '--- code signing certificates visible to this account ---'
+$seen = 0
+foreach ($store in @('Cert:\CurrentUser\My', 'Cert:\LocalMachine\My')) {
+    $certificates = @()
+    try {
+        $certificates = @(Get-ChildItem -Path $store -ErrorAction Stop | Where-Object { Test-CodeSigningEku $_ })
+    }
+    catch {
+        Write-Host "$store : not readable ($($_.Exception.Message))"
+        continue
+    }
+
+    Write-Host "$store : $($certificates.Count) code signing certificate(s)"
+    foreach ($certificate in $certificates) {
+        $seen++
+        $daysLeft = [int][math]::Floor(($certificate.NotAfter - (Get-Date)).TotalDays)
+        Write-Host "  subject         : $($certificate.Subject)"
+        Write-Host "    issuer        : $($certificate.Issuer)"
+        Write-Host "    thumbprint    : $($certificate.Thumbprint)"
+        Write-Host "    valid         : $($certificate.NotBefore.ToString('yyyy-MM-dd')) .. $($certificate.NotAfter.ToString('yyyy-MM-dd')) ($daysLeft days left)"
+        Write-Host "    private key   : $($certificate.HasPrivateKey)"
+    }
+}
+
+if ($seen -eq 0) {
+    Write-Host 'None. With a Certum cloud certificate this is what an expired SimplySign session looks'
+    Write-Host 'like - the certificate is only in the store while the session is open.'
+}
+
+# ---------------------------------------------------------------------------------------------
+# The configured thumbprint.
+# ---------------------------------------------------------------------------------------------
+Write-Host ''
+Write-Host '--- configured signing certificate ---'
+if ([string]::IsNullOrWhiteSpace($Thumbprint)) {
+    # Not a failure even under -RequireSigning: see the note at the top of this file. Loud, though -
+    # an accidentally deleted secret and a deliberate switch-off look identical from here, and the
+    # accidental one is how releases start going out unsigned without anybody noticing.
+    Write-Host 'No thumbprint configured (CODESIGN_WIN_THUMBPRINT is empty and -Thumbprint was not given).'
+    Write-Host 'In a release build that is the deliberate kill switch: it ships an unsigned binary.'
+    Write-Host '::warning title=Windows code signing is switched off::CODESIGN_WIN_THUMBPRINT is empty, so nothing will be signed. If that was not intended, check the WIN_CODESIGN_THUMBPRINT repository secret.'
+}
+else {
+    $status = Test-BsiSigningCertificate -Thumbprint $Thumbprint
+    Write-Host "thumbprint        : $($status.Thumbprint)"
+    Write-Host "result            : $($status.Reason)"
+
+    if ($status.Found) {
+        Write-Host "store             : $($status.StorePath)"
+        Write-Host "subject           : $($status.Subject)"
+        Write-Host "issuer            : $($status.Issuer)"
+        Write-Host "valid until       : $($status.NotAfter.ToString('yyyy-MM-dd')) ($($status.DaysRemaining) days left)"
+        Write-Host "private key       : $($status.HasPrivateKey)"
+    }
+
+    if ($status.Usable) {
+        # Deliberately not "this host can sign right now" - the store cannot tell us that. See the
+        # note on -ProveSigning at the top of this file.
+        Write-Host 'The certificate is registered and within its validity period.'
+
+        # A renewal that lapses repeats the outage this whole change exists to undo, and 30 days is
+        # enough warning to arrange one without hurrying.
+        if ($status.DaysRemaining -le 30) {
+            Write-Host "::warning title=Code signing certificate expires soon::The Windows code signing certificate expires in $($status.DaysRemaining) days ($($status.NotAfter.ToString('yyyy-MM-dd')))."
+        }
+
+        if ($ProveSigning) {
+            Write-Host ''
+            Write-Host '--- proving the signing session is live ---'
+            try {
+                Invoke-BsiProveSigning -Thumbprint $Thumbprint -Signtool $signtool
+                Write-Host 'This host can sign right now.'
+            }
+            catch {
+                Write-Host ''
+                if ($_.Exception.Message -match 'timed out') {
+                    # A different failure with a different fix, so keep its own wording.
+                    Write-Host $_.Exception.Message
+                }
+                else {
+                    # Registered but unusable is a *specific* diagnosis, not an ambiguous one, and
+                    # saying so beats repeating the generic two-causes help: the store lookup
+                    # directly above matched this exact thumbprint, so the thumbprint is not stale.
+                    Write-Host 'The certificate is registered, but signing with it failed.'
+                    Write-Host ''
+                    Write-Host 'That combination has one cause. SimplySign leaves certificates registered'
+                    Write-Host 'after a session ends, so the lookup above can pass while the private key is'
+                    Write-Host 'unreachable in the cloud. The SimplySign session is not open. The thumbprint'
+                    Write-Host 'is fine - it was just matched.'
+                    Write-Host ''
+                    Write-Host 'Fix: on this machine, open SimplySign Desktop, choose "Connect to SimplySign",'
+                    Write-Host 'enter the token from the SimplySign mobile app, then run this again.'
+                }
+                Add-Failure 'the certificate is registered, but signing with it failed - the SimplySign session is not open.'
+            }
+        }
+        else {
+            Write-Host 'NOTE: not proven. Certificates stay registered after a SimplySign session ends,'
+            Write-Host '      so this says a session existed, not that one is open. Pass -ProveSigning'
+            Write-Host '      to actually sign a scratch file and find out.'
+        }
+    }
+    elseif ($RequireSigning -or $ProveSigning) {
+        # -ProveSigning counts here too: being unable to prove signing because there is no usable
+        # certificate is a negative answer to the question, not an absence of one.
+        Write-Host ''
+        Write-Host (Get-BsiSimplySignHelp)
+        Add-Failure "the configured certificate is not usable ($($status.Reason))."
+    }
+    else {
+        Write-Host ''
+        Write-Host (Get-BsiSimplySignHelp)
+    }
+}
+
+# ---------------------------------------------------------------------------------------------
+# The timestamp server. Reachability only - see the note in scripts/lib/win-signing.ps1 for why
+# this URL is http and must stay that way.
+# ---------------------------------------------------------------------------------------------
+Write-Host ''
+Write-Host '--- timestamp server ---'
+try {
+    $response = Invoke-WebRequest -Uri 'http://time.certum.pl' -Method Get -TimeoutSec 15 -UseBasicParsing
+    Write-Host "http://time.certum.pl : reachable (HTTP $([int]$response.StatusCode))"
+}
+catch {
+    # An RFC 3161 responder is entitled to refuse GET while happily answering the POST signtool
+    # makes, so any HTTP answer at all counts as reachable. Only a connection failure is a finding.
+    $webResponse = $null
+    if ($_.Exception.PSObject.Properties.Name -contains 'Response') { $webResponse = $_.Exception.Response }
+
+    if ($webResponse) {
+        Write-Host "http://time.certum.pl : reachable (HTTP $([int]$webResponse.StatusCode) to a GET, which is fine - signtool POSTs)"
+    }
+    else {
+        Add-Failure "http://time.certum.pl is unreachable: $($_.Exception.Message)"
+        Write-Host 'Signing cannot complete without it. Check egress rules and any proxy on this host.'
+        Write-Host 'Note the URL is http on purpose: time.certum.pl refuses connections on port 443.'
+    }
+}
+
+Write-Host ''
+if ($failures -eq 0) {
+    Write-Host 'Windows signing setup looks healthy.'
+    exit 0
+}
+
+Write-Host "$failures problem(s) found."
+exit 1

--- a/scripts/diag/win-signing-smoke.ps1
+++ b/scripts/diag/win-signing-smoke.ps1
@@ -1,0 +1,207 @@
+# Signs one throwaway file and checks the result. Seconds, not minutes.
+#
+# The point is to be able to prove the certificate works without running a release build. The real
+# Windows build spends almost all of its time on `npm ci`, esbuild and postject, none of which have
+# anything to do with signing - so testing a certificate through it means waiting ten minutes to
+# find out a thumbprint has a typo in it.
+#
+# The file signed is a copy of node.exe, and that choice is deliberate. It is the very binary the
+# real build starts from, and it arrives carrying Node's own Authenticode signature, so the copy
+# exercises `signtool remove` as well as signing. A small system utility would not: most are catalog
+# signed rather than embedded signed, so there would be no signature to strip and that half of the
+# path would go untested.
+#
+# Usage:
+#   pwsh -File scripts/diag/win-signing-smoke.ps1
+#   pwsh -File scripts/diag/win-signing-smoke.ps1 -Thumbprint <hex> -KeepOutput
+#
+# Exits 0 when the file came out correctly signed, 1 otherwise.
+
+[CmdletBinding()]
+param(
+    [string] $Thumbprint = $env:CODESIGN_WIN_THUMBPRINT,
+    [string] $SourceExe,
+    [switch] $KeepOutput
+)
+
+$ErrorActionPreference = 'Stop'
+
+$onWindows = if ($PSVersionTable.PSEdition -eq 'Core') { [bool]$IsWindows } else { $true }
+if (-not $onWindows) {
+    Write-Host 'FAIL: Authenticode signing only runs on Windows.'
+    exit 1
+}
+
+. "$PSScriptRoot/../lib/win-signing.ps1"
+
+$stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+$scratch = $null
+
+try {
+    if ([string]::IsNullOrWhiteSpace($Thumbprint)) {
+        Write-Host 'FAIL: no certificate thumbprint. Pass -Thumbprint, or set CODESIGN_WIN_THUMBPRINT.'
+        Write-Host 'Run scripts/diag/win-signing-check.ps1 to list the certificates on this machine.'
+        exit 1
+    }
+
+    # Preflight before copying 100 MB around. This is also the check that distinguishes an expired
+    # SimplySign session from a broken script, and it cannot itself trigger a login prompt.
+    $status = Test-BsiSigningCertificate -Thumbprint $Thumbprint
+    if (-not $status.Usable) {
+        Write-Host "FAIL: the configured certificate is not usable ($($status.Reason))."
+        Write-Host ''
+        Write-Host (Get-BsiSimplySignHelp)
+        exit 1
+    }
+
+    Write-Host '--- certificate ---'
+    Write-Host "subject           : $($status.Subject)"
+    Write-Host "issuer            : $($status.Issuer)"
+    Write-Host "thumbprint        : $($status.Thumbprint)"
+    Write-Host "valid until       : $($status.NotAfter.ToString('yyyy-MM-dd')) ($($status.DaysRemaining) days left)"
+
+    # ---------------------------------------------------------------------------------------------
+    # Pick the file to sign.
+    # ---------------------------------------------------------------------------------------------
+    if ([string]::IsNullOrWhiteSpace($SourceExe)) {
+        $node = Get-Command -Name 'node.exe' -CommandType Application -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+        if ($node) {
+            $SourceExe = $node.Source
+        }
+        else {
+            # Not fatal, but not equivalent either. Windows ships its own executables *catalog*
+            # signed rather than embedded signed, so a copy of powershell.exe carries no signature
+            # inside the file for signtool to remove - the strip below is skipped for it. Signing
+            # and verification are exercised in full; only the strip is not.
+            $SourceExe = (Get-Process -Id $PID).Path
+            Write-Host 'NOTE: node.exe is not on PATH, so the current PowerShell executable is being'
+            Write-Host '      used as the test subject instead. Put node on PATH for a test that'
+            Write-Host '      also covers stripping an existing signature.'
+        }
+    }
+
+    if (-not (Test-Path -LiteralPath $SourceExe -PathType Leaf)) {
+        Write-Host "FAIL: source executable '$SourceExe' does not exist."
+        exit 1
+    }
+
+    $scratchRoot = if ($env:RUNNER_TEMP) { $env:RUNNER_TEMP } else { [System.IO.Path]::GetTempPath() }
+    $scratch = Join-Path -Path $scratchRoot -ChildPath "bsi-signing-smoke-$([System.Guid]::NewGuid().ToString('N').Substring(0, 8))"
+    New-Item -ItemType Directory -Path $scratch -Force | Out-Null
+
+    $target = Join-Path -Path $scratch -ChildPath 'bsi-signing-smoke.exe'
+    Copy-Item -LiteralPath $SourceExe -Destination $target -Force
+
+    Write-Host ''
+    Write-Host '--- subject ---'
+    Write-Host "copied from       : $SourceExe"
+    Write-Host "signing           : $target"
+    Write-Host "size              : $([math]::Round((Get-Item -LiteralPath $target).Length / 1MB, 1)) MB"
+
+    # ---------------------------------------------------------------------------------------------
+    # The same three operations, in the same order, that the release build performs.
+    # ---------------------------------------------------------------------------------------------
+    Write-Host ''
+    Write-Host '--- strip the existing signature ---'
+
+    # Only an *embedded* signature can be removed. A catalog-signed file - which is how Windows
+    # signs its own binaries - verifies happily but carries nothing inside the PE, and asking
+    # signtool to remove it fails. The release build always starts from node.exe, which is embedded
+    # signed, so it strips unconditionally; here the subject may be whatever was to hand.
+    $existing = Get-AuthenticodeSignature -LiteralPath $target
+    $signatureType = 'Unknown'
+    if ($existing.PSObject.Properties.Name -contains 'SignatureType') {
+        $signatureType = [string]$existing.SignatureType
+    }
+
+    if ($signatureType -eq 'Catalog') {
+        Write-Host "skipped: the source is catalog signed ($($existing.Status)), so there is no"
+        Write-Host '         embedded signature in the file to remove.'
+    }
+    elseif ($existing.Status -eq 'NotSigned') {
+        Write-Host 'skipped: the source carries no signature.'
+    }
+    else {
+        Invoke-BsiStripSignature -Path $target
+    }
+
+    Write-Host ''
+    Write-Host '--- sign ---'
+    $verifyOutput = Invoke-BsiSignFile -Path $target -Thumbprint $Thumbprint
+
+    # ---------------------------------------------------------------------------------------------
+    # Assert on the signature itself rather than on signtool's console output. Get-AuthenticodeSignature
+    # reads the PE, so these assertions cannot pass because a message happened to be worded a certain
+    # way - and the timestamp check in particular is the one that would have caught the 4.0.0 bug.
+    # ---------------------------------------------------------------------------------------------
+    Write-Host ''
+    Write-Host '--- verify ---'
+    $signature = Get-AuthenticodeSignature -LiteralPath $target
+
+    Write-Host "status            : $($signature.Status)"
+    Write-Host "signer            : $($signature.SignerCertificate.Subject)"
+    Write-Host "signer thumbprint : $($signature.SignerCertificate.Thumbprint)"
+
+    # Taken from signtool's own verify output rather than the signature object: Windows PowerShell
+    # 5.1 does not expose a digest algorithm on a Signature, and 5.1 is what the signing host runs.
+    $digest = 'unknown'
+    if ($verifyOutput -match 'Hash of file \((\w+)\)') { $digest = $Matches[1] }
+    Write-Host "file digest       : $digest"
+
+    $problems = 0
+
+    # The property that silently regressed before: the old script signed SHA-1 first and SHA-256
+    # second, and because the second call was missing /as it replaced rather than appended. Only
+    # flagged when signtool positively reports something other than sha256 - a wording change in a
+    # future signtool must not be able to fail a release on its own.
+    if ($digest -ne 'unknown' -and $digest -ne 'sha256') {
+        Write-Host "FAIL: the file was signed with a $digest digest, expected sha256."
+        $problems++
+    }
+
+    if ($signature.Status -ne 'Valid') {
+        Write-Host "FAIL: signature status is '$($signature.Status)', expected 'Valid'."
+        Write-Host "      $($signature.StatusMessage)"
+        $problems++
+    }
+
+    if ($signature.SignerCertificate.Thumbprint -ne $status.Thumbprint) {
+        Write-Host "FAIL: the file was signed by $($signature.SignerCertificate.Thumbprint), not the requested $($status.Thumbprint)."
+        $problems++
+    }
+
+    if ($null -eq $signature.TimeStamperCertificate) {
+        Write-Host 'FAIL: the signature carries no RFC 3161 timestamp.'
+        Write-Host '      Without one the signature stops validating the day the certificate expires.'
+        $problems++
+    }
+    else {
+        Write-Host "timestamped by    : $($signature.TimeStamperCertificate.Subject)"
+    }
+
+    $stopwatch.Stop()
+    Write-Host ''
+
+    if ($problems -gt 0) {
+        Write-Host "$problems problem(s) found after $([int]$stopwatch.Elapsed.TotalSeconds)s."
+        exit 1
+    }
+
+    Write-Host "Signed and verified in $([int]$stopwatch.Elapsed.TotalSeconds)s."
+    if ($KeepOutput) {
+        Write-Host "Signed file kept at: $target"
+        # Handed to the caller so a workflow can upload it without hard-coding the random directory.
+        # Written through .NET rather than Out-File: on Windows PowerShell 5.1 `-Encoding utf8`
+        # means UTF-8 *with a BOM*, and the runner does not strip it before parsing the line.
+        if ($env:GITHUB_OUTPUT) {
+            [System.IO.File]::AppendAllText($env:GITHUB_OUTPUT, "signed_file=$target$([System.Environment]::NewLine)")
+        }
+    }
+    exit 0
+}
+finally {
+    if ($scratch -and (-not $KeepOutput) -and (Test-Path -LiteralPath $scratch)) {
+        Remove-Item -LiteralPath $scratch -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/scripts/insider-build-win.ps1
+++ b/scripts/insider-build-win.ps1
@@ -1,6 +1,44 @@
 $ErrorActionPreference = 'Stop'
 
-$signtool = "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x64\signtool.exe"
+# See scripts/lib/win-signing.ps1 for how signing works here and why it is shaped this way.
+. "$PSScriptRoot/lib/win-signing.ps1"
+
+$signtool = Get-BsiSigntoolPath
+Write-Host "signtool: $signtool"
+
+# -------------------
+# Signing is best-effort in insider builds.
+#
+# This job runs on every push to main, and the Certum cloud session it would need lasts about two
+# hours after a human logs in - so most pushes will find no certificate. Failing them would turn
+# main red for a reason that has nothing to do with the commit.
+#
+# But skipping signing entirely is what this build did until now, and it had a cost worth
+# remembering: signing was then exercised nowhere except an actual release. That is exactly how the
+# timestamp URL could be switched from http to https in May and go unnoticed until the 4.0.0
+# release failed in August.
+#
+# So: no certificate is fine and says so, while a certificate that *is* available and then fails to
+# sign fails the build. That way this job still catches a broken invocation, which is the whole
+# reason for signing here.
+$signingRequested = -not [string]::IsNullOrWhiteSpace($env:CODESIGN_WIN_THUMBPRINT)
+$signingAvailable = $false
+
+if ($signingRequested) {
+    $certificate = Test-BsiSigningCertificate -Thumbprint $env:CODESIGN_WIN_THUMBPRINT
+    $signingAvailable = $certificate.Usable
+
+    if ($signingAvailable) {
+        Write-Host "Signing with: $($certificate.Subject)"
+        Write-Host "Certificate valid until $($certificate.NotAfter.ToString('yyyy-MM-dd')) ($($certificate.DaysRemaining) days left)."
+    }
+    else {
+        Write-Host "::notice title=Unsigned insider build::No usable code signing certificate right now ($($certificate.Reason)), so this insider build is unsigned. That is expected unless somebody has an open SimplySign session on the runner."
+    }
+}
+else {
+    Write-Host '::notice title=Unsigned insider build::CODESIGN_WIN_THUMBPRINT is not set, so this insider build is unsigned.'
+}
 
 # Inject git SHA into package.json
 $GIT_SHA = (git rev-parse --short HEAD)
@@ -16,46 +54,31 @@ New-Item -ItemType Directory -Force -Path ./build | Out-Null
 node --experimental-sea-config build-script/sea-config.json
 
 # Get a copy of the Node executable
-node -e "require('fs').copyFileSync(process.execPath, '${env:DIST_FILE_NAME}.exe')" 
+node -e "require('fs').copyFileSync(process.execPath, '${env:DIST_FILE_NAME}.exe')"
 
 pwd
 dir
 
 # -------------------
-# Remove the signature from the executable
-& $signtool remove /s "./${env:DIST_FILE_NAME}.exe"
-if ($LASTEXITCODE -ne 0) { throw "signtool remove failed with exit code $LASTEXITCODE" }
+# Remove Node's own signature. Required whether or not we sign afterwards - postject rewrites the
+# binary below, which would leave any existing signature broken rather than merely absent.
+Invoke-BsiStripSignature -Path "./${env:DIST_FILE_NAME}.exe" -Signtool $signtool
 
 npx postject "${env:DIST_FILE_NAME}.exe" NODE_SEA_BLOB ./build/sea-prep.blob --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2
 
 # -------------------
-# Sign the executable.
-#
-# Disabled, so insider builds ship unsigned. That is a deliberate choice to leave alone here, but it
-# is worth knowing what it costs: because these lines never run, Windows signing is exercised
-# nowhere except an actual release. That is exactly how the timestamp URL below could be switched
-# from http to https in May and not be discovered until the 4.0.0 release failed in August.
-#
-# The URLs are corrected in step with release-win.ps1 so that uncommenting these does not
-# resurrect the same failure. time.certum.pl serves no HTTPS - port 443 refuses the connection -
-# and signtool answers `SignTool Error: Invalid Timestamp URL`. See release-win.ps1 for why plain
-# HTTP is correct here rather than a weakness.
-#
-# 1st signing
-# & $signtool sign /sha1 "$env:CODESIGN_WIN_THUMBPRINT" /tr http://time.certum.pl /td sha256 /fd sha1 /v "./${env:DIST_FILE_NAME}.exe"
-# if ($LASTEXITCODE -ne 0) { throw "signtool sign (sha1) failed with exit code $LASTEXITCODE" }
-
-# -------------------
-# 2nd signing
-# & $signtool sign /sha1 "$env:CODESIGN_WIN_THUMBPRINT" /tr http://time.certum.pl /td sha256 /fd sha256 /v "./${env:DIST_FILE_NAME}.exe"
-# if ($LASTEXITCODE -ne 0) { throw "signtool sign (sha256) failed with exit code $LASTEXITCODE" }
+# Sign the executable, when a certificate is actually available. Failures here are fatal on purpose
+# - see the note above.
+if ($signingAvailable) {
+    Invoke-BsiSignFile -Path "./${env:DIST_FILE_NAME}.exe" -Thumbprint $env:CODESIGN_WIN_THUMBPRINT -Signtool $signtool | Out-Null
+}
 
 # -------------------
 # Create insider's build zip
 $compress = @{
-  Path = "./${env:DIST_FILE_NAME}.exe"
-  CompressionLevel = "Fastest"
-  DestinationPath = "${env:DIST_FILE_NAME}--win-x64--${env:GITHUB_SHA}.zip"
+    Path             = "./${env:DIST_FILE_NAME}.exe"
+    CompressionLevel = "Fastest"
+    DestinationPath  = "${env:DIST_FILE_NAME}--win-x64--${env:GITHUB_SHA}.zip"
 }
 Compress-Archive @compress
 

--- a/scripts/lib/win-signing.ps1
+++ b/scripts/lib/win-signing.ps1
@@ -1,0 +1,510 @@
+# Shared Windows code signing helpers, dot-sourced by the release build, the insider build and the
+# diagnostics under scripts/diag. The macOS side has the same arrangement in
+# scripts/lib/macos-signing-keychain.sh, and for the same reason: signing logic that lives in one
+# place cannot drift between the release path and the path that is supposed to be testing it.
+#
+# ---------------------------------------------------------------------------------------------
+# How signing works here
+#
+# The certificate is a Certum cloud certificate. SimplySign Desktop runs on the win-code-sign
+# runner and presents it to Windows as a virtual smart card through its Key Storage Provider, so
+# the certificate turns up in Cert:\CurrentUser\My like any locally installed one and signtool
+# selects it by thumbprint. There is no /csp, no /kc and no separate cloud signing tool - the
+# invocation is the ordinary one, exactly as Certum's own manual documents it.
+#
+# That is worth stating plainly because the comments this replaces predicted the opposite: that a
+# cloud service would need the invocation reworked. It does not.
+#
+# ---------------------------------------------------------------------------------------------
+# The two-hour session
+#
+# What a cloud certificate *does* change is availability. A SimplySign session lasts about two
+# hours, after which it needs a fresh token from the SimplySign mobile app. Nothing in CI can
+# renew it. So the certificate is present in the store for two hours after a human logs in, and
+# absent the rest of the time, and every caller here has to cope with that:
+#
+#   - Test-BsiSigningCertificate answers "can we sign right now?" without ever blocking.
+#   - Invoke-BsiSigntool runs signtool under a hard timeout, because a dead session makes signtool
+#     raise a *graphical* login prompt. On a runner nobody is watching - and in a service session
+#     nobody can even see - that prompt waits forever. A killed process is recoverable; a job
+#     wedged for six hours until the workflow timeout is not.
+#
+# ---------------------------------------------------------------------------------------------
+# The timestamp URL
+#
+# The timestamp URL is http, not https, and has to stay that way: time.certum.pl serves no HTTPS at
+# all - port 443 refuses the connection - so signtool answers `SignTool Error: Invalid Timestamp
+# URL`. That is not a hypothetical either; it is the bug that broke the 4.0.0 Windows release
+# before the certificate expiry was known about.
+#
+# This is not a security weakness, which is why an https "fix" keeps looking tempting. An RFC 3161
+# timestamp token is signed by the timestamping authority, so it is verified on its own signature
+# rather than on the transport, and signtool rejects a token that does not verify. Plain HTTP is
+# what the RFC expects and what essentially every public TSA offers.
+
+# Deliberately no Set-StrictMode here. Dot-sourcing runs this in the caller's scope, so a strict
+# mode set here would silently change the semantics of every script that includes it - including
+# their use of $LASTEXITCODE, which is undefined until the first native command runs.
+
+$BsiTimestampUrl = 'http://time.certum.pl'
+$BsiSignDescription = 'Butler Sheet Icons'
+$BsiSignDescriptionUrl = 'https://butler-sheet-icons.ptarmiganlabs.com'
+
+# Guidance printed whenever signing cannot proceed. Both likely causes, because they look identical
+# from here - the certificate is simply not in the store either way - and the fix differs.
+function Get-BsiSimplySignHelp {
+    return @'
+No usable code signing certificate is available on this machine. The two likely causes:
+
+  1. The SimplySign session has expired. It lasts about two hours. Open SimplySign Desktop on the
+     win-code-sign runner, choose "Connect to SimplySign", and enter the token from the SimplySign
+     mobile app. Then re-run this job.
+
+  2. The certificate was renewed and the WIN_CODESIGN_THUMBPRINT repository secret still holds the
+     old thumbprint. Run scripts/diag/win-signing-check.ps1 on the runner to list the certificates
+     actually present, and update the secret.
+
+Note that signtool only sees certificates belonging to the Windows account it runs as. If the
+GitHub Actions runner runs as a service, or as a different account than the one with SimplySign
+Desktop connected, the certificate is invisible to it no matter how healthy the session is.
+'@
+}
+
+# Locates signtool.exe.
+#
+# This used to be a hard-coded path to Windows SDK 10.0.22621.0. That pins the whole Windows build -
+# not just signing - to one SDK version on one machine, because `signtool remove` runs whether or
+# not we go on to sign. Installing a newer SDK, or removing the old one, broke the build.
+function Get-BsiSigntoolPath {
+    [CmdletBinding()]
+    param()
+
+    if (-not [string]::IsNullOrWhiteSpace($env:BSI_SIGNTOOL)) {
+        if (-not (Test-Path -LiteralPath $env:BSI_SIGNTOOL -PathType Leaf)) {
+            throw "BSI_SIGNTOOL is set to '$($env:BSI_SIGNTOOL)', but there is no file at that path."
+        }
+        return (Resolve-Path -LiteralPath $env:BSI_SIGNTOOL).Path
+    }
+
+    # Both program files roots, skipping any the machine does not define. ${env:ProgramFiles(x86)}
+    # is absent on an arm64 host, and Join-Path throws on a null path rather than returning null.
+    $roots = @()
+    foreach ($base in @(${env:ProgramFiles(x86)}, $env:ProgramFiles)) {
+        if ([string]::IsNullOrWhiteSpace($base)) { continue }
+        $root = Join-Path -Path $base -ChildPath 'Windows Kits\10\bin'
+        if (Test-Path -LiteralPath $root -PathType Container) { $roots += $root }
+    }
+
+    $candidates = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($root in $roots) {
+        foreach ($dir in (Get-ChildItem -LiteralPath $root -Directory -ErrorAction SilentlyContinue)) {
+            $exe = Join-Path -Path $dir.FullName -ChildPath 'x64\signtool.exe'
+            if (-not (Test-Path -LiteralPath $exe -PathType Leaf)) { continue }
+
+            # SDK 8.x and some 10.x layouts put signtool straight under bin\x64 with no version
+            # directory, so a name that is not a version is not an error - it just sorts last.
+            $version = [version]'0.0.0.0'
+            try { $version = [version]$dir.Name } catch { }
+
+            $candidates.Add([pscustomobject]@{ Path = $exe; Version = $version })
+        }
+
+        $legacy = Join-Path -Path $root -ChildPath 'x64\signtool.exe'
+        if (Test-Path -LiteralPath $legacy -PathType Leaf) {
+            $candidates.Add([pscustomobject]@{ Path = $legacy; Version = [version]'0.0.0.0' })
+        }
+    }
+
+    if ($candidates.Count -gt 0) {
+        return ($candidates | Sort-Object -Property Version -Descending | Select-Object -First 1).Path
+    }
+
+    $onPath = Get-Command -Name 'signtool.exe' -CommandType Application -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($onPath) { return $onPath.Source }
+
+    throw @'
+signtool.exe was not found. It ships with the Windows SDK; install the "Windows SDK Signing Tools
+for Desktop Apps" component, or set BSI_SIGNTOOL to the full path of a signtool.exe to use.
+Searched: %ProgramFiles(x86)%\Windows Kits\10\bin\*\x64, %ProgramFiles%\Windows Kits\10\bin\*\x64,
+and PATH.
+'@
+}
+
+# Answers whether a given thumbprint resolves to a certificate that can sign right now.
+#
+# Read-only and non-blocking by design: it inspects the certificate store and never asks signtool
+# or the KSP for anything, so it cannot itself trigger the SimplySign login dialog. That is what
+# makes it safe to run as a fast preflight before an expensive build.
+function Test-BsiSigningCertificate {
+    [CmdletBinding()]
+    param(
+        # AllowEmptyString so that "no certificate configured" is an answer this function can give,
+        # rather than a parameter binding error the caller has to pre-empt.
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string] $Thumbprint,
+
+        [string[]] $StorePath = @('Cert:\CurrentUser\My', 'Cert:\LocalMachine\My')
+    )
+
+    # Thumbprints get copied out of the Windows certificate dialog, which renders them in lowercase
+    # with spaces between the bytes. Normalise rather than make the caller care.
+    $wanted = ($Thumbprint -replace '[^0-9A-Fa-f]', '').ToUpperInvariant()
+
+    $result = [pscustomobject]@{
+        Thumbprint    = $wanted
+        Found         = $false
+        Usable        = $false
+        Reason        = 'NotFound'
+        StorePath     = $null
+        Subject       = $null
+        Issuer        = $null
+        NotBefore     = $null
+        NotAfter      = $null
+        HasPrivateKey = $false
+        DaysRemaining = $null
+        Certificate   = $null
+    }
+
+    if ([string]::IsNullOrWhiteSpace($wanted)) {
+        $result.Reason = 'NoThumbprintConfigured'
+        return $result
+    }
+
+    foreach ($store in $StorePath) {
+        $cert = $null
+        try {
+            $cert = Get-ChildItem -Path $store -ErrorAction Stop |
+                Where-Object { $_.Thumbprint -eq $wanted } |
+                Select-Object -First 1
+        }
+        catch {
+            # LocalMachine\My is readable without elevation, but a locked-down host can still deny
+            # it. An unreadable store is not a finding - it just means look in the next one.
+            continue
+        }
+
+        if (-not $cert) { continue }
+
+        $now = Get-Date
+        $result.Found = $true
+        $result.StorePath = $store
+        $result.Subject = $cert.Subject
+        $result.Issuer = $cert.Issuer
+        $result.NotBefore = $cert.NotBefore
+        $result.NotAfter = $cert.NotAfter
+        $result.HasPrivateKey = $cert.HasPrivateKey
+        $result.DaysRemaining = [int][math]::Floor(($cert.NotAfter - $now).TotalDays)
+        $result.Certificate = $cert
+
+        if ($now -lt $cert.NotBefore) { $result.Reason = 'NotYetValid' }
+        elseif ($now -gt $cert.NotAfter) { $result.Reason = 'Expired' }
+        elseif (-not $cert.HasPrivateKey) { $result.Reason = 'NoPrivateKey' }
+        else {
+            $result.Reason = 'Ok'
+            $result.Usable = $true
+        }
+
+        break
+    }
+
+    return $result
+}
+
+# Quotes one argument for a Windows command line.
+#
+# Start-Process takes a single argument *string* and hands it to CreateProcess unchanged, so the
+# quoting is ours to get right. The rule is the awkward one every Windows runtime implements:
+# backslashes are literal, except in a run immediately before a quote, where each one has to be
+# doubled and the quote escaped. Without that, a path such as `C:\a b\x.exe` loses characters.
+function ConvertTo-BsiCommandLineArgument {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string] $Value
+    )
+
+    if ($Value -eq '') { return '""' }
+    if ($Value -notmatch '[\s"]') { return $Value }
+
+    # Double any backslash run that precedes a quote, and escape the quote itself.
+    $escaped = [regex]::Replace($Value, '(\\*)"', '$1$1\"')
+    # Do the same for a backslash run at the very end, which would otherwise escape our closing quote.
+    $escaped = [regex]::Replace($escaped, '(\\+)$', '$1$1')
+
+    return '"' + $escaped + '"'
+}
+
+# Turns a path into an absolute one, and fails if it names nothing.
+#
+# Every path handed to signtool goes through here, because Start-Process resolves relative paths
+# against the *process* working directory rather than PowerShell's $PWD. The two normally agree, and
+# then quietly stop agreeing after a Set-Location somewhere up the call chain - at which point
+# `./butler-sheet-icons.exe` starts meaning a different file, or no file. Resolving up front also
+# makes the logged command line say exactly which file was signed.
+function Resolve-BsiPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Path
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "File not found: '$Path' (resolved from working directory '$($PWD.Path)')."
+    }
+
+    return (Resolve-Path -LiteralPath $Path).Path
+}
+
+# Runs signtool under a hard timeout and returns its exit code and output rather than throwing.
+#
+# The timeout is the whole point. See the header: a lapsed SimplySign session turns signtool into a
+# process waiting on a dialog box that nothing will ever click.
+function Invoke-BsiSigntool {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Signtool,
+
+        [Parameter(Mandatory = $true)]
+        [string[]] $Arguments,
+
+        [int] $TimeoutSeconds = 0
+    )
+
+    if ($TimeoutSeconds -le 0) {
+        $TimeoutSeconds = 180
+        if (-not [string]::IsNullOrWhiteSpace($env:BSI_SIGN_TIMEOUT_SECONDS)) {
+            try {
+                $configured = [int]$env:BSI_SIGN_TIMEOUT_SECONDS
+                if ($configured -gt 0) { $TimeoutSeconds = $configured }
+            }
+            catch { }
+        }
+    }
+
+    $argumentString = ($Arguments | ForEach-Object { ConvertTo-BsiCommandLineArgument -Value $_ }) -join ' '
+
+    $outFile = [System.IO.Path]::GetTempFileName()
+    $errFile = [System.IO.Path]::GetTempFileName()
+
+    try {
+        Write-Host "  signtool $argumentString"
+
+        $proc = Start-Process -FilePath $Signtool -ArgumentList $argumentString -NoNewWindow -PassThru `
+            -RedirectStandardOutput $outFile -RedirectStandardError $errFile
+
+        # Touching Handle caches the process handle while the process is still alive. Without it,
+        # Windows PowerShell can report a null ExitCode after the process has exited, because the
+        # handle it needed to read the code was already released.
+        $null = $proc.Handle
+
+        $timedOut = $false
+        if ($proc.WaitForExit($TimeoutSeconds * 1000)) {
+            # The parameterless overload returns immediately once the process is gone, and
+            # guarantees the exit code is populated.
+            $proc.WaitForExit()
+        }
+        else {
+            $timedOut = $true
+            try { $proc.Kill() } catch { }
+            [void]$proc.WaitForExit(5000)
+        }
+
+        $exitCode = -1
+        if (-not $timedOut) { $exitCode = $proc.ExitCode }
+
+        $stdout = (Get-Content -LiteralPath $outFile -Raw -ErrorAction SilentlyContinue)
+        $stderr = (Get-Content -LiteralPath $errFile -Raw -ErrorAction SilentlyContinue)
+
+        if ($stdout) { Write-Host $stdout.TrimEnd() }
+        if ($stderr) { Write-Host $stderr.TrimEnd() }
+
+        return [pscustomobject]@{
+            ExitCode = $exitCode
+            StdOut   = [string]$stdout
+            StdErr   = [string]$stderr
+            Output   = ([string]$stdout + "`n" + [string]$stderr)
+            TimedOut = $timedOut
+        }
+    }
+    finally {
+        Remove-Item -LiteralPath $outFile, $errFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# Strips an existing Authenticode signature.
+#
+# Not optional, and not part of signing: postject rewrites the binary afterwards, which invalidates
+# any signature already on it. Shipping a binary carrying a broken signature is worse than shipping
+# an unsigned one - Windows reports it as corrupt or tampered with, which alarms users and antivirus
+# far more than no signature at all.
+function Invoke-BsiStripSignature {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Path,
+
+        [string] $Signtool
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Signtool)) { $Signtool = Get-BsiSigntoolPath }
+
+    $Path = Resolve-BsiPath -Path $Path
+
+    $result = Invoke-BsiSigntool -Signtool $Signtool -Arguments @('remove', '/s', $Path)
+    if ($result.TimedOut) {
+        throw "signtool remove timed out on '$Path'."
+    }
+    if ($result.ExitCode -ne 0) {
+        throw "signtool remove failed with exit code $($result.ExitCode) on '$Path'."
+    }
+}
+
+# Proves a signing session is alive by actually signing something, and cleans up after itself.
+#
+# Necessary because looking in the certificate store is not a reliable test. SimplySign Desktop
+# leaves certificates registered after a session ends unless "Unregister certificates after
+# disconnecting" is ticked - and even then it is unclear whether a session *timeout* counts as
+# disconnecting. So a certificate being present says only that a session existed at some point,
+# which is exactly the wrong thing to build a fail-fast check on.
+#
+# The only question that matters is "can this host sign right now", and the only honest way to ask
+# it is to sign. A few kilobytes of scratch file makes that cost about a second.
+function Invoke-BsiProveSigning {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Thumbprint,
+
+        [string] $Signtool
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Signtool)) { $Signtool = Get-BsiSigntoolPath }
+
+    # signtool signs PE files, not arbitrary bytes, so the scratch file has to be a real executable.
+    # These are the smallest things guaranteed to be on any Windows install; node.exe works too but
+    # is 80 MB, and hashing that is the bulk of the time.
+    $source = $null
+    foreach ($candidate in @('hostname.exe', 'whoami.exe', 'where.exe')) {
+        $path = Join-Path -Path ([System.Environment]::SystemDirectory) -ChildPath $candidate
+        if (Test-Path -LiteralPath $path -PathType Leaf) { $source = $path; break }
+    }
+
+    if (-not $source) {
+        $node = Get-Command -Name 'node.exe' -CommandType Application -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+        if ($node) { $source = $node.Source }
+    }
+
+    if (-not $source) {
+        throw 'Cannot prove signing: no scratch executable found to sign.'
+    }
+
+    $scratchRoot = if ($env:RUNNER_TEMP) { $env:RUNNER_TEMP } else { [System.IO.Path]::GetTempPath() }
+    $scratch = Join-Path -Path $scratchRoot -ChildPath "bsi-signing-proof-$([System.Guid]::NewGuid().ToString('N').Substring(0, 8))"
+
+    try {
+        New-Item -ItemType Directory -Path $scratch -Force | Out-Null
+        $target = Join-Path -Path $scratch -ChildPath 'proof.exe'
+        Copy-Item -LiteralPath $source -Destination $target -Force
+
+        Write-Host "Proving the signing session by signing a scratch copy of $(Split-Path -Leaf $source)."
+        Invoke-BsiSignFile -Path $target -Thumbprint $Thumbprint | Out-Null
+    }
+    finally {
+        if (Test-Path -LiteralPath $scratch) {
+            Remove-Item -LiteralPath $scratch -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+# Signs a file and verifies the result, throwing if either step fails.
+#
+# One SHA-256 signature, not the SHA-1 + SHA-256 pair this replaces. That pair never worked as
+# intended: the second `signtool sign` was missing /as, so instead of appending a second signature
+# it replaced the first, and the SHA-1 pass was two seconds of cloud round-trip producing a
+# signature that was then thrown away. Restoring it correctly would be worse, not better - Windows
+# has distrusted SHA-1 Authenticode since 2016, so the only thing a real dual signature would add
+# is a signature nothing trusts.
+function Invoke-BsiSignFile {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Path,
+
+        [Parameter(Mandatory = $true)]
+        [string] $Thumbprint,
+
+        [string] $Signtool,
+
+        [int] $TimestampAttempts = 3
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Signtool)) { $Signtool = Get-BsiSigntoolPath }
+
+    $Path = Resolve-BsiPath -Path $Path
+
+    $signArguments = @(
+        'sign'
+        '/sha1', $Thumbprint
+        '/fd', 'sha256'
+        '/tr', $BsiTimestampUrl
+        '/td', 'sha256'
+        '/d', $BsiSignDescription
+        '/du', $BsiSignDescriptionUrl
+        '/v'
+        $Path
+    )
+
+    for ($attempt = 1; $attempt -le $TimestampAttempts; $attempt++) {
+        $result = Invoke-BsiSigntool -Signtool $Signtool -Arguments $signArguments
+
+        if (-not $result.TimedOut -and $result.ExitCode -eq 0) { break }
+
+        if ($result.TimedOut) {
+            throw @"
+signtool timed out while signing '$Path' and was killed.
+
+That almost always means it was waiting on a graphical SimplySign login or PIN prompt that nothing
+on a build runner will ever answer.
+
+$(Get-BsiSimplySignHelp)
+"@
+        }
+
+        # Only a timestamping failure is worth another go - a public TSA refusing one request will
+        # usually take the next. Everything else (missing certificate, bad thumbprint, unreadable
+        # file) fails identically on every attempt, so retrying just delays the report.
+        $isTimestampFailure = $result.Output -match 'timestamp'
+
+        if (-not $isTimestampFailure -or $attempt -eq $TimestampAttempts) {
+            $hint = if ($isTimestampFailure) {
+                "The timestamp server $BsiTimestampUrl did not answer after $TimestampAttempts attempts."
+            }
+            else {
+                Get-BsiSimplySignHelp
+            }
+
+            throw @"
+signtool sign failed with exit code $($result.ExitCode) on '$Path'.
+
+$hint
+"@
+        }
+
+        Write-Host "Timestamping failed on attempt $attempt of $TimestampAttempts; retrying in 15 seconds."
+        Start-Sleep -Seconds 15
+    }
+
+    # Fail loudly rather than shipping something that only looks signed.
+    $verify = Invoke-BsiSigntool -Signtool $Signtool -Arguments @('verify', '/pa', '/v', $Path)
+    if ($verify.TimedOut -or $verify.ExitCode -ne 0) {
+        throw "signtool verify failed with exit code $($verify.ExitCode) - '$Path' is not correctly signed."
+    }
+
+    return $verify.Output
+}

--- a/scripts/release-win.ps1
+++ b/scripts/release-win.ps1
@@ -1,6 +1,60 @@
 $ErrorActionPreference = 'Stop'
 
-$signtool = "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x64\signtool.exe"
+# Signing helpers, shared with the insider build and the diagnostics under scripts/diag. The
+# certificate is a Certum cloud certificate reached through SimplySign Desktop; that library's
+# header explains how it appears to signtool, why the timestamp URL is http, and why a hard timeout
+# wraps every signtool call.
+. "$PSScriptRoot/lib/win-signing.ps1"
+
+$signtool = Get-BsiSigntoolPath
+Write-Host "signtool: $signtool"
+
+# -------------------
+# Decide about signing before building anything.
+#
+# The build below takes minutes; deciding afterwards means spending all of them only to discover
+# the certificate is not there. A SimplySign session lasts about two hours, so "not there" is a
+# routine state rather than an exotic one, and it is worth one second to find out first.
+#
+# This is a store lookup, which catches a missing or expired certificate but NOT an expired
+# SimplySign session - SimplySign leaves certificates registered after a session ends. The job that
+# calls this script preflights with `win-signing-check.ps1 -ProveSigning`, which settles that by
+# signing a scratch file. Treat the check here as the second line, not the first.
+$signingRequested = -not [string]::IsNullOrWhiteSpace($env:CODESIGN_WIN_THUMBPRINT)
+
+if ($signingRequested) {
+    $certificate = Test-BsiSigningCertificate -Thumbprint $env:CODESIGN_WIN_THUMBPRINT
+
+    if (-not $certificate.Usable) {
+        # A hard failure, deliberately. release-win64 uploads to a *draft* release, so a failed job
+        # costs a re-run once somebody has logged in to SimplySign - while an unsigned binary
+        # published under a release that is supposed to be signed is not something a re-run fixes.
+        Write-Host "::error title=Windows code signing unavailable::The configured signing certificate is not usable ($($certificate.Reason)). See the job log for what to do."
+        throw @"
+Refusing to build: signing was requested but no usable certificate is available ($($certificate.Reason)).
+
+$(Get-BsiSimplySignHelp)
+"@
+    }
+
+    Write-Host "Signing with: $($certificate.Subject)"
+    Write-Host "Certificate valid until $($certificate.NotAfter.ToString('yyyy-MM-dd')) ($($certificate.DaysRemaining) days left)."
+
+    if ($certificate.DaysRemaining -le 30) {
+        Write-Host "::warning title=Code signing certificate expires soon::The Windows code signing certificate expires in $($certificate.DaysRemaining) days ($($certificate.NotAfter.ToString('yyyy-MM-dd'))). Renew it before it lapses - an expired certificate is what left 4.0.0 without a Windows binary."
+    }
+}
+else {
+    # The deliberate kill switch. Signing is skipped when CODESIGN_WIN_THUMBPRINT is empty, and the
+    # release ships unsigned rather than failing: that is what happened to 4.0.0, where the signing
+    # step failed and the release was published with Linux and macOS binaries and no Windows one at
+    # all. A user can click through a SmartScreen warning; they cannot click through a missing file.
+    #
+    # This is only for switching signing off on purpose. A configured certificate that turns out to
+    # be unusable takes the branch above and fails.
+    Write-Host "::warning title=Unsigned Windows binary::CODESIGN_WIN_THUMBPRINT is not set, so this release ships an UNSIGNED Windows binary. Users will see a Microsoft Defender SmartScreen warning, and environments enforcing AppLocker or WDAC publisher rules will refuse to run it."
+    Write-Host 'Skipping Windows code signing - no certificate thumbprint configured.'
+}
 
 # Create build directory if it doesn't exist
 New-Item -ItemType Directory -Force -Path ./build | Out-Null
@@ -12,7 +66,7 @@ New-Item -ItemType Directory -Force -Path ./build | Out-Null
 node --experimental-sea-config build-script/sea-config.json
 
 # Get a copy of the Node executable
-node -e "require('fs').copyFileSync(process.execPath, '${env:DIST_FILE_NAME}.exe')" 
+node -e "require('fs').copyFileSync(process.execPath, '${env:DIST_FILE_NAME}.exe')"
 
 # -------------------
 # Remove Node's own signature from the copied executable.
@@ -21,59 +75,27 @@ node -e "require('fs').copyFileSync(process.execPath, '${env:DIST_FILE_NAME}.exe
 # binary below, which invalidates any signature already on it. Shipping a binary carrying a broken
 # signature is worse than shipping an unsigned one - Windows reports it as corrupt or tampered
 # with, which alarms users and antivirus far more than no signature at all.
-& $signtool remove /s "./${env:DIST_FILE_NAME}.exe"
-if ($LASTEXITCODE -ne 0) { throw "signtool remove failed with exit code $LASTEXITCODE" }
+Invoke-BsiStripSignature -Path "./${env:DIST_FILE_NAME}.exe" -Signtool $signtool
 
 npx --no-install postject "${env:DIST_FILE_NAME}.exe" NODE_SEA_BLOB ./build/sea-prep.blob --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2
 
 # -------------------
-# Sign the executable, if there is a certificate to sign with.
+# Sign the executable.
 #
-# Signing is skipped when CODESIGN_WIN_THUMBPRINT is empty, and the release ships unsigned. That is
-# deliberate: the code signing certificate expired, and a release that fails outright is worse than
-# one that ships a working binary with a warning. It is what happened to 4.0.0 - the signing step
-# failed and the release was published with Linux and macOS binaries and no Windows one at all. A
-# user can click through a SmartScreen warning; they cannot click through a missing file.
-#
-# To turn signing back on, set the WIN_CODESIGN_THUMBPRINT secret again. Nothing else needs
-# changing - which is the reason this is a guard rather than deleted code. Note that Certum
-# SimplySign is a cloud signing service, so when that route lands the invocation below will likely
-# need reworking rather than merely re-enabling.
-#
-# The timestamp URL is http, not https, and has to stay that way: time.certum.pl serves no HTTPS at
-# all - port 443 refuses the connection - so signtool answers `SignTool Error: Invalid Timestamp
-# URL`. That is not a hypothetical either; it is the bug that broke the 4.0.0 Windows release
-# before the certificate expiry was known about.
-#
-# This is not a security weakness, which is why an https "fix" keeps looking tempting. An RFC 3161
-# timestamp token is signed by the timestamping authority, so it is verified on its own signature
-# rather than on the transport, and signtool rejects a token that does not verify. Plain HTTP is
-# what the RFC expects and what essentially every public TSA offers.
-if ([string]::IsNullOrWhiteSpace($env:CODESIGN_WIN_THUMBPRINT)) {
-  Write-Host "::warning title=Unsigned Windows binary::CODESIGN_WIN_THUMBPRINT is not set, so this release ships an UNSIGNED Windows binary. Users will see a Microsoft Defender SmartScreen warning, and environments enforcing AppLocker or WDAC publisher rules will refuse to run it."
-  Write-Host "Skipping Windows code signing - no certificate thumbprint configured."
-}
-else {
-  # 1st signing
-  & $signtool sign /sha1 "$env:CODESIGN_WIN_THUMBPRINT" /tr http://time.certum.pl /td sha256 /fd sha1 /v "./${env:DIST_FILE_NAME}.exe"
-  if ($LASTEXITCODE -ne 0) { throw "signtool sign (sha1) failed with exit code $LASTEXITCODE" }
-
-  # -------------------
-  # 2nd signing
-  & $signtool sign /sha1 "$env:CODESIGN_WIN_THUMBPRINT" /tr http://time.certum.pl /td sha256 /fd sha256 /v "./${env:DIST_FILE_NAME}.exe"
-  if ($LASTEXITCODE -ne 0) { throw "signtool sign (sha256) failed with exit code $LASTEXITCODE" }
-
-  # Fail loudly rather than shipping something that only looks signed.
-  & $signtool verify /pa /v "./${env:DIST_FILE_NAME}.exe"
-  if ($LASTEXITCODE -ne 0) { throw "signtool verify failed with exit code $LASTEXITCODE - the binary is not correctly signed" }
+# One SHA-256 signature. This used to be a SHA-1 pass followed by a SHA-256 pass, which was neither
+# a dual signature nor useful: the second call was missing /as, so it replaced the first rather than
+# appending to it, and Windows has distrusted SHA-1 Authenticode since 2016 anyway. See
+# scripts/lib/win-signing.ps1 for the invocation and the timestamping rationale.
+if ($signingRequested) {
+    Invoke-BsiSignFile -Path "./${env:DIST_FILE_NAME}.exe" -Thumbprint $env:CODESIGN_WIN_THUMBPRINT -Signtool $signtool | Out-Null
 }
 
 # -------------------
 # Create release binary zip
 $compress = @{
-  Path = "./${env:DIST_FILE_NAME}.exe"
-  CompressionLevel = "Fastest"
-  DestinationPath = "${env:RELEASE_VERSION}-win.zip"
+    Path             = "./${env:DIST_FILE_NAME}.exe"
+    CompressionLevel = "Fastest"
+    DestinationPath  = "${env:RELEASE_VERSION}-win.zip"
 }
 Compress-Archive @compress
 


### PR DESCRIPTION
## What & why

The Windows code signing certificate expired and signing was switched off in `990c0b8`, so 4.0.0 and 4.1.0 shipped unsigned — a SmartScreen warning for everyone, and no way at all to run them where AppLocker or WDAC allow programs by publisher. A replacement Certum cloud certificate is now in place, and this turns signing back on.

The comments left behind predicted that a cloud certificate would need the signtool invocation reworked. **It does not.** SimplySign Desktop presents the certificate to Windows as a virtual smart card, so it lands in the ordinary certificate store and `signtool sign /sha1 <thumbprint>` is exactly what Certum documents. Those comments are corrected rather than left to mislead the next person.

Four things did need fixing:

- **The SHA-1 pass was a no-op.** The second `signtool sign` was missing `/as`, so it *replaced* the first rather than appending — two cloud round-trips to keep one SHA-256 signature. Removed rather than repaired; Windows has distrusted SHA-1 Authenticode since 2016.
- **The signtool path was hard-coded** to one SDK version, on a line that runs whether or not we sign — so an SDK change broke the *build*, not just signing.
- **A lapsed session could hang a job for six hours.** `timeout-minutes` was commented out.
- **Signing was exercised only during a live release.** That is how the timestamp URL could be switched to https in May and go unnoticed until 4.0.0 failed in August.

What a cloud certificate *does* change is availability: a SimplySign session lasts about two hours, so "no certificate right now" is routine. The two builds want opposite answers. `release-win64` preflights before installing anything and fails in seconds; the insider build signs when a session happens to be open and says so when not, restoring the safety net without turning `main` red on every push.

## How it was verified

Run on the `win-code-sign` host (`PVE-WINSRV19-1`, Server 2019, PowerShell 5.1):

| Path | Result |
|---|---|
| Certificate, strip → sign → verify on `node.exe` (`win-signing-smoke.ps1`) | Signed + verified, 12s |
| Preflight `win-signing-check.ps1 -RequireSigning -ProveSigning` | Pass, 5s |
| **Expired session** (SimplySign disconnected) | Fails in **3s**, no dialog, correct diagnosis |
| **Real binary, runner service, session 0, RDP disconnected** ([run 31629753798](https://github.com/ptarmiganlabs/butler-sheet-icons/actions/runs/31629753798)) | **Signed and verified** |

That last row is the important one: it signed from the runner service with nobody at the console, so the runner does not need converting to interactive.

The disconnect test earned its keep — it proved the certificate **stays registered after a session ends**, so a store lookup reports `Ok` while signing fails. That is why the preflight actually signs a scratch file rather than trusting the store; a lookup alone would wave a doomed build through and fail ten minutes later.

Locally: argument quoting against 7 Windows cases, timeout/exit-code/retry-classification behaviour against a stubbed signtool, exit-code propagation through the Actions PowerShell wrapper, all scripts parse, zizmor adds no surfaced findings.

Verified signature: SHA-256, full Certum chain, timestamped `2026-08-12 21:02:14`.

## Docs

`docs/to-doc-site/windows-binary-signed-again.md`

Two claims in it are deliberately *not* what a first draft assumed, both checked against the signing host: the publisher users see is **Open Source Developer Karl Göran Sander**, not Ptarmigan Labs, and the page does **not** promise the SmartScreen warning disappears — that holds for EV certificates, and this is a standard one.

The retirement note on `done_windows-binary-temporarily-unsigned.md` is corrected too: it read the two live `signtool sign` calls as proof releases were signed, when they were guarded by a variable `ci.yaml` left unset.
