### PR TITLE
Stop generated option tables reporting defaulted options as required

### DIFF
--- a/docs/cli-table-examples.json
+++ b/docs/cli-table-examples.json
@@ -1,0 +1,88 @@
+{
+    "_comment": [
+        "Hand-written examples for the doc site's generated CLI option tables.",
+        "",
+        "Everything else in those tables comes from the Commander definitions under",
+        "src/lib/commands/. The Example column cannot: an example for --host or --appid is a",
+        "value someone has to invent, and only options with a fixed set of accepted choices get",
+        "one derived automatically. This file is where the invented ones live.",
+        "",
+        "Picked up automatically by scripts/docs-cli-tables.js; pass --examples <file> to",
+        "override. Keys are the command path, then the option's long flag exactly as declared",
+        "(no argument placeholder). An option with no entry here renders '-' unless the",
+        "generator can derive one from its choices.",
+        "",
+        "Values are examples, not defaults, so prefer one that differs from the default -- a",
+        "reader learns nothing from an example that restates the value already in the Default",
+        "column."
+    ],
+
+    "qseow create-sheet-thumbnails": {
+        "--host": "--host qlik-server.company.com",
+        "--engineport": "--engineport 4748",
+        "--qrsport": "--qrsport 4243",
+        "--port": "--port 8443",
+        "--certfile": "--certfile ./cert/client.pem",
+        "--certkeyfile": "--certkeyfile ./cert/client_key.pem",
+        "--rejectUnauthorized": "--rejectUnauthorized true",
+        "--secure": "--secure false",
+        "--apiuserdir": "--apiuserdir Internal",
+        "--apiuserid": "--apiuserid sa_api",
+        "--logonuserdir": "--logonuserdir Internal",
+        "--logonuserid": "--logonuserid goran",
+        "--logonpwd": "--logonpwd MyPassword",
+        "--appid": "--appid a3e0f5d2-000a-464f-998d-33d333b175d7",
+        "--qliksensetag": "--qliksensetag updateSheetThumbnails",
+        "--prefix": "--prefix form",
+        "--headless": "--headless false",
+        "--pagewait": "--pagewait 10",
+        "--imagedir": "--imagedir ./img",
+        "--contentlibrary": "--contentlibrary \"Butler sheet thumbnails\"",
+        "--exclude-sheet-tag": "--exclude-sheet-tag excludeFromUpdate",
+        "--exclude-sheet-number": "--exclude-sheet-number 1 2",
+        "--exclude-sheet-title": "--exclude-sheet-title Intro Help",
+        "--blur-sheet-tag": "--blur-sheet-tag sensitive",
+        "--blur-sheet-number": "--blur-sheet-number 3 5",
+        "--blur-sheet-title": "--blur-sheet-title \"Financial Data\"",
+        "--blur-factor": "--blur-factor 10",
+        "--browser-version": "--browser-version stable",
+        "--browser-page-timeout": "--browser-page-timeout 120",
+        "--browser-cache-dir": "--browser-cache-dir D:\\qlik\\browsers"
+    },
+
+    "qscloud create-sheet-thumbnails": {
+        "--tenanturl": "--tenanturl tenant.eu.qlikcloud.com",
+        "--apikey": "--apikey eyJhbGciOiJFUzM4NC...",
+        "--logonuserid": "--logonuserid user@company.com",
+        "--logonpwd": "--logonpwd MyPassword",
+        "--appid": "--appid 12345678-1234-1234-1234-123456789012",
+        "--collectionid": "--collectionid 6547e7e0d0b3b0c1e4e0f1a2",
+        "--headless": "--headless false",
+        "--pagewait": "--pagewait 10",
+        "--imagedir": "--imagedir ./screenshots",
+        "--exclude-sheet-tag": "--exclude-sheet-tag excludeFromUpdate",
+        "--exclude-sheet-number": "--exclude-sheet-number 1 2",
+        "--exclude-sheet-title": "--exclude-sheet-title Intro Help",
+        "--blur-sheet-tag": "--blur-sheet-tag sensitive",
+        "--blur-sheet-number": "--blur-sheet-number 3 5",
+        "--blur-sheet-title": "--blur-sheet-title \"Financial Data\"",
+        "--blur-factor": "--blur-factor 10",
+        "--browser-version": "--browser-version stable",
+        "--browser-page-timeout": "--browser-page-timeout 120",
+        "--browser-cache-dir": "--browser-cache-dir /opt/butler-sheet-icons/browsers"
+    },
+
+    "qscloud remove-sheet-icons": {
+        "--tenanturl": "--tenanturl tenant.eu.qlikcloud.com",
+        "--apikey": "--apikey eyJhbGciOiJFUzM4NC...",
+        "--logonuserid": "--logonuserid user@company.com",
+        "--logonpwd": "--logonpwd MyPassword",
+        "--appid": "--appid 12345678-1234-1234-1234-123456789012",
+        "--collectionid": "--collectionid 6547e7e0d0b3b0c1e4e0f1a2"
+    },
+
+    "qscloud list-collections": {
+        "--tenanturl": "--tenanturl tenant.eu.qlikcloud.com",
+        "--apikey": "--apikey eyJhbGciOiJFUzM4NC..."
+    }
+}

--- a/scripts/docs-cli-tables.js
+++ b/scripts/docs-cli-tables.js
@@ -26,12 +26,14 @@
  *   --check             Report whether the blocks in the named files are current. Exit 1 if not.
  *   --write             Rewrite the blocks in the named files.
  *   --examples <file>   JSON of hand-written examples: { "<command path>": { "--flag": "..." } }.
+ *                       Defaults to docs/cli-table-examples.json when that file exists.
  *
  * With neither --check nor --write, the named files are rendered to stdout and left untouched.
  */
 
-import { readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import process from 'node:process';
+import { fileURLToPath } from 'node:url';
 
 import {
     knownCommandPaths,
@@ -98,25 +100,46 @@ const parseArgs = (argv) => {
 };
 
 /**
- * Load the hand-written examples file, if one was named.
+ * Where hand-written examples live when `--examples` is not given.
  *
- * @param {string|null} path - Path to a JSON file, or null.
+ * Defaulted rather than left to the caller because the failure mode is silent and destructive:
+ * the `Example` column is the one part of a generated table that is not derived from the code,
+ * so anyone who regenerates without remembering the flag blanks every example on the page and
+ * the diff looks like an ordinary refresh. A default that is picked up automatically means the
+ * examples survive a regeneration by whoever happens to run it next.
+ *
+ * Resolved against this repository rather than the working directory, so it does not matter
+ * where the script is invoked from.
+ */
+const DEFAULT_EXAMPLES_FILE = fileURLToPath(
+    new URL('../docs/cli-table-examples.json', import.meta.url)
+);
+
+/**
+ * Load the hand-written examples file.
+ *
+ * A file named explicitly must exist - naming one that does not is a typo worth reporting. The
+ * default file is optional, so a checkout without one still generates tables.
+ *
+ * @param {string|null} path - Path to a JSON file, or null to use the default.
  *
  * @returns {Record<string, Record<string, string>>} Examples keyed by command path, then flag.
  */
 const loadExamples = (path) => {
-    if (!path) {
+    if (!path && !existsSync(DEFAULT_EXAMPLES_FILE)) {
         return {};
     }
 
-    const text = readText(path);
+    const source = path ?? DEFAULT_EXAMPLES_FILE;
+    const text = readText(source);
 
     try {
         return JSON.parse(text);
     } catch (err) {
-        // JSON.parse names neither the file nor what was expected of it.
+        // JSON.parse names neither the file nor what was expected of it. `source` rather than
+        // `path` so the default file is named too, rather than reported as "null".
         throw new Error(
-            `${path}: not valid JSON (${err.message}). Expected { "<command path>": { "--flag": "example" } }.`,
+            `${source}: not valid JSON (${err.message}). Expected { "<command path>": { "--flag": "example" } }.`,
             { cause: err }
         );
     }

--- a/src/lib/docs/__tests__/cli-option-tables.test.js
+++ b/src/lib/docs/__tests__/cli-option-tables.test.js
@@ -92,8 +92,17 @@ describe('codeCell', () => {
 });
 
 describe('formatDefault', () => {
-    test('reports a mandatory option as required rather than as having no default', () => {
+    test('reports a mandatory option with no default as required', () => {
         expect(formatDefault({ mandatory: true, defaultValue: undefined })).toBe('**Required**');
+    });
+
+    // `.default(x).makeOptionMandatory()` is the shape of thirteen options on
+    // `qseow create-sheet-thumbnails`. Commander satisfies the mandatory check from the default,
+    // so the flag can be omitted - reporting it as required both overstates what the
+    // administrator must supply and hides the value they came to look up.
+    test('shows the default of a mandatory option that has one', () => {
+        expect(formatDefault({ mandatory: true, defaultValue: '4242' })).toBe('`4242`');
+        expect(formatDefault({ mandatory: true, defaultValue: true })).toBe('`true`');
     });
 
     test('renders a missing default as a dash', () => {
@@ -103,6 +112,10 @@ describe('formatDefault', () => {
     test('renders a scalar default as a code span', () => {
         expect(formatDefault({ mandatory: false, defaultValue: 'info' })).toBe('`info`');
         expect(formatDefault({ mandatory: false, defaultValue: false })).toBe('`false`');
+    });
+
+    test('renders an empty-string default visibly rather than as a blank code span', () => {
+        expect(formatDefault({ mandatory: false, defaultValue: '' })).toBe('`""`');
     });
 
     test('joins an array default, and treats an empty array as no default', () => {

--- a/src/lib/docs/cli-option-tables.js
+++ b/src/lib/docs/cli-option-tables.js
@@ -109,25 +109,36 @@ export const codeCell = (value) => `\`${String(value).replace(/\|/g, '\\|')}\``;
 /**
  * Render the `Default` cell for one option.
  *
- * A mandatory option has no default by definition, and saying so is more useful to an
- * administrator than an empty cell: it is the difference between an option they may omit and
- * one the command refuses to run without.
+ * `**Required**` is reserved for an option the command genuinely refuses to run without: one
+ * marked mandatory *and* carrying no default.
+ *
+ * The two are not the same thing, which is what an earlier version of this got wrong. Commander
+ * satisfies `makeOptionMandatory()` from the default value, so `.default('4242')
+ * .makeOptionMandatory()` - the shape used by `--qrsport`, `--engineport`, `--secure`,
+ * `--contentlibrary` and nine others on `qseow create-sheet-thumbnails` - parses perfectly well
+ * with the flag absent and yields `4242`. Printing `**Required**` there tells an administrator
+ * they must supply thirteen options that they may safely omit, and throws away the default they
+ * came to the page to look up.
+ *
+ * The default is therefore what gets shown whenever there is one.
  *
  * @param {import('commander').Option} option - The option to describe.
  *
  * @returns {string} Markdown for the cell.
  */
 export const formatDefault = (option) => {
-    if (option.mandatory) {
-        return '**Required**';
-    }
-
     if (option.defaultValue === undefined) {
-        return '-';
+        return option.mandatory ? '**Required**' : '-';
     }
 
     if (Array.isArray(option.defaultValue)) {
         return option.defaultValue.length > 0 ? codeCell(option.defaultValue.join(', ')) : '-';
+    }
+
+    // An empty-string default - `--prefix` and `--qliksensetag` both have one - would otherwise
+    // render as an empty code span, which reads as a rendering fault rather than as a value.
+    if (option.defaultValue === '') {
+        return codeCell('""');
     }
 
     return codeCell(option.defaultValue);


### PR DESCRIPTION
Found while converting the QSEoW and Qlik Sense Cloud reference pages to generated option tables ([docs #76](https://github.com/ptarmiganlabs/butler-sheet-icons-docs/pull/76)). Without this fix that conversion would have published thirteen wrong rows.

## The bug

`formatDefault` assumed a mandatory option has no default:

```js
if (option.mandatory) {
    return '**Required**';
}
```

Thirteen options on `qseow create-sheet-thumbnails` are declared `.default(x).makeOptionMandatory()` — `--qrsport`, `--engineport`, `--secure`, `--contentlibrary`, `--certfile` and the rest. Commander satisfies the mandatory check from the default, so the flag can be omitted and the default applies. Verified rather than assumed:

```js
c.addOption(new Option('--qrsport <port>', 'x').default('4242').makeOptionMandatory());
c.parse(['node', 't']);
// → parsed OK without the flag; value = "4242"
```

Reporting those as **Required** told an administrator they must supply thirteen options they may safely omit, and threw away the value they came to the page to look up.

**This was already live.** The `browser uninstall` table published in [docs #74](https://github.com/ptarmiganlabs/butler-sheet-icons-docs/pull/74) said `--browser` was required when it defaults to `chrome`.

`**Required**` is now reserved for an option that is mandatory *and* has no default — the case that actually stops a run.

## Also here

- **An empty-string default renders as `""`** rather than an empty code span. `--prefix` and `--qliksensetag` both have one, and a blank cell reads as a rendering fault.
- **`docs/cli-table-examples.json`**, picked up automatically by `scripts/docs-cli-tables.js`. The `Example` column is the one part of a generated table not derived from the code, so before this it was lost the moment anyone regenerated without remembering `--examples` — in a diff that looked like an ordinary refresh.

## Testing

New cases for both fixes, including the mandatory-with-default shape that let the bug through. `src/lib/docs` passes (59 tests), eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)