### PR TITLE
Stop promising a pre-fill that masked credential prompts cannot show

### DIFF
--- a/docs/to-doc-site/creating-thumbnails-interactively.md
+++ b/docs/to-doc-site/creating-thumbnails-interactively.md
@@ -137,7 +137,7 @@ Those lines are also why the wizard pauses for a moment — it is contacting you
 
 **One check often covers several options**, and each gets its own line. The certificate check needs both paths and verifies both, and says so rather than naming only the key file. On Qlik Sense Cloud the connection test does the same for `--tenanturl` and `--apikey`: a wrong tenant URL fails it as surely as a revoked key does.
 
-If the check fails, the wizard names the option, the environment variable the value came from, and what is wrong. It then asks you the question after all, opening on the value that failed, so correcting it is an edit rather than a retype:
+If the check fails, the wizard names the option, the environment variable the value came from, and what is wrong. It then asks you the question after all, opening on the value that failed, so correcting it is an edit rather than a retype — except for a credential such as `--apikey`, which is asked as a masked prompt and cannot be pre-filled:
 
 ```
   ✗ --contentlibrary (from BSI_QSEOW_CST_CONTENT_LIBRARY):

--- a/src/lib/commands/qscloud/__tests__/qscloud_wizard.test.js
+++ b/src/lib/commands/qscloud/__tests__/qscloud_wizard.test.js
@@ -160,7 +160,7 @@ describe('an API key supplied before the wizard starts', () => {
         expect(picker.choices.map((choice) => choice.value)).toEqual(['app-a', 'app-b']);
     });
 
-    test('becomes a question, opening on the supplied key, when the tenant rejects it', async () => {
+    test('becomes a question when the tenant rejects it', async () => {
         qscloudTestConnection
             .mockRejectedValueOnce(new Error('401 Unauthorized'))
             .mockResolvedValue({ user: 'someone' });
@@ -178,9 +178,33 @@ describe('an API key supplied before the wizard starts', () => {
         const asked = runtime.asked.filter((a) => a.key === 'apikey');
 
         expect(asked).toHaveLength(1);
-        expect(asked[0].default).toBe('revoked-key');
         expect(runtime.output()).toContain('--apikey (from BSI_QSCLOUD_CST_APIKEY)');
         expect(runtime.output()).toContain('401 Unauthorized');
+    });
+
+    test('is not pre-filled, because a secret prompt cannot offer one', async () => {
+        // This used to assert `default` was the supplied key, which was true of
+        // the config the driver built and false of anything the operator would
+        // see: `@inquirer/password` accepts message, mask, validate and theme,
+        // and never reads `default`. Asserting our own output rather than the
+        // library's contract is exactly what let the --qrsport bug live (#1050),
+        // so this pins the contract instead.
+        qscloudTestConnection
+            .mockRejectedValueOnce(new Error('401 Unauthorized'))
+            .mockResolvedValue({ user: 'someone' });
+
+        const runtime = scriptedRuntime(baseAnswers());
+
+        await runInteractive({
+            path: PATH,
+            presetOptions: { apikey: 'revoked-key' },
+            runtime,
+        });
+
+        const asked = runtime.asked.find((a) => a.key === 'apikey');
+
+        expect(asked.type).toBe('password');
+        expect(asked.default).toBeUndefined();
     });
 
     test('says so when the check passes, so a pause on the network is explained', async () => {

--- a/src/lib/interactive/__tests__/ask-questions.test.js
+++ b/src/lib/interactive/__tests__/ask-questions.test.js
@@ -149,6 +149,34 @@ describe('askQuestions', () => {
         expect(runtime.output()).toContain('Connection');
         expect(runtime.output()).toContain('Output');
     });
+
+    test('offers a default to a text prompt', async () => {
+        const runtime = scriptedRuntime({ k: 'typed' });
+
+        await askQuestions([spec({ default: 'from-env' })], ctx(), { runtime });
+
+        expect(runtime.asked[0].default).toBe('from-env');
+    });
+
+    test('never offers a default to a password prompt', async () => {
+        // `@inquirer/password` accepts message, mask, validate and theme, and its
+        // implementation never reads `default` - so one set here would be
+        // silently dropped and the wizard would be promising a pre-fill that a
+        // masked prompt cannot give. The library is right to omit it: an
+        // invisible default is one you answer blind.
+        //
+        // Kept as a rule about the prompt type rather than about any one option,
+        // because every secret goes through here - `logonpwd` as much as
+        // `apikey` - and a default reaches them whenever their BSI_* variable is
+        // set or a supplied value is promoted after a failed check.
+        const runtime = scriptedRuntime({ k: 'typed' });
+
+        await askQuestions([spec({ type: 'password', default: 'a-real-secret' })], ctx(), {
+            runtime,
+        });
+
+        expect(runtime.asked[0].default).toBeUndefined();
+    });
 });
 
 describe('live choices', () => {

--- a/src/lib/interactive/ask-questions.js
+++ b/src/lib/interactive/ask-questions.js
@@ -301,7 +301,16 @@ const CONFIG_BUILDERS = Object.freeze({
 const textConfig = (spec) => {
     const config = {};
 
-    if (hasDefault(spec)) {
+    // Never for a password. `@inquirer/password` accepts message, mask, validate
+    // and theme, and its implementation never reads `config.default` - so one
+    // set here was silently dropped, and the wizard was quietly promising a
+    // pre-fill that a secret prompt cannot give.
+    //
+    // Not worth working around, because the library is right: a masked default
+    // is invisible, so pressing Enter over one is answering blind. Left off
+    // deliberately rather than left in as a no-op, since the value would be a
+    // live credential put into an object handed to code that never looks at it.
+    if (hasDefault(spec) && spec.type !== 'password') {
         config.default =
             spec.type === 'list' ? splitEntries(spec.default).join(', ') : spec.default;
     }


### PR DESCRIPTION
A supplied credential promoted after a failed check was handed to the prompt with `default` set. `@inquirer/password` accepts `message`, `mask`, `validate` and `theme` — its implementation never reads `default`, so the value was silently dropped and the wizard was promising a pre-fill that a masked prompt cannot give. The staged doc page said so in as many words.

Not worked around, because the library is right: an invisible default is one you answer blind. The key is left off rather than left in as a no-op, since it would put a live credential into an object handed to code that never looks at it.

## The test was the real problem

It asserted `asked[0].default` — the config the driver built, checked against itself — so it passed throughout while the behaviour it described never happened.

That is the same shape as #1050, where `portnumber` was asserted against our own output rather than against what `qrs-interact` actually reads. Both bugs were invisible to a green suite for months for the same reason.

Replaced with a rule stated where the rule lives: a text prompt gets a default, a password prompt never does. It covers `logonpwd` as much as `apikey`, and a default reaches either whenever its `BSI_*` variable is set or a supplied value is promoted after a failed check. Reverting the fix fails it with `Received: "revoked-key"`.

## Where this came from

An audit of every config object handed to a third party, looking for the mismatch #1050 turned out to be.

| Hand-off | Library | Rejects unknown keys? | Verdict |
| --- | --- | --- | --- |
| `setupQseowQrsConnection` | qrs-interact | no | **was broken** — fixed in #1051 |
| `SenseUtilities.buildUrl` | enigma.js | no | correct; verified by building URLs with a custom port |
| enigma `create()` config | enigma.js | — | `schema`/`url`/`createSocket` valid |
| `new WebSocket(url, opts)` | ws | no | `key`/`cert`/`headers`/`rejectUnauthorized` are correct Node TLS names |
| `puppeteer.launch()` | puppeteer-core | no | all keys present; `ignoreHTTPSErrors` confirmed gone |
| `install`/`uninstall`/`canDownload`/`getInstalledBrowsers` | @puppeteer/browsers | no | match `InstallOptions`/`UninstallOptions` |
| axios request config | axios | no | `method`/`baseURL`/`url`/`headers`/`data` standard |
| `formData.append` options | form-data | no | `contentType`/`filename` valid |
| `table()` config | table | **yes — throws** | safe by construction; verified a typo is rejected |
| inquirer input/select/checkbox/confirm/search | @inquirer/* | no | correct |
| **inquirer password** | @inquirer/password | no | **`default` never read** — this PR |

Ten of the eleven libraries ignore unrecognised keys in silence. In that world a test asserting the object we built proves nothing about what the library does with it.

## Verification

92 suites, 2573 tests, lint clean. Contracts checked by executing the libraries where that was possible rather than by reading types — the enigma URLs were built and inspected, `table` was fed a deliberate typo, and the password implementation was read for `config.default` rather than trusted from its `.d.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
