### PR TITLE
Make --qrsport actually apply to QRS connections

### DIFF
--- a/src/lib/qseow/__tests__/qseow_contentlibrary.test.js
+++ b/src/lib/qseow/__tests__/qseow_contentlibrary.test.js
@@ -9,7 +9,7 @@ jest.unstable_mockModule('qrs-interact', () => ({ default: qrsInteract }));
 
 const setupQseowQrsConnection = jest
     .fn()
-    .mockReturnValue({ hostname: 'sense.example.com', portnumber: 4242 });
+    .mockReturnValue({ hostname: 'sense.example.com', portNumber: 4242 });
 
 jest.unstable_mockModule('../qseow-qrs.js', () => ({ setupQseowQrsConnection }));
 
@@ -30,7 +30,7 @@ const OPTIONS = { contentlibrary: 'BSI thumbnails' };
 
 beforeEach(() => {
     jest.clearAllMocks();
-    setupQseowQrsConnection.mockReturnValue({ hostname: 'sense.example.com', portnumber: 4242 });
+    setupQseowQrsConnection.mockReturnValue({ hostname: 'sense.example.com', portNumber: 4242 });
 });
 
 describe('qseowVerifyContentLibraryExists', () => {
@@ -119,7 +119,7 @@ describe('qseowVerifyContentLibraryExists', () => {
         expect(setupQseowQrsConnection).toHaveBeenCalledWith(OPTIONS);
         expect(qrsInteract).toHaveBeenCalledWith({
             hostname: 'sense.example.com',
-            portnumber: 4242,
+            portNumber: 4242,
         });
     });
 

--- a/src/lib/qseow/__tests__/qseow_qrs.test.js
+++ b/src/lib/qseow/__tests__/qseow_qrs.test.js
@@ -1,5 +1,7 @@
 import { jest, describe, test, expect } from '@jest/globals';
 import upath from 'upath';
+import extend from 'extend';
+import qrsInteractDefaults from 'qrs-interact/config/config.js';
 
 const BSI_EXECUTABLE_PATH = '/opt/butler-sheet-icons';
 
@@ -30,7 +32,26 @@ describe('setupQseowQrsConnection', () => {
         const config = setupQseowQrsConnection(BASE_OPTIONS);
 
         expect(config.hostname).toBe('sense.example.com');
-        expect(config.portnumber).toBe(4242);
+        expect(config.portNumber).toBe(4242);
+    });
+
+    test('the port survives the merge qrs-interact does with its own defaults', () => {
+        // The test that was missing. The old assertions checked the key this
+        // function *produces* against itself, so a spelling qrs-interact does not
+        // read passed happily: `portnumber` was merged in as a second key and the
+        // library went on using its own default of 4242, which made --qrsport a
+        // no-op on the command line as well as in the wizard.
+        //
+        // This asserts the contract instead - the merge the library actually
+        // performs, against the defaults it actually ships - so a re-typo fails
+        // here rather than silently on a customer's non-standard port.
+        const merged = extend(
+            true,
+            { ...qrsInteractDefaults },
+            setupQseowQrsConnection({ ...BASE_OPTIONS, qrsport: '4999' })
+        );
+
+        expect(merged.portNumber).toBe('4999');
     });
 
     test('always connects directly to QRS, with no virtual proxy', () => {
@@ -104,7 +125,7 @@ describe('setupQseowQrsConnection', () => {
             'certificates',
             'headers',
             'hostname',
-            'portnumber',
+            'portNumber',
             'virtualProxyPrefix',
         ]);
     });

--- a/src/lib/qseow/qseow-qrs.js
+++ b/src/lib/qseow/qseow-qrs.js
@@ -28,7 +28,15 @@ export const setupQseowQrsConnection = (options) => {
     // Always connect directly to QRS, i.e. with virtual proxy ''
     return {
         hostname: options.host,
-        portnumber: options.qrsport,
+        // `portNumber`, capital N. qrs-interact merges this object over its own
+        // defaults with `extend`, which matches keys literally, then reads
+        // `localConfig.portNumber` - so the lowercase spelling this carried until
+        // now was added as a second, unread key while the default 4242 survived
+        // underneath it. `--qrsport` therefore did nothing at all, on the command
+        // line as well as in the wizard: verified against a live server, a QRS
+        // call with `--qrsport 9999` succeeded and returned the same 15 content
+        // libraries as port 4242.
+        portNumber: options.qrsport,
         virtualProxyPrefix: '',
         certificates: {
             certFile,


### PR DESCRIPTION
`setupQseowQrsConnection()` returned the QRS port under the key `portnumber`. `qrs-interact` reads `portNumber` — capital N — and its factory merges our object over its own defaults with `extend(true, ...)`, which matches keys literally. So the lowercase spelling was added as a second, never-read key while the library went on using its shipped default of `4242`.

**`--qrsport` therefore did nothing at all.** Not only in the interactive wizard: every QRS call in the product goes through this function — app lookup, content library, upload, process-app — so the plain CLI ignored it too. Anyone running QRS on a non-default port could not use Butler Sheet Icons, and the option that exists to fix that was silently inert.

Closes #1050.

## Verified against a live server

QSEoW with QRS on the default 4242, asking for a port nothing listens on:

**Before**

```
KEY HANDED OVER : [ 'portnumber' ] = 9999
RESULT          : SUCCEEDED with qrsport=9999 -> port ignored, went to 4242
LIBRARIES       : 15
```

**After**

```
  qrsport=9999 -> refused (QRS request error:Error: connect ECONNREFUSED 192.168.100.10)
  qrsport=4242 -> SUCCESS, 15 libraries
```

## Why the tests did not catch it

They asserted `config.portnumber` — this function's own output, checked against itself. One was even named *"returns only the keys qrs-interact consumes"* and listed the misspelling, which is exactly the claim that was false. A test written against our own output cannot detect a mismatch with the library's input contract.

The replacement asserts the contract: it performs the same `extend()` merge over `qrs-interact`'s shipped defaults and checks the port survives it. Re-introducing the typo fails it with `Expected "4999", Received 4242` — confirmed by reverting the fix and watching it go red.

## Upgrade note

After this, `--qrsport` is honoured. Anyone who set it to a wrong value while their QRS actually listens on 4242 has been working by accident and will now get `ECONNREFUSED`. The fix on their side is to correct or remove `--qrsport` / `BSI_QSEOW_CST_QRS_PORT`. Worth a line in the release notes.

## Scope checked

`--engineport` is correct — `SenseUtilities.buildUrl()` genuinely takes `port`. This was the only instance of the mismatch.

92 suites, 2570 tests, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
