### PR TITLE
Fix the duplicate timeout key that stops insiders-build from starting

### DIFF
--- a/.github/workflows/insiders-build.yaml
+++ b/.github/workflows/insiders-build.yaml
@@ -19,6 +19,11 @@ jobs:
     # self-hosted code-signing runners, so an untimed hang would hold one of them for GitHub's
     # 6-hour default and queue every later insiders build and signed release behind it.
     # 20 minutes is roughly 3x the slowest observed run of this job (6m34s, on win).
+    #
+    # Signing is a second way the win leg can stall, since #1041: on a host configured to show
+    # SimplySign's login dialog, signtool would wait on a prompt nobody can answer.
+    # scripts/lib/win-signing.ps1 kills signtool itself, so this stays a backstop rather than the
+    # primary guard - and signing adds well under a minute, so 20 still holds.
     timeout-minutes: 20
     strategy:
       matrix:
@@ -45,10 +50,6 @@ jobs:
               - ubuntu-latest
             artifact_insider: butler-sheet-icons--linux-x64--${{ github.sha }}.tgz
     runs-on: ${{ matrix.runs_on }}
-    # The win leg signs when a SimplySign session happens to be open on the runner, so it can in
-    # principle sit on a graphical prompt nobody will answer. scripts/lib/win-signing.ps1 kills
-    # signtool itself; this is the backstop, because the default is six hours per leg.
-    timeout-minutes: 45
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## What & why

`insiders-build` fails at startup on `main` — invalid YAML, no jobs run at all.

#1039 added `timeout-minutes: 20` at job level and #1041 added `timeout-minutes: 45` a few lines further down. Both were valid on their own branch; git merged them cleanly because they touch different lines, and the result is a job mapping with the same key twice.

Neither PR could have caught this — the defect exists only in the merge result, which is what a textual three-way merge is structurally unable to see. Worth knowing that `check-yaml` in pre-commit does not catch it either, since it only ever sees one side.

Keeping **20** from #1039: it is calibrated against a measured run (3x the slowest observed, 6m34s on win) rather than guessed, and signing adds well under a minute. #1041's reasoning about signing stalls is folded into the surviving comment so it is not lost along with the line.

## How it was verified

`js-yaml` parses the file and reports a single `timeout-minutes: 20` for the job; every other workflow on `main` was checked the same way and only this one was broken. zizmor: no findings. The merge result is what a run will actually use, so the real proof is the insiders-build run that follows this merge.

## Docs

Internal only.