### PR TITLE
Stop captured output writing a crash dump when its reader goes away

### DIFF
--- a/docs/to-doc-site/closed-output-pipe-when-another-program-reads-the-output.md
+++ b/docs/to-doc-site/closed-output-pipe-when-another-program-reads-the-output.md
@@ -1,0 +1,66 @@
+# A closed output pipe, when the reader is another program rather than `head`
+
+This extends something already on the doc site rather than describing anything new to an
+administrator. It should be folded into the existing section, not published as a page of its own.
+
+| |  |
+| --- | --- |
+| Target page | `docs/guide/advanced/crash-dumps.md` |
+| Target section | **A closed output pipe is not a crash** (`#a-closed-output-pipe-is-not-a-crash`) |
+| Draft this follows | `done/done_piping-output-to-head-or-less.md`, published as that section |
+
+## What the published section says today
+
+That Butler Sheet Icons treats a closed output pipe as an ordinary end to the run: no crash report,
+nothing printed, exit code 141. The example is `... | head -12`.
+
+That was true only when the reader was something like `head`. It was **not** true when the thing
+reading the output was another program.
+
+## What to add
+
+Butler Sheet Icons is not always run by hand at a prompt. It is also started by wrapper scripts, job
+runners and scheduling tools that capture its output and read it themselves. When one of those stops
+reading early, the run should end the same quiet way — and until now it did not. It wrote a crash
+report and exited with code 1, exactly the thing this section says no longer happens.
+
+The reason is invisible from the outside: output captured by another program travels over a slightly
+different kind of connection than output piped to `head`, and that kind reports its reader leaving
+with a different message. Butler Sheet Icons now recognises both, so the promise the section already
+makes holds however the output was being read.
+
+Suggested wording, to follow the paragraph beginning "A closed output pipe is now treated as an
+ordinary end to the run":
+
+> This applies whether the reader is a command such as `head`, a pager you quit early, or **another
+> program that started Butler Sheet Icons and captured its output** — a wrapper script, a job runner,
+> or a scheduling tool. If you have seen occasional unexplained crash reports from a run driven by
+> another tool, with `write ENOTCONN` or `write ECONNRESET` as the error message, that is what they
+> were. Whether one appeared depended on timing, so they were most likely on a busy machine.
+
+## One clarification worth adding to "Real failures are unaffected"
+
+That subsection currently lists a full disk and a permission problem as things that still produce a
+crash report. There is a fourth case that matters more to a Qlik Sense administrator and is worth
+stating, because the two can look similar:
+
+> - **A lost connection to Qlik Sense still produces a crash report.** A dropped server connection and
+>   a reader that stopped reading can surface with the same error name. Butler Sheet Icons only takes
+>   the quiet path when it knows the failure was its own output; anything else keeps its crash report
+>   and exit code 1, which is what you need when a run against a Qlik Sense server fails halfway.
+
+Nothing else in the section changes. The exit code is still 141, the `BSI_CRASH_DUMP_*` variables are
+unchanged, and the `| head -12` example is still correct.
+
+## Notes for the publishing pass
+
+- The existing section carries `::: warning Requires BSI 5.0.0 or later`. If this change ships in
+  5.0.0 as well, that warning already covers it and no second gate is needed — check the version on
+  the open release-please pull request before publishing, rather than assuming.
+- The **troubleshooting page** entry for this symptom needs no change: it describes the symptom, which
+  is the same either way.
+- The **exit code 141** entry on the commands reference needs no change either. 141 was already the
+  code for this; the change is which situations reach it.
+- Verified on macOS. A real shell pipe reports the reader leaving one way in every one of 30 runs;
+  captured output intermittently reports it another way, and that case was still writing crash
+  reports. Checked across 120 runs after the fix, including runs that took the intermittent path.

--- a/src/__tests__/butler-sheet-icons.test.js
+++ b/src/__tests__/butler-sheet-icons.test.js
@@ -367,7 +367,21 @@ describe('a closed output pipe leaves nothing behind, end to end (issue #1019)',
     test('no crash dump is written', () => {
         // The whole point of the issue: an operator piping to `head` should not
         // accumulate crash reports in the working directory.
-        expect(fs.readdirSync(dumpDir)).toEqual([]);
+        //
+        // Asserted with the dump's own error message rather than as a bare file
+        // list, because a bare list cannot be diagnosed after the fact. Which
+        // error a dead output stream raises depends on whether it is a pipe or a
+        // socket and on how much was still unread when the reader went - so a
+        // failure here is almost always one more code that is not recognised as
+        // the reader leaving. `ENOTCONN` was exactly that, and cost several
+        // hundred re-runs to identify from a list of two filenames.
+        const files = fs.readdirSync(dumpDir);
+        const reasons = files
+            .filter((file) => file.endsWith('.json'))
+            .map((file) => JSON.parse(fs.readFileSync(path.join(dumpDir, file), 'utf-8')))
+            .map((dump) => `${dump?.context?.source}: ${dump?.error?.message}`);
+
+        expect({ files, reasons }).toEqual({ files: [], reasons: [] });
     });
 
     test('the run ends on its own, with the shell convention for a closed pipe', () => {

--- a/src/lib/util/__tests__/fatal-handlers.test.js
+++ b/src/lib/util/__tests__/fatal-handlers.test.js
@@ -51,16 +51,23 @@ const install = (overrides = {}) =>
         ...overrides,
     });
 
+/** The wording Node uses for the codes that do not follow the `write X` shape. */
+const WRITE_ERROR_MESSAGES = { ERR_STREAM_DESTROYED: 'Cannot call write after destroy' };
+
 /**
- * Builds an error carrying a broken-pipe code, shaped like the one Node raises
- * when the reader of a pipe closes it.
+ * Builds an error carrying a write-failure code, shaped like the one Node raises
+ * when a write cannot be delivered.
+ *
+ * The messages are the real ones: `write EPIPE` and `write ENOTCONN` are what a
+ * dead pipe and a dead socket actually produce, which matters because a reader
+ * of a failing test should recognise what they are looking at.
  *
  * @param {string} [code] - The error code. Defaults to `EPIPE`.
  *
  * @returns {Error} The error, with `code` and `syscall` set.
  */
 const brokenPipeError = (code = 'EPIPE') => {
-    const err = new Error(code === 'EPIPE' ? 'write EPIPE' : 'Cannot call write after destroy');
+    const err = new Error(WRITE_ERROR_MESSAGES[code] ?? `write ${code}`);
     err.code = code;
     err.syscall = 'write';
     return err;
@@ -358,15 +365,105 @@ describe('output pipe closing is not a crash (issue #1019)', () => {
     // used to leave a crash report behind for an operator who did nothing
     // wrong.
 
+    // Which error codes each catch site treats as "the reader went away", stated
+    // as one table rather than as scattered cases, because the whole point is
+    // that the two sites deliberately DISAGREE. Reading down the two verdict
+    // columns is how that disagreement stays visible; a code asserted at only
+    // one site says nothing about the other, which is how ENOTCONN came to be
+    // handled at neither.
+    //
+    // `quiet` is exit 141 with no crash dump. `crash` is the ordinary fatal
+    // path: one dump, exit 1.
+    const CODE_MATRIX = [
+        {
+            code: 'EPIPE',
+            why: 'a pipe closed by its reader, the original #1019 case',
+            atStream: 'quiet',
+            atBackstop: 'quiet',
+        },
+        {
+            code: 'ERR_STREAM_DESTROYED',
+            why: 'a write after Node tore the stream down in response',
+            atStream: 'quiet',
+            atBackstop: 'quiet',
+        },
+        {
+            code: 'ENOTCONN',
+            // The flake this table was written for. Captured output is a socket
+            // rather than a pipe, and a socket reports its reader leaving this
+            // way when data was still buffered - so the end-to-end test for
+            // #1019 wrote crash dumps about one loaded run in sixty.
+            why: 'the same event over a socket, which captured output is',
+            atStream: 'quiet',
+            atBackstop: 'crash',
+        },
+        {
+            code: 'ECONNRESET',
+            // Why the two sets cannot be collapsed into one. On a stream we
+            // watch this is our own output going away; arriving loose, it is far
+            // more likely to be a Qlik Sense connection dropping, and that needs
+            // its dump.
+            why: 'a socket reader that went away - or a Qlik Sense connection reset',
+            atStream: 'quiet',
+            atBackstop: 'crash',
+        },
+        {
+            code: 'ENOSPC',
+            why: 'a full disk is a real failure however it arrives',
+            atStream: 'crash',
+            atBackstop: 'crash',
+        },
+        {
+            code: 'EACCES',
+            why: 'so is a permission problem',
+            atStream: 'crash',
+            atBackstop: 'crash',
+        },
+    ];
+
+    /**
+     * Asserts one row of the matrix against whichever site raised the error.
+     *
+     * @param {'quiet'|'crash'} verdict - What the site is required to do.
+     * @param {Function} writeCrashDump - The crash dump spy.
+     * @param {Error} err - The error that was raised.
+     *
+     * @returns {void}
+     */
+    const expectVerdict = (verdict, writeCrashDump, err) => {
+        if (verdict === 'quiet') {
+            expect(writeCrashDump).not.toHaveBeenCalled();
+            expect(exit).toHaveBeenCalledTimes(1);
+            expect(exit).toHaveBeenCalledWith(BROKEN_PIPE_EXIT_CODE);
+
+            return;
+        }
+
+        expect(writeCrashDump).toHaveBeenCalledTimes(1);
+        expect(writeCrashDump).toHaveBeenCalledWith(err, 'uncaughtException');
+        expect(exit).toHaveBeenCalledWith(1);
+    };
+
     describe('caught at the stream, which is where the pipe is known', () => {
-        test.each([
-            ['stdout', () => stdout],
-            ['stderr', () => stderr],
-        ])('an EPIPE on %s exits quietly without a dump', async (_name, streamOf) => {
+        test.each(CODE_MATRIX)(
+            'a $code on the stream is $atStream — $why',
+            async ({ code, atStream }) => {
+                const writeCrashDump = jest.fn().mockResolvedValue(undefined);
+                install({ writeCrashDump });
+
+                const err = brokenPipeError(code);
+                stdout.emit('error', err);
+                await flush();
+
+                expectVerdict(atStream, writeCrashDump, err);
+            }
+        );
+
+        test('stderr is watched on the same terms as stdout', async () => {
             const writeCrashDump = jest.fn().mockResolvedValue(undefined);
             install({ writeCrashDump });
 
-            streamOf().emit('error', brokenPipeError());
+            stderr.emit('error', brokenPipeError());
             await flush();
 
             expect(writeCrashDump).not.toHaveBeenCalled();
@@ -385,34 +482,6 @@ describe('output pipe closing is not a crash (issue #1019)', () => {
             expect(consoleError).not.toHaveBeenCalled();
 
             consoleError.mockRestore();
-        });
-
-        test('ERR_STREAM_DESTROYED — a write after Node tore the stream down — counts too', async () => {
-            const writeCrashDump = jest.fn().mockResolvedValue(undefined);
-            install({ writeCrashDump });
-
-            stdout.emit('error', brokenPipeError('ERR_STREAM_DESTROYED'));
-            await flush();
-
-            expect(writeCrashDump).not.toHaveBeenCalled();
-            expect(exit).toHaveBeenCalledWith(BROKEN_PIPE_EXIT_CODE);
-        });
-
-        test('a stream error that is not a broken pipe is still a crash', async () => {
-            // Registering the listener took these errors away from Node's
-            // uncaughtException path, so the fatal handling has to be preserved
-            // here rather than assumed.
-            const writeCrashDump = jest.fn().mockResolvedValue(undefined);
-            install({ writeCrashDump });
-
-            const err = new Error('EACCES: permission denied, write');
-            err.code = 'EACCES';
-            stdout.emit('error', err);
-            await flush();
-
-            expect(writeCrashDump).toHaveBeenCalledTimes(1);
-            expect(writeCrashDump).toHaveBeenCalledWith(err, 'uncaughtException');
-            expect(exit).toHaveBeenCalledWith(1);
         });
 
         test('the stream listeners are removed on reset, and not doubled up on re-install', () => {
@@ -448,21 +517,35 @@ describe('output pipe closing is not a crash (issue #1019)', () => {
     });
 
     describe('backstop on the uncaughtException path', () => {
-        test.each([['EPIPE'], ['ERR_STREAM_DESTROYED']])(
-            'an uncaught %s exits quietly without a dump',
-            async (code) => {
+        // The same table, read down the other column. Attribution here is a
+        // guess - nothing says the error came from stdout - so this site matches
+        // fewer codes, and the rows where the two columns differ are the ones
+        // carrying the design.
+        test.each(CODE_MATRIX)(
+            'an uncaught $code is $atBackstop — $why',
+            async ({ code, atBackstop }) => {
                 const writeCrashDump = jest.fn().mockResolvedValue(undefined);
                 install({ writeCrashDump });
 
-                target.emit('uncaughtException', brokenPipeError(code));
+                const err = brokenPipeError(code);
+                target.emit('uncaughtException', err);
                 await flush();
 
-                expect(writeCrashDump).not.toHaveBeenCalled();
-                expect(logger.error).not.toHaveBeenCalled();
-                expect(exit).toHaveBeenCalledTimes(1);
-                expect(exit).toHaveBeenCalledWith(BROKEN_PIPE_EXIT_CODE);
+                expectVerdict(atBackstop, writeCrashDump, err);
             }
         );
+
+        test('the backstop is narrower than the stream listener, on purpose', () => {
+            // A guard on the table itself rather than on the code. Widening the
+            // backstop to match the stream listener would pass every case above
+            // if the table were widened with it, and would mean a Qlik Sense
+            // connection reset silently losing its crash dump.
+            const widerAtStream = CODE_MATRIX.filter(
+                (row) => row.atStream === 'quiet' && row.atBackstop === 'crash'
+            ).map((row) => row.code);
+
+            expect(widerAtStream).toEqual(['ENOTCONN', 'ECONNRESET']);
+        });
 
         test('an EPIPE-coded rejection is still a crash', async () => {
             // Every network call in BSI is promise-based, and a wrapper such as

--- a/src/lib/util/fatal-handlers.js
+++ b/src/lib/util/fatal-handlers.js
@@ -54,19 +54,29 @@
  * stream it would go to is the one that just died), no crash dump, and an
  * immediate exit with {@link BROKEN_PIPE_EXIT_CODE}.
  *
- * It is caught in two places, because certainty differs between them:
+ * It is caught in two places, because certainty differs between them — and they
+ * match on *different sets of error codes* for that reason:
  *
  *   - An `error` listener on stdout and stderr. This is the path that fires in
  *     practice, and it is exact: the event names the stream, so there is no
- *     guessing about which pipe broke.
+ *     guessing about which pipe broke. It therefore matches the wider
+ *     {@link STREAM_BROKEN_PIPE_CODES}, which covers the socket wording of the
+ *     same event as well as the pipe wording.
  *   - The `uncaughtException` path, as a backstop for anything that writes to
  *     fd 1 or 2 without going through those stream objects. Attribution there
  *     is a judgement call — a raw socket write can raise `EPIPE` too — so the
- *     backstop is deliberately narrow: `unhandledRejection` never takes it (all
- *     of BSI's network I/O is promise-based, and an `AxiosError` can carry
+ *     backstop is deliberately narrow: it matches only
+ *     {@link BACKSTOP_BROKEN_PIPE_CODES}, `unhandledRejection` never takes it
+ *     (all of BSI's network I/O is promise-based, and an `AxiosError` can carry
  *     `code: 'EPIPE'` across), and the exit code stays non-zero, so a
  *     misattributed socket failure still fails a scheduled task. What it would
  *     cost is the crash dump for that one rare case.
+ *
+ * Keeping the two sets apart is the point rather than an accident of history.
+ * The wider one exists because stdout is not always a pipe — captured output is
+ * a socket, which reports the reader leaving as `ENOTCONN` or `ECONNRESET`. The
+ * narrow one stays narrow because `ECONNRESET` is also what a Qlik Sense server
+ * dropping a connection looks like, and that must keep its crash dump.
  */
 
 import { logger as defaultLogger } from '../../globals.js';
@@ -98,12 +108,51 @@ export const FATAL_EXIT_WATCHDOG_MS = 10000;
 export const BROKEN_PIPE_EXIT_CODE = 141;
 
 /**
- * Error codes a stream raises once whatever it writes into has gone away.
+ * Error codes that mean the reader went away, for an error that arrived on one
+ * of the streams this module watches.
  *
- * `EPIPE` is the pipe being closed by the reader; `ERR_STREAM_DESTROYED` is a
- * later write to the stream Node then tore down in response.
+ * `EPIPE` is a pipe closed by its reader, and `ERR_STREAM_DESTROYED` a later
+ * write to the stream Node tore down in response. The other two are the same
+ * event over a socket. Standard output is not always a pipe: when one program
+ * runs another and captures its output, libuv hands the child a socket rather
+ * than a `pipe(2)` on macOS, and a write once the far end has gone reports
+ * `ENOTCONN` or `ECONNRESET` instead of `EPIPE`.
+ *
+ * `ENOTCONN` is not a theoretical addition. It is what made the end-to-end test
+ * for #1019 fail about one run in sixty: which of the two a dead socket reports
+ * depends on whether unread data was still buffered when the reader closed, so
+ * a loaded machine - where the reader reacts late and more has piled up behind
+ * it - brought back crash dumps for a closed pipe, the exact thing #1019
+ * removed. Measured on macOS, writing to a `spawn`ed child's stdout: 290 runs
+ * where the reader closed promptly were all `EPIPE`, while delaying the close by
+ * a single event loop turn produced `ENOTCONN`.
+ *
+ * Deliberately still an allowlist rather than "any write error". A full disk
+ * (`ENOSPC`) or a permission problem is a genuine failure that must keep its
+ * crash dump.
  */
-const BROKEN_PIPE_CODES = new Set(['EPIPE', 'ERR_STREAM_DESTROYED']);
+const STREAM_BROKEN_PIPE_CODES = new Set([
+    'EPIPE',
+    'ERR_STREAM_DESTROYED',
+    'ENOTCONN',
+    'ECONNRESET',
+]);
+
+/**
+ * The narrower set the `uncaughtException` backstop matches on.
+ *
+ * Narrower because that path is guessing. An error reaching the stream listener
+ * names the stream it came from, so "my output has gone" is a fact; the same
+ * code reaching `uncaughtException` might have come from anywhere.
+ *
+ * `ECONNRESET` is the reason the two sets have to differ rather than one being
+ * widened. Every Qlik Sense connection BSI opens can be reset by the far end,
+ * and that is a real failure an operator needs the crash dump for. Accepting it
+ * here would trade a rare missing dump for routinely discarding the dump that
+ * matters most. `ENOTCONN` is left out for the same reason, being just as much
+ * a socket error as a stdout error.
+ */
+const BACKSTOP_BROKEN_PIPE_CODES = new Set(['EPIPE', 'ERR_STREAM_DESTROYED']);
 
 /** True once a fatal event is being handled. Later fatal events are dropped. */
 let handlingFatal = false;
@@ -152,12 +201,18 @@ function toError(reason) {
 /**
  * Reports whether an error says the stream being written to has gone away.
  *
+ * The set is a parameter rather than a constant read from the enclosing scope,
+ * so that the two call sites have to name which one they mean. They differ - see
+ * {@link STREAM_BROKEN_PIPE_CODES} and {@link BACKSTOP_BROKEN_PIPE_CODES} - and
+ * the difference is easy to erase by accident when it lives out of sight.
+ *
  * @param {Error|unknown} err - The error to classify.
+ * @param {Set<string>} codes - The error codes that count as the reader going away.
  *
  * @returns {boolean} `true` for a broken-pipe error code.
  */
-function isBrokenPipeError(err) {
-    return BROKEN_PIPE_CODES.has(err?.code);
+function isBrokenPipeError(err, codes) {
+    return codes.has(err?.code);
 }
 
 /**
@@ -273,7 +328,7 @@ function handleFatal(err, source, deps) {
     // Output going away is an ordinary end to a piped run, not a crash. Only
     // from `uncaughtException`, and only as a backstop to the stream listeners
     // below — see the header for why a rejection never qualifies.
-    if (source === 'uncaughtException' && isBrokenPipeError(err)) {
+    if (source === 'uncaughtException' && isBrokenPipeError(err, BACKSTOP_BROKEN_PIPE_CODES)) {
         handleBrokenOutputPipe(deps);
         return;
     }
@@ -409,12 +464,16 @@ export function installFatalHandlers({
      * genuine failure to write output still produces a dump and exit 1, exactly
      * as it did when it arrived as an uncaught exception.
      *
+     * Matches the wider {@link STREAM_BROKEN_PIPE_CODES}, because the event
+     * names the stream: whatever this error says, it is about output that can no
+     * longer be written, not about some socket elsewhere in the process.
+     *
      * @param {Error} err - The stream error.
      *
      * @returns {void}
      */
     const onOutputStreamError = (err) => {
-        if (isBrokenPipeError(err)) {
+        if (isBrokenPipeError(err, STREAM_BROKEN_PIPE_CODES)) {
             handleBrokenOutputPipe(deps);
             return;
         }


### PR DESCRIPTION
The end-to-end test for #1019 — `a closed output pipe leaves nothing behind` — has been failing at
random, roughly one full run in eight on a loaded machine. It turns out the test was right and the
product was wrong.

## What was happening

#1019 taught the fatal handlers that a closed output pipe is an ordinary end to a run rather than a
crash: no dump, no log line, exit 141. It recognised that state from a set of two error codes,
`EPIPE` and `ERR_STREAM_DESTROYED`.

Standard output is not always a pipe. When one program runs another and captures its output, libuv
hands the child a socket, and a socket reports its reader leaving as `ENOTCONN` or `ECONNRESET`.
Which one arrives depends on whether unread data was still buffered when the reader closed — which
is why it only showed up under load, where the reader reacts late and more has piled up behind it.
`ENOTCONN` fell through to the crash path and wrote the very dump #1019 exists to prevent.

Measured on macOS against a `spawn`ed child:

| | result |
| --- | --- |
| 290 runs, reader closing promptly (idle and under 12-way CPU load) | all `EPIPE`, 0 failures |
| Reader closing one event-loop turn later | **1 in 60** drew `ENOTCONN` → exit 1, two dump files |
| Error codes injected directly at `process.stdout` | `EPIPE`/`ERR_STREAM_DESTROYED` quiet; `ENOTCONN`/`ECONNRESET`/`ENOSPC` crash |
| Real shell pipe `\| head` — `pipe(2)`, not a socket | 30/30 `EPIPE` |

So the documented `... | head -12` scenario was never affected. The exposure is Butler Sheet Icons
run as a child of another program that stops reading — including its own test suite.

## The fix

Widening the one set would have been wrong. The two catch sites differ in how sure they can be, so
they now match different sets:

- The **stream `error` listener** knows which stream the error came from, so "my output has gone" is
  a fact. It matches the wider set: `EPIPE`, `ERR_STREAM_DESTROYED`, `ENOTCONN`, `ECONNRESET`.
- The **`uncaughtException` backstop** is guessing, and `ECONNRESET` is also what a Qlik Sense server
  dropping a connection looks like. Accepting it there would trade a rare missing dump for routinely
  discarding the dump that matters most, so it stays exactly as narrow as it was.

Both remain allowlists rather than "any write error" — a full disk or a permission problem is a real
failure and keeps its crash dump.

## How it was verified

- The unit tests become a matrix over codes × catch sites, asserting **every code at both sites**.
  Asserting one site is how `ENOTCONN` came to be handled at neither. Reverting the fix fails exactly
  the two cases that claim to cover it.
- The check no unit test can do: the natural reproduction now passes **120/120 at exit 141 with no
  dumps, including a run that actually drew `ENOTCONN`** — the same code that failed before.
- Full unit suite green, lint and Prettier clean, re-run after rebasing onto current `main`.

The end-to-end assertion now names the crash dump's own error message when it fails, so the next
unrecognised code takes one run to identify rather than several hundred.

## The doc draft

`piping-output-to-head-or-less.md` was published and archived by #1055 while this was being written,
so there is no pending draft left to extend. This adds a **new** pending draft instead, naming the
published section it should be folded into.

Worth flagging for anyone rebasing a branch of this era: git follows the rename into `done/`, so a
rebase applies a draft edit to the *archived* file without reporting a conflict. That publishes
nothing and misrepresents what shipped. The archived file here is untouched — please check that in
review rather than taking my word for it.

The draft also asks for one clarification the original did not need: that a lost connection to Qlik
Sense still produces a crash report. That is the direct consequence of the two catch sites matching
different codes, and an administrator reading only the good news would draw the wrong conclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
