### PR TITLE
Archive the two republished drafts and record why a draft can go stale

### DIFF
--- a/docs/to-doc-site/README.md
+++ b/docs/to-doc-site/README.md
@@ -139,7 +139,13 @@ Where two drafts touch the same page, publishing them back to back keeps the rew
 For each unprefixed file, answer three questions before writing anything:
 
 1. **Should it be published at all?** Some drafts describe internal refactors, or behaviour that never reaches a user. Some are already covered on the site. Some describe behaviour that has since changed again. Say so and process the file into `done/` without publishing rather than adding noise to the site.
+
+    **A draft that states its own precondition is not ready until that precondition holds**, and it stays pending rather than being archived. `windows-binary-signed-again.md` says "do not publish until a signed release actually exists" — publishing it early would have told administrators the Windows download is signed while the only download available was not, which is worse than silence: the page tells them to distrust a binary whose signature does not match.
+
 2. **Where does it fit?** See "Site structure" below. Strongly prefer **editing an existing page** over adding a new one — a fact stated in two places drifts out of sync. A draft's suggested target page is a starting point, not a decision.
+
+    **Check whether the site already covers the symptom** before writing a new section. `browser-build-stops-responding-immediately.md` was most of the way covered by an existing troubleshooting section quoting the same two error lines; publishing it as written would have produced two answers to one search. What it actually needed was three paragraphs added to what was there.
+
 3. **What is the right wording and cross-linking?** Rewrite in the doc site's voice rather than pasting the draft. Add cross-links both ways: from the concept page to the reference page, and back.
 
 ### 3. Verify every claim against the implementation
@@ -297,6 +303,20 @@ Then **stop and wait for approval of that page** before touching the next draft.
 A file that was **not approved** is not processed. Leave it unprefixed and in place — it is still pending, and it is the next thing to revise, not to move on from.
 
 Where the draft contained a claim that turned out to be wrong, add a short HTML comment recording the correction before moving it, so a later reader of `done/` does not trust it.
+
+#### Re-read the draft against `main` before moving it
+
+**A draft can be rewritten while it is being published.** Publishing a batch takes hours or days; the feature it describes is often still being worked on, and the person working on it updates the draft. Archiving the version you started from then buries content nobody has published, in the one folder nobody re-reads.
+
+Before each `git mv`, check the file against current `main`:
+
+```bash
+git fetch upstream main && git diff HEAD..upstream/main -- docs/to-doc-site/<draft>.md
+```
+
+If it has changed, **do not archive it**. Treat it as pending again: read the new version, publish what is new, and check whether anything already on the site has been contradicted. Quotes are the usual casualty — a prompt or a log line reworded in the same commit that expanded the draft.
+
+This is not hypothetical. In the 5.0.0 batch, `creating-thumbnails-interactively.md` gained about 130 lines mid-pass and two of the strings already published from it were reworded in the code at the same time. The archive commit hit a merge conflict, which is the only reason it was caught.
 
 Then start the next draft at step 2.
 

--- a/docs/to-doc-site/done/done_browser-build-stops-responding-immediately.md
+++ b/docs/to-doc-site/done/done_browser-build-stops-responding-immediately.md
@@ -1,3 +1,23 @@
+<!--
+PUBLISHED 2026-08-13 to the doc site `next` branch, PR ptarmiganlabs/butler-sheet-icons-docs#91.
+
+NOT published as a new page. The troubleshooting section "Every app fails with `Target closed` or
+`Protocol error`" already carried this symptom and quoted the same two error lines verbatim, so a
+second section would have been two answers to one search. That section was extended instead, and
+guide/concepts/browser-management gained a "What `recommended` points at" section.
+
+Version gate: 5.0.0, not the 4.2.0 stated below.
+
+THE BUILD IDS BELOW ARE CORRECT, but do not verify them from the repo's node_modules. That install
+was puppeteer-core 25.4.0, whose Chrome revision is 151.0.7922.47 -- the OLD value, and the one this
+draft attributes to 4.1.0. package.json requires ^25.5.0 and the lockfile pins 25.5.0, whose
+revision is 151.0.7922.71. Confirmed by installing 25.5.0 in a scratch directory and reading its
+revisions.js.
+
+The published page states the build for the named release and tells readers to trust their own run's
+log line over the page, since the value is version-specific by nature.
+-->
+
 # "Browser build … started but stopped responding immediately"
 
 Suggested target pages: `/guide/troubleshooting` (symptom → cause → fix) and

--- a/docs/to-doc-site/done/done_creating-thumbnails-interactively.md
+++ b/docs/to-doc-site/done/done_creating-thumbnails-interactively.md
@@ -1,3 +1,33 @@
+<!--
+PUBLISHED 2026-08-13 to the doc site `next` branch, into guide/interactive-mode.md.
+
+Published TWICE. PR ptarmiganlabs/butler-sheet-icons-docs#79 published an earlier version of this
+draft; #90 republished it after this file was substantially rewritten mid-pass.
+
+THAT REWRITE IS WHY THE "re-read against main before archiving" RULE EXISTS. About 130 lines were
+added here while the earlier version was being published, and two strings already published from it
+were reworded in the code at the same time:
+
+  "Choose from all apps on the server" / "Choose a tag, then apps carrying it" / "Type an app id"
+    -> "Pick apps from a list" / "Update every app carrying a tag" / "Type app id(s)"
+  "Supplied, but asked about again so the answer can be picked from what is actually there"
+    -> "Supplied, but asked about again so you can change it for this run"
+
+Both were wrong on the live site until #90. The archive commit hit a merge conflict, which is the
+only reason it was caught at all.
+
+ONE CLAIM BELOW IS STILL WRONG. The empty-selection message is quoted as offering to "go back and
+choose a tag". There is no way back to a previous question, and the code says "press Ctrl+C and
+start again to choose <tag|collection> instead". Published as the code has it.
+
+A section that stopped being true: browser uninstall's picker was documented as "One exception, and
+it says so" to the option-skipping rule. Under the two-kinds framing it is not an exception at all,
+and is now a note under that rule.
+
+Question counts (36->14, 25->10) were measured by running each wizard's refine(), not taken from
+here. Nothing in the test suite locks them.
+-->
+
 # Creating sheet thumbnails without assembling a command line
 
 `qseow create-sheet-thumbnails` takes 36 options. `qscloud create-sheet-thumbnails` takes 25. Getting a first run working has meant reading `--help`, assembling a long command line, and finding out only at the end if a certificate path or an API key was wrong.


### PR DESCRIPTION
Finishes the doc site publishing pass. Touches nothing outside `docs/to-doc-site/`.

## Archived

| Draft | Doc site |
| --- | --- |
| `creating-thumbnails-interactively.md` | [#79](https://github.com/ptarmiganlabs/butler-sheet-icons-docs/pull/79), then republished in [#90](https://github.com/ptarmiganlabs/butler-sheet-icons-docs/pull/90) |
| `browser-build-stops-responding-immediately.md` | [#91](https://github.com/ptarmiganlabs/butler-sheet-icons-docs/pull/91) |

## Deliberately still pending

`windows-binary-signed-again.md`. Its own notes say **"do not publish until a signed release actually exists"**, and none does — the signing fix is in no released tag, and the latest release is 4.1.0, which the draft itself lists as unsigned.

Publishing it would have told administrators the Windows download is signed while the only available download was not. That is worse than silence: the page tells them to distrust a binary whose thumbprint does not match, so an admin checking 4.1.0 would find no signature and reasonably conclude their download had been tampered with.

It becomes publishable when 5.0.0 ships. Two things to do then: set the gate and confirm the unsigned list is exactly 4.0.0 and 4.1.0, and re-read the thumbprint off a real signed artifact rather than off the signing host.

## Three rules added to the README

One per thing this pass got wrong before catching it.

**Re-read a draft against `main` before archiving it.** Publishing a batch takes days; the feature is often still being worked on, and whoever is working on it updates the draft. `creating-thumbnails-interactively.md` gained ~130 lines mid-pass, and two strings already published from it were reworded in the code at the same time — so the live site carried two wrong quotes until it was republished. The archive commit hit a merge conflict, which is the only reason any of it surfaced. A rule that depends on a merge conflict for enforcement is worth writing down.

**A draft stating its own precondition is not ready until that precondition holds** — the case above.

**Check whether the site already covers the symptom** before writing a new section. `browser-build-stops-responding-immediately.md` was mostly covered by an existing troubleshooting section quoting the same two error lines; publishing it as written would have produced two answers to one search.

## Correction notes on the archived drafts

Both carry an HTML comment recording what did not survive contact with the implementation:

- `creating-thumbnails-interactively.md` **still contains a wrong quote** — it has the empty-selection message offering to "go back and choose a tag", when there is no way back to a previous question and the code says "press Ctrl+C and start again". Recorded so it is not trusted from `done/`.
- `browser-build-stops-responding-immediately.md` records that its build ids are correct but **must not be verified from the repo's `node_modules`**, which has puppeteer-core 25.4.0 (revision `151.0.7922.47`, the old value) while the lockfile pins 25.5.0 (`151.0.7922.71`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)