### PR TITLE
Interactive mode asks about app selection that a .env file already supplied

### DIFF
--- a/docs/to-doc-site/creating-thumbnails-interactively.md
+++ b/docs/to-doc-site/creating-thumbnails-interactively.md
@@ -52,9 +52,9 @@ Rather than typing an app ID from memory:
 
 ```
 ? Which apps should be updated?
-❯ Choose from all apps on the server
-  Choose a tag, then apps carrying it
-  Type an app id
+❯ Pick apps from a list
+  Update every app carrying a tag
+  Type app id(s)
 
 ? Which apps?
 ❯ ◯ Finance dashboard  (id: a1b2c3d4-1111-2222-3333-444455556666)
@@ -69,6 +69,31 @@ Typing an ID directly is still offered, for when you already have it.
 
 If the list cannot be fetched — a network problem, or an account without permission to read the app list — the wizard falls back to asking you to type the ID rather than stranding you.
 
+### Choosing by tag or collection updates all of them
+
+The middle route does not show you a list to tick. It cannot: a tag reaches Butler Sheet Icons as `--qliksensetag`, which selects every app carrying it, so a list there would invite a choice that could not be honoured. Instead the wizard resolves the tag and tells you what it found:
+
+```
+? Which tag? BSI
+  7 app(s) carry the tag 'BSI' and will be updated.
+```
+
+A tag that matches no apps is rejected there and then, so you fix it at the prompt rather than discovering it when the run reports that it had nothing to do.
+
+If you want only some of the tagged apps, pick them from the list route instead.
+
+### A run with nothing to do is refused
+
+Untick every app and the wizard says so rather than letting you confirm a run that would process nothing:
+
+```
+? Which apps?
+✖ No apps selected, so there would be nothing to do. Pick at least one app, or go back and choose a tag instead.
+? Which apps?
+```
+
+Naming no apps is still fine when a tag or collection is carrying the selection — the two add together, and one of them having apps is enough.
+
 ## Everything you already supplied is kept
 
 Options given on the command line, or set through their `BSI_*` environment variables, are not asked about again:
@@ -82,6 +107,37 @@ Already supplied, so not asked about again: --host.
 ```
 
 This makes `-i` useful for filling the gaps in a command you have partly written, not only for starting from nothing.
+
+### Except which apps to update, which you always get to confirm
+
+App selection is the exception, and it is asked about even when `--appid` — or `BSI_QSEOW_CST_APP_ID` in a `.env` file — already names one. The wizard says so:
+
+```
+Supplied, but asked about again so the answer can be picked from what is actually there: --appid.
+```
+
+You get the full list of apps from the server, with the ones you supplied already ticked. Pressing Enter accepts them unchanged, so the common case still costs one keystroke — but you can add an app, swap it for another, or notice that the ID in your `.env` file names an app that has since been deleted. If you choose to type an ID instead, that question opens on the value you supplied.
+
+This is why the app question is treated differently from `--host` or `--certfile`: a hostname you set once stays correct, while a stored app ID quietly goes stale when someone deletes or republishes the app.
+
+### A supplied tag or collection is shown too, whichever way you pick apps
+
+`--qliksensetag` on Qlik Sense Enterprise on Windows, and `--collectionid` on Qlik Sense Cloud, are not alternatives to naming apps — they are a second way of naming them. The run covers every app you name **and** every app carrying the tag or held in the collection.
+
+So when one of them is already set, the wizard asks about it on every route, not only when you chose to pick apps by tag or collection:
+
+```
+── Apps ──────────────────────────────────────────
+
+✓ Which apps should be updated? Pick apps from a list
+
+? Which tag?
+  Every app carrying it is updated, on top of any apps named below. Leave empty for none.
+> BSI
+  7 app(s) carry the tag 'BSI' and will be updated.
+```
+
+Leave the tag empty — or choose `None - do not add a collection` in the collection list — and only the apps you picked are updated. Keep it, and the tagged apps are added, exactly as they would be from the command line. Without this the tag would sit in your `.env` file and quietly widen every interactive run to apps you were never shown.
 
 ## Nothing happens until you confirm
 

--- a/src/lib/commands/qscloud/__tests__/qscloud_wizard.test.js
+++ b/src/lib/commands/qscloud/__tests__/qscloud_wizard.test.js
@@ -139,26 +139,46 @@ describe('choosing which apps to update', () => {
         expect(question.choices[0].name).toBe('Finance  (id: app-a)');
     });
 
-    test('lists apps from a collection when that is how they are chosen', async () => {
+    test('reports what a collection holds instead of a list that cannot narrow', async () => {
+        // The collection reaches the worker as well, and the two are additive,
+        // so unticking an app in a list of its apps never removed it from the
+        // run. Saying how many it holds is the honest version of that.
         const runtime = scriptedRuntime(
-            baseAnswers({ _appSource: 'collection', collectionid: 'coll-1', appid: ['app-c'] })
+            baseAnswers({ _appSource: 'grouped', collectionid: 'coll-1' })
         );
 
         await runInteractive({ path: PATH, runtime });
 
         expect(listAppsByCollection).toHaveBeenCalledWith(expect.anything(), 'coll-1');
         expect(listApps).not.toHaveBeenCalled();
+        expect(runtime.asked.map((a) => a.key)).not.toContain('appid');
+        expect(runtime.output()).toContain(
+            "1 app(s) are in collection 'coll-1' and will be updated."
+        );
     });
 
     test('shows how many items a collection holds, so an empty one is visible', async () => {
         const runtime = scriptedRuntime(
-            baseAnswers({ _appSource: 'collection', collectionid: 'coll-1', appid: ['app-c'] })
+            baseAnswers({ _appSource: 'grouped', collectionid: 'coll-1' })
         );
 
         await runInteractive({ path: PATH, runtime });
 
         const question = runtime.asked.find((a) => a.key === 'collectionid');
         expect(question.choices[0].name).toBe('Finance  (4 items)');
+    });
+
+    test('re-asks a collection that holds no apps, rather than running over nothing', async () => {
+        listAppsByCollection.mockResolvedValueOnce([]).mockResolvedValue([{ id: 'app-c' }]);
+
+        const runtime = scriptedRuntime(
+            baseAnswers({ _appSource: 'grouped', collectionid: ['coll-1', 'coll-1'] })
+        );
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(runtime.asked.filter((a) => a.key === 'collectionid')).toHaveLength(2);
+        expect(runtime.output()).toContain("Collection 'coll-1' holds no apps.");
     });
 
     test('still lets an app id be typed, without fetching any list', async () => {
@@ -171,6 +191,156 @@ describe('choosing which apps to update', () => {
     });
 
     test('does not ask which collection when apps are chosen another way', async () => {
+        const runtime = scriptedRuntime(baseAnswers());
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(runtime.asked.map((a) => a.key)).not.toContain('collectionid');
+    });
+});
+
+describe('a selection that would process nothing', () => {
+    test('is refused where it was made, not after the run is confirmed', async () => {
+        const runtime = scriptedRuntime(baseAnswers({ _appSource: 'typed', appid: ['', 'app-z'] }));
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(runtime.asked.filter((a) => a.key === 'appid')).toHaveLength(2);
+        expect(runtime.output()).toContain('No apps selected');
+        expect(qscloudCreateThumbnails).not.toHaveBeenCalled();
+    });
+
+    test('is allowed when a collection is carrying the selection instead', async () => {
+        // The run is the union of the two, so naming no apps is fine as long as
+        // the collection holds some.
+        const runtime = scriptedRuntime(
+            baseAnswers({ collectionid: 'coll-1', appid: [], _review: 'run' })
+        );
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { collectionid: 'coll-1' },
+            runtime,
+        });
+
+        expect(runtime.asked.filter((a) => a.key === 'appid')).toHaveLength(1);
+        expect(qscloudCreateThumbnails).toHaveBeenCalledWith(
+            expect.objectContaining({ collectionid: 'coll-1' })
+        );
+    });
+});
+
+describe('an app id supplied before the wizard starts', () => {
+    // QSEoW twin of the same block: an id in a .env file used to remove the app
+    // question but leave the question that leads to it, so the wizard asked how
+    // apps should be chosen and then never showed a list.
+    const supplied = {
+        tenanturl: 'acme.eu.qlikcloud.com',
+        apikey: 'a-real-key',
+        appid: ['app-b'],
+    };
+
+    test('still gets the picker, with the supplied app already ticked', async () => {
+        const runtime = scriptedRuntime(baseAnswers({ appid: ['app-a'] }));
+
+        await runInteractive({ path: PATH, presetOptions: supplied, runtime });
+
+        const question = runtime.asked.find((a) => a.key === 'appid');
+        expect(question).toBeDefined();
+        expect(question.choices).toEqual([
+            expect.objectContaining({ value: 'app-a', checked: false }),
+            expect.objectContaining({ value: 'app-b', checked: true }),
+        ]);
+    });
+
+    test('is announced as asked again rather than as skipped', async () => {
+        const runtime = scriptedRuntime(baseAnswers({ appid: ['app-a'] }));
+
+        await runInteractive({ path: PATH, presetOptions: supplied, runtime });
+
+        expect(runtime.output()).toContain('picked from what is actually there: --appid');
+        expect(runtime.output()).not.toMatch(/not asked about again:[^\n]*--appid/);
+    });
+
+    test('opens the typed question on the supplied id', async () => {
+        const runtime = scriptedRuntime(baseAnswers({ _appSource: 'typed', appid: 'app-z' }));
+
+        await runInteractive({ path: PATH, presetOptions: supplied, runtime });
+
+        expect(runtime.asked.find((a) => a.key === 'appid').default).toBe('app-b');
+    });
+
+    test('the picked apps win over the supplied ones', async () => {
+        const runtime = scriptedRuntime(baseAnswers({ appid: ['app-a'], _review: 'run' }));
+
+        await runInteractive({ path: PATH, presetOptions: supplied, runtime });
+
+        expect(qscloudCreateThumbnails).toHaveBeenCalledWith(
+            expect.objectContaining({ appid: ['app-a'] })
+        );
+    });
+});
+
+describe('a collection supplied before the wizard starts', () => {
+    // QSEoW twin of the same block. A collection is a second way of naming
+    // apps, not an alternative to naming them, so a supplied one applies
+    // whichever route is taken - and asking about it only on the collection
+    // route let it add apps the operator was never shown.
+    const supplied = {
+        tenanturl: 'acme.eu.qlikcloud.com',
+        apikey: 'a-real-key',
+        collectionid: 'coll-1',
+    };
+
+    test('is asked about on the all-apps route too, opening on the supplied one', async () => {
+        const runtime = scriptedRuntime(baseAnswers({ collectionid: 'coll-1' }));
+
+        await runInteractive({ path: PATH, presetOptions: supplied, runtime });
+
+        const question = runtime.asked.find((a) => a.key === 'collectionid');
+        expect(question).toBeDefined();
+        expect(question.default).toBe('coll-1');
+    });
+
+    test('offers a way to drop it, which the collection route does not need', async () => {
+        const runtime = scriptedRuntime(baseAnswers({ collectionid: '' }));
+
+        await runInteractive({ path: PATH, presetOptions: supplied, runtime });
+
+        const question = runtime.asked.find((a) => a.key === 'collectionid');
+        expect(question.choices[0]).toEqual(expect.objectContaining({ value: '' }));
+    });
+
+    test('choosing none stops the collection apps being added to the run', async () => {
+        const runtime = scriptedRuntime(
+            baseAnswers({ collectionid: '', appid: ['app-a'], _review: 'run' })
+        );
+
+        await runInteractive({ path: PATH, presetOptions: supplied, runtime });
+
+        // An empty collection matches the option's own default, so it is never
+        // emitted to the command line and the bag carries exactly what the plain
+        // CLI produces when no collection is given. qscloudCreateThumbnails
+        // gates on `collectionid && length > 0`, so no collection lookup
+        // happens: the run covers the picked app and nothing else.
+        const bag = qscloudCreateThumbnails.mock.calls[0][0];
+        expect(bag.appid).toEqual(['app-a']);
+        expect(bag.collectionid).toBe('');
+    });
+
+    test('keeping it still adds the collection apps, as the CLI does', async () => {
+        const runtime = scriptedRuntime(
+            baseAnswers({ collectionid: 'coll-1', appid: ['app-a'], _review: 'run' })
+        );
+
+        await runInteractive({ path: PATH, presetOptions: supplied, runtime });
+
+        expect(qscloudCreateThumbnails).toHaveBeenCalledWith(
+            expect.objectContaining({ appid: ['app-a'], collectionid: 'coll-1' })
+        );
+    });
+
+    test('a collection that was never supplied is still only asked on its own route', async () => {
         const runtime = scriptedRuntime(baseAnswers());
 
         await runInteractive({ path: PATH, runtime });

--- a/src/lib/commands/qscloud/create-sheet-thumbnails.interactive.js
+++ b/src/lib/commands/qscloud/create-sheet-thumbnails.interactive.js
@@ -2,15 +2,25 @@ import QlikSaas from '../../cloud/cloud-repo.js';
 import { qscloudTestConnection } from '../../cloud/cloud-test-connection.js';
 import { listCollections, listApps, listAppsByCollection } from '../../cloud/cloud-apps.js';
 import { qscloudCreateThumbnails } from '../../cloud/cloud-create-thumbnails.js';
-import { gate, gatedBy, inSections, SHEET_FILTER_KEYS } from '../../interactive/spec-ops.js';
+import {
+    gate,
+    gatedBy,
+    inSections,
+    openingOn,
+    isSupplied,
+    appSourceQuestion,
+    appPickerQuestion,
+    typedAppQuestion,
+    resolvesToApps,
+    APP_SOURCE,
+    APP_SOURCES,
+    SHEET_FILTER_KEYS,
+} from '../../interactive/spec-ops.js';
 import { labelForApp, labelForCollection } from '../../interactive/labels.js';
 
-// Re-exported so a reader following this wizard finds the labels it uses without
-// having to know they are shared with the QSEoW twin.
-export { labelForApp, labelForCollection };
-
-/** Key of the synthetic question asking how apps should be chosen. */
-const APP_SOURCE = '_appSource';
+// Re-exported so a reader following this wizard finds the labels and the route
+// vocabulary it uses without having to know they are shared with the QSEoW twin.
+export { labelForApp, labelForCollection, APP_SOURCES };
 
 /** Key of the synthetic question gating the sheet exclude/blur filters. */
 const FILTERING = '_filtering';
@@ -18,12 +28,8 @@ const FILTERING = '_filtering';
 /** Key of the synthetic question gating the long tail of options. */
 const ADVANCED = '_advanced';
 
-/** How apps can be picked, in the order the choices are offered. */
-export const APP_SOURCES = Object.freeze({
-    ALL: 'all',
-    COLLECTION: 'collection',
-    TYPED: 'typed',
-});
+/** What the collection route is called wherever it has to be named in a sentence. */
+const GROUPING_LABEL = 'a collection';
 
 /** Questions asked before anything else, in this order. */
 const CONNECTION_KEYS = ['tenanturl', 'apikey', 'skipLogin', 'logonuserid', 'logonpwd'];
@@ -40,6 +46,33 @@ const ADVANCED_KEYS = [
     'browserCacheDir',
     'headless',
 ];
+
+/**
+ * The connected tenant the pickers list from.
+ *
+ * Normally the API key's probe stashes this, which is the cheapest place to
+ * build it: the connection has just been tested, so reusing it costs nothing.
+ * But a key supplied in `.env` or on the command line is never asked about, so
+ * its probe never runs - and the pickers would then have no client at all and
+ * degrade to "type an id", which is exactly what they exist to avoid.
+ *
+ * Building it here on demand keeps the pickers working in that case. A bad key
+ * still fails, only at the picker rather than at a prompt that was never shown.
+ *
+ * @param {object} ctx - Wizard context.
+ *
+ * @returns {object} A connected QlikSaas client.
+ */
+const tenantClient = (ctx) => {
+    if (!ctx.clients?.tenant) {
+        ctx.clients = {
+            ...ctx.clients,
+            tenant: new QlikSaas({ url: ctx.answers.tenanturl, token: ctx.answers.apikey }),
+        };
+    }
+
+    return ctx.clients.tenant;
+};
 
 /** Which section each question belongs under, in the order the sections run. */
 const SECTIONS = [
@@ -74,10 +107,13 @@ export default {
      * `probe`, which the driver invokes.
      *
      * @param {import('../../interactive/option-introspect.js').QuestionSpec[]} specs - Derived questions.
+     * @param {object} [context] - What the command line and environment already supplied.
+     * @param {object} [context.answers] - Those values, keyed by option name. Used as the starting
+     *     point for the app and collection questions, which are asked again rather than skipped.
      *
      * @returns {Array} The questions to actually ask.
      */
-    refine(specs) {
+    refine(specs, { answers = {} } = {}) {
         const byKey = Object.fromEntries(specs.map((spec) => [spec.key, spec]));
 
         const connection = CONNECTION_KEYS.map((key) => byKey[key])
@@ -106,60 +142,78 @@ export default {
                     : spec
             );
 
-        const appSource = {
-            key: APP_SOURCE,
-            type: 'select',
-            message: 'Which apps should be updated?',
-            required: true,
-            variadic: false,
-            secret: false,
+        const appSource = appSourceQuestion({
             needs: ['apikey'],
-            choices: [
-                { name: 'Choose from all apps on the tenant', value: APP_SOURCES.ALL },
-                { name: 'Choose a collection, then apps within it', value: APP_SOURCES.COLLECTION },
-                { name: 'Type an app id', value: APP_SOURCES.TYPED },
-            ],
-        };
+            groupingKey: 'collectionid',
+            groupingChoice: 'Update every app in a collection',
+        });
 
+        // A collection is not an alternative to naming apps, it is a second way
+        // of naming them: the run covers everything --appid names *and* every
+        // app in the collection. So a collection that is already set changes
+        // what the run does no matter which route is taken here, and hiding it
+        // behind the collection route would let it add apps the operator was
+        // never shown.
         const collection = {
-            ...byKey.collectionid,
-            type: 'select',
-            message: 'Which collection?',
+            ...openingOn(
+                {
+                    ...byKey.collectionid,
+                    type: 'select',
+                    message: 'Which collection?',
+                    hint: 'Every app in it is updated, on top of any apps named below.',
+                },
+                answers.collectionid
+            ),
             needs: [APP_SOURCE],
-            when: (ctx) => ctx.answers[APP_SOURCE] === APP_SOURCES.COLLECTION,
+            // Asked on the collection route because that is how apps are being
+            // chosen there - and on every other route when a collection was
+            // already supplied, because it still applies there and the banner
+            // has just promised it would be asked about rather than skipped.
+            when: (ctx) =>
+                ctx.answers[APP_SOURCE] === APP_SOURCES.GROUPED || isSupplied(answers.collectionid),
             choices: async (ctx) => {
-                const collections = await listCollections(ctx.clients.tenant);
-
-                return collections.map((entry) => ({
+                const collections = await listCollections(tenantClient(ctx));
+                const picked = collections.map((entry) => ({
                     name: labelForCollection(entry),
                     value: entry.id,
                 }));
+
+                // Off the collection route this question exists only because a
+                // collection was already supplied, so "I do not want it after
+                // all" has to be expressible. A select with no such choice would
+                // make a supplied collection impossible to drop. On the
+                // collection route it is how apps are being chosen, so there is
+                // nothing for "none" to mean.
+                return ctx.answers[APP_SOURCE] === APP_SOURCES.GROUPED
+                    ? picked
+                    : [{ name: 'None - do not add a collection', value: '' }, ...picked];
             },
+            probe: resolvesToApps({
+                groupingKey: 'collectionid',
+                resolve: (ctx) => listAppsByCollection(tenantClient(ctx), ctx.answers.collectionid),
+                whenEmpty: (value) => `Collection '${value}' holds no apps.`,
+                whenFound: (count, value) =>
+                    `${count} app(s) are in collection '${value}' and will be updated.`,
+            }),
             fallback: { type: 'input', message: 'Collection id (could not fetch the list)' },
         };
 
-        const app = {
-            ...byKey.appid,
-            type: 'checkbox',
-            message: 'Which apps?',
-            needs: [APP_SOURCE],
-            when: (ctx) => ctx.answers[APP_SOURCE] !== APP_SOURCES.TYPED,
-            choices: async (ctx) => {
-                const apps =
-                    ctx.answers[APP_SOURCE] === APP_SOURCES.COLLECTION
-                        ? await listAppsByCollection(ctx.clients.tenant, ctx.answers.collectionid)
-                        : await listApps(ctx.clients.tenant);
-
-                return apps.map((entry) => ({ name: labelForApp(entry), value: entry.id }));
-            },
-            fallback: { type: 'list', message: 'App id(s) (could not fetch the list)' },
-        };
+        const app = appPickerQuestion({
+            spec: byKey.appid,
+            supplied: answers.appid,
+            groupingKey: 'collectionid',
+            groupingLabel: GROUPING_LABEL,
+            listApps: (ctx) => listApps(tenantClient(ctx)),
+            label: labelForApp,
+        });
 
         // The derived question unchanged, for anyone who already knows the id.
-        const typedApp = {
-            ...byKey.appid,
-            when: (ctx) => ctx.answers[APP_SOURCE] === APP_SOURCES.TYPED,
-        };
+        const typedApp = typedAppQuestion({
+            spec: byKey.appid,
+            supplied: answers.appid,
+            groupingKey: 'collectionid',
+            groupingLabel: GROUPING_LABEL,
+        });
 
         const rest = specs
             .filter(

--- a/src/lib/commands/qseow/__tests__/qseow_wizard.test.js
+++ b/src/lib/commands/qseow/__tests__/qseow_wizard.test.js
@@ -145,15 +145,51 @@ describe('choosing which apps to update', () => {
         expect(question.choices[0].name).toBe('Finance  (id: app-a)');
     });
 
-    test('lists apps carrying a tag when that is how they are chosen', async () => {
+    test('reports what a tag matches instead of offering a list that cannot narrow', async () => {
+        // The tag reaches the worker as well, and the two are additive, so
+        // unticking an app in a list of tagged apps never removed it from the
+        // run. Saying how many the tag matched is the honest version of that.
         const runtime = scriptedRuntime(
-            baseAnswers({ _appSource: 'tag', qliksensetag: 'BSI', appid: ['app-c'] })
+            baseAnswers({ _appSource: 'grouped', qliksensetag: 'BSI' })
         );
 
         await runInteractive({ path: PATH, runtime });
 
         expect(listAppsByTag).toHaveBeenCalledTimes(1);
         expect(listAllApps).not.toHaveBeenCalled();
+        expect(runtime.asked.map((a) => a.key)).not.toContain('appid');
+        expect(runtime.output()).toContain("1 app(s) carry the tag 'BSI' and will be updated.");
+    });
+
+    test('re-asks a tag that matches no apps, rather than running over nothing', async () => {
+        listAppsByTag
+            .mockResolvedValueOnce([])
+            .mockResolvedValue([{ id: 'app-c', name: 'Tagged' }]);
+
+        const runtime = scriptedRuntime(
+            baseAnswers({ _appSource: 'grouped', qliksensetag: ['nosuchtag', 'BSI'] })
+        );
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(runtime.asked.filter((a) => a.key === 'qliksensetag')).toHaveLength(2);
+        expect(runtime.output()).toContain("No apps on the server carry the tag 'nosuchtag'.");
+    });
+
+    test('still asks for app ids on the tag route when some were supplied', async () => {
+        // Otherwise the banner promises --appid is asked about again and then
+        // this route quietly skips it.
+        const runtime = scriptedRuntime(
+            baseAnswers({ _appSource: 'grouped', qliksensetag: 'BSI', appid: ['app-a'] })
+        );
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { appid: ['app-a'] },
+            runtime,
+        });
+
+        expect(runtime.asked.map((a) => a.key)).toContain('appid');
     });
 
     test('still lets an app id be typed, without fetching any list', async () => {
@@ -166,6 +202,173 @@ describe('choosing which apps to update', () => {
     });
 
     test('does not ask for a tag when apps are chosen another way', async () => {
+        const runtime = scriptedRuntime(baseAnswers());
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(runtime.asked.map((a) => a.key)).not.toContain('qliksensetag');
+    });
+});
+
+describe('a selection that would process nothing', () => {
+    test('is refused where it was made, not after the run is confirmed', async () => {
+        const runtime = scriptedRuntime(baseAnswers({ _appSource: 'typed', appid: ['', 'app-z'] }));
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(runtime.asked.filter((a) => a.key === 'appid')).toHaveLength(2);
+        expect(runtime.output()).toContain('No apps selected');
+        expect(qseowCreateThumbnails).not.toHaveBeenCalled();
+    });
+
+    test('is allowed when a tag is carrying the selection instead', async () => {
+        // The run is the union of the two, so naming no apps is fine as long as
+        // the tag names some.
+        const runtime = scriptedRuntime(
+            baseAnswers({ qliksensetag: 'BSI', appid: [], _review: 'run' })
+        );
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { qliksensetag: 'BSI' },
+            runtime,
+        });
+
+        expect(runtime.asked.filter((a) => a.key === 'appid')).toHaveLength(1);
+        expect(qseowCreateThumbnails).toHaveBeenCalledWith(
+            expect.objectContaining({ qliksensetag: 'BSI' })
+        );
+    });
+});
+
+describe('an app id supplied before the wizard starts', () => {
+    // An id in a .env file used to remove the app question but leave the
+    // question that leads to it, so the wizard asked how apps should be chosen,
+    // was answered, and then went straight on to the sheet question without
+    // ever showing a list.
+    const supplied = {
+        host: 'sense.acme.com',
+        certfile: './cert/client.pem',
+        certkeyfile: './cert/client_key.pem',
+        apiuserdir: 'INTERNAL',
+        apiuserid: 'sa_api',
+        logonuserdir: 'ACME',
+        logonuserid: 'goran',
+        logonpwd: 'a-password',
+        appid: ['app-b'],
+        contentlibrary: 'Butler sheet thumbnails',
+    };
+
+    test('still gets the picker, with the supplied app already ticked', async () => {
+        const runtime = scriptedRuntime(baseAnswers({ appid: ['app-a'] }));
+
+        await runInteractive({ path: PATH, presetOptions: supplied, runtime });
+
+        const question = runtime.asked.find((a) => a.key === 'appid');
+        expect(question).toBeDefined();
+        expect(question.choices).toEqual([
+            expect.objectContaining({ value: 'app-a', checked: false }),
+            expect.objectContaining({ value: 'app-b', checked: true }),
+        ]);
+    });
+
+    test('is announced as asked again rather than as skipped', async () => {
+        const runtime = scriptedRuntime(baseAnswers({ appid: ['app-a'] }));
+
+        await runInteractive({ path: PATH, presetOptions: supplied, runtime });
+
+        expect(runtime.output()).toContain('picked from what is actually there: --appid');
+        expect(runtime.output()).not.toMatch(/not asked about again:[^\n]*--appid/);
+    });
+
+    test('opens the typed question on the supplied id', async () => {
+        const runtime = scriptedRuntime(baseAnswers({ _appSource: 'typed', appid: 'app-z' }));
+
+        await runInteractive({ path: PATH, presetOptions: supplied, runtime });
+
+        expect(runtime.asked.find((a) => a.key === 'appid').default).toBe('app-b');
+    });
+
+    test('the picked apps win over the supplied ones', async () => {
+        const runtime = scriptedRuntime(baseAnswers({ appid: ['app-a'], _review: 'run' }));
+
+        await runInteractive({ path: PATH, presetOptions: supplied, runtime });
+
+        expect(qseowCreateThumbnails).toHaveBeenCalledWith(
+            expect.objectContaining({ appid: ['app-a'] })
+        );
+    });
+});
+
+describe('a tag supplied before the wizard starts', () => {
+    // A tag is a second way of naming apps, not an alternative to naming them:
+    // the run covers --appid *and* everything carrying the tag. So a supplied
+    // tag applies whichever route is taken, and asking about it only on the tag
+    // route let it add apps the operator was never shown - while the banner
+    // said it would be asked about again.
+    const supplied = {
+        host: 'sense.acme.com',
+        certfile: './cert/client.pem',
+        certkeyfile: './cert/client_key.pem',
+        apiuserdir: 'INTERNAL',
+        apiuserid: 'sa_api',
+        logonuserdir: 'ACME',
+        logonuserid: 'goran',
+        logonpwd: 'a-password',
+        qliksensetag: 'BSI',
+        contentlibrary: 'Butler sheet thumbnails',
+    };
+
+    test('is asked about on the all-apps route too, opening on the supplied tag', async () => {
+        const runtime = scriptedRuntime(baseAnswers({ qliksensetag: 'BSI' }));
+
+        await runInteractive({ path: PATH, presetOptions: supplied, runtime });
+
+        const question = runtime.asked.find((a) => a.key === 'qliksensetag');
+        expect(question).toBeDefined();
+        expect(question.default).toBe('BSI');
+    });
+
+    test('is asked about on the typed route too', async () => {
+        const runtime = scriptedRuntime(
+            baseAnswers({ _appSource: 'typed', appid: 'app-z', qliksensetag: 'BSI' })
+        );
+
+        await runInteractive({ path: PATH, presetOptions: supplied, runtime });
+
+        expect(runtime.asked.map((a) => a.key)).toContain('qliksensetag');
+    });
+
+    test('clearing it stops the tagged apps being added to the run', async () => {
+        const runtime = scriptedRuntime(
+            baseAnswers({ qliksensetag: '', appid: ['app-a'], _review: 'run' })
+        );
+
+        await runInteractive({ path: PATH, presetOptions: supplied, runtime });
+
+        // An empty tag matches the option's own default, so it is never emitted
+        // to the command line and the bag carries exactly what the plain CLI
+        // produces when no tag is given. qseowCreateThumbnails gates on
+        // `qliksensetag && length > 0`, so no tag lookup happens: the run covers
+        // the picked app and nothing else.
+        const bag = qseowCreateThumbnails.mock.calls[0][0];
+        expect(bag.appid).toEqual(['app-a']);
+        expect(bag.qliksensetag).toBe('');
+    });
+
+    test('keeping it still adds the tagged apps, as the CLI does', async () => {
+        const runtime = scriptedRuntime(
+            baseAnswers({ qliksensetag: 'BSI', appid: ['app-a'], _review: 'run' })
+        );
+
+        await runInteractive({ path: PATH, presetOptions: supplied, runtime });
+
+        expect(qseowCreateThumbnails).toHaveBeenCalledWith(
+            expect.objectContaining({ appid: ['app-a'], qliksensetag: 'BSI' })
+        );
+    });
+
+    test('a tag that was never supplied is still only asked on the tag route', async () => {
         const runtime = scriptedRuntime(baseAnswers());
 
         await runInteractive({ path: PATH, runtime });

--- a/src/lib/commands/qseow/create-sheet-thumbnails.interactive.js
+++ b/src/lib/commands/qseow/create-sheet-thumbnails.interactive.js
@@ -2,15 +2,25 @@ import { qseowVerifyCertificatesExist } from '../../qseow/qseow-certificates.js'
 import { qseowVerifyContentLibraryExists } from '../../qseow/qseow-contentlibrary.js';
 import { listAppsByTag, listAllApps } from '../../qseow/qseow-app-lookup.js';
 import { qseowCreateThumbnails } from '../../qseow/qseow-create-thumbnails.js';
-import { gate, gatedBy, inSections, SHEET_FILTER_KEYS } from '../../interactive/spec-ops.js';
+import {
+    gate,
+    gatedBy,
+    inSections,
+    openingOn,
+    isSupplied,
+    appSourceQuestion,
+    appPickerQuestion,
+    typedAppQuestion,
+    resolvesToApps,
+    APP_SOURCE,
+    APP_SOURCES,
+    SHEET_FILTER_KEYS,
+} from '../../interactive/spec-ops.js';
 import { labelForApp } from '../../interactive/labels.js';
 
-// Re-exported so a reader following this wizard finds the label it uses without
-// having to know it is shared with the Cloud twin.
-export { labelForApp };
-
-/** Key of the synthetic question asking how apps should be chosen. */
-const APP_SOURCE = '_appSource';
+// Re-exported so a reader following this wizard finds the label and the route
+// vocabulary it uses without having to know they are shared with the Cloud twin.
+export { labelForApp, APP_SOURCES };
 
 /** Key of the synthetic question gating the sheet exclude/blur filters. */
 const FILTERING = '_filtering';
@@ -18,12 +28,8 @@ const FILTERING = '_filtering';
 /** Key of the synthetic question gating the long tail of options. */
 const ADVANCED = '_advanced';
 
-/** How apps can be picked, in the order the choices are offered. */
-export const APP_SOURCES = Object.freeze({
-    ALL: 'all',
-    TAG: 'tag',
-    TYPED: 'typed',
-});
+/** What the tag route is called wherever it has to be named in a sentence. */
+const GROUPING_LABEL = 'a tag';
 
 /** Questions asked before anything else, in this order. */
 const CONNECTION_KEYS = [
@@ -99,10 +105,13 @@ export default {
      * asks 14 questions.
      *
      * @param {import('../../interactive/option-introspect.js').QuestionSpec[]} specs - Derived questions.
+     * @param {object} [context] - What the command line and environment already supplied.
+     * @param {object} [context.answers] - Those values, keyed by option name. Used as the starting
+     *     point for the app and tag questions, which are asked again rather than skipped.
      *
      * @returns {Array} The questions to actually ask.
      */
-    refine(specs) {
+    refine(specs, { answers = {} } = {}) {
         const byKey = Object.fromEntries(specs.map((spec) => [spec.key, spec]));
 
         const connection = CONNECTION_KEYS.map((key) => byKey[key])
@@ -127,49 +136,59 @@ export default {
                     : spec
             );
 
-        const appSource = {
-            key: APP_SOURCE,
-            type: 'select',
-            message: 'Which apps should be updated?',
-            required: true,
-            variadic: false,
-            secret: false,
+        const appSource = appSourceQuestion({
             needs: ['logonpwd'],
-            choices: [
-                { name: 'Choose from all apps on the server', value: APP_SOURCES.ALL },
-                { name: 'Choose a tag, then apps carrying it', value: APP_SOURCES.TAG },
-                { name: 'Type an app id', value: APP_SOURCES.TYPED },
-            ],
-        };
+            groupingKey: 'qliksensetag',
+            groupingChoice: 'Update every app carrying a tag',
+        });
 
+        // A tag is not an alternative to naming apps, it is a second way of
+        // naming them: the run covers everything --appid names *and* everything
+        // carrying the tag. So a tag that is already set changes what the run
+        // does no matter which route is taken here, and hiding it behind the
+        // tag route would let it add apps the operator was never shown.
         const tag = {
-            ...byKey.qliksensetag,
+            ...openingOn(
+                {
+                    ...byKey.qliksensetag,
+                    message: 'Which tag?',
+                    hint: 'Every app carrying it is updated, on top of any apps named below. Leave empty for none.',
+                },
+                answers.qliksensetag
+            ),
             needs: [APP_SOURCE],
-            when: (ctx) => ctx.answers[APP_SOURCE] === APP_SOURCES.TAG,
+            // Asked on the tag route because that is how apps are being chosen
+            // there - and on every other route when a tag was already supplied,
+            // because it still applies there and the banner has just promised it
+            // would be asked about rather than skipped. Clearing it is how an
+            // operator says "not this time".
+            when: (ctx) =>
+                ctx.answers[APP_SOURCE] === APP_SOURCES.GROUPED || isSupplied(answers.qliksensetag),
+            probe: resolvesToApps({
+                groupingKey: 'qliksensetag',
+                resolve: (ctx) => listAppsByTag(ctx.answers),
+                whenEmpty: (value) => `No apps on the server carry the tag '${value}'.`,
+                whenFound: (count, value) =>
+                    `${count} app(s) carry the tag '${value}' and will be updated.`,
+            }),
         };
 
-        const app = {
-            ...byKey.appid,
-            type: 'checkbox',
-            message: 'Which apps?',
-            needs: [APP_SOURCE],
-            when: (ctx) => ctx.answers[APP_SOURCE] !== APP_SOURCES.TYPED,
-            choices: async (ctx) => {
-                const apps =
-                    ctx.answers[APP_SOURCE] === APP_SOURCES.TAG
-                        ? await listAppsByTag(ctx.answers)
-                        : await listAllApps(ctx.answers);
-
-                return apps.map((entry) => ({ name: labelForApp(entry), value: entry.id }));
-            },
-            fallback: { type: 'list', message: 'App id(s) (could not fetch the list)' },
-        };
+        const app = appPickerQuestion({
+            spec: byKey.appid,
+            supplied: answers.appid,
+            groupingKey: 'qliksensetag',
+            groupingLabel: GROUPING_LABEL,
+            listApps: (ctx) => listAllApps(ctx.answers),
+            label: labelForApp,
+        });
 
         // The derived question unchanged, for anyone who already knows the id.
-        const typedApp = {
-            ...byKey.appid,
-            when: (ctx) => ctx.answers[APP_SOURCE] === APP_SOURCES.TYPED,
-        };
+        const typedApp = typedAppQuestion({
+            spec: byKey.appid,
+            supplied: answers.appid,
+            groupingKey: 'qliksensetag',
+            groupingLabel: GROUPING_LABEL,
+        });
 
         const contentLibrary = {
             ...byKey.contentlibrary,

--- a/src/lib/interactive/__tests__/spec-ops.test.js
+++ b/src/lib/interactive/__tests__/spec-ops.test.js
@@ -1,5 +1,15 @@
 import { describe, test, expect } from '@jest/globals';
-import { gate, gatedBy, inSections, SHEET_FILTER_KEYS } from '../spec-ops.js';
+import {
+    gate,
+    gatedBy,
+    inSections,
+    isSupplied,
+    openingOn,
+    assertAppSelectionNotEmpty,
+    appSourceQuestion,
+    APP_SOURCES,
+    SHEET_FILTER_KEYS,
+} from '../spec-ops.js';
 import { labelForApp, labelForCollection } from '../labels.js';
 
 const spec = (key, overrides = {}) => ({
@@ -163,5 +173,86 @@ describe('labels', () => {
 
     test('a collection with no item count reads as empty rather than undefined', () => {
         expect(labelForCollection({ name: 'Finance' })).toBe('Finance  (0 items)');
+    });
+});
+
+describe('isSupplied', () => {
+    test('an empty string is not supplied, because that is how both say "none"', () => {
+        // --qliksensetag and --collectionid both declare '' as their default, so
+        // treating it as a value would offer to re-confirm something nobody set.
+        expect(isSupplied('')).toBe(false);
+        expect(isSupplied('   ')).toBe(false);
+        expect(isSupplied(undefined)).toBe(false);
+        expect(isSupplied([])).toBe(false);
+    });
+
+    test('anything with something in it is supplied', () => {
+        expect(isSupplied('BSI')).toBe(true);
+        expect(isSupplied(['app-a'])).toBe(true);
+    });
+});
+
+describe('openingOn', () => {
+    test('a supplied value becomes the question default', () => {
+        expect(openingOn(spec('appid'), ['app-a']).default).toEqual(['app-a']);
+    });
+
+    test('nothing supplied leaves the question exactly as it was', () => {
+        const original = spec('appid', { default: 'from-the-option' });
+
+        expect(openingOn(original, '')).toBe(original);
+    });
+});
+
+describe('assertAppSelectionNotEmpty', () => {
+    test('passes when apps are named', () => {
+        expect(() =>
+            assertAppSelectionNotEmpty(
+                { appid: ['app-a'], qliksensetag: '' },
+                'qliksensetag',
+                'a tag'
+            )
+        ).not.toThrow();
+    });
+
+    test('passes on a tag alone, because the run is the union of the two', () => {
+        expect(() =>
+            assertAppSelectionNotEmpty({ appid: [], qliksensetag: 'BSI' }, 'qliksensetag', 'a tag')
+        ).not.toThrow();
+    });
+
+    test('throws when neither names anything', () => {
+        // runOverApps would report this too, but only after every remaining
+        // question has been answered and the run confirmed.
+        expect(() =>
+            assertAppSelectionNotEmpty(
+                { appid: [], collectionid: '' },
+                'collectionid',
+                'a collection'
+            )
+        ).toThrow('No apps selected');
+    });
+
+    test('an unanswered appid counts as nothing, not as a crash', () => {
+        expect(() => assertAppSelectionNotEmpty({}, 'qliksensetag', 'a tag')).toThrow(
+            'No apps selected'
+        );
+    });
+});
+
+describe('appSourceQuestion', () => {
+    test('claims both keys it leads to, so neither is silently skipped', () => {
+        const question = appSourceQuestion({
+            needs: ['logonpwd'],
+            groupingKey: 'qliksensetag',
+            groupingChoice: 'Update every app carrying a tag',
+        });
+
+        expect(question.replaces).toEqual(['appid', 'qliksensetag']);
+        expect(question.choices.map((choice) => choice.value)).toEqual([
+            APP_SOURCES.ALL,
+            APP_SOURCES.GROUPED,
+            APP_SOURCES.TYPED,
+        ]);
     });
 });

--- a/src/lib/interactive/index.js
+++ b/src/lib/interactive/index.js
@@ -139,14 +139,21 @@ export const runInteractive = async ({
     // Computed once rather than per restart: `refine` sees the same specs and
     // the same preset answers every time round the loop, and the banner below
     // has to be built from the result before the first question is asked.
-    const asked = refined.filter((spec) => !(spec.key in presetOptions));
+    const kept = refined.filter((spec) => !(spec.key in presetOptions));
 
     // What a question stands in for counts as asked, even though its key
     // differs. uninstall's picker is keyed `_build` and collects `browser` and
     // `browserVersion` between them, so without this the banner announced that
     // --browser-version would not be asked about and the wizard then asked for
     // exactly that, using that option's help text as the prompt (issue #1013).
-    const covered = new Set(asked.flatMap((spec) => spec.replaces ?? []));
+    const covered = new Set(kept.flatMap((spec) => spec.replaces ?? []));
+
+    // A supplied value whose question a synthetic one stands in for is kept in
+    // the conversation rather than dropped: the synthetic question is asked, so
+    // the questions it leads to have to be there to be led to. Without this the
+    // app picker announced itself, was answered, and then asked nothing at all,
+    // because --appid was already supplied and its question had been removed.
+    const asked = refined.filter((spec) => !(spec.key in presetOptions) || covered.has(spec.key));
 
     // Named by flag rather than by storage key, because the flag is what the
     // user typed. Secrets are named but never shown.

--- a/src/lib/interactive/spec-ops.js
+++ b/src/lib/interactive/spec-ops.js
@@ -13,6 +13,8 @@
  * a spec's `choices` or `probe`, which the driver invokes.
  */
 
+import { splitEntries } from './validators.js';
+
 /**
  * The sheet exclude and blur options, which are identical on both platforms.
  *
@@ -32,6 +34,223 @@ export const SHEET_FILTER_KEYS = Object.freeze([
     'blurSheetTitle',
     'blurFactor',
 ]);
+
+/**
+ * Whether a value was actually supplied, as opposed to left at nothing.
+ *
+ * An empty string is how both `--qliksensetag` and `--collectionid` say "none" -
+ * it is their declared default - so it has to read as absent here, or a wizard
+ * would offer to re-confirm a value nobody set.
+ *
+ * @param {unknown} value - The value to test.
+ *
+ * @returns {boolean} True when there is something there.
+ */
+export const isSupplied = (value) =>
+    Array.isArray(value) ? value.length > 0 : String(value ?? '').trim().length > 0;
+
+/**
+ * Open a question on a value that was already supplied.
+ *
+ * The pre-fill is the whole reason a supplied value can be asked about again
+ * without costing anything: the answer from the last run is one keystroke away
+ * rather than gone, so re-asking stays cheap enough to be the default.
+ *
+ * @param {object} spec - The question.
+ * @param {unknown} supplied - What the command line or environment already gave.
+ *
+ * @returns {object} The question, opening on that value when there is one.
+ */
+export const openingOn = (spec, supplied) =>
+    isSupplied(supplied) ? { ...spec, default: supplied } : spec;
+
+/**
+ * Refuse to go on when the run would have no apps to process.
+ *
+ * `runOverApps` already treats an empty selection as a failure rather than a
+ * no-op, but it says so *after* every remaining question has been answered and
+ * the run confirmed. A wizard can know sooner: app selection is one question
+ * away from where the mistake was made, so this is thrown from a probe and the
+ * driver re-asks on the spot.
+ *
+ * Both sources count. Naming no apps is perfectly fine when a tag or collection
+ * is carrying the selection - the run covers the union of the two - so this
+ * fires only when neither has anything in it.
+ *
+ * @param {object} answers - The answers so far.
+ * @param {string} groupingKey - `qliksensetag` or `collectionid`.
+ * @param {string} groupingLabel - What to call it in the message, e.g. `a tag`.
+ *
+ * @returns {void}
+ *
+ * @throws {Error} When nothing at all has been selected.
+ */
+export const assertAppSelectionNotEmpty = (answers, groupingKey, groupingLabel) => {
+    if (splitEntries(answers.appid).length > 0 || isSupplied(answers[groupingKey])) {
+        return;
+    }
+
+    throw new Error(
+        `No apps selected, so there would be nothing to do. Pick at least one app, or go back and choose ${groupingLabel} instead.`
+    );
+};
+
+/** Key of the synthetic question asking how apps should be chosen. */
+export const APP_SOURCE = '_appSource';
+
+/**
+ * How apps can be picked, in the order the choices are offered.
+ *
+ * One vocabulary for both platforms. The middle route is a tag on QSEoW and a
+ * collection on Cloud, but it plays the same part in the conversation, and
+ * giving it one value is what lets the questions below be built once.
+ */
+export const APP_SOURCES = Object.freeze({
+    ALL: 'all',
+    GROUPED: 'grouped',
+    TYPED: 'typed',
+});
+
+/**
+ * Ask how apps should be chosen.
+ *
+ * @param {object} args - Arguments.
+ * @param {string[]} args.needs - Keys that must be answered first, i.e. the credentials a lookup needs.
+ * @param {string} args.groupingKey - `qliksensetag` or `collectionid`.
+ * @param {string} args.groupingChoice - Label for the middle route.
+ *
+ * @returns {object} A question spec.
+ */
+export const appSourceQuestion = ({ needs, groupingKey, groupingChoice }) => ({
+    key: APP_SOURCE,
+    type: 'select',
+    message: 'Which apps should be updated?',
+    required: true,
+    variadic: false,
+    secret: false,
+    needs,
+    // This one question leads to both of these, so a value already supplied for
+    // either is not "not asked about again": it is asked about under this
+    // question's routes, opening on what was supplied.
+    replaces: ['appid', groupingKey],
+    choices: [
+        { name: 'Pick apps from a list', value: APP_SOURCES.ALL },
+        { name: groupingChoice, value: APP_SOURCES.GROUPED },
+        { name: 'Type app id(s)', value: APP_SOURCES.TYPED },
+    ],
+});
+
+/**
+ * Turn a tag or collection into the apps it actually names.
+ *
+ * Two jobs, both of which need the lookup, which is why they are one probe.
+ *
+ * It **reports what was matched**, which is what lets the grouped route drop its
+ * app checkbox. That checkbox listed the tagged apps and invited a selection it
+ * could not honour: the tag reaches the worker as well, and the two are additive,
+ * so unticking an app there never removed it from the run. Saying "7 apps carry
+ * this tag" is the honest version of what that list was for.
+ *
+ * It also **rejects a value that matches nothing**, at the prompt where it was
+ * typed rather than after every other question has been answered.
+ *
+ * @param {object} args - Arguments.
+ * @param {string} args.groupingKey - `qliksensetag` or `collectionid`.
+ * @param {(ctx: object) => Promise<Array<{id: string, name: string}>>} args.resolve - The lookup.
+ * @param {(value: string) => string} args.whenEmpty - Message for a value that matched nothing.
+ * @param {(count: number, value: string) => string} args.whenFound - Line shown for a value that matched.
+ *
+ * @returns {(ctx: object) => Promise<void>} A probe.
+ */
+export const resolvesToApps =
+    ({ groupingKey, resolve, whenEmpty, whenFound }) =>
+    async (ctx) => {
+        const value = String(ctx.answers[groupingKey] ?? '').trim();
+
+        if (!isSupplied(value)) {
+            if (ctx.answers[APP_SOURCE] === APP_SOURCES.GROUPED) {
+                throw new Error('This is how apps are being chosen, so it cannot be empty.');
+            }
+
+            // Empty is a real answer on the other routes: it is how someone
+            // says "not this time" to a value their .env file supplied.
+            return;
+        }
+
+        const apps = await resolve(ctx);
+
+        if (apps.length === 0) {
+            throw new Error(whenEmpty(value));
+        }
+
+        ctx.write(`  ${whenFound(apps.length, value)}\n`);
+    };
+
+/**
+ * Ask which individual apps to update, from what the server actually holds.
+ *
+ * Asked on the list route because that is the route, and on the grouped route
+ * only when app ids were supplied as well - because there the banner has
+ * promised they would be asked about rather than skipped, and they are added to
+ * whatever the tag or collection matches.
+ *
+ * @param {object} args - Arguments.
+ * @param {object} args.spec - The derived `appid` question.
+ * @param {unknown} args.supplied - App ids already supplied, pre-ticked.
+ * @param {string} args.groupingKey - `qliksensetag` or `collectionid`.
+ * @param {string} args.groupingLabel - What to call the other route, e.g. `a tag`.
+ * @param {(ctx: object) => Promise<Array<{id: string, name: string}>>} args.listApps - The lookup.
+ * @param {(app: object) => string} args.label - How to label one app.
+ *
+ * @returns {object} A question spec.
+ */
+export const appPickerQuestion = ({
+    spec,
+    supplied,
+    groupingKey,
+    groupingLabel,
+    listApps,
+    label,
+}) => ({
+    ...openingOn(
+        {
+            ...spec,
+            type: 'checkbox',
+            message: 'Which apps?',
+            hint: `Individually named apps. They are updated in addition to anything ${groupingLabel} matches.`,
+        },
+        supplied
+    ),
+    needs: [APP_SOURCE],
+    when: (ctx) =>
+        ctx.answers[APP_SOURCE] === APP_SOURCES.ALL ||
+        (ctx.answers[APP_SOURCE] === APP_SOURCES.GROUPED && isSupplied(supplied)),
+    choices: async (ctx) => {
+        const apps = await listApps(ctx);
+
+        return apps.map((entry) => ({ name: label(entry), value: entry.id }));
+    },
+    probe: async (ctx) => assertAppSelectionNotEmpty(ctx.answers, groupingKey, groupingLabel),
+    fallback: { type: 'list', message: 'App id(s) (could not fetch the list)' },
+});
+
+/**
+ * Ask for app ids directly, for someone who already knows them.
+ *
+ * @param {object} args - Arguments.
+ * @param {object} args.spec - The derived `appid` question, used unchanged apart from the pre-fill.
+ * @param {unknown} args.supplied - App ids already supplied.
+ * @param {string} args.groupingKey - `qliksensetag` or `collectionid`.
+ * @param {string} args.groupingLabel - What to call the other route, e.g. `a tag`.
+ *
+ * @returns {object} A question spec.
+ */
+export const typedAppQuestion = ({ spec, supplied, groupingKey, groupingLabel }) => ({
+    ...openingOn(spec, supplied),
+    needs: [APP_SOURCE],
+    when: (ctx) => ctx.answers[APP_SOURCE] === APP_SOURCES.TYPED,
+    probe: async (ctx) => assertAppSelectionNotEmpty(ctx.answers, groupingKey, groupingLabel),
+});
 
 /**
  * Build a synthetic yes/no question that hides a block of others behind it.


### PR DESCRIPTION
Reported from a real run: with `BSI_QSEOW_CST_APP_ID` set in `.env`, `qseow create-sheet-thumbnails -i` asked "Which apps should be updated?", accepted the answer, and then went straight on to the sheet question without ever showing a list.

The driver dropped every question whose value was already supplied, including the ones a synthetic question stands in for. `--appid` was supplied, so its picker was deleted — but the question leading to it survived, because its key is synthetic and nothing had supplied that.

## What this changes

**Supplied values that name something on a server are asked about again**, opening on what was supplied. This is what `replaces` was added for in #1013; the driver's own filter had been defeating it. A hostname you set once stays correct — a stored app id quietly goes stale when someone deletes or republishes the app.

Fixing that exposed three more problems with the same root. A tag or collection is a *second way of naming apps*, not an alternative to naming them: the run covers the union of `--appid` and whatever the tag or collection matches. The wizard treated it as a filter while the worker treats it as a selector.

- **A supplied tag or collection applied on every route but was only asked about on its own**, so it silently widened a run to apps the operator was never shown. It is now asked wherever it applies, and clearing it is how you say "not this time".
- **The tag route offered a list of tagged apps to tick, which could never narrow anything** — the tag reaches the worker too, and the two are additive, so unticking an app never removed it from the run. It now resolves the tag and reports what it found, and rejects one matching no apps at the prompt.
- **Nothing stopped a run with no apps at all.** `runOverApps` reported it, but only after every remaining question had been answered and the run confirmed. It is now refused where the mistake was made, counting app ids and tag/collection together.

On Cloud, the app and collection pickers read the tenant client that the API key's probe stashes, so a key supplied in `.env` left them with no client and degraded them to "type an id". They build one on demand instead.

The app-selection block is now built from shared factories in `spec-ops.js` rather than written twice, including one route vocabulary for both platforms, so the QSEoW and Cloud wizards cannot drift on any of it.

## Verification

Full unit suite: **2521 passed, 92 suites**. eslint and prettier clean.

Checked against a live QSEoW server, not only against mocks:

- the app id from `.env` arrives already ticked in a 519-app picker, and the banner moves `--appid` from "not asked about again" to "asked about again"
- a real tag reports `4 app(s) carry the tag '👍😎 updateSheetThumbnail' and will be updated`
- an unknown tag is rejected with `No apps on the server carry the tag 'no-such-tag-xyz'` and re-asked
- an empty selection is rejected with `No apps selected, so there would be nothing to do` and re-asked

The Cloud path is the exact mirror and its unit tests pass, but it has not been exercised against a real tenant.

## Known gap, not addressed here

No probe runs for any value that came from `.env` — content library, certificates, API key. A wrong Cloud API key still surfaces as "could not fetch the list" rather than as a credential problem. That needs a decision about where to report a failure for a question that was never asked, so it belongs on its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)