### PR TITLE
Interactive mode separates per-run choices from environment settings

### DIFF
--- a/docs/to-doc-site/creating-thumbnails-interactively.md
+++ b/docs/to-doc-site/creating-thumbnails-interactively.md
@@ -94,31 +94,51 @@ Untick every app and the wizard says so rather than letting you confirm a run th
 
 Naming no apps is still fine when a tag or collection is carrying the selection — the two add together, and one of them having apps is enough.
 
-## Everything you already supplied is kept
+## Two kinds of options, and only one of them is skipped
 
-Options given on the command line, or set through their `BSI_*` environment variables, are not asked about again:
+Options given on the command line, or set through their `BSI_*` environment variables, are treated in one of two ways, and the wizard opens by telling you which is which:
+
+```
+Already supplied, so not asked about again: --host, --certfile, --certkeyfile,
+  --apiuserdir, --apiuserid, --logonuserdir, --logonuserid, --logonpwd, --contentlibrary.
+Supplied, but asked about again so you can change it for this run: --appid, --includesheetpart.
+```
+
+**Options that describe your environment are skipped.** A hostname, a port, a certificate path, a credential, a browser build, the content library — properties of the server you are pointing at. They stay true until the environment itself changes, so re-asking them every run is exactly the tedium `-i` exists to remove. This is what makes `-i` useful for filling the gaps in a command you have partly written:
 
 ```bash
 butler-sheet-icons qseow create-sheet-thumbnails --host sense.acme.com -i
 ```
 
-```
-Already supplied, so not asked about again: --host.
-```
+**Options that describe this run are always asked**, opening on whatever you supplied. Which apps to update, which tag or collection to include, how much of each sheet to capture, which sheets to exclude or blur. These are decisions, not facts — and a decision taken once and left in a `.env` file should not be taken again silently on every later run, where you can neither see it nor change it without editing the file.
 
-This makes `-i` useful for filling the gaps in a command you have partly written, not only for starting from nothing.
+Confirming one costs a single keystroke, because the question opens on the value that was already there.
 
-### Except which apps to update, which you always get to confirm
+### What that looks like for app selection
 
-App selection is the exception, and it is asked about even when `--appid` — or `BSI_QSEOW_CST_APP_ID` in a `.env` file — already names one. The wizard says so:
+You get the full list of apps from the server, and **the ones you supplied are listed first and already ticked**:
 
 ```
-Supplied, but asked about again so the answer can be picked from what is actually there: --appid.
+  Apps you already supplied are listed first, ticked. Untick to leave one out.
+? Which apps?
+❯◉ Employee salaries  (id: ded8d27d-53b1-4d46-8d4e-44f552aeb8bc)
+ ◯ _s_QVD Generator - App scriptlog extract  (id: ede067b0-cbf9-4a2c-a422-bac1ffbdd4de)
+ ◯ User reload demo(2)  (id: ec31f83b-e8cd-41f8-846e-abd8b4e193ff)
 ```
 
-You get the full list of apps from the server, with the ones you supplied already ticked. Pressing Enter accepts them unchanged, so the common case still costs one keystroke — but you can add an app, swap it for another, or notice that the ID in your `.env` file names an app that has since been deleted. If you choose to type an ID instead, that question opens on the value you supplied.
+First, not merely ticked. On a server with several hundred apps, a ticked row sorted somewhere into the middle of the list is one you will never see — so pressing Enter would quietly update an app you had not chosen for this run. At the top it takes one keystroke to remove.
 
-This is why the app question is treated differently from `--host` or `--certfile`: a hostname you set once stays correct, while a stored app ID quietly goes stale when someone deletes or republishes the app.
+If an app ID in your `.env` file names an app the server no longer has, the wizard says so rather than letting it disappear from the selection without comment:
+
+```
+  ded8d27d-53b1-4d46-8d4e-44f552aeb8bc - supplied, but no longer on the server, so not listed below.
+```
+
+If you choose to type an ID instead, that question opens on the value you supplied.
+
+### And for the sheet filters
+
+A supplied `--exclude-sheet-number` or `--blur-sheet-tag` is shown even if you answer **no** to "Exclude or blur any sheets?". Declining that question means "nothing more", not "and forget what I already set" — the alternative would be a filter from your `.env` file silently skipping sheets behind a question you just declined. Filters you have not set stay behind the gate as before.
 
 ### A supplied tag or collection is shown too, whichever way you pick apps
 

--- a/src/lib/commands/browser/__tests__/browser_wizards.test.js
+++ b/src/lib/commands/browser/__tests__/browser_wizards.test.js
@@ -301,7 +301,7 @@ describe('an option a synthetic question stands in for', () => {
         await runInteractive({ path: 'browser uninstall', presetOptions: PRESET, runtime });
 
         const output = runtime.output();
-        expect(output).toContain('asked about again so the answer can be picked');
+        expect(output).toContain('asked about again so you can change it for this run');
         expect(output).toContain('--browser-version');
     });
 

--- a/src/lib/commands/qscloud/__tests__/qscloud_wizard.test.js
+++ b/src/lib/commands/qscloud/__tests__/qscloud_wizard.test.js
@@ -199,6 +199,54 @@ describe('choosing which apps to update', () => {
     });
 });
 
+describe('the static/dynamic classification', () => {
+    // QSEoW twin of the same block: PER_RUN_KEYS in spec-ops.js is the one
+    // statement of the rule, so both platforms get the same treatment.
+    const connection = { tenanturl: 'acme.eu.qlikcloud.com', apikey: 'a-real-key' };
+
+    test('a supplied --includesheetpart is asked again, opening on that value', async () => {
+        const runtime = scriptedRuntime(baseAnswers({ includesheetpart: '4' }));
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { ...connection, includesheetpart: '2' },
+            runtime,
+        });
+
+        const question = runtime.asked.find((a) => a.key === 'includesheetpart');
+        expect(question).toBeDefined();
+        expect(question.default).toBe('2');
+    });
+
+    test('a supplied sheet filter is shown even when the filtering gate is declined', async () => {
+        const runtime = scriptedRuntime(
+            baseAnswers({ _filtering: false, excludeSheetNumber: '2' })
+        );
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { ...connection, excludeSheetNumber: ['7'] },
+            runtime,
+        });
+
+        const question = runtime.asked.find((a) => a.key === 'excludeSheetNumber');
+        expect(question).toBeDefined();
+        expect(question.default).toBe('7');
+    });
+
+    test('an option describing the environment stays answered', async () => {
+        const runtime = scriptedRuntime(baseAnswers());
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { ...connection, imagedir: './img' },
+            runtime,
+        });
+
+        expect(runtime.asked.map((a) => a.key)).not.toContain('imagedir');
+    });
+});
+
 describe('a selection that would process nothing', () => {
     test('is refused where it was made, not after the run is confirmed', async () => {
         const runtime = scriptedRuntime(baseAnswers({ _appSource: 'typed', appid: ['', 'app-z'] }));
@@ -240,7 +288,9 @@ describe('an app id supplied before the wizard starts', () => {
         appid: ['app-b'],
     };
 
-    test('still gets the picker, with the supplied app already ticked', async () => {
+    test('still gets the picker, with the supplied app ticked and listed first', async () => {
+        // First, not merely ticked: a ticked row below the fold of a long list
+        // is the same as no choice at all.
         const runtime = scriptedRuntime(baseAnswers({ appid: ['app-a'] }));
 
         await runInteractive({ path: PATH, presetOptions: supplied, runtime });
@@ -248,9 +298,21 @@ describe('an app id supplied before the wizard starts', () => {
         const question = runtime.asked.find((a) => a.key === 'appid');
         expect(question).toBeDefined();
         expect(question.choices).toEqual([
-            expect.objectContaining({ value: 'app-a', checked: false }),
             expect.objectContaining({ value: 'app-b', checked: true }),
+            expect.objectContaining({ value: 'app-a', checked: false }),
         ]);
+    });
+
+    test('says a supplied app the tenant no longer has is not in the list', async () => {
+        const runtime = scriptedRuntime(baseAnswers({ appid: ['app-a'] }));
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { ...supplied, appid: ['app-gone'] },
+            runtime,
+        });
+
+        expect(runtime.output()).toContain('app-gone - supplied, but no longer on the server');
     });
 
     test('is announced as asked again rather than as skipped', async () => {
@@ -258,7 +320,7 @@ describe('an app id supplied before the wizard starts', () => {
 
         await runInteractive({ path: PATH, presetOptions: supplied, runtime });
 
-        expect(runtime.output()).toContain('picked from what is actually there: --appid');
+        expect(runtime.output()).toContain('so you can change it for this run: --appid');
         expect(runtime.output()).not.toMatch(/not asked about again:[^\n]*--appid/);
     });
 

--- a/src/lib/commands/qscloud/create-sheet-thumbnails.interactive.js
+++ b/src/lib/commands/qscloud/create-sheet-thumbnails.interactive.js
@@ -12,6 +12,7 @@ import {
     appPickerQuestion,
     typedAppQuestion,
     resolvesToApps,
+    markPerRun,
     APP_SOURCE,
     APP_SOURCES,
     SHEET_FILTER_KEYS,
@@ -221,9 +222,19 @@ export default {
                     !CONNECTION_KEYS.includes(spec.key) &&
                     !['appid', 'collectionid'].includes(spec.key)
             )
-            .map(gatedBy(ADVANCED, ADVANCED_KEYS))
-            .map(gatedBy(FILTERING, SHEET_FILTER_KEYS));
+            // Both gates get what was already supplied, not just the filters.
+            // A gate that does not know cannot show a supplied value, and a
+            // per-run option inside a gated block would then be announced as
+            // asked about and never asked - the exact defect this wizard was
+            // rewritten to remove, re-armed by nothing more than moving a key
+            // into PER_RUN_KEYS.
+            .map(gatedBy(ADVANCED, ADVANCED_KEYS, answers))
+            .map(gatedBy(FILTERING, SHEET_FILTER_KEYS, answers));
 
+        // markPerRun last, over everything: PER_RUN_KEYS in spec-ops.js is the
+        // one statement of which options describe this run rather than this
+        // environment, and applying it here means no question can be left out
+        // of the classification by being built somewhere else in this file.
         return inSections(
             [
                 ...connection,
@@ -237,7 +248,7 @@ export default {
                     message: 'Configure advanced options (schema version, timeouts, browser)?',
                 }),
                 ...rest,
-            ],
+            ].map(markPerRun),
             SECTIONS
         );
     },

--- a/src/lib/commands/qseow/__tests__/qseow_wizard.test.js
+++ b/src/lib/commands/qseow/__tests__/qseow_wizard.test.js
@@ -210,6 +210,102 @@ describe('choosing which apps to update', () => {
     });
 });
 
+describe('the static/dynamic classification', () => {
+    // PER_RUN_KEYS in spec-ops.js is the one statement of the rule: an option
+    // describing this run is always asked, opening on what was supplied; an
+    // option describing this environment stays answered.
+    const connection = {
+        host: 'sense.acme.com',
+        certfile: './cert/client.pem',
+        certkeyfile: './cert/client_key.pem',
+        apiuserdir: 'INTERNAL',
+        apiuserid: 'sa_api',
+        logonuserdir: 'ACME',
+        logonuserid: 'goran',
+        logonpwd: 'a-password',
+    };
+
+    test('a supplied --includesheetpart is asked again, opening on that value', async () => {
+        const runtime = scriptedRuntime(baseAnswers({ includesheetpart: '4' }));
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { ...connection, includesheetpart: '2' },
+            runtime,
+        });
+
+        const question = runtime.asked.find((a) => a.key === 'includesheetpart');
+        expect(question).toBeDefined();
+        expect(question.default).toBe('2');
+    });
+
+    test('a supplied sheet filter is shown even when the filtering gate is declined', async () => {
+        // Otherwise the worst of both worlds: a filter from a .env file quietly
+        // excluding sheets, behind a question answered "no".
+        const runtime = scriptedRuntime(
+            baseAnswers({ _filtering: false, excludeSheetNumber: '2' })
+        );
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { ...connection, excludeSheetNumber: ['7'] },
+            runtime,
+        });
+
+        const question = runtime.asked.find((a) => a.key === 'excludeSheetNumber');
+        expect(question).toBeDefined();
+        expect(question.default).toBe('7');
+    });
+
+    test('the other filters stay behind the gate', async () => {
+        const runtime = scriptedRuntime(
+            baseAnswers({ _filtering: false, excludeSheetNumber: '2' })
+        );
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { ...connection, excludeSheetNumber: ['7'] },
+            runtime,
+        });
+
+        expect(runtime.asked.map((a) => a.key)).not.toContain('blurSheetNumber');
+    });
+
+    test('an option describing the environment stays answered', async () => {
+        // --contentlibrary and --imagedir sit outside PER_RUN_KEYS on purpose.
+        const runtime = scriptedRuntime(baseAnswers());
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { ...connection, contentlibrary: 'Butler sheet thumbnails' },
+            runtime,
+        });
+
+        expect(runtime.asked.map((a) => a.key)).not.toContain('contentlibrary');
+        expect(runtime.output()).toContain('not asked about again');
+    });
+
+    test('a supplied option inside the advanced block is shown, gate declined or not', async () => {
+        // PER_RUN_KEYS promises that moving a key in or out is the whole edit.
+        // It only holds if a gated question can see what was supplied: without
+        // that, reclassifying --image-dir would have the banner promise it and
+        // the advanced gate silently swallow it.
+        const runtime = scriptedRuntime(baseAnswers({ _advanced: false, imagedir: './out' }));
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { ...connection, imagedir: './from-env' },
+            runtime,
+        });
+
+        // Static today, so not asked - but the gate no longer hides it, which is
+        // what makes the reclassification safe.
+        const hidden = runtime.asked.map((a) => a.key);
+        expect(hidden).not.toContain('imagedir');
+        expect(runtime.output()).toContain('not asked about again');
+    });
+});
+
 describe('a selection that would process nothing', () => {
     test('is refused where it was made, not after the run is confirmed', async () => {
         const runtime = scriptedRuntime(baseAnswers({ _appSource: 'typed', appid: ['', 'app-z'] }));
@@ -259,7 +355,11 @@ describe('an app id supplied before the wizard starts', () => {
         contentlibrary: 'Butler sheet thumbnails',
     };
 
-    test('still gets the picker, with the supplied app already ticked', async () => {
+    test('still gets the picker, with the supplied app ticked and listed first', async () => {
+        // First, not merely ticked. On the QSEoW test server the app that came
+        // from a .env file sat at index 16 of 519, ten rows below the fold, so
+        // the list looked entirely unticked and submitting it silently kept an
+        // app nobody had chosen in this run.
         const runtime = scriptedRuntime(baseAnswers({ appid: ['app-a'] }));
 
         await runInteractive({ path: PATH, presetOptions: supplied, runtime });
@@ -267,9 +367,40 @@ describe('an app id supplied before the wizard starts', () => {
         const question = runtime.asked.find((a) => a.key === 'appid');
         expect(question).toBeDefined();
         expect(question.choices).toEqual([
-            expect.objectContaining({ value: 'app-a', checked: false }),
             expect.objectContaining({ value: 'app-b', checked: true }),
+            expect.objectContaining({ value: 'app-a', checked: false }),
         ]);
+    });
+
+    test('matches a supplied id that differs only in case', async () => {
+        // GUIDs are not case-sensitive and are routinely pasted out of the QMC
+        // in upper case. Comparing exactly reported an app that is plainly on
+        // the server as missing, and left its row unticked so it was dropped.
+        const runtime = scriptedRuntime(baseAnswers({ appid: ['app-a'] }));
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { ...supplied, appid: ['APP-B'] },
+            runtime,
+        });
+
+        const question = runtime.asked.find((a) => a.key === 'appid');
+        expect(question.choices[0]).toEqual(
+            expect.objectContaining({ value: 'app-b', checked: true })
+        );
+        expect(runtime.output()).not.toContain('no longer on the server');
+    });
+
+    test('says a supplied app the server no longer has is not in the list', async () => {
+        const runtime = scriptedRuntime(baseAnswers({ appid: ['app-a'] }));
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { ...supplied, appid: ['app-gone'] },
+            runtime,
+        });
+
+        expect(runtime.output()).toContain('app-gone - supplied, but no longer on the server');
     });
 
     test('is announced as asked again rather than as skipped', async () => {
@@ -277,7 +408,7 @@ describe('an app id supplied before the wizard starts', () => {
 
         await runInteractive({ path: PATH, presetOptions: supplied, runtime });
 
-        expect(runtime.output()).toContain('picked from what is actually there: --appid');
+        expect(runtime.output()).toContain('so you can change it for this run: --appid');
         expect(runtime.output()).not.toMatch(/not asked about again:[^\n]*--appid/);
     });
 

--- a/src/lib/commands/qseow/create-sheet-thumbnails.interactive.js
+++ b/src/lib/commands/qseow/create-sheet-thumbnails.interactive.js
@@ -12,6 +12,7 @@ import {
     appPickerQuestion,
     typedAppQuestion,
     resolvesToApps,
+    markPerRun,
     APP_SOURCE,
     APP_SOURCES,
     SHEET_FILTER_KEYS,
@@ -209,9 +210,19 @@ export default {
                     !CONNECTION_KEYS.includes(spec.key) &&
                     !['appid', 'qliksensetag', 'contentlibrary'].includes(spec.key)
             )
-            .map(gatedBy(ADVANCED, ADVANCED_KEYS))
-            .map(gatedBy(FILTERING, SHEET_FILTER_KEYS));
+            // Both gates get what was already supplied, not just the filters.
+            // A gate that does not know cannot show a supplied value, and a
+            // per-run option inside a gated block would then be announced as
+            // asked about and never asked - the exact defect this wizard was
+            // rewritten to remove, re-armed by nothing more than moving a key
+            // into PER_RUN_KEYS.
+            .map(gatedBy(ADVANCED, ADVANCED_KEYS, answers))
+            .map(gatedBy(FILTERING, SHEET_FILTER_KEYS, answers));
 
+        // markPerRun last, over everything: PER_RUN_KEYS in spec-ops.js is the
+        // one statement of which options describe this run rather than this
+        // environment, and applying it here means no question can be left out
+        // of the classification by being built somewhere else in this file.
         return inSections(
             [
                 ...connection,
@@ -227,7 +238,7 @@ export default {
                         'Configure advanced options (ports, certificates, schema version, browser)?',
                 }),
                 ...rest,
-            ],
+            ].map(markPerRun),
             SECTIONS
         );
     },

--- a/src/lib/interactive/__tests__/ask-questions.test.js
+++ b/src/lib/interactive/__tests__/ask-questions.test.js
@@ -374,4 +374,53 @@ describe('scriptedRuntime', () => {
 
         expect(answers.status).toEqual(['private', 'published']);
     });
+
+    test('pre-ticks a checkbox default that differs only in case', async () => {
+        // App ids are GUIDs, which are not case-sensitive and are routinely
+        // pasted out of the QMC in upper case. Comparing them exactly left the
+        // row unticked, so submitting the list dropped an id that was supplied.
+        const runtime = scriptedRuntime({ appid: ['a1b2'] });
+
+        await askQuestions(
+            [
+                spec({
+                    key: 'appid',
+                    type: 'checkbox',
+                    default: ['A1B2'],
+                    choices: ['a1b2', 'c3d4'],
+                }),
+            ],
+            ctx(),
+            { runtime }
+        );
+
+        const offered = runtime.asked.find((entry) => entry.key === 'appid').choices;
+        expect(offered).toEqual([
+            expect.objectContaining({ value: 'a1b2', checked: true }),
+            expect.objectContaining({ value: 'c3d4', checked: false }),
+        ]);
+    });
+
+    test('a <true|false> option supplied as "false" opens on no, not yes', async () => {
+        // These are string options carrying boolean defaults, and
+        // Boolean('false') is true - so reading the value that way offered to
+        // turn --secure or --reject-unauthorized back on.
+        const runtime = scriptedRuntime({ secure: false });
+
+        await askQuestions([spec({ key: 'secure', type: 'confirm', default: 'false' })], ctx(), {
+            runtime,
+        });
+
+        expect(runtime.asked.find((entry) => entry.key === 'secure').default).toBe(false);
+    });
+
+    test('a <true|false> option supplied as "true" still opens on yes', async () => {
+        const runtime = scriptedRuntime({ secure: true });
+
+        await askQuestions([spec({ key: 'secure', type: 'confirm', default: 'true' })], ctx(), {
+            runtime,
+        });
+
+        expect(runtime.asked.find((entry) => entry.key === 'secure').default).toBe(true);
+    });
 });

--- a/src/lib/interactive/__tests__/spec-ops.test.js
+++ b/src/lib/interactive/__tests__/spec-ops.test.js
@@ -61,6 +61,21 @@ describe('gatedBy', () => {
         expect(hidden.when({ answers: {} })).toBe(false);
     });
 
+    test('shows a supplied value whatever the gate says', () => {
+        // Declining the gate means "nothing more", not "and forget what I set".
+        const hidden = gatedBy('_advanced', ['pagewait'], { pagewait: '7' })(spec('pagewait'));
+
+        expect(hidden.when({ answers: { _advanced: false } })).toBe(true);
+    });
+
+    test('an empty supplied value still respects the gate', () => {
+        const hidden = gatedBy('_filtering', ['excludeSheetTag'], { excludeSheetTag: '' })(
+            spec('excludeSheetTag')
+        );
+
+        expect(hidden.when({ answers: { _filtering: false } })).toBe(false);
+    });
+
     test('leaves other questions untouched, identity included', () => {
         const untouched = spec('host');
 
@@ -219,6 +234,21 @@ describe('assertAppSelectionNotEmpty', () => {
         expect(() =>
             assertAppSelectionNotEmpty({ appid: [], qliksensetag: 'BSI' }, 'qliksensetag', 'a tag')
         ).not.toThrow();
+    });
+
+    test('names only what can actually be done from this prompt', () => {
+        // There is no way back to an earlier question, so advising one sends
+        // the operator hunting for a key that does not exist.
+        let thrown;
+
+        try {
+            assertAppSelectionNotEmpty({}, 'qliksensetag', 'a tag');
+        } catch (err) {
+            thrown = err;
+        }
+
+        expect(thrown.message).toContain('Ctrl+C');
+        expect(thrown.message).not.toContain('go back');
     });
 
     test('throws when neither names anything', () => {

--- a/src/lib/interactive/ask-questions.js
+++ b/src/lib/interactive/ask-questions.js
@@ -131,11 +131,26 @@ const hasDefault = (spec) => spec.default !== undefined && spec.default !== '';
  * behaviour to this. An if-chain grows a branch each time; a table grows a row.
  */
 const CONFIG_BUILDERS = Object.freeze({
-    confirm: (spec) => ({ default: Boolean(spec.default) }),
+    // A `<true|false>` option is a *string* option, so its supplied value is the
+    // word rather than the boolean - and `Boolean('false')` is `true`. Reading
+    // it that way pre-filled the prompt with the opposite of what was supplied,
+    // which on --secure or --reject-unauthorized silently offers to weaken a TLS
+    // setting the operator had deliberately turned off. `to-cli-options` already
+    // treats the string 'true' as the true value; this is the same rule on the
+    // way in.
+    confirm: (spec) => ({
+        default: spec.default === true || String(spec.default).toLowerCase() === 'true',
+    }),
 
     checkbox: (spec, choices) => {
-        const chosen = new Set(splitEntries(spec.default).map(String));
-        const check = (value) => chosen.has(String(value));
+        // Case-insensitive, because the values here are frequently GUIDs, which
+        // are not case-sensitive and are routinely pasted in upper case. An id
+        // that differs only in case would otherwise leave its row unticked, so
+        // submitting the list would drop a value the operator had supplied.
+        const chosen = new Set(
+            splitEntries(spec.default).map((entry) => String(entry).toLowerCase())
+        );
+        const check = (value) => chosen.has(String(value).toLowerCase());
 
         return {
             choices: (choices ?? []).map((choice) =>

--- a/src/lib/interactive/index.js
+++ b/src/lib/interactive/index.js
@@ -10,6 +10,7 @@ import { getSymbols } from './symbols.js';
 import { loadWizard } from './registry.js';
 import { formatReviewTable } from './review-table.js';
 import { saveEnvFile, ENV_FILE } from './save-env-file.js';
+import { openingOn } from './spec-ops.js';
 
 /** What the review step can decide. */
 const REVIEW_CHOICES = [
@@ -141,26 +142,44 @@ export const runInteractive = async ({
     // has to be built from the result before the first question is asked.
     const kept = refined.filter((spec) => !(spec.key in presetOptions));
 
-    // What a question stands in for counts as asked, even though its key
-    // differs. uninstall's picker is keyed `_build` and collects `browser` and
-    // `browserVersion` between them, so without this the banner announced that
-    // --browser-version would not be asked about and the wizard then asked for
-    // exactly that, using that option's help text as the prompt (issue #1013).
-    const covered = new Set(kept.flatMap((spec) => spec.replaces ?? []));
+    // Two reasons a question survives having been answered already, and one set
+    // to hold both, because everything downstream - the filter, the banner, the
+    // pre-fill - treats them identically.
+    //
+    // A question another one **stands in for**. uninstall's picker is keyed
+    // `_build` and collects `browser` and `browserVersion` between them, so
+    // without this the banner announced that --browser-version would not be
+    // asked about and the wizard then asked for exactly that, using that
+    // option's help text as the prompt (issue #1013). The Qlik wizards' app
+    // picker is the same shape: the question leading to it is synthetic, so
+    // dropping the questions it leads to left it announcing itself and then
+    // asking nothing at all.
+    //
+    // A question describing **this run rather than this environment**. A host or
+    // a certificate path is a property of the server and stays true; which apps
+    // to update, how much of each sheet to capture and which sheets to skip are
+    // decisions, and a decision taken once in a .env file should not be taken
+    // again silently on every later run. Wizards mark these with `perRun`.
+    const alwaysAsk = new Set([
+        ...kept.flatMap((spec) => spec.replaces ?? []),
+        ...refined.filter((spec) => spec.perRun).map((spec) => spec.key),
+    ]);
 
-    // A supplied value whose question a synthetic one stands in for is kept in
-    // the conversation rather than dropped: the synthetic question is asked, so
-    // the questions it leads to have to be there to be led to. Without this the
-    // app picker announced itself, was answered, and then asked nothing at all,
-    // because --appid was already supplied and its question had been removed.
-    const asked = refined.filter((spec) => !(spec.key in presetOptions) || covered.has(spec.key));
+    // Opened on whatever was supplied, so asking again costs a keystroke rather
+    // than a retype. Done here rather than in each wizard: the driver is what
+    // decided to ask, so it is what owes the pre-fill.
+    const asked = refined
+        .filter((spec) => !(spec.key in presetOptions) || alwaysAsk.has(spec.key))
+        .map((spec) =>
+            spec.key in presetOptions ? openingOn(spec, presetOptions[spec.key]) : spec
+        );
 
     // Named by flag rather than by storage key, because the flag is what the
     // user typed. Secrets are named but never shown.
     const nameOf = (spec) => spec.option?.long ?? spec.key;
     const supplied = specs.filter((spec) => spec.key in presetOptions);
-    const prefilled = supplied.filter((spec) => !covered.has(spec.key)).map(nameOf);
-    const overridden = supplied.filter((spec) => covered.has(spec.key)).map(nameOf);
+    const prefilled = supplied.filter((spec) => !alwaysAsk.has(spec.key)).map(nameOf);
+    const overridden = supplied.filter((spec) => alwaysAsk.has(spec.key)).map(nameOf);
 
     // Said once, up front. There is no way back to a previous question - the
     // prompt library has no such gesture - so the two things a user can do
@@ -176,12 +195,13 @@ export const runInteractive = async ({
     }
 
     if (overridden.length > 0) {
-        // Deliberately still asked. A picker over what is really there beats a
-        // value remembered from an earlier run - which may name something that
-        // has since been removed - but saying nothing would leave someone who
-        // set the value wondering why it was ignored.
+        // Deliberately still asked, and the wording has to cover both reasons:
+        // a picker over what is really there beats a value remembered from an
+        // earlier run, and a decision about this run should not be taken
+        // silently by a file. Saying nothing would leave someone who set the
+        // value wondering why it was ignored.
         runtime.write(
-            `${theme.style.help(`Supplied, but asked about again so the answer can be picked from what is actually there: ${overridden.join(', ')}.`)}\n`
+            `${theme.style.help(`Supplied, but asked about again so you can change it for this run: ${overridden.join(', ')}.`)}\n`
         );
     }
 

--- a/src/lib/interactive/spec-ops.js
+++ b/src/lib/interactive/spec-ops.js
@@ -36,6 +36,55 @@ export const SHEET_FILTER_KEYS = Object.freeze([
 ]);
 
 /**
+ * THE STATIC/DYNAMIC CLASSIFICATION. Edit this list to change it.
+ *
+ * Every option a Qlik wizard asks about falls into one of two kinds:
+ *
+ * - **This environment.** A host, a port, a certificate path, a credential, a
+ *   browser build. Properties of the server you are pointing at, true until the
+ *   environment itself changes. Supplied once in a `.env` file, they should stay
+ *   answered - re-asking them every run is the tedium `-i` exists to remove.
+ *
+ * - **This run.** Which apps to update, which sheets to skip, how much of each
+ *   sheet to capture. Decisions, not facts. A decision taken once and left in a
+ *   `.env` file should not be taken again silently on every later run, because
+ *   the operator cannot see it and cannot change it without editing the file.
+ *
+ * Keys listed here are the second kind: always asked, opening on whatever was
+ * supplied, so confirming costs one keystroke and changing costs a few.
+ * Everything not listed is the first kind and is skipped once supplied.
+ *
+ * **To reclassify an option, move its key in or out of this list.** Nothing else
+ * needs editing: the driver reads the `perRun` mark this produces, and the
+ * banner, the pre-fill and the gate bypass all follow from it. `contentlibrary`
+ * and `imagedir` sit outside deliberately - both were judged properties of the
+ * environment rather than of the run.
+ */
+export const PER_RUN_KEYS = Object.freeze([
+    // What gets updated.
+    'appid',
+    'qliksensetag',
+    'collectionid',
+    // How much of each sheet the screenshot covers.
+    'includesheetpart',
+    // Which sheets are skipped or blurred.
+    ...SHEET_FILTER_KEYS,
+]);
+
+/**
+ * Mark a question as describing this run, if the classification says it does.
+ *
+ * Applied to every question a wizard returns, so {@link PER_RUN_KEYS} is the
+ * single statement of the rule rather than a thing each question repeats.
+ *
+ * @param {object} spec - The question.
+ *
+ * @returns {object} The question, marked when it names a per-run decision.
+ */
+export const markPerRun = (spec) =>
+    PER_RUN_KEYS.includes(spec.key) ? { ...spec, perRun: true } : spec;
+
+/**
  * Whether a value was actually supplied, as opposed to left at nothing.
  *
  * An empty string is how both `--qliksensetag` and `--collectionid` say "none" -
@@ -90,8 +139,12 @@ export const assertAppSelectionNotEmpty = (answers, groupingKey, groupingLabel) 
         return;
     }
 
+    // Names only what can actually be done here. There is no way back to an
+    // earlier question - the prompt library has no such gesture, which is why
+    // the wizard says up front that Ctrl+C cancels - so telling someone to "go
+    // back" sends them hunting for a key that does not exist.
     throw new Error(
-        `No apps selected, so there would be nothing to do. Pick at least one app, or go back and choose ${groupingLabel} instead.`
+        `No apps selected, so there would be nothing to do. Pick at least one app, or press Ctrl+C and start again to choose ${groupingLabel} instead.`
     );
 };
 
@@ -217,7 +270,9 @@ export const appPickerQuestion = ({
             ...spec,
             type: 'checkbox',
             message: 'Which apps?',
-            hint: `Individually named apps. They are updated in addition to anything ${groupingLabel} matches.`,
+            hint: isSupplied(supplied)
+                ? `Apps you already supplied are listed first, ticked. Untick to leave one out. Anything ${groupingLabel} matches is updated as well.`
+                : `Individually named apps. They are updated in addition to anything ${groupingLabel} matches.`,
         },
         supplied
     ),
@@ -228,7 +283,36 @@ export const appPickerQuestion = ({
     choices: async (ctx) => {
         const apps = await listApps(ctx);
 
-        return apps.map((entry) => ({ name: label(entry), value: entry.id }));
+        // Compared case-insensitively, because an app id is a GUID and a GUID
+        // is not case-sensitive. They are routinely copied out of the QMC in
+        // upper case, and Qlik's own APIs match them either way, so treating
+        // 'DED8...' and 'ded8...' as different ids would report an app that is
+        // plainly there as missing and then drop it from the run.
+        const alreadyChosen = new Set(splitEntries(supplied).map((id) => String(id).toLowerCase()));
+        const wasSupplied = (entry) => alreadyChosen.has(String(entry.id).toLowerCase());
+
+        // Supplied ids first, because a ticked row the operator cannot see is
+        // the same as no choice at all. On a server with 519 apps the one that
+        // came from a .env file sat at index 16, ten rows below the fold: the
+        // list looked entirely unticked, and submitting it silently kept an app
+        // nobody had chosen in this run.
+        const ranked = [...apps.filter(wasSupplied), ...apps.filter((e) => !wasSupplied(e))];
+
+        // A supplied id the server no longer has cannot be shown, ticked or
+        // otherwise, so it would just vanish from the selection. Saying so is
+        // the whole reason this question is asked again rather than skipped.
+        const missing = splitEntries(supplied).filter(
+            (id) =>
+                !apps.some((entry) => String(entry.id).toLowerCase() === String(id).toLowerCase())
+        );
+
+        if (missing.length > 0) {
+            ctx.write(
+                `  ${missing.join(', ')} - supplied, but no longer on the server, so not listed below.\n`
+            );
+        }
+
+        return ranked.map((entry) => ({ name: label(entry), value: entry.id }));
     },
     probe: async (ctx) => assertAppSelectionNotEmpty(ctx.answers, groupingKey, groupingLabel),
     fallback: { type: 'list', message: 'App id(s) (could not fetch the list)' },
@@ -290,16 +374,27 @@ export const gate = ({ key, message, default: defaultValue = false }) => {
  * Returns a mapper, so it composes with the other reshaping a wizard does rather
  * than needing its own pass over the list.
  *
+ * A question whose value was already supplied is shown whatever the gate says.
+ * Hiding it would put the operator in the worst position of all: a filter from
+ * a `.env` file silently excluding sheets, behind a question they answered "no"
+ * to. Declining the gate means "nothing more", not "and forget what I set".
+ *
  * @param {string} gateKey - Key of the gate question.
  * @param {string[]|Set<string>} keys - Keys to hide behind it.
+ * @param {object} [supplied] - What the command line and environment already gave.
  *
  * @returns {(spec: object) => object} A mapper leaving other questions untouched.
  */
-export const gatedBy = (gateKey, keys) => {
+export const gatedBy = (gateKey, keys, supplied = {}) => {
     const hidden = new Set(keys);
 
     return (spec) =>
-        hidden.has(spec.key) ? { ...spec, when: (ctx) => ctx.answers[gateKey] === true } : spec;
+        hidden.has(spec.key)
+            ? {
+                  ...spec,
+                  when: (ctx) => ctx.answers[gateKey] === true || isSupplied(supplied[spec.key]),
+              }
+            : spec;
 };
 
 /**


### PR DESCRIPTION
Follow-up to #1043, from a real run: with `BSI_QSEOW_CST_APP_ID` set in `.env`, the wizard offered the app picker and the supplied app *was* ticked — at index 16 of 519, ten rows below the visible viewport. The list looked entirely unticked. Ticking one more app and pressing Enter updated two, and there was no practical way to find the pre-ticked row and remove it.

Underneath that was a missing distinction. There was no static/dynamic rule in the code — only "supplied, so skip", with app selection special-cased on top. That is why `--includesheetpart` was also being decided by a file, with no way to change it for a single run.

## The rule, in one editable list

`PER_RUN_KEYS` in `spec-ops.js`:

- **This environment** — host, ports, certificates, credentials, browser, `--contentlibrary`, `--imagedir`. Stays answered once supplied; re-asking is the tedium `-i` exists to remove.
- **This run** — which apps, which tag or collection, `--includesheetpart`, the nine sheet exclude/blur filters. Always asked, opening on whatever was supplied, so confirming costs one keystroke.

Reclassifying an option is meant to be a one-line edit, so the two things that would have quietly broken that promise are fixed rather than documented as caveats:

- **Both gates now see what was supplied.** Only the filtering gate did. A per-run option inside the advanced block would have been announced in the banner and then hidden by the gate, with its `.env` value still reaching the run — exactly the defect #1043 fixed, re-armed by the documented edit.
- **`<true|false>` options no longer invert.** These are *string* options, and `Boolean('false')` is `true`, so a supplied `false` pre-filled the prompt as yes. On `--secure` or `--reject-unauthorized` that offers to turn a deliberately disabled TLS setting back on.

## In the app picker

- Supplied apps are **listed first**, so the ticked row is the one you see.
- A supplied id the server no longer has is **reported**, not silently dropped from the selection.
- Ids are matched **case-insensitively**. GUIDs are not case-sensitive and are routinely pasted out of the QMC in upper case; comparing them exactly reported an app that was plainly there as missing and then dropped it from the run.
- The empty-selection message names Ctrl+C instead of telling the operator to "go back", which this prompt library cannot do.

## Verification

Full unit suite: **2538 passed, 92 suites**, on two consecutive runs. eslint and prettier clean.

Checked against a live QSEoW server:

- the app from `.env` is row 0 and ticked, in a 519-app list
- the same id in upper case still matches, and the false "no longer on the server" warning is gone
- `--browser-page-timeout` stays skipped while `--includesheetpart` is asked
- a real tag reports what it matched; an unknown tag and an empty selection are both re-asked

The Cloud path is the exact mirror and its unit tests pass, but it has not been exercised against a real tenant.

## Note for the reviewer

The code landed as one commit rather than several. The topics — picker visibility, the classification, and the follow-up review fixes — interleave inside `spec-ops.js`, `ask-questions.js` and the shared test files, and `git add -p` is not available in this environment, so splitting further at file granularity would have produced commits whose tests fail in isolation.

Two of the fixes touch `ask-questions.js`, which every wizard shares. Both are strictly more permissive — a checkbox that previously failed to pre-tick now does, and a confirm that read `'false'` as yes now reads it as no — so nothing that worked before changes behaviour. The browser wizards' tests cover that path and pass.

## Still open, deliberately

No probe runs for any value that came from `.env` — content library, certificates, API key. A wrong Cloud API key still surfaces as "could not fetch the list" rather than as a credential problem. That needs a decision about where to report a failure for a question that was never asked, so it belongs on its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)