### PR TITLE
Sheet status filters can now be ticked in interactive mode

### DIFF
--- a/src/lib/commands/qscloud/__tests__/qscloud_wizard.test.js
+++ b/src/lib/commands/qscloud/__tests__/qscloud_wizard.test.js
@@ -247,6 +247,40 @@ describe('the static/dynamic classification', () => {
     });
 });
 
+describe('the sheet filters', () => {
+    test('a status can actually be ticked and submitted', async () => {
+        // QSEoW twin of the same block. The fix lives in the shared driver, so
+        // both platforms were affected and both are covered: --exclude-sheet-
+        // status and --blur-sheet-status are checkboxes over closed value sets,
+        // and the prompt validates the selected *choices* rather than their
+        // values, so every entry stringified to "[object Object]" and the
+        // prompt could not be answered at all.
+        const runtime = scriptedRuntime(
+            baseAnswers({
+                _filtering: true,
+                excludeSheetStatus: ['private'],
+                blurSheetStatus: ['published'],
+                _review: 'run',
+            })
+        );
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(qscloudCreateThumbnails).toHaveBeenCalledWith(
+            expect.objectContaining({
+                excludeSheetStatus: ['private'],
+                blurSheetStatus: ['published'],
+            })
+        );
+        // Accepted first time. A rejected answer is re-asked, so a second entry
+        // here is what the defect looked like from the operator's seat - the
+        // validator message itself never reaches the transcript, so asserting on
+        // its text would prove nothing.
+        expect(runtime.asked.filter((a) => a.key === 'excludeSheetStatus')).toHaveLength(1);
+        expect(runtime.asked.filter((a) => a.key === 'blurSheetStatus')).toHaveLength(1);
+    });
+});
+
 describe('a selection that would process nothing', () => {
     test('is refused where it was made, not after the run is confirmed', async () => {
         const runtime = scriptedRuntime(baseAnswers({ _appSource: 'typed', appid: ['', 'app-z'] }));

--- a/src/lib/commands/qseow/__tests__/qseow_wizard.test.js
+++ b/src/lib/commands/qseow/__tests__/qseow_wizard.test.js
@@ -306,6 +306,50 @@ describe('the static/dynamic classification', () => {
     });
 });
 
+describe('the sheet filters', () => {
+    test('a status can actually be ticked and submitted', async () => {
+        // --exclude-sheet-status is a checkbox over a closed value set, and the
+        // prompt validates the selected *choices* rather than their values. That
+        // made every entry stringify to "[object Object]", so ticking `private`
+        // was rejected with "Allowed choices are private, published, public" and
+        // the operator could not get past the prompt at all.
+        const runtime = scriptedRuntime(
+            baseAnswers({
+                _filtering: true,
+                excludeSheetStatus: ['private'],
+                excludeSheetTag: '',
+                excludeSheetNumber: '',
+                excludeSheetTitle: '',
+                // Covered too, and not as an empty list: --blur-sheet-status
+                // takes a narrower set than --exclude-sheet-status, and an empty
+                // list short-circuits validateEntries without calling the
+                // option's parser even once.
+                blurSheetStatus: ['published'],
+                blurSheetTag: '',
+                blurSheetNumber: '',
+                blurSheetTitle: '',
+                blurFactor: '5',
+                _review: 'run',
+            })
+        );
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(qseowCreateThumbnails).toHaveBeenCalledWith(
+            expect.objectContaining({
+                excludeSheetStatus: ['private'],
+                blurSheetStatus: ['published'],
+            })
+        );
+        // Accepted first time. A rejected answer is re-asked, so a second entry
+        // here is what the defect looked like from the operator's seat - the
+        // validator message itself never reaches the transcript, so asserting on
+        // its text would prove nothing.
+        expect(runtime.asked.filter((a) => a.key === 'excludeSheetStatus')).toHaveLength(1);
+        expect(runtime.asked.filter((a) => a.key === 'blurSheetStatus')).toHaveLength(1);
+    });
+});
+
 describe('a selection that would process nothing', () => {
     test('is refused where it was made, not after the run is confirmed', async () => {
         const runtime = scriptedRuntime(baseAnswers({ _appSource: 'typed', appid: ['', 'app-z'] }));

--- a/src/lib/interactive/__tests__/ask-questions.test.js
+++ b/src/lib/interactive/__tests__/ask-questions.test.js
@@ -375,6 +375,58 @@ describe('scriptedRuntime', () => {
         expect(answers.status).toEqual(['private', 'published']);
     });
 
+    test('validates a checkbox against the values, not the choice objects', async () => {
+        // The prompt hands its validator the selected *choices*. A spec's
+        // validator comes from the option's own parser and expects values, so
+        // passing the objects through made every entry stringify to
+        // "[object Object]" - and any option with a closed value set could never
+        // be answered. Ticking `private` on --exclude-sheet-status was rejected
+        // with `Entry 1 ("[object Object]"): Allowed choices are private,
+        // published, public.` with no way past the prompt.
+        const seen = [];
+        const runtime = scriptedRuntime({ status: ['private'] });
+
+        await askQuestions(
+            [
+                spec({
+                    key: 'status',
+                    type: 'checkbox',
+                    choices: ['private', 'published', 'public'],
+                    validate: (values) => {
+                        seen.push(values);
+
+                        return values.every((v) => typeof v === 'string') ? true : 'not values';
+                    },
+                }),
+            ],
+            ctx(),
+            { runtime }
+        );
+
+        expect(seen).toEqual([['private']]);
+    });
+
+    test('refuses a checkbox answer the prompt never offered', async () => {
+        // Silently dropping it would let a script assert against an answer no
+        // user could give - and because an empty list passes most validators,
+        // the validator would never see it either.
+        const runtime = scriptedRuntime({ status: ['bogus'] });
+
+        await expect(
+            askQuestions(
+                [
+                    spec({
+                        key: 'status',
+                        type: 'checkbox',
+                        choices: ['private', 'published', 'public'],
+                    }),
+                ],
+                ctx(),
+                { runtime }
+            )
+        ).rejects.toThrow(/"status" was answered with \["bogus"\], which the prompt never offered/);
+    });
+
     test('pre-ticks a checkbox default that differs only in case', async () => {
         // App ids are GUIDs, which are not case-sensitive and are routinely
         // pasted out of the QMC in upper case. Comparing them exactly left the

--- a/src/lib/interactive/ask-questions.js
+++ b/src/lib/interactive/ask-questions.js
@@ -158,7 +158,17 @@ const CONFIG_BUILDERS = Object.freeze({
                     ? { ...choice, checked: check(choice.value) }
                     : { value: choice, name: String(choice), checked: check(choice) }
             ),
-            ...(spec.validate ? { validate: spec.validate } : {}),
+            // The prompt hands its validator the *selected choices* - whole
+            // objects - while a spec's validator is built from the option's own
+            // parser and expects the values. Passing it straight through meant
+            // every entry stringified to "[object Object]", so any option with a
+            // closed value set could never be answered: ticking `private` on
+            // --exclude-sheet-status was rejected with `Entry 1
+            // ("[object Object]"): Allowed choices are private, published,
+            // public.` and there was no way past the prompt.
+            ...(spec.validate
+                ? { validate: (picked) => spec.validate(picked.map((choice) => choice.value)) }
+                : {}),
         };
     },
 

--- a/src/lib/interactive/test-helpers/scripted-runtime.js
+++ b/src/lib/interactive/test-helpers/scripted-runtime.js
@@ -9,10 +9,15 @@
  *
  * - It **fails loudly on an unqueued key**, so a question added without a test
  *   answer breaks the test rather than hanging it, which is the failure mode
- *   that makes prompt testing miserable.
+ *   that makes prompt testing miserable. It fails the same way on a checkbox
+ *   answer naming a value the prompt never offered, because a script asserting
+ *   against an answer no user could give proves nothing.
  * - It **runs the real validator and re-asks on rejection**, exactly as a real
  *   prompt does. Queue `['abc', '7']` against a numeric question and the key is
- *   recorded twice: once rejected, once accepted.
+ *   recorded twice: once rejected, once accepted. A checkbox validator is given
+ *   the selected choices rather than their values, which is what the real
+ *   prompt passes - being kinder here once let a validator that stringified its
+ *   input pass every test and then reject every answer in front of a user.
  * - It **records what it was asked**, so "the version list was fetched for the
  *   browser the user chose" is an ordinary assertion.
  *
@@ -108,11 +113,38 @@ export const scriptedRuntime = (script = {}) => {
                     source: config.source,
                 });
 
+                // The real checkbox prompt validates the *selected choices* -
+                // whole objects - not the values behind them. Handing the
+                // validator plain values here would make this double kinder
+                // than the terminal, and it was: a validator that stringified
+                // its input passed every test and then rejected every answer in
+                // front of a user, because each entry became "[object Object]".
+                const selected =
+                    spec.type === 'checkbox' && Array.isArray(answer)
+                        ? (config.choices ?? []).filter((choice) => answer.includes(choice.value))
+                        : undefined;
+
+                // A checkbox answer can only ever be values the prompt offered.
+                // Quietly dropping the rest would let a script assert against an
+                // answer no user could give - and because an empty list passes
+                // most validators, the validator would never see it either.
+                // Loud, like an unqueued key, for the same reason.
+                if (selected) {
+                    const offered = (config.choices ?? []).map((choice) => choice.value);
+                    const impossible = answer.filter((value) => !offered.includes(value));
+
+                    if (impossible.length > 0) {
+                        throw new Error(
+                            `scriptedRuntime: "${spec.key}" was answered with ${JSON.stringify(impossible)}, which the prompt never offered. It offered ${JSON.stringify(offered)}.`
+                        );
+                    }
+                }
+
                 if (!config.validate) {
                     return answer;
                 }
 
-                lastVerdict = await config.validate(answer);
+                lastVerdict = await config.validate(selected ?? answer);
 
                 if (lastVerdict === true) {
                     return answer;


### PR DESCRIPTION
Reported from a real run. Answering **yes** to "Exclude or blur any sheets?" and ticking `private` was rejected, with no answer that got past the prompt:

```
? Exclude all sheets with specified status(es)
❯◉ private
 ◯ published
 ◯ public

✗ Entry 1 ("[object Object]"): Allowed choices are private, published, public.
```

## Cause

The checkbox prompt hands its validator the selected **choices** — whole objects — while a spec's validator is built from the option's own Commander parser and expects the **values** behind them:

```js
const isValid = await validate([...selection]);   // @inquirer/checkbox
```

Passing it straight through stringified every entry to `"[object Object]"`, which no closed value set accepts. So every checkbox over a closed value set was unanswerable:

| Option | QSEoW | Cloud |
|---|---|---|
| `--exclude-sheet-status` | broken | broken |
| `--blur-sheet-status` | broken | broken |
| `--appid` | unaffected — its parser accepts anything |

The bug predates the interactive rework — it has been there since the sheet filters became checkboxes — and it blocks anyone who opens the filtering gate. `--appid` escaping is why it went unnoticed for so long.

## The more useful half

**The test double was kinder than the terminal.** `scriptedRuntime` handed validators plain values, so a validator that stringified its input passed every test and then rejected every answer in front of a user. That is why 2500 tests were green while the feature was unusable.

It now passes the selected choices, exactly as the real prompt does — and refuses, as it already does for an unqueued key, when a script names a checkbox value the prompt never offered. Dropping those silently would let a test assert against an answer no user could give, and since an empty list satisfies most validators, the validator would never see it either.

## Verification

Full unit suite: **2542 passed, 92 suites**. eslint and prettier clean.

Each fix was reverted in turn to confirm the matching test fails:

| Fix removed | Result |
|---|---|
| object→value mapping in `ask-questions.js` | 3 tests fail, including both wizard tests |
| loud refusal in the test double | `refuses a checkbox answer the prompt never offered` fails |

Both platforms are covered, including `--blur-sheet-status`, which takes a narrower set than its exclude twin and which an empty scripted list would have short-circuited without calling the parser once.

## No doc page

Deliberate: the docs already describe the sheet filters as working. This restores documented behaviour rather than changing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)