### PR TITLE
Check the answers a .env file supplies, before the run starts

### DIFF
--- a/docs/to-doc-site/creating-thumbnails-interactively.md
+++ b/docs/to-doc-site/creating-thumbnails-interactively.md
@@ -118,22 +118,24 @@ Confirming one costs a single keystroke, because the question opens on the value
 
 A skipped option is still **verified against your server**. Not asking you about it does not mean trusting it: an API key can be revoked, a content library deleted, a certificate moved, long after the `.env` file that names them was written.
 
-The check happens at the point in the conversation where the question would have been asked, and says so:
+**With a complete `.env` file, the checks run before the first question.** Everything the checks need is already in the file, so there is nothing to wait for:
 
 ```
-── Connection ────────────────────────────────────
+── Checking what you supplied ────────────────────
 
   ✓ --certfile (from BSI_QSEOW_CST_CERT_FILE) checked
   ✓ --certkeyfile (from BSI_QSEOW_CST_CERTKEY_FILE) checked
 
-── Sheets ────────────────────────────────────────
-
   ✓ --contentlibrary (from BSI_QSEOW_CST_CONTENT_LIBRARY) checked
 ```
 
-That line is also why the wizard pauses for a moment there — it is contacting your server.
+This is the common case once you have saved your answers, and it is the one worth having: a content library that was deleted last month is reported immediately, rather than after you have picked your way through a list of several hundred apps.
 
-**One check often covers several options**, and each gets its own line. The certificate check needs both paths, so it cannot run until you have given the second one — but it verifies both, and says so. On Qlik Sense Cloud the connection test does the same for `--tenanturl` and `--apikey`: a wrong tenant URL fails it as surely as a revoked key does.
+**A check waits when it depends on something you have not given yet.** The content library check opens a connection to the Qlik Sense repository service built from the host, the certificates and the API user — so if the host is not in your `.env` file, the check cannot run until you have typed it, and happens further down instead, at the point the question would have been asked. Nothing is skipped either way; only the timing differs.
+
+Those lines are also why the wizard pauses for a moment — it is contacting your server.
+
+**One check often covers several options**, and each gets its own line. The certificate check needs both paths and verifies both, and says so rather than naming only the key file. On Qlik Sense Cloud the connection test does the same for `--tenanturl` and `--apikey`: a wrong tenant URL fails it as surely as a revoked key does.
 
 If the check fails, the wizard names the option, the environment variable the value came from, and what is wrong. It then asks you the question after all, opening on the value that failed, so correcting it is an edit rather than a retype:
 

--- a/docs/to-doc-site/creating-thumbnails-interactively.md
+++ b/docs/to-doc-site/creating-thumbnails-interactively.md
@@ -114,6 +114,39 @@ butler-sheet-icons qseow create-sheet-thumbnails --host sense.acme.com -i
 
 Confirming one costs a single keystroke, because the question opens on the value that was already there.
 
+### Skipped does not mean unchecked
+
+A skipped option is still **verified against your server**. Not asking you about it does not mean trusting it: an API key can be revoked, a content library deleted, a certificate moved, long after the `.env` file that names them was written.
+
+The check happens at the point in the conversation where the question would have been asked, and says so:
+
+```
+── Connection ────────────────────────────────────
+
+  ✓ --certfile (from BSI_QSEOW_CST_CERT_FILE) checked
+  ✓ --certkeyfile (from BSI_QSEOW_CST_CERTKEY_FILE) checked
+
+── Sheets ────────────────────────────────────────
+
+  ✓ --contentlibrary (from BSI_QSEOW_CST_CONTENT_LIBRARY) checked
+```
+
+That line is also why the wizard pauses for a moment there — it is contacting your server.
+
+**One check often covers several options**, and each gets its own line. The certificate check needs both paths, so it cannot run until you have given the second one — but it verifies both, and says so. On Qlik Sense Cloud the connection test does the same for `--tenanturl` and `--apikey`: a wrong tenant URL fails it as surely as a revoked key does.
+
+If the check fails, the wizard names the option, the environment variable the value came from, and what is wrong. It then asks you the question after all, opening on the value that failed, so correcting it is an edit rather than a retype:
+
+```
+  ✗ --contentlibrary (from BSI_QSEOW_CST_CONTENT_LIBRARY):
+    Content library 'Deleted last year' does not exist on sense.acme.com.
+    This check also uses these values you supplied: --host, --certfile.
+```
+
+That last line matters when the value being complained about is not the one at fault. A wrong `--host` in the same `.env` file makes the content library check fail too, and no amount of retyping the library name will fix it — press **Ctrl+C**, correct the file, and start again. Only the values this particular check reads are listed, so the line stays short even when your `.env` file sets everything.
+
+Without this, a stale `.env` file failed only once the run had started: on QSEoW, a missing content library aborts after every screenshot has already been taken.
+
 ### What that looks like for app selection
 
 You get the full list of apps from the server, and **the ones you supplied are listed first and already ticked**:

--- a/src/lib/commands/qscloud/__tests__/qscloud_wizard.test.js
+++ b/src/lib/commands/qscloud/__tests__/qscloud_wizard.test.js
@@ -117,6 +117,150 @@ describe('the connection probe', () => {
     });
 });
 
+describe('an API key supplied before the wizard starts', () => {
+    // Issue #975, the Cloud half. A key is a property of the environment, so it
+    // stays answered once supplied - but skipping the question was skipping the
+    // connection test with it, and a key revoked since the .env file was written
+    // failed only once the run started.
+
+    /**
+     * What a run needs when the API key is supplied rather than asked for.
+     *
+     * @param {object} [overrides] - Answers to replace or add.
+     *
+     * @returns {object} Answers for the scripted runtime, with no API key queued.
+     */
+    const withoutKey = (overrides = {}) => {
+        const answers = baseAnswers(overrides);
+        delete answers.apikey;
+
+        return answers;
+    };
+
+    test('is tested rather than trusted, without being asked about', async () => {
+        const runtime = scriptedRuntime(withoutKey());
+
+        await runInteractive({ path: PATH, presetOptions: { apikey: 'from-dot-env' }, runtime });
+
+        expect(qscloudTestConnection).toHaveBeenCalledTimes(1);
+        expect(runtime.asked.map((a) => a.key)).not.toContain('apikey');
+    });
+
+    test('still leaves the pickers a connected tenant to list from', async () => {
+        // The probe is what stashes the client. This is what makes the lazy
+        // `tenantClient` helper the app-selection work needed unnecessary: with
+        // the key checked, the pickers have a client the ordinary way.
+        const runtime = scriptedRuntime(withoutKey());
+
+        await runInteractive({ path: PATH, presetOptions: { apikey: 'from-dot-env' }, runtime });
+
+        const picker = runtime.asked.find((a) => a.key === 'appid');
+
+        expect(listApps).toHaveBeenCalledTimes(1);
+        expect(picker.choices.map((choice) => choice.value)).toEqual(['app-a', 'app-b']);
+    });
+
+    test('becomes a question, opening on the supplied key, when the tenant rejects it', async () => {
+        qscloudTestConnection
+            .mockRejectedValueOnce(new Error('401 Unauthorized'))
+            .mockResolvedValue({ user: 'someone' });
+
+        // The promoted question needs an answer queued: it is asked after all.
+        const runtime = scriptedRuntime(baseAnswers());
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { apikey: 'revoked-key' },
+            presetSources: { apikey: 'env' },
+            runtime,
+        });
+
+        const asked = runtime.asked.filter((a) => a.key === 'apikey');
+
+        expect(asked).toHaveLength(1);
+        expect(asked[0].default).toBe('revoked-key');
+        expect(runtime.output()).toContain('--apikey (from BSI_QSCLOUD_CST_APIKEY)');
+        expect(runtime.output()).toContain('401 Unauthorized');
+    });
+
+    test('says so when the check passes, so a pause on the network is explained', async () => {
+        const runtime = scriptedRuntime(withoutKey());
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { apikey: 'from-dot-env' },
+            presetSources: { apikey: 'env' },
+            runtime,
+        });
+
+        expect(runtime.output()).toContain('--apikey (from BSI_QSCLOUD_CST_APIKEY) checked');
+    });
+
+    test('reports the tenant url as well as the key, on a line each', async () => {
+        // The QSEoW twin of the certificate pair: the connection test proves the
+        // url as surely as the key, so a passing check says both.
+        const answers = baseAnswers();
+        delete answers.tenanturl;
+        delete answers.apikey;
+
+        const runtime = scriptedRuntime(answers);
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { tenanturl: 'acme.eu.qlikcloud.com', apikey: 'from-dot-env' },
+            presetSources: { tenanturl: 'env', apikey: 'env' },
+            runtime,
+        });
+
+        const lines = runtime
+            .output()
+            .split('\n')
+            .filter((text) => text.includes(' checked'));
+
+        expect(lines).toHaveLength(2);
+        expect(lines[0]).toContain('--tenanturl (from BSI_QSCLOUD_CST_TENANTURL) checked');
+        expect(lines[1]).toContain('--apikey (from BSI_QSCLOUD_CST_APIKEY) checked');
+    });
+
+    test('names the other values the check reads, because one may be the real cause', async () => {
+        // The QSEoW twin of this: a wrong tenant URL fails the key check just as
+        // a revoked key does, and re-typing the key can never fix it.
+        qscloudTestConnection
+            .mockRejectedValueOnce(new Error('401 Unauthorized'))
+            .mockResolvedValue({ user: 'someone' });
+
+        const answers = baseAnswers();
+        delete answers.tenanturl;
+
+        const runtime = scriptedRuntime(answers);
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { apikey: 'revoked-key', tenanturl: 'wrong.eu.qlikcloud.com' },
+            runtime,
+        });
+
+        expect(runtime.output()).toContain('This check also uses these values you supplied');
+        expect(runtime.output()).toContain('--tenanturl');
+    });
+
+    test('the corrected answer is what the run uses', async () => {
+        qscloudTestConnection
+            .mockRejectedValueOnce(new Error('401 Unauthorized'))
+            .mockResolvedValue({ user: 'someone' });
+
+        const runtime = scriptedRuntime(baseAnswers({ _review: 'run' }));
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { apikey: 'revoked-key' },
+            runtime,
+        });
+
+        expect(qscloudCreateThumbnails.mock.calls[0][0].apikey).toBe('a-real-key');
+    });
+});
+
 describe('choosing which apps to update', () => {
     test('offers the apps the tenant actually has', async () => {
         const runtime = scriptedRuntime(baseAnswers());

--- a/src/lib/commands/qscloud/__tests__/qscloud_wizard.test.js
+++ b/src/lib/commands/qscloud/__tests__/qscloud_wizard.test.js
@@ -118,7 +118,7 @@ describe('the connection probe', () => {
 });
 
 describe('an API key supplied before the wizard starts', () => {
-    // Issue #975, the Cloud half. A key is a property of the environment, so it
+    // Issue #897, the Cloud half. A key is a property of the environment, so it
     // stays answered once supplied - but skipping the question was skipping the
     // connection test with it, and a key revoked since the .env file was written
     // failed only once the run started.

--- a/src/lib/commands/qscloud/__tests__/qscloud_wizard.test.js
+++ b/src/lib/commands/qscloud/__tests__/qscloud_wizard.test.js
@@ -196,6 +196,49 @@ describe('an API key supplied before the wizard starts', () => {
         expect(runtime.output()).toContain('--apikey (from BSI_QSCLOUD_CST_APIKEY) checked');
     });
 
+    test('is tested before the first question when the tenant url was supplied too', async () => {
+        // The QSEoW twin of checking a supplied content library up front: with
+        // both halves of the connection in .env, a revoked key is reported before
+        // the operator answers anything.
+        let askedWhenProbed;
+        qscloudTestConnection.mockImplementation(async () => {
+            askedWhenProbed = runtime.asked.map((entry) => entry.key);
+
+            return { user: 'someone' };
+        });
+
+        const answers = baseAnswers();
+        delete answers.tenanturl;
+        delete answers.apikey;
+
+        const runtime = scriptedRuntime(answers);
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { tenanturl: 'acme.eu.qlikcloud.com', apikey: 'from-dot-env' },
+            runtime,
+        });
+
+        expect(askedWhenProbed).toEqual([]);
+        expect(runtime.output()).toContain('Checking what you supplied');
+    });
+
+    test('is tested in place when the tenant url still has to be asked', async () => {
+        let askedWhenProbed;
+        qscloudTestConnection.mockImplementation(async () => {
+            askedWhenProbed = runtime.asked.map((entry) => entry.key);
+
+            return { user: 'someone' };
+        });
+
+        const runtime = scriptedRuntime(withoutKey());
+
+        await runInteractive({ path: PATH, presetOptions: { apikey: 'from-dot-env' }, runtime });
+
+        expect(askedWhenProbed).toContain('tenanturl');
+        expect(runtime.output()).not.toContain('Checking what you supplied');
+    });
+
     test('reports the tenant url as well as the key, on a line each', async () => {
         // The QSEoW twin of the certificate pair: the connection test proves the
         // url as surely as the key, so a passing check says both.

--- a/src/lib/commands/qscloud/create-sheet-thumbnails.interactive.js
+++ b/src/lib/commands/qscloud/create-sheet-thumbnails.interactive.js
@@ -48,33 +48,6 @@ const ADVANCED_KEYS = [
     'headless',
 ];
 
-/**
- * The connected tenant the pickers list from.
- *
- * Normally the API key's probe stashes this, which is the cheapest place to
- * build it: the connection has just been tested, so reusing it costs nothing.
- * But a key supplied in `.env` or on the command line is never asked about, so
- * its probe never runs - and the pickers would then have no client at all and
- * degrade to "type an id", which is exactly what they exist to avoid.
- *
- * Building it here on demand keeps the pickers working in that case. A bad key
- * still fails, only at the picker rather than at a prompt that was never shown.
- *
- * @param {object} ctx - Wizard context.
- *
- * @returns {object} A connected QlikSaas client.
- */
-const tenantClient = (ctx) => {
-    if (!ctx.clients?.tenant) {
-        ctx.clients = {
-            ...ctx.clients,
-            tenant: new QlikSaas({ url: ctx.answers.tenanturl, token: ctx.answers.apikey }),
-        };
-    }
-
-    return ctx.clients.tenant;
-};
-
 /** Which section each question belongs under, in the order the sections run. */
 const SECTIONS = [
     ['Connection', CONNECTION_KEYS],
@@ -178,7 +151,7 @@ export default {
             when: (ctx) =>
                 ctx.answers[APP_SOURCE] === APP_SOURCES.GROUPED || isSupplied(answers.collectionid),
             choices: async (ctx) => {
-                const collections = await listCollections(tenantClient(ctx));
+                const collections = await listCollections(ctx.clients.tenant);
                 const picked = collections.map((entry) => ({
                     name: labelForCollection(entry),
                     value: entry.id,
@@ -196,7 +169,8 @@ export default {
             },
             probe: resolvesToApps({
                 groupingKey: 'collectionid',
-                resolve: (ctx) => listAppsByCollection(tenantClient(ctx), ctx.answers.collectionid),
+                resolve: (ctx) =>
+                    listAppsByCollection(ctx.clients.tenant, ctx.answers.collectionid),
                 whenEmpty: (value) => `Collection '${value}' holds no apps.`,
                 whenFound: (count, value) =>
                     `${count} app(s) are in collection '${value}' and will be updated.`,
@@ -209,7 +183,7 @@ export default {
             supplied: answers.appid,
             groupingKey: 'collectionid',
             groupingLabel: GROUPING_LABEL,
-            listApps: (ctx) => listApps(tenantClient(ctx)),
+            listApps: (ctx) => listApps(ctx.clients.tenant),
             label: labelForApp,
         });
 

--- a/src/lib/commands/qscloud/create-sheet-thumbnails.interactive.js
+++ b/src/lib/commands/qscloud/create-sheet-thumbnails.interactive.js
@@ -124,6 +124,11 @@ export default {
                     ? {
                           ...spec,
                           needs: ['tenanturl'],
+                          // The connection test proves both: a wrong tenant url
+                          // fails the request outright, a wrong key fails it with
+                          // a 401. So a passing check has confirmed the url as
+                          // surely as the key, and says so.
+                          checks: ['tenanturl', 'apikey'],
                           probe: async (ctx) => {
                               const saas = new QlikSaas({
                                   url: ctx.answers.tenanturl,

--- a/src/lib/commands/qseow/__tests__/qseow_wizard.test.js
+++ b/src/lib/commands/qseow/__tests__/qseow_wizard.test.js
@@ -125,6 +125,269 @@ describe('the content library probe', () => {
     });
 });
 
+describe('a value supplied before the wizard starts, carrying a probe', () => {
+    // Issue #975. A content library or a certificate path is a property of the
+    // environment, so it stays answered once supplied - but skipping the question
+    // was skipping its check with it, and a `.env` naming a library that has since
+    // been deleted failed only after every other question had been answered.
+
+    /**
+     * What a run needs when the content library is supplied rather than asked for.
+     *
+     * @param {object} [overrides] - Answers to replace or add.
+     *
+     * @returns {object} Answers for the scripted runtime, with no content library queued.
+     */
+    const withoutLibrary = (overrides = {}) => {
+        const answers = baseAnswers(overrides);
+        delete answers.contentlibrary;
+
+        return answers;
+    };
+
+    test('is checked rather than trusted, without being asked about', async () => {
+        const runtime = scriptedRuntime(withoutLibrary());
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { contentlibrary: 'From dot env' },
+            runtime,
+        });
+
+        expect(qseowVerifyContentLibraryExists).toHaveBeenCalledTimes(1);
+        expect(runtime.asked.map((a) => a.key)).not.toContain('contentlibrary');
+    });
+
+    test('is checked only once everything the check reads has been answered', async () => {
+        // The reason the check happens here rather than in a pass before the
+        // first question: this probe opens a QRS connection built from the host,
+        // the certificates and the credentials, none of which a .env supplying
+        // only the library name has provided.
+        const runtime = scriptedRuntime(withoutLibrary());
+
+        // Snapshotted at call time, not read from `mock.calls` afterwards: the
+        // driver hands the probe the live answers object and keeps filling it in,
+        // so inspecting it after the run shows every later answer too - and the
+        // assertion would hold even if these had been answered afterwards, which
+        // is the one thing this test exists to rule out.
+        let seenByProbe;
+        qseowVerifyContentLibraryExists.mockImplementation(async (options) => {
+            seenByProbe = { ...options };
+
+            return true;
+        });
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { contentlibrary: 'From dot env' },
+            runtime,
+        });
+
+        expect(seenByProbe.contentlibrary).toBe('From dot env');
+        expect(seenByProbe.host).toBe('sense.acme.com');
+        expect(seenByProbe.logonpwd).toBe('a-password');
+    });
+
+    test('says so when the check passes, so a pause on the network is explained', async () => {
+        const runtime = scriptedRuntime(withoutLibrary());
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { contentlibrary: 'From dot env' },
+            runtime,
+        });
+
+        // One string, not two `toContain`s: '--contentlibrary' appears in the
+        // opening banner as well, so asserting the two halves separately would
+        // pass even if the confirmation named a different option.
+        expect(runtime.output()).toContain('--contentlibrary checked');
+    });
+
+    test('becomes a question, opening on the supplied value, when the check fails', async () => {
+        qseowVerifyContentLibraryExists.mockResolvedValueOnce(false).mockResolvedValue(true);
+
+        // The promoted question needs an answer queued: it is asked after all.
+        const runtime = scriptedRuntime(baseAnswers());
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { contentlibrary: 'Deleted last year' },
+            runtime,
+        });
+
+        const asked = runtime.asked.filter((a) => a.key === 'contentlibrary');
+
+        expect(asked).toHaveLength(1);
+        // Opened on what was supplied, so correcting it is an edit not a retype.
+        expect(asked[0].default).toBe('Deleted last year');
+        expect(qseowCreateThumbnails).not.toHaveBeenCalled();
+    });
+
+    test('the corrected answer is what the run uses', async () => {
+        qseowVerifyContentLibraryExists.mockResolvedValueOnce(false).mockResolvedValue(true);
+
+        const runtime = scriptedRuntime(
+            baseAnswers({ contentlibrary: 'Butler sheet thumbnails', _review: 'run' })
+        );
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { contentlibrary: 'Deleted last year' },
+            runtime,
+        });
+
+        expect(qseowCreateThumbnails.mock.calls[0][0].contentlibrary).toBe(
+            'Butler sheet thumbnails'
+        );
+    });
+
+    test('names the option and the environment variable the value came from', async () => {
+        // The value is usually in a .env file nobody has opened in months, so
+        // naming the variable is what makes the failure actionable.
+        qseowVerifyContentLibraryExists.mockResolvedValueOnce(false).mockResolvedValue(true);
+
+        // The promoted question needs an answer queued: it is asked after all.
+        const runtime = scriptedRuntime(baseAnswers());
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { contentlibrary: 'Deleted last year' },
+            presetSources: { contentlibrary: 'env' },
+            runtime,
+        });
+
+        const output = runtime.output();
+
+        expect(output).toContain('--contentlibrary (from BSI_QSEOW_CST_CONTENT_LIBRARY)');
+        expect(output).toContain("Content library 'Deleted last year' does not exist");
+    });
+
+    test('names the other values the check reads, because one may be the real cause', async () => {
+        // A wrong --host is what makes this check fail, and re-typing the library
+        // name can never fix it. Without this line the only clue is a message
+        // about a value that is perfectly correct.
+        qseowVerifyContentLibraryExists.mockResolvedValueOnce(false).mockResolvedValue(true);
+
+        const answers = baseAnswers();
+        delete answers.host;
+
+        const runtime = scriptedRuntime(answers);
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { contentlibrary: 'Deleted last year', host: 'wrong.acme.com' },
+            runtime,
+        });
+
+        expect(runtime.output()).toContain('This check also uses these values you supplied');
+        expect(runtime.output()).toContain('--host');
+    });
+
+    test('names only what the check reads, not everything the .env file supplied', async () => {
+        // The list exists to narrow the search. Naming every supplied option is
+        // two dozen flags on the .env workflow this feature is for, which pushes
+        // the actual error off screen and narrows nothing.
+        qseowVerifyContentLibraryExists.mockResolvedValueOnce(false).mockResolvedValue(true);
+
+        const answers = baseAnswers();
+        delete answers.host;
+        delete answers.logonuserid;
+
+        const runtime = scriptedRuntime(answers);
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: {
+                contentlibrary: 'Deleted last year',
+                host: 'wrong.acme.com',
+                // Supplied, but nothing the content library check reads.
+                logonuserid: 'goran',
+            },
+            runtime,
+        });
+
+        const line = runtime
+            .output()
+            .split('\n')
+            .find((text) => text.includes('This check also uses'));
+
+        expect(line).toContain('--host');
+        expect(line).not.toContain('--logonuserid');
+    });
+
+    test('reports both certificate files, on a line each', async () => {
+        // The probe hangs off --certkeyfile only because it is the second of the
+        // pair and cannot run before both paths are known. It checks --certfile
+        // just as thoroughly, and naming only the key file hid that.
+        const answers = baseAnswers();
+        delete answers.certfile;
+        delete answers.certkeyfile;
+
+        const runtime = scriptedRuntime(answers);
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: {
+                certfile: '/certs/client.pem',
+                certkeyfile: '/certs/client_key.pem',
+            },
+            presetSources: { certfile: 'env', certkeyfile: 'env' },
+            runtime,
+        });
+
+        const lines = runtime
+            .output()
+            .split('\n')
+            .filter((text) => text.includes(' checked'));
+
+        expect(lines).toHaveLength(2);
+        expect(lines[0]).toContain('--certfile (from BSI_QSEOW_CST_CERT_FILE) checked');
+        expect(lines[1]).toContain('--certkeyfile (from BSI_QSEOW_CST_CERTKEY_FILE) checked');
+    });
+
+    test('reports only the covered options that were supplied', async () => {
+        // --certfile was typed on screen a moment ago, so confirming it exists
+        // tells the operator nothing they did not just do themselves.
+        const answers = baseAnswers();
+        delete answers.certkeyfile;
+
+        const runtime = scriptedRuntime(answers);
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { certkeyfile: '/certs/client_key.pem' },
+            runtime,
+        });
+
+        const lines = runtime
+            .output()
+            .split('\n')
+            .filter((text) => text.includes(' checked'));
+
+        expect(lines).toHaveLength(1);
+        expect(lines[0]).toContain('--certkeyfile checked');
+    });
+
+    test('checks the certificates supplied for it too', async () => {
+        // The other probe on this wizard, and a local one rather than a network
+        // one - the twin cases have to behave the same way.
+        qseowVerifyCertificatesExist.mockResolvedValueOnce(false).mockResolvedValue(true);
+
+        const answers = baseAnswers({ certkeyfile: './cert/client_key.pem' });
+
+        const runtime = scriptedRuntime(answers);
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { certkeyfile: './moved/client_key.pem' },
+            runtime,
+        });
+
+        expect(qseowVerifyCertificatesExist).toHaveBeenCalled();
+        expect(runtime.output()).toContain('Certificate file(s) not found');
+    });
+});
+
 describe('choosing which apps to update', () => {
     test('offers every app on the server', async () => {
         const runtime = scriptedRuntime(baseAnswers());

--- a/src/lib/commands/qseow/__tests__/qseow_wizard.test.js
+++ b/src/lib/commands/qseow/__tests__/qseow_wizard.test.js
@@ -158,6 +158,63 @@ describe('a value supplied before the wizard starts, carrying a probe', () => {
         expect(runtime.asked.map((a) => a.key)).not.toContain('contentlibrary');
     });
 
+    test('is checked before the first question when its inputs were supplied too', async () => {
+        // The saved-.env case: everything the QRS connection needs is in the
+        // file, so a library that no longer exists can be reported before the
+        // operator answers anything - rather than after the app picker has
+        // fetched and listed several hundred apps.
+        let askedWhenProbed;
+        qseowVerifyContentLibraryExists.mockImplementation(async () => {
+            askedWhenProbed = runtime.asked.map((entry) => entry.key);
+
+            return true;
+        });
+
+        const answers = baseAnswers();
+        const preset = {};
+        for (const key of [
+            'host',
+            'certfile',
+            'certkeyfile',
+            'apiuserdir',
+            'apiuserid',
+            'contentlibrary',
+        ]) {
+            preset[key] = answers[key];
+            delete answers[key];
+        }
+
+        const runtime = scriptedRuntime(answers);
+
+        await runInteractive({ path: PATH, presetOptions: preset, runtime });
+
+        expect(askedWhenProbed).toEqual([]);
+        expect(runtime.output()).toContain('Checking what you supplied');
+    });
+
+    test('is checked in place when one of its inputs still has to be asked', async () => {
+        // The objection that ruled out an unconditional up-front pass: this probe
+        // opens a QRS connection built from the host, so with the host still to
+        // come it has to wait for its own position in the conversation.
+        let askedWhenProbed;
+        qseowVerifyContentLibraryExists.mockImplementation(async () => {
+            askedWhenProbed = runtime.asked.map((entry) => entry.key);
+
+            return true;
+        });
+
+        const runtime = scriptedRuntime(withoutLibrary());
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { contentlibrary: 'From dot env' },
+            runtime,
+        });
+
+        expect(askedWhenProbed).toContain('host');
+        expect(runtime.output()).not.toContain('Checking what you supplied');
+    });
+
     test('is checked only once everything the check reads has been answered', async () => {
         // The reason the check happens here rather than in a pass before the
         // first question: this probe opens a QRS connection built from the host,

--- a/src/lib/commands/qseow/__tests__/qseow_wizard.test.js
+++ b/src/lib/commands/qseow/__tests__/qseow_wizard.test.js
@@ -126,7 +126,7 @@ describe('the content library probe', () => {
 });
 
 describe('a value supplied before the wizard starts, carrying a probe', () => {
-    // Issue #975. A content library or a certificate path is a property of the
+    // Issue #897. A content library or a certificate path is a property of the
     // environment, so it stays answered once supplied - but skipping the question
     // was skipping its check with it, and a `.env` naming a library that has since
     // been deleted failed only after every other question had been answered.

--- a/src/lib/commands/qseow/create-sheet-thumbnails.interactive.js
+++ b/src/lib/commands/qseow/create-sheet-thumbnails.interactive.js
@@ -122,6 +122,13 @@ export default {
                     ? {
                           ...spec,
                           needs: ['certfile'],
+                          // Both paths, because the helper checks both and this
+                          // question only carries the probe by virtue of being
+                          // the second of the pair - it cannot run until the key
+                          // file is known. Reporting only `--certkeyfile` as
+                          // checked hid the fact that `--certfile` had been
+                          // verified just as thoroughly.
+                          checks: ['certfile', 'certkeyfile'],
                           probe: async (ctx) => {
                               const ok = await qseowVerifyCertificatesExist(ctx.answers);
 
@@ -193,6 +200,20 @@ export default {
 
         const contentLibrary = {
             ...byKey.contentlibrary,
+            // What the probe actually reads, and therefore what can be at fault
+            // when it fails. `setupQseowQrsConnection` builds the QRS connection
+            // from exactly these, so when the library is supplied in a `.env`
+            // file and the check fails, these are the other values worth
+            // pointing at - a wrong host fails this check just as surely as a
+            // deleted library does.
+            //
+            // `qrsport` is read too, but it is deliberately absent: it lives in
+            // the Advanced section, which is asked *after* this question, so
+            // declaring it here would fail `assertNeedsAreSatisfiable` - the
+            // ordering graph correctly reporting issue #1047, where this check
+            // reaches QRS with `qrsport` undefined rather than with whatever the
+            // operator is about to set. Add it here as part of fixing that.
+            needs: ['host', 'certfile', 'certkeyfile', 'apiuserdir', 'apiuserid'],
             probe: async (ctx) => {
                 const exists = await qseowVerifyContentLibraryExists(ctx.answers);
 

--- a/src/lib/interactive/__tests__/launch.test.js
+++ b/src/lib/interactive/__tests__/launch.test.js
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
-import { presetOptionsFrom } from '../launch.js';
+import { presetOptionsFrom, presetSourcesFrom } from '../launch.js';
 import { addInteractiveOption } from '../interactive-option.js';
 import { buildQseowCommand } from '../../commands/qseow/index.js';
 
@@ -93,5 +93,50 @@ describe('presetOptionsFrom', () => {
 
     test('tolerates being handed no command at all', () => {
         expect(presetOptionsFrom(undefined)).toEqual({});
+    });
+});
+
+describe('presetSourcesFrom', () => {
+    // What lets a failing check name the environment variable behind the value.
+    // Read from Commander rather than inferred, because `.env` is loaded into
+    // process.env: testing whether BSI_* is set cannot tell a value that came
+    // from the file apart from one typed on the command line with a stale
+    // variable behind it - and that is the case an operator most needs named
+    // correctly.
+
+    test('reports a value given on the command line as cli', () => {
+        const sources = presetSourcesFrom(parseQseow(['--host', 'sense.acme.com', '-i']));
+
+        expect(sources.host).toBe('cli');
+    });
+
+    test('reports a value given through a BSI_* variable as env', () => {
+        process.env.BSI_QSEOW_CST_API_USER_DIR = 'INTERNAL';
+
+        const sources = presetSourcesFrom(parseQseow(['-i']));
+
+        expect(sources.apiuserdir).toBe('env');
+    });
+
+    test('the command line wins over a variable that is also set', () => {
+        // The misdiagnosis this exists to prevent: naming the variable when the
+        // value in force came from the command line.
+        process.env.BSI_QSEOW_CST_HOST = 'stale.acme.com';
+
+        const command = parseQseow(['--host', 'sense.acme.com', '-i']);
+
+        expect(presetOptionsFrom(command).host).toBe('sense.acme.com');
+        expect(presetSourcesFrom(command).host).toBe('cli');
+    });
+
+    test('leaves defaults out, so only supplied values are named', () => {
+        const sources = presetSourcesFrom(parseQseow(['-i']));
+
+        expect(sources).not.toHaveProperty('engineport');
+        expect(sources).not.toHaveProperty('contentlibrary');
+    });
+
+    test('tolerates being handed no command at all', () => {
+        expect(presetSourcesFrom(undefined)).toEqual({});
     });
 });

--- a/src/lib/interactive/ask-questions.js
+++ b/src/lib/interactive/ask-questions.js
@@ -116,6 +116,110 @@ const runProbe = async (spec, ctx) => {
     }
 };
 
+/**
+ * Name a supplied value the way the operator will recognise it.
+ *
+ * The environment variable rather than the flag whenever the value came from one,
+ * because that is what has to be edited to fix it - and the file it lives in is
+ * usually one nobody has opened in months.
+ *
+ * @param {object} [info] - What the driver recorded about a supplied value.
+ *
+ * @returns {string} The flag, and where the value came from when that is known.
+ */
+const describeSupplied = (info) => {
+    if (!info) {
+        return '';
+    }
+
+    if (info.source === 'env' && info.envVar) {
+        return `${info.flag} (from ${info.envVar})`;
+    }
+
+    return info.source === 'cli' ? `${info.flag} (from the command line)` : info.flag;
+};
+
+/**
+ * Report the supplied values a check has just confirmed.
+ *
+ * One line each, because a probe often covers more than the question it hangs
+ * off: `qseowVerifyCertificatesExist` needs both certificate paths, so it cannot
+ * run until the second one is known and is therefore attached to `certkeyfile` -
+ * but it checks `certfile` just as thoroughly, and a single line naming only the
+ * key file under-reports what was verified. A spec says what it covers with
+ * `checks`; the default is the question's own key.
+ *
+ * Only the covered options that were actually supplied are named. One that was
+ * answered on screen a moment ago needs no confirmation that it exists - the
+ * operator just typed it - and this report is about the values they were not
+ * asked about.
+ *
+ * @param {import('./option-introspect.js').QuestionSpec} spec - The question that was checked.
+ * @param {object} ctx - Wizard context, carrying what the driver recorded about supplied values.
+ *
+ * @returns {string} The lines to write.
+ */
+const describePassedCheck = (spec, ctx) => {
+    const info = ctx.supplied ?? {};
+    const covered = (spec.checks ?? [spec.key]).filter((key) => key in info);
+    const named = covered.length > 0 ? covered : [spec.key];
+
+    return named
+        .map((key) => `  ${ctx.symbols.done} ${describeSupplied(info[key]) || key} checked\n`)
+        .join('');
+};
+
+/**
+ * Report a supplied value that failed its check.
+ *
+ * Names the other values the check reads, when those were supplied rather than
+ * asked about, because the real culprit is often one of them: a wrong `--host`
+ * is what makes the content library check fail, and re-typing the library name
+ * can never fix it. Without this line the only clue is a message about a value
+ * that is perfectly correct.
+ *
+ * Taken from the question's declared `needs` rather than from everything that
+ * was supplied. Naming all of them was the first attempt, and on the `.env`
+ * workflow this feature exists for that is two dozen flags wrapped over several
+ * rows, pushing the actual error off screen - a list that narrows nothing is
+ * worse than no list.
+ *
+ * @param {import('./option-introspect.js').QuestionSpec} spec - The question that was checked.
+ * @param {string} failure - The probe's message.
+ * @param {object} ctx - Wizard context, carrying what the driver recorded about supplied values.
+ *
+ * @returns {string} The block to write.
+ */
+const describeFailedCheck = (spec, failure, ctx) => {
+    const info = ctx.supplied ?? {};
+    const others = (spec.needs ?? []).filter((key) => key in info).map((key) => info[key].flag);
+
+    // `theme.style.error` supplies the ✗ itself, so the heading carries it and
+    // the two lines below are left plain - three of them in a row reads as three
+    // separate failures rather than as one explained.
+    const lines = [
+        `  ${ctx.theme.style.error(`${describeSupplied(info[spec.key]) || spec.key}:`)}`,
+        `    ${failure}`,
+    ];
+
+    if (others.length > 0) {
+        // Nothing is said when none of them were supplied: everything this check
+        // reads was then answered on screen a moment ago, so there is no unseen
+        // value to point at.
+        //
+        // "Uses", not "any of them could be the real cause". Measured against a
+        // live QRS: it answers 200 to a `/contentlibrary` GET carrying a
+        // nonsense `X-Qlik-User`, so `apiuserdir` and `apiuserid` are read by
+        // this check but cannot be what failed it. Naming them as suspects would
+        // send an operator to edit values that are fine.
+        lines.push(
+            `    ${ctx.theme.style.help(`This check also uses these values you supplied: ${others.join(', ')}.`)}`
+        );
+    }
+
+    return `${lines.join('\n')}\n`;
+};
+
 // The text shown for a choice, which may be a bare value or a {name, value}.
 const labelOf = (choice) =>
     typeof choice === 'object' && choice !== null ? choice.name : String(choice);
@@ -268,6 +372,31 @@ export const askQuestions = async (specs, ctx = {}, { runtime = defaultRuntime }
             currentGroup = spec.group;
             const rule = symbols.rule.repeat(Math.max(3, 46 - spec.group.length));
             runtime.write(`\n${symbols.rule.repeat(2)} ${spec.group} ${rule}\n`);
+        }
+
+        // Already answered, so check the answer instead of asking for it. The
+        // value is in `answers` already - the driver seeds them from what was
+        // supplied - so the probe has everything it needs.
+        if (spec.checkOnly) {
+            runtime.write('\n');
+
+            const failure = await runProbe(spec, context);
+
+            if (!failure) {
+                // Said out loud rather than passed over in silence. A probe
+                // reaches the network, so the wizard pauses here; without a line
+                // the pause has no explanation, and the operator has no way to
+                // tell a check that passed from one that never ran.
+                runtime.write(describePassedCheck(spec, context));
+
+                continue;
+            }
+
+            // Fall through and ask it after all. A value that cannot be used is
+            // worth one question however it arrived, and the spec is already
+            // opened on the supplied value, so correcting it is an edit rather
+            // than a retype. From here it behaves as any other question does.
+            runtime.write(describeFailedCheck(spec, failure, context));
         }
 
         const { choices, spec: asked } = await resolveChoices(spec, context);

--- a/src/lib/interactive/index.js
+++ b/src/lib/interactive/index.js
@@ -12,6 +12,9 @@ import { formatReviewTable } from './review-table.js';
 import { saveEnvFile, ENV_FILE } from './save-env-file.js';
 import { openingOn } from './spec-ops.js';
 
+/** Heading for the checks that run before the first question is asked. */
+const CHECKED_UP_FRONT = 'Checking what you supplied';
+
 /** What the review step can decide. */
 const REVIEW_CHOICES = [
     { name: 'Run it', value: 'run' },
@@ -201,6 +204,38 @@ export const runInteractive = async ({
         )
         .map((spec) => (checkOnly(spec) ? { ...spec, checkOnly: true } : spec));
 
+    // A check whose every input was supplied too can run before the first
+    // question, and should.
+    //
+    // The objection to checking everything up front is that a probe reads more
+    // than its own answer, so a `.env` supplying only the content library name
+    // would fail a check on a value that is fine. That objection is exactly
+    // `needs`, and it disappears when those keys were supplied as well - which is
+    // the saved-`.env` case this feature is for, and the one the wizard itself
+    // creates through "Save the answers to .env".
+    //
+    // What it buys is the whole point of probing: on a full `.env` the content
+    // library check used to fire after the app picker had fetched and listed
+    // several hundred apps. Now a library that no longer exists is reported
+    // before the first question, and the run becomes "verify the environment,
+    // then ask about this run".
+    //
+    // A question carrying `when` is left where it is regardless: its condition is
+    // written against answers that may not have been given yet, and evaluating it
+    // early would read a blank.
+    const upFront = (spec) =>
+        spec.checkOnly && !spec.when && (spec.needs ?? []).every((key) => key in presetOptions);
+
+    // Re-grouped rather than specially cased. Everything downstream - the
+    // heading, the probe, the promotion to a real question on failure - already
+    // works off order and `group`, so moving these to the front under one heading
+    // is the whole change. `specs` is untouched, so the review table and the
+    // echoed command line are unaffected.
+    const ordered = [
+        ...asked.filter(upFront).map((spec) => ({ ...spec, group: CHECKED_UP_FRONT })),
+        ...asked.filter((spec) => !upFront(spec)),
+    ];
+
     // Named by flag rather than by storage key, because the flag is what the
     // user typed. Secrets are named but never shown.
     const nameOf = (spec) => spec.option?.long ?? spec.key;
@@ -257,7 +292,7 @@ export const runInteractive = async ({
         const raw = await askQuestions(
             // Seeded with what is already known, so a later `when` or `choices`
             // sees the pre-filled answers as well as the typed ones.
-            asked,
+            ordered,
             { symbols, theme, answers: { ...presetOptions }, supplied: suppliedInfo },
             { runtime }
         );

--- a/src/lib/interactive/index.js
+++ b/src/lib/interactive/index.js
@@ -176,7 +176,7 @@ export const runInteractive = async ({
     // stale API key or a moved certificate is reported where it can be fixed,
     // rather than after every other question has been answered and the run
     // confirmed. Skipping the question was skipping the check with it, which is
-    // exactly the failure probes were added to prevent (issue #975).
+    // exactly the failure probes were added to prevent (issue #897).
     //
     // Checked in place rather than in a pass before the first question, because
     // a probe reads more than its own answer: `qseowVerifyContentLibraryExists`

--- a/src/lib/interactive/index.js
+++ b/src/lib/interactive/index.js
@@ -80,6 +80,8 @@ const review = async ({ path, specs, answers, runtime, theme, symbols }) => {
  * @param {object} args - Arguments.
  * @param {string} args.path - Command path, e.g. `browser uninstall`.
  * @param {object} [args.presetOptions] - Answers already known, used as starting values.
+ * @param {object} [args.presetSources] - Where each of those came from, `cli` or `env`, keyed the
+ *     same way. Used to name the environment variable behind a value whose check fails.
  * @param {object} [args.runtime] - Prompt runtime. Injectable for tests.
  * @param {string} [args.cwd] - Directory a saved `.env` is written to. Injectable for tests.
  *
@@ -89,6 +91,7 @@ const review = async ({ path, specs, answers, runtime, theme, symbols }) => {
 export const runInteractive = async ({
     path,
     presetOptions = {},
+    presetSources = {},
     runtime = defaultRuntime,
     cwd = process.cwd(),
 } = {}) => {
@@ -165,14 +168,38 @@ export const runInteractive = async ({
         ...refined.filter((spec) => spec.perRun).map((spec) => spec.key),
     ]);
 
+    // A supplied answer that carries a probe is checked rather than trusted.
+    //
+    // Not asked - it stays a property of the environment, and re-asking it is
+    // the tedium `-i` exists to remove - but the probe is the whole reason the
+    // wizard beats the plain CLI: a content library that no longer exists, a
+    // stale API key or a moved certificate is reported where it can be fixed,
+    // rather than after every other question has been answered and the run
+    // confirmed. Skipping the question was skipping the check with it, which is
+    // exactly the failure probes were added to prevent (issue #975).
+    //
+    // Checked in place rather than in a pass before the first question, because
+    // a probe reads more than its own answer: `qseowVerifyContentLibraryExists`
+    // opens a QRS connection built from the host, the certificates and the
+    // credentials. Run up front, against a `.env` supplying only the library
+    // name, it would fail on a value that is perfectly good. At its own position
+    // in the conversation everything it reads has been answered or supplied.
+    const checkOnly = (spec) =>
+        spec.key in presetOptions && !alwaysAsk.has(spec.key) && Boolean(spec.probe);
+
     // Opened on whatever was supplied, so asking again costs a keystroke rather
     // than a retype. Done here rather than in each wizard: the driver is what
-    // decided to ask, so it is what owes the pre-fill.
+    // decided to ask, so it is what owes the pre-fill. A checked question gets
+    // it too - if its check fails it becomes a real question, and it should open
+    // on the value being complained about.
     const asked = refined
-        .filter((spec) => !(spec.key in presetOptions) || alwaysAsk.has(spec.key))
+        .filter(
+            (spec) => !(spec.key in presetOptions) || alwaysAsk.has(spec.key) || checkOnly(spec)
+        )
         .map((spec) =>
             spec.key in presetOptions ? openingOn(spec, presetOptions[spec.key]) : spec
-        );
+        )
+        .map((spec) => (checkOnly(spec) ? { ...spec, checkOnly: true } : spec));
 
     // Named by flag rather than by storage key, because the flag is what the
     // user typed. Secrets are named but never shown.
@@ -180,6 +207,27 @@ export const runInteractive = async ({
     const supplied = specs.filter((spec) => spec.key in presetOptions);
     const prefilled = supplied.filter((spec) => !alwaysAsk.has(spec.key)).map(nameOf);
     const overridden = supplied.filter((spec) => alwaysAsk.has(spec.key)).map(nameOf);
+
+    // What a failing check needs in order to be actionable: the flag the user
+    // typed, and where the value came from. Naming the environment variable
+    // matters more than naming the flag here - the value is usually in a `.env`
+    // file the operator has not looked at in months, and "which of my settings
+    // is this?" is the question they are about to ask.
+    //
+    // Only the values that were not asked about, because those are the ones the
+    // operator has not just seen on screen.
+    const suppliedInfo = Object.fromEntries(
+        supplied
+            .filter((spec) => !alwaysAsk.has(spec.key))
+            .map((spec) => [
+                spec.key,
+                {
+                    flag: nameOf(spec),
+                    source: presetSources[spec.key],
+                    envVar: spec.option?.envVar,
+                },
+            ])
+    );
 
     // Said once, up front. There is no way back to a previous question - the
     // prompt library has no such gesture - so the two things a user can do
@@ -210,7 +258,7 @@ export const runInteractive = async ({
             // Seeded with what is already known, so a later `when` or `choices`
             // sees the pre-filled answers as well as the typed ones.
             asked,
-            { symbols, theme, answers: { ...presetOptions } },
+            { symbols, theme, answers: { ...presetOptions }, supplied: suppliedInfo },
             { runtime }
         );
         const answers = {

--- a/src/lib/interactive/launch.js
+++ b/src/lib/interactive/launch.js
@@ -6,11 +6,12 @@ import { runInteractive } from './index.js';
 import { isInteractiveOption } from './interactive-option.js';
 
 /**
- * The answers a wizard should start from, taken from what was already supplied.
+ * Every option the user actually supplied, with its value and where it came from.
  *
- * This is what makes `-i` compose rather than merely exist:
- * `bsi qseow create-sheet-thumbnails --host sense.acme.com -i` should ask for
- * everything *except* the host.
+ * One definition of "supplied", read once. The two exported maps below are keyed
+ * identically by construction, which matters: the wizard looks a value up in one
+ * and its origin in the other, and a key present in only one would name an option
+ * with no origin - or leave a supplied value unexplained.
  *
  * `getOptionValueSource()` is Commander's own record of where each value came
  * from, so no guessing is involved. Only `cli` and `env` count as supplied - a
@@ -20,10 +21,10 @@ import { isInteractiveOption } from './interactive-option.js';
  *
  * @param {import('commander').Command} command - The parsed command.
  *
- * @returns {object} Answers keyed by option attribute name.
+ * @returns {Array<[string, {value: unknown, source: string}]>} One entry per supplied option.
  */
-export const presetOptionsFrom = (command) => {
-    const presets = {};
+const suppliedEntries = (command) => {
+    const entries = [];
 
     for (const option of command?.options ?? []) {
         // The flag that started the wizard is not an answer to anything, and
@@ -37,12 +38,43 @@ export const presetOptionsFrom = (command) => {
         const source = command.getOptionValueSource(key);
 
         if (source === 'cli' || source === 'env') {
-            presets[key] = command.getOptionValue(key);
+            entries.push([key, { value: command.getOptionValue(key), source }]);
         }
     }
 
-    return presets;
+    return entries;
 };
+
+/**
+ * The answers a wizard should start from, taken from what was already supplied.
+ *
+ * This is what makes `-i` compose rather than merely exist:
+ * `bsi qseow create-sheet-thumbnails --host sense.acme.com -i` should ask for
+ * everything *except* the host.
+ *
+ * @param {import('commander').Command} command - The parsed command.
+ *
+ * @returns {object} Answers keyed by option attribute name.
+ */
+export const presetOptionsFrom = (command) =>
+    Object.fromEntries(suppliedEntries(command).map(([key, { value }]) => [key, value]));
+
+/**
+ * Where each supplied answer came from, `cli` or `env`.
+ *
+ * Read from Commander rather than inferred: `globals.js` loads `.env` into
+ * `process.env`, so testing whether an option's `BSI_*` variable is set cannot
+ * tell a value that came from the file apart from one typed on the command line
+ * that happens to have a stale variable behind it. That is precisely the case an
+ * operator needs named correctly, because it is the one they will otherwise
+ * misdiagnose.
+ *
+ * @param {import('commander').Command} command - The parsed command.
+ *
+ * @returns {object} `cli` or `env` per option attribute name, for supplied options only.
+ */
+export const presetSourcesFrom = (command) =>
+    Object.fromEntries(suppliedEntries(command).map(([key, { source }]) => [key, source]));
 
 /**
  * Run a leaf command's wizard instead of the command itself.
@@ -70,6 +102,7 @@ export const launchInteractive = async (logPrefix, path, command) =>
                 return await runInteractive({
                     path,
                     presetOptions: presetOptionsFrom(command),
+                    presetSources: presetSourcesFrom(command),
                 });
             } catch (err) {
                 if (isPromptCancellation(err)) {

--- a/src/lib/interactive/option-introspect.js
+++ b/src/lib/interactive/option-introspect.js
@@ -22,6 +22,12 @@ const SECRET_KEYS = new Set(BSI_SECRET_KEYS.map((key) => key.toLowerCase()));
  * @property {QuestionSpec} [fallback] - Used when an async `choices` throws.
  * @property {string[]} [replaces] - Real option keys a synthetic question collects between them, so
  *     the wizard knows a value supplied for one of them is asked about rather than skipped.
+ * @property {boolean} [checkOnly] - Set by the driver on a question whose answer was already
+ *     supplied but which carries a `probe`. The probe runs where the question would have been
+ *     asked; only if it fails is the question put to the user after all.
+ * @property {string[]} [checks] - Option keys this question's `probe` verifies, when it covers more
+ *     than its own. A probe needing two answers hangs off the second of them, so the question it is
+ *     attached to is not the whole of what it checks. Defaults to `[key]`.
  * @property {import('commander').Option} [option] - The option this was derived from.
  */
 


### PR DESCRIPTION
The wizard attaches probes to questions so a wrong answer is reported at the prompt where it was typed, rather than after every other question has been answered. But a value supplied on the command line or in a `.env` file was dropped from the questions — and dropping the question dropped its probe with it.

So a `.env` naming a content library deleted months ago was not reported at all. The operator answered everything else, confirmed, and the run failed after every screenshot had been taken. That is precisely the failure the probes exist to prevent.

Part of #897.

## What changes

A supplied value keeps its probe. The question is still not asked — it describes the environment, and re-asking it is the tedium `-i` exists to remove — but the check runs. Only if it fails does the question get put to the operator, opening on the value that failed, so correcting it is an edit rather than a retype.

**Checks run before the first question when every value they need was supplied too.** That is the saved-`.env` case, and the one the wizard itself creates through "Save the answers to .env":

```
── Checking what you supplied ────────────────────

  ✓ --certfile (from BSI_QSEOW_CST_CERT_FILE) checked
  ✓ --certkeyfile (from BSI_QSEOW_CST_CERTKEY_FILE) checked

  ✓ --contentlibrary (from BSI_QSEOW_CST_CONTENT_LIBRARY) checked
```

A check whose inputs are not all supplied waits for its own position instead — the content library probe builds a QRS connection from the host and certificates, so with the host still to be typed it cannot run early.

On failure:

```
  ✗ --contentlibrary (from BSI_QSEOW_CST_CONTENT_LIBRARY):
    Content library 'abc 123' does not exist on sense.acme.com.
    This check also uses these values you supplied: --host, --certfile, --certkeyfile, --apiuserdir, --apiuserid.
```

## Two declarations, because they are not the same thing

- **`needs`** — what a check *reads*. Used to decide whether it can run early, and to name the other supplied values in play when it fails. Naming everything supplied was the first attempt and is two dozen flags on the `.env` workflow this is for, which pushes the actual error off screen.
- **`checks`** — what a check *verifies*. The certificate probe hangs off `--certkeyfile` only because it cannot run until the second path is known, but it verifies `--certfile` just as thoroughly; both are reported, on a line each.

Keeping them apart matters. Measured against a live QSEoW server: QRS answers `200` to a `/contentlibrary` GET carrying `X-Qlik-User: UserDirectory=NOPE; UserId=nosuchuser`, so the content library check *reads* `--apiuserid` but does not *validate* it. It is named as read, never as a suspect.

Where a value came from is read from Commander rather than inferred: `globals.js` loads `.env` into `process.env`, so testing whether a `BSI_*` variable is set cannot tell a value that came from the file apart from one typed on the command line with a stale variable behind it — the one case an operator most needs named correctly.

## Also

`tenantClient()` in the Cloud wizard is removed. It built a client on demand because a supplied API key was never probed, so nothing stashed one and the pickers degraded to "type an id". A supplied key is now checked, and that check stashes the client the ordinary way.

## Verification

- 92 suites, 2565 tests, lint clean.
- Rendered transcripts read directly for the passing and failing paths, both platforms — which is how a doubled `✗` glyph was caught (`theme.style.error` already prepends the symbol).
- Both wizard suites carry the same cases; the twins do not drift.
- Ordering assertions capture what had been asked *at probe time* from inside the mock. Reading `mock.calls` afterwards proves nothing: the driver hands the probe the live answers object and keeps filling it in.

**Verified against a live QSEoW server.** With `BSI_QSEOW_CST_CONTENT_LIBRARY` set to a library that does not exist, and the rest of the connection in the same `.env`:

```
── Checking what you supplied ────────────────────

  ✓ --certfile (from BSI_QSEOW_CST_CERT_FILE) checked
  ✓ --certkeyfile (from BSI_QSEOW_CST_CERTKEY_FILE) checked

  ✗ --contentlibrary (from BSI_QSEOW_CST_CONTENT_LIBRARY):
    Content library 'abc 12' does not exist on 192.168.100.109.
    This check also uses these values you supplied: --host, --certfile, --certkeyfile, --apiuserdir, --apiuserid.

? Qlik Sense content library to which thumbnails will be uploaded (abc 12)
```

The check reached QRS and reported before a single question was asked, and the promoted prompt opened on the value that failed. With a library that does exist, all three checks pass and nothing is asked until app selection.

## Found along the way, filed not fixed

- #1047 — the content library check reaches QRS with `qrsport` undefined, so it always uses the default port whatever `--qrsport` says.
- #1048 — nothing can verify `--logonpwd` without launching a browser, so a wrong password still fails late.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
