### PR TITLE
Let administrators verify the Windows publisher, not just the signature

### DIFF
--- a/docs/to-doc-site/windows-binary-signed-again.md
+++ b/docs/to-doc-site/windows-binary-signed-again.md
@@ -48,12 +48,41 @@ especially in the first weeks after a new certificate is put into use. Choose **
 Worth doing if you are deploying into a controlled environment, or confirming a download before distributing it internally. In PowerShell, in the folder holding the executable:
 
 ```powershell
-Get-AuthenticodeSignature -LiteralPath .\butler-sheet-icons.exe | Format-List Status, StatusMessage, SignerCertificate
+$sig = Get-AuthenticodeSignature -LiteralPath .\butler-sheet-icons.exe
+$sig | Format-List Status, StatusMessage
+$sig.SignerCertificate | Format-List Subject, Issuer, Thumbprint, NotAfter
 ```
 
-`Status` reads `Valid` for a correctly signed file, and the signer certificate names the publisher above, issued by `Certum Code Signing 2021 CA`.
-
 You can also right-click the file, choose **Properties**, and look at the **Digital Signatures** tab.
+
+### Check the thumbprint, not only the status
+
+`Status` reading `Valid` means the file carries an intact signature from a certificate Windows trusts. It does **not** mean the file came from us — any correctly signed program on earth passes that test. Comparing the thumbprint is what actually confirms the publisher.
+
+| | |
+|---|---|
+| Subject | `CN=Open Source Developer Karl Göran Sander, O=Open Source Developer, L=Saltsjö-Duvnäs, S=Stockholm, C=SE` |
+| Issuer | `CN=Certum Code Signing 2021 CA, O=Asseco Data Systems S.A., C=PL` |
+| Thumbprint | `1674DF1C6EAD6DB9D816705CD230281B87A1C97E` |
+| Valid | 2026-08-12 to 2027-08-12 |
+
+None of this is confidential. The certificate is embedded in every signed release, so anyone holding a download can read it out; publishing it here only saves you the step.
+
+Two things that surprise people:
+
+- **The thumbprint is a SHA-1 hash _of the certificate_**, which has nothing to do with the SHA-256 digest used for the signature itself. Windows has identified certificates this way for years. It is not a weakness in the signature.
+- **A renewal changes the thumbprint.** Releases signed before 2026-08-12 carry an older certificate, and releases after 2027-08-12 will carry its replacement. If the thumbprint does not match, check this page before assuming the worst.
+
+### Building an application control rule
+
+If you allow programs by publisher through AppLocker or Windows Defender Application Control, you can build the rule from the publisher certificate rather than from a specific binary. Export it from any signed release:
+
+```powershell
+$sig = Get-AuthenticodeSignature -LiteralPath .\butler-sheet-icons.exe
+[System.IO.File]::WriteAllBytes("$PWD\butler-sheet-icons-publisher.cer", $sig.SignerCertificate.RawData)
+```
+
+That `.cer` file is what `Add-SignerRule` expects when adding a signer to a WDAC policy. Prefer this to a file hash rule: a publisher rule keeps working across releases, while a hash rule has to be updated for every new version.
 
 One point worth understanding: **the signature is timestamped**. It therefore stays valid after the signing certificate itself expires, so a release downloaded years from now still verifies. Without a timestamp, every previously released binary would stop validating the day the certificate lapsed.
 
@@ -83,6 +112,21 @@ Still to confirm before publishing:
     release is also unsigned depends on when this change ships - check the releases
     page and update.
   - Set the version gate at the top.
+  - Re-check the certificate table against the live certificate. The thumbprint in it
+    was read off the signing host on 2026-08-12 and matches the WIN_CODESIGN_THUMBPRINT
+    secret; confirm both still agree at publication.
+
+MAINTENANCE, and the reason this page is not fire-and-forget: it publishes the
+certificate thumbprint, so it goes stale the moment the certificate is renewed - due
+2027-08-12. A wrong thumbprint on this page is worse than no thumbprint, because the
+whole point of the section is telling administrators to distrust a binary whose
+thumbprint does not match. Renewing the certificate means updating this page in the
+same pass as the WIN_CODESIGN_THUMBPRINT secret.
+
+The certificate details are deliberately public. The certificate is embedded in every
+signed binary, so nothing here is disclosed that a release download does not already
+carry - which is also why the page can tell administrators to export it from a release
+rather than asking us for a file.
 
 The SmartScreen section deliberately does NOT promise the warning disappears. This is a
 standard certificate, not EV, so it earns reputation over time rather than receiving it


### PR DESCRIPTION
## What & why

The staged doc page told readers to check that `Get-AuthenticodeSignature` reports `Valid`. That is a weaker check than it looks: `Valid` means the file carries an intact signature from a certificate Windows trusts, which **any** correctly signed program satisfies. It says nothing about who published *this* one.

The page now states the expected subject, issuer, thumbprint and validity, and says plainly that comparing the thumbprint is the step that identifies the publisher. None of it is confidential — the certificate is embedded in every signed release, so a reader holding a download can already read it out. ggshield agrees it is not a credential.

Two clarifications ride along, each pre-empting a question the page would otherwise invite:

- The thumbprint is a SHA-1 hash **of the certificate**, unrelated to the SHA-256 signature digest the same page describes. Without saying so, that reads as a contradiction.
- A renewal changes the thumbprint, so a mismatch means "check this page" before "assume the worst".

It also gains a WDAC section for exactly the locked-down environments that could not run 4.0.0 or 4.1.0 at all. It shows how to export the publisher certificate from any signed release rather than asking us for a file — so nothing has to be distributed — and recommends a publisher rule over a file hash rule, since the latter needs updating for every version.

## How it was verified

The export snippet was run rather than assumed: `X509Certificate2.RawData` written with `WriteAllBytes` produces a valid DER `.cer` whose SHA-1 fingerprint matches its source exactly. That also demonstrates the page's thumbprint claim — PowerShell's `5E9CCF79…` equalled openssl's `5E:9C:CF:79:…` on the same certificate.

Both PowerShell blocks parse via the PowerShell AST parser; the markdown tables are well-formed. The certificate details match what `scripts/diag/win-signing-check.ps1` reports on the signing host and the `WIN_CODESIGN_THUMBPRINT` secret.

## Docs

`docs/to-doc-site/windows-binary-signed-again.md` — still an unpublished draft.

**One cost worth flagging on review:** publishing a thumbprint makes the page stale on renewal in 2027, and a wrong thumbprint is worse than none given what the section is for. That is recorded in the draft's maintenance comment, next to the note that it must stay in step with the `WIN_CODESIGN_THUMBPRINT` secret. If that obligation is unwelcome, dropping the thumbprint row and keeping subject and issuer is the zero-maintenance alternative — weaker verification, no upkeep.