### PR TITLE
Check that a cached browser can actually run here before using it

### DIFF
--- a/docs/to-doc-site/browser-cache-checked-before-use.md
+++ b/docs/to-doc-site/browser-cache-checked-before-use.md
@@ -1,0 +1,150 @@
+# Butler Sheet Icons now checks a cached browser before using it
+
+**Target pages:** `guide/troubleshooting.md` (new entries), with a short pointer added to
+`guide/concepts/browser-detection-and-environment-variables.md`.
+
+**Version gate:** confirm the next released version at publication time from the open release-please
+pull request, and add `::: warning Requires BSI X.Y.Z or later` at the top of each new entry.
+
+---
+
+## What changed
+
+Butler Sheet Icons keeps downloaded browsers in a cache directory, and reuses one from there instead
+of downloading it again. Until now it checked only two things about a cached browser: that it was the
+right browser, and that it was the right version.
+
+That was not enough. A browser copied from a machine running a different operating system was
+accepted and used, as was a cache folder whose browser files were incomplete. In both cases the run
+appeared to start normally — the log even said which browser it was using — and then failed later
+with an error that gave no hint of the real cause.
+
+Butler Sheet Icons now also checks that a cached browser was **built for the operating system it is
+running on**, and that the **browser program is actually present** in the cache. A browser that fails
+either check is not used, and Butler Sheet Icons says why.
+
+## Why this matters if you copy a browser cache between machines
+
+Copying a browser cache from a machine with internet access to one without is a documented way to set
+up Butler Sheet Icons in a network with no internet access. The mistake it invites is easy to make:
+the machine with internet access is often an administrator's Mac or Windows laptop, while the target
+is a Windows Server running Qlik Sense.
+
+**A browser cache only works on the same operating system it was downloaded for.** A cache prepared
+on macOS cannot be used on Windows, and neither can be used on Linux. If you are staging a browser
+this way, download it on a machine running the same operating system as the Qlik Sense server.
+
+Previously, getting this wrong produced a confusing failure with no obvious cause. Now it produces a
+clear message, and Butler Sheet Icons falls back to downloading a browser — which succeeds if the
+machine has internet access, and fails with an explanation if it does not.
+
+## New messages, and what to do about each
+
+### The cache came from a different operating system
+
+```
+Found 1 cached chrome build(s), but none built for this machine (platform "win64").
+Cached chrome builds are for: mac_arm. A browser cache copied from a machine with a
+different operating system cannot be used.
+Browser cache directory: C:\butler-sheet-icons\browser-cache
+```
+
+The message names both sides: the operating system this machine needs, and the one the cached
+browsers were built for. The names are the ones the browser download service uses:
+
+| Name | Operating system |
+| --- | --- |
+| `win64` | 64-bit Windows |
+| `win32` | 32-bit Windows |
+| `mac_arm` | macOS on Apple Silicon |
+| `mac` | macOS on Intel |
+| `linux` | 64-bit Linux |
+| `linux_arm` | Linux on ARM |
+
+There are two combinations that are **not** a mismatch, because the machine can run the build even
+though the names differ. Butler Sheet Icons accepts both without a warning:
+
+- A **32-bit Windows** (`win32`) build on **64-bit Windows** (`win64`).
+- An **Intel macOS** (`mac`) build on **Apple Silicon** (`mac_arm`), which runs through Rosetta.
+  This assumes Rosetta is installed, as it normally is; if it is not, the browser will fail to
+  start.
+
+Everything else must match. In particular, no Windows build runs on Linux or macOS, and no 64-bit
+build runs on a 32-bit or ARM host.
+
+**What to do:** download the browser again on a machine running the same operating system as this
+one, and copy that cache across instead. On a machine with internet access you can simply let Butler
+Sheet Icons download a browser itself.
+
+### The cache is incomplete
+
+```
+Found 1 cached chrome build(s) for this machine, but none has a usable executable. The
+cache directory may be incomplete - for example copied without the browser binary, or
+left behind by a failed install.
+Browser cache directory: C:\butler-sheet-icons\browser-cache
+```
+
+The cache folder is there and looks right, but the browser program inside it is missing. This
+usually means the copy did not include everything — some archiving tools skip hidden files by
+default — or that an earlier download was interrupted.
+
+**What to do:** delete the incomplete folder and copy or download the browser again. If you are
+copying from another machine, make sure your archiving tool includes hidden files — several skip
+them by default, and one of the files Butler Sheet Icons needs is hidden.
+
+To check a copy, list the installed browsers and then confirm that the browser program is really
+present in the folder shown:
+
+```
+butler-sheet-icons browser list-installed
+```
+
+That command prints the installation folder for each cached build. Note that it lists a build
+whether or not the browser program inside it survived the copy, so seeing the build listed is not
+by itself proof that the copy is complete — open the folder and confirm the browser program is
+there.
+
+### The requested browser version is not the one you have
+
+```
+No cached chrome build matches --browser-version "recommended" (build 138.0.7204.94).
+Cached chrome builds that this machine can run: 131.0.6778.204. Set --browser-version to
+one of those build ids to use it instead.
+Butler Sheet Icons will now try to download chrome 138.0.7204.94, which needs internet
+access. On a machine without internet access this will fail.
+```
+
+The version Butler Sheet Icons was asked for is not the one in the cache. On a machine with internet
+access this is only a warning: the requested version is downloaded and the run continues. On a
+machine without internet access the download cannot succeed, so the run will fail.
+
+The message names the version **as you set it**, with the exact build it resolved to in brackets.
+You will see a bracketed build even if you never set `--browser-version` at all: the default,
+`recommended`, is a name for a specific build that Butler Sheet Icons ships with, and that build is
+what gets looked for in the cache.
+
+**What to do:** set `--browser-version` to one of the build ids the message lists, which uses the
+browser you already have. The alternative is to stage the exact build it asked for.
+
+::: warning Version keywords are not wildcards
+`latest`, `stable` and `recommended` each resolve to **one specific build** before the cache is
+searched. Switching from one keyword to another will not make Butler Sheet Icons accept a build it
+already rejected — it will simply look for a different specific build. Only an exact build id from
+the list in the message is guaranteed to match what you have.
+:::
+
+## What has not changed
+
+- A healthy cache behaves exactly as before, with no new messages. A single unusable folder sitting
+  beside a working browser is ignored quietly.
+- Pointing Butler Sheet Icons at a browser with `PUPPETEER_EXECUTABLE_PATH` is unaffected — that
+  browser is used as-is, without these checks.
+- Where the browser cache lives, and how to change it with `--browser-cache-dir` or
+  `BSI_BROWSER_CACHE_DIR`, is unchanged.
+
+## Note for the publishing pass
+
+Verify each message above against the current implementation before publishing, and quote it
+**verbatim** — administrators search for these strings, so a paraphrase on the doc site is worse
+than no entry at all.

--- a/docs/todo/airgap-browser-phase-1.md
+++ b/docs/todo/airgap-browser-phase-1.md
@@ -1,7 +1,26 @@
 # Air-gapped browser support, phase 1: make the browser findable
 
 Design document for the first phase of [issue #809](https://github.com/ptarmiganlabs/butler-sheet-icons/issues/809).
-Not yet implemented.
+
+**Partly implemented.** Status against the sequencing in §12, which is the order this was meant to
+ship in:
+
+| # | Commit | Status |
+| --- | --- | --- |
+| 1 | Read the cache directory from one place | **Landed**, by another route: #887 consolidated the eight hardcoded sites into `browser-cache-dir.js`, which #1024 then grew into `browser-paths.js` |
+| 2 | Stop detection accepting cached browsers this machine cannot run | **Landed** |
+| 3 | `--browser-cache-dir` | **Landed** (#1024) |
+| 4 | `--browser-executable-path` | Not started |
+| 5 | `browser install` offline for an already-staged build | Not started |
+| 6 | `browser check`, on the check contract of §15.3 | Not started |
+| 7 | Uninstall the build that was actually found | **Landed** |
+
+Commits 1 and 3 shipped before commit 2, inverting the order §12 argues for. That is why the
+platform filter arrived after administrators could already point `--browser-cache-dir` anywhere.
+
+**Read the source before trusting the detail here.** Two sections are known to describe a codebase
+that no longer exists: §10's call-site table predates #887, and §11.1's version gate names 3.12.0
+when the open release train is well past it. Where this document and `src/` disagree, `src/` wins.
 
 **Phase 1 in one sentence:** Butler Sheet Icons (BSI) can already run without internet access if it
 finds a browser — so let administrators tell it where the browser is, and make it honest about what
@@ -361,7 +380,12 @@ Butler Sheet Icons will not fall back to downloading a browser when an executabl
 explicitly. Correct the path, or remove the option to let Butler Sheet Icons find a browser itself.
 ```
 
-**Platform mismatch** — `logger.warn`, three lines. The highest-value message in this change:
+**Platform mismatch** — `logger.warn`, three lines. The highest-value message in this change.
+
+Note that "platform mismatch" is not the same as "platforms differ": 64-bit Windows runs 32-bit
+builds, and Apple Silicon runs Intel builds under Rosetta, so those two pairings are accepted
+silently rather than reported here. The rule lives in `canRunOnHost()` in `browser-inventory.js`,
+which is also what `canRunHere` on each inventory entry is computed from — do not re-derive it.
 
 ```
 Found 2 cached chrome build(s), but none built for this machine (platform "win64").
@@ -386,12 +410,25 @@ Skipping cached chrome 138.0.7204.94: executable not found at <path>
 **Pinned version missed, but a usable build is cached** — `logger.warn`, three lines:
 
 ```
-No cached chrome build matches --browser-version "121.0.6167.85".
-Cached chrome builds that this machine can run: 138.0.7204.94. Use --browser-version latest to
-accept any of them.
-Butler Sheet Icons will now try to download chrome "121.0.6167.85", which needs internet access. On
+No cached chrome build matches --browser-version "recommended" (build 138.0.7204.94).
+Cached chrome builds that this machine can run: 131.0.6778.204. Set --browser-version to one of
+those build ids to use it instead.
+Butler Sheet Icons will now try to download chrome 138.0.7204.94, which needs internet access. On
 a machine without internet access this will fail.
 ```
+
+Two things this wording is careful about, both of which an earlier draft of this section got wrong:
+
+- **Name the version as the user set it, with the resolved build in brackets.** `recommended` is the
+  default and resolves from a constant, so most readers of this message never typed a version at
+  all. Quoting the resolved build id as the value of `--browser-version` describes a command line
+  nobody wrote, and sends them hunting through scheduled tasks for a version they never set. The raw
+  value is on `options.browserVersion`; the resolved one arrives as `resolvedBuildId`.
+- **Do not suggest `--browser-version latest`.** Since #878 every version resolves to exactly one
+  build *before* the cache is searched, keywords included, so `latest` misses in precisely the same
+  way and merely changes which build is missed. The earlier draft of this document advised it, which
+  would have sent the administrator round the same loop. Listing the cached build ids is the only
+  remedy that works.
 
 `warn`, not `error`: on a connected machine the run still succeeds. Do not promise a `--no-download`
 behaviour in this text — that is phase 2.

--- a/src/lib/browser/__tests__/browser_detect.test.js
+++ b/src/lib/browser/__tests__/browser_detect.test.js
@@ -11,10 +11,14 @@ jest.unstable_mockModule('@puppeteer/browsers', () => ({
             a.split('.').map(Number)[3] - b.split('.').map(Number)[3] ||
             a.localeCompare(b, undefined, { numeric: true })
     ),
-    detectBrowserPlatform: jest.fn().mockResolvedValue('mac_arm'),
+    // `mockReturnValue`, not `mockResolvedValue`: the real `detectBrowserPlatform()` is
+    // synchronous and returns `BrowserPlatform | undefined`. A promise here would be truthy,
+    // match no entry's `platform`, and empty the cache funnel in every test - a failure that
+    // looks like a bug in the filter rather than a bug in the mock.
+    detectBrowserPlatform: jest.fn().mockReturnValue('mac_arm'),
     resolveBuildId: jest.fn(),
 }));
-const { getInstalledBrowsers } = await import('@puppeteer/browsers');
+const { getInstalledBrowsers, detectBrowserPlatform } = await import('@puppeteer/browsers');
 
 jest.unstable_mockModule('../../../globals.js', () => ({
     logger: {
@@ -51,6 +55,16 @@ beforeEach(() => {
     for (const name of AMBIENT_ENV) {
         delete process.env[name];
     }
+
+    // `clearMocks` clears call records but keeps implementations, so both of these are set here
+    // rather than in the factory: a test that overrides either one would otherwise leak its
+    // override into every test that follows it.
+    detectBrowserPlatform.mockReturnValue('mac_arm');
+
+    // Path-aware rather than a blanket boolean. Detection now checks that a cached executable
+    // exists, so `mockReturnValue(false)` for a missing *system* browser would delete the cached
+    // entries too and prove the wrong thing.
+    fs.existsSync.mockImplementation((candidate) => String(candidate).startsWith('/cache/'));
 });
 
 afterEach(() => {
@@ -68,14 +82,18 @@ afterEach(() => {
  *
  * @param {string} browser - Browser type, e.g. `chrome`.
  * @param {string} buildId - Build id, e.g. `138.0.7204.94`.
+ * @param {string} [platform] - Puppeteer platform the build was made for. Defaults to the host
+ * platform the mocked `detectBrowserPlatform()` reports, so an entry is usable unless a test
+ * deliberately says otherwise.
  *
- * @returns {object} Entry with `browser`, `buildId` and `executablePath`.
+ * @returns {object} Entry with `browser`, `buildId`, `platform` and `executablePath`.
  */
-function cachedBrowser(browser, buildId) {
+function cachedBrowser(browser, buildId, platform = 'mac_arm') {
     return {
         browser,
         buildId,
-        executablePath: `/cache/${browser}/${buildId}/${browser}`,
+        platform,
+        executablePath: `/cache/${browser}/${platform}-${buildId}/${browser}`,
     };
 }
 
@@ -89,7 +107,7 @@ describe('detectAvailableBrowser — cached browsers', () => {
         const result = await detectAvailableBrowser({ browser: 'chrome' });
 
         expect(result).toEqual({
-            executablePath: '/cache/chrome/138.0.7204.94/chrome',
+            executablePath: '/cache/chrome/mac_arm-138.0.7204.94/chrome',
             source: 'cache',
             browser: 'chrome',
             buildId: '138.0.7204.94',
@@ -108,6 +126,156 @@ describe('detectAvailableBrowser — cached browsers', () => {
         ]);
 
         expect(await detectAvailableBrowser({ browser: 'chrome' })).toBeNull();
+    });
+});
+
+describe('detectAvailableBrowser — cached builds this machine cannot run', () => {
+    // Issue #943, reproduced against the released 4.0.0 image: a cache staged on the
+    // administrator's Mac and copied to a Windows server was accepted, logged as
+    // "Using cached browser", and then failed at launch with an unrelated-looking error.
+    test('ignores a cached build made for another platform', async () => {
+        detectBrowserPlatform.mockReturnValue('win64');
+        getInstalledBrowsers.mockResolvedValue([
+            cachedBrowser('chrome', '138.0.7204.94', 'mac_arm'),
+        ]);
+
+        expect(await detectAvailableBrowser({ browser: 'chrome' })).toBeNull();
+    });
+
+    test('names both platforms when the cache was staged on another operating system', async () => {
+        detectBrowserPlatform.mockReturnValue('win64');
+        getInstalledBrowsers.mockResolvedValue([
+            cachedBrowser('chrome', '138.0.7204.94', 'mac_arm'),
+            cachedBrowser('chrome', '131.0.6778.204', 'mac_arm'),
+        ]);
+
+        await detectAvailableBrowser({ browser: 'chrome' });
+
+        // Both sides of the mismatch have to appear: "wrong platform" alone leaves the reader
+        // guessing which machine is wrong, and this text is quoted verbatim by the
+        // troubleshooting documentation.
+        const warned = logger.warn.mock.calls.map(([msg]) => msg).join('\n');
+        expect(warned).toContain('win64');
+        expect(warned).toContain('mac_arm');
+        expect(warned).toContain('2 cached chrome build(s)');
+    });
+
+    test('names the cache directory that was searched', async () => {
+        // Quoted verbatim by the troubleshooting documentation, and the single most useful fact
+        // in the message now that --browser-cache-dir can point somewhere unexpected.
+        detectBrowserPlatform.mockReturnValue('win64');
+        getInstalledBrowsers.mockResolvedValue([
+            cachedBrowser('chrome', '138.0.7204.94', 'mac_arm'),
+        ]);
+
+        await detectAvailableBrowser({ browser: 'chrome', browserCacheDir: '/qlik/browsers' });
+
+        const warned = logger.warn.mock.calls.map(([msg]) => msg).join('\n');
+        expect(warned).toContain(path.resolve('/qlik/browsers'));
+    });
+
+    test('logs each build it skipped for being unrunnable', async () => {
+        // The per-entry lines are what let a support log account for every build the funnel
+        // discarded; the summary warning only gives counts.
+        detectBrowserPlatform.mockReturnValue('win64');
+        getInstalledBrowsers.mockResolvedValue([
+            cachedBrowser('chrome', '138.0.7204.94', 'mac_arm'),
+        ]);
+
+        await detectAvailableBrowser({ browser: 'chrome' });
+
+        const verbose = logger.verbose.mock.calls.map(([msg]) => msg).join('\n');
+        expect(verbose).toContain('138.0.7204.94');
+        expect(verbose).toContain('mac_arm');
+    });
+
+    test('logs each build it skipped for a missing executable', async () => {
+        getInstalledBrowsers.mockResolvedValue([cachedBrowser('chrome', '138.0.7204.94')]);
+        fs.existsSync.mockReturnValue(false);
+
+        await detectAvailableBrowser({ browser: 'chrome' });
+
+        const verbose = logger.verbose.mock.calls.map(([msg]) => msg).join('\n');
+        expect(verbose).toContain('executable not found');
+        expect(verbose).toContain('138.0.7204.94');
+    });
+
+    test('accepts a 32-bit Windows build on a 64-bit Windows host', async () => {
+        // WOW64 has been standard for two decades, so rejecting this would break a setup that
+        // works - and offline, a rejection means a download that cannot succeed.
+        detectBrowserPlatform.mockReturnValue('win64');
+        getInstalledBrowsers.mockResolvedValue([cachedBrowser('chrome', '138.0.7204.94', 'win32')]);
+
+        const result = await detectAvailableBrowser({ browser: 'chrome' });
+
+        expect(result?.buildId).toBe('138.0.7204.94');
+        expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    test('accepts an Intel macOS build on Apple Silicon', async () => {
+        // Runs under Rosetta 2. Optimistic if Rosetta is absent, but that was the behaviour
+        // before cached builds were filtered at all, and it still fails at launch as it did.
+        detectBrowserPlatform.mockReturnValue('mac_arm');
+        getInstalledBrowsers.mockResolvedValue([cachedBrowser('chrome', '138.0.7204.94', 'mac')]);
+
+        const result = await detectAvailableBrowser({ browser: 'chrome' });
+
+        expect(result?.buildId).toBe('138.0.7204.94');
+    });
+
+    test('still rejects a Windows build on macOS', async () => {
+        // The compatibility rule widens equality; it does not abandon it.
+        detectBrowserPlatform.mockReturnValue('mac_arm');
+        getInstalledBrowsers.mockResolvedValue([cachedBrowser('chrome', '138.0.7204.94', 'win64')]);
+
+        expect(await detectAvailableBrowser({ browser: 'chrome' })).toBeNull();
+    });
+
+    test('does not filter by platform when the host platform is unknown', async () => {
+        // `detectBrowserPlatform()` returns undefined off darwin/linux/win32. Filtering on that
+        // would empty the funnel and break a setup that works today.
+        detectBrowserPlatform.mockReturnValue(undefined);
+        // A real BrowserPlatform value, and deliberately not the host's: with no host platform
+        // to compare against, even a foreign build has to survive the filter.
+        getInstalledBrowsers.mockResolvedValue([cachedBrowser('chrome', '138.0.7204.94', 'linux')]);
+
+        const result = await detectAvailableBrowser({ browser: 'chrome' });
+
+        expect(result?.buildId).toBe('138.0.7204.94');
+    });
+
+    test('ignores a cached build whose executable is missing', async () => {
+        // What a `tar` invocation that skips dotfiles produces: the directory is there and
+        // parses, but `computeExecutablePath()` points at a file that was never copied.
+        getInstalledBrowsers.mockResolvedValue([cachedBrowser('chrome', '138.0.7204.94')]);
+        fs.existsSync.mockReturnValue(false);
+
+        expect(await detectAvailableBrowser({ browser: 'chrome' })).toBeNull();
+    });
+
+    test('says the cache may be incomplete when no executable is present', async () => {
+        getInstalledBrowsers.mockResolvedValue([cachedBrowser('chrome', '138.0.7204.94')]);
+        fs.existsSync.mockReturnValue(false);
+
+        await detectAvailableBrowser({ browser: 'chrome' });
+
+        const warned = logger.warn.mock.calls.map(([msg]) => msg).join('\n');
+        expect(warned).toContain('usable executable');
+    });
+
+    test('stays quiet when a usable build sits beside an unusable one', async () => {
+        // The funnel never empties here, so a single stale directory in an otherwise healthy
+        // cache must not produce a warning. Warn on every successful run and administrators
+        // learn to ignore the warnings that matter.
+        getInstalledBrowsers.mockResolvedValue([
+            cachedBrowser('chrome', '131.0.6778.204', 'win64'),
+            cachedBrowser('chrome', '138.0.7204.94'),
+        ]);
+
+        const result = await detectAvailableBrowser({ browser: 'chrome' });
+
+        expect(result?.buildId).toBe('138.0.7204.94');
+        expect(logger.warn).not.toHaveBeenCalled();
     });
 });
 
@@ -178,12 +346,81 @@ describe('detectAvailableBrowser — build id matching', () => {
     });
 
     test('reports a build miss as a build miss, not a type miss', async () => {
+        // Saying "no browsers of type chrome" here, as this once did, sends the reader looking
+        // for the wrong problem. The report was a debug line until the cache funnel landed; a
+        // pin that misses on an offline machine is a failed run, so it is now a warning.
         getInstalledBrowsers.mockResolvedValue([cachedBrowser('chrome', '138.0.7204.94')]);
 
         await detectAvailableBrowser({ browser: 'chrome' }, '121.0.6167.85');
 
-        const debugOutput = logger.debug.mock.calls.map(([msg]) => msg).join('\n');
-        expect(debugOutput).toContain('none matching build 121.0.6167.85');
+        const warned = logger.warn.mock.calls.map(([msg]) => msg).join('\n');
+        expect(warned).toContain('No cached chrome build matches');
+        expect(warned).not.toContain('matching type');
+    });
+
+    test('names the usable cached builds when the pin misses', async () => {
+        // The pin missed but the machine does have a browser it can run. Offline that is the
+        // difference between a fixable situation and a run that dies on a download it can
+        // never make, so the alternatives have to be named rather than logged at debug.
+        getInstalledBrowsers.mockResolvedValue([cachedBrowser('chrome', '138.0.7204.94')]);
+
+        await detectAvailableBrowser(
+            { browser: 'chrome', browserVersion: '121.0.6167.85' },
+            '121.0.6167.85'
+        );
+
+        const warned = logger.warn.mock.calls.map(([msg]) => msg).join('\n');
+        expect(warned).toContain('138.0.7204.94');
+        expect(warned).toContain('121.0.6167.85');
+        expect(warned).toContain('internet access');
+    });
+
+    test('quotes the version the user set, not the build it resolved to', async () => {
+        // `recommended` is the default, and resolves from a constant to a concrete build. Naming
+        // the resolved id as the value of --browser-version describes a command line nobody
+        // typed, and sends the reader hunting through scheduled tasks for a version they never
+        // set.
+        getInstalledBrowsers.mockResolvedValue([cachedBrowser('chrome', '131.0.6778.204')]);
+
+        await detectAvailableBrowser(
+            { browser: 'chrome', browserVersion: 'recommended' },
+            '138.0.7204.94'
+        );
+
+        const warned = logger.warn.mock.calls.map(([msg]) => msg).join('\n');
+        expect(warned).toContain('--browser-version "recommended"');
+        expect(warned).toContain('build 138.0.7204.94');
+    });
+
+    test('does not advise --browser-version latest, which is also an exact pin', async () => {
+        // Since issue #878 every version resolves to exactly one build before the cache is
+        // searched, so `latest` misses in precisely the same way. Advising it would send the
+        // administrator round the same loop with a different build id.
+        getInstalledBrowsers.mockResolvedValue([cachedBrowser('chrome', '138.0.7204.94')]);
+
+        await detectAvailableBrowser(
+            { browser: 'chrome', browserVersion: 'latest' },
+            '121.0.6167.85'
+        );
+
+        const warned = logger.warn.mock.calls.map(([msg]) => msg).join('\n');
+        expect(warned).not.toContain('--browser-version latest');
+        expect(warned).toContain('Set --browser-version to one of those build ids');
+    });
+
+    test('does not offer alternatives that this machine cannot run', async () => {
+        // The pinned build is absent and the only other cached build is foreign. Listing it as
+        // an alternative would send the administrator to a build that fails at launch.
+        detectBrowserPlatform.mockReturnValue('win64');
+        getInstalledBrowsers.mockResolvedValue([
+            cachedBrowser('chrome', '138.0.7204.94', 'mac_arm'),
+        ]);
+
+        await detectAvailableBrowser({ browser: 'chrome' }, '121.0.6167.85');
+
+        const warned = logger.warn.mock.calls.map(([msg]) => msg).join('\n');
+        expect(warned).toContain('mac_arm');
+        expect(warned).not.toContain('Use --browser-version latest');
     });
 });
 
@@ -218,7 +455,10 @@ describe('detectAvailableBrowser — no resolved build id (offline fallback)', (
 describe('detectAvailableBrowser — system browser', () => {
     test('prefers PUPPETEER_EXECUTABLE_PATH and does not consult the cache', async () => {
         process.env.PUPPETEER_EXECUTABLE_PATH = '/usr/bin/chromium-browser';
-        fs.existsSync.mockReturnValue(true);
+        fs.existsSync.mockImplementation(
+            (candidate) =>
+                candidate === '/usr/bin/chromium-browser' || String(candidate).startsWith('/cache/')
+        );
 
         const result = await detectAvailableBrowser({ browser: 'chrome' });
 
@@ -233,7 +473,9 @@ describe('detectAvailableBrowser — system browser', () => {
 
     test('warns and falls back to the cache when the configured path does not exist', async () => {
         process.env.PUPPETEER_EXECUTABLE_PATH = '/nope/chromium';
-        fs.existsSync.mockReturnValue(false);
+        // The default implementation already answers `false` for this path and `true` for the
+        // cached executable. A blanket `mockReturnValue(false)` would also hide the cached build
+        // and turn a fall-through test into a no-browser-anywhere test.
         getInstalledBrowsers.mockResolvedValue([cachedBrowser('chrome', '138.0.7204.94')]);
 
         const result = await detectAvailableBrowser({ browser: 'chrome' });

--- a/src/lib/browser/__tests__/browser_installed.test.js
+++ b/src/lib/browser/__tests__/browser_installed.test.js
@@ -74,7 +74,7 @@ afterEach(() => {
 describe('browserInstalled', () => {
     test('returns the installed builds as plain data', async () => {
         await expect(browserInstalled({ loglevel: 'info' })).resolves.toEqual([
-            { ...INSTALLED[0], isCurrentPlatform: true },
+            { ...INSTALLED[0], isCurrentPlatform: true, canRunHere: true },
         ]);
     });
 

--- a/src/lib/browser/__tests__/browser_inventory.test.js
+++ b/src/lib/browser/__tests__/browser_inventory.test.js
@@ -28,7 +28,7 @@ jest.unstable_mockModule('../../../globals.js', () => ({
     isSea: false,
 }));
 
-const { getBrowserInventory } = await import('../browser-inventory.js');
+const { getBrowserInventory, canRunOnHost } = await import('../browser-inventory.js');
 const { redactValue } = await import('../../util/redact-secrets.js');
 
 /**
@@ -127,6 +127,7 @@ describe('getBrowserInventory', () => {
             executablePath:
                 '/home/tester/.cache/puppeteer/chrome/mac_arm-151.0.7922.77/chrome-mac-arm64/chrome',
             isCurrentPlatform: true,
+            canRunHere: true,
         });
     });
 
@@ -190,11 +191,52 @@ describe('isCurrentPlatform', () => {
         expect(entry.isCurrentPlatform).toBe(true);
     });
 
+    test('is false for a build the host can run but was not built for', async () => {
+        // The narrower of the two fields on purpose: `browser uninstall` picks between several
+        // builds sharing an id and wants the exact host build, not merely a runnable one.
+        detectBrowserPlatform.mockReturnValue('win64');
+        getInstalledBrowsers.mockResolvedValue([fakeBuild({ platform: 'win32' })]);
+
+        const [entry] = await getBrowserInventory();
+
+        expect(entry.isCurrentPlatform).toBe(false);
+        expect(entry.canRunHere).toBe(true);
+    });
+
     test('detects the host platform once, not once per build', async () => {
         getInstalledBrowsers.mockResolvedValue([fakeBuild(), fakeBuild(), fakeBuild()]);
 
         await getBrowserInventory();
 
         expect(detectBrowserPlatform).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('canRunOnHost', () => {
+    test.each([
+        ['win64', 'win64', true],
+        // WOW64: 64-bit Windows runs 32-bit builds. detectBrowserPlatform() also reports win64
+        // for Windows 11 on ARM, which emulates x64, so this covers that host too.
+        ['win64', 'win32', true],
+        // Not the other way round: a 32-bit Windows host cannot run a 64-bit build.
+        ['win32', 'win64', false],
+        ['mac_arm', 'mac_arm', true],
+        // Rosetta 2.
+        ['mac_arm', 'mac', true],
+        ['mac', 'mac_arm', false],
+        ['linux', 'linux', true],
+        ['linux', 'linux_arm', false],
+        ['linux_arm', 'linux', false],
+        ['win64', 'mac_arm', false],
+        ['mac_arm', 'win64', false],
+        ['linux', 'win64', false],
+    ])('host %s running a %s build -> %s', (host, build, expected) => {
+        expect(canRunOnHost(host, build)).toBe(expected);
+    });
+
+    test('treats every build as runnable when the host platform is unknown', () => {
+        // Absence of evidence that a build is foreign is not evidence that it is.
+        expect(canRunOnHost(undefined, 'win64')).toBe(true);
+        expect(canRunOnHost('', 'linux_arm')).toBe(true);
     });
 });

--- a/src/lib/browser/browser-detect.js
+++ b/src/lib/browser/browser-detect.js
@@ -1,4 +1,5 @@
-import { getInstalledBrowsers, getVersionComparator } from '@puppeteer/browsers';
+import { getVersionComparator, detectBrowserPlatform } from '@puppeteer/browsers';
+import { getBrowserInventory } from './browser-inventory.js';
 import { resolveBrowserCacheDir } from './browser-paths.js';
 import fs from 'fs';
 
@@ -37,10 +38,111 @@ const sortNewestFirst = (browsers, browser) => {
 };
 
 /**
+ * Lists the distinct platforms a set of cache entries was built for.
+ *
+ * @param {Array<object>} browsers - Installed browser entries.
+ *
+ * @returns {string} Comma-separated platform names.
+ */
+const platformsOf = (browsers) => [...new Set(browsers.map((b) => b.platform))].join(', ');
+
+/**
+ * Explains why the cache yielded nothing usable.
+ *
+ * Called only once the funnel has emptied, and reports on the last stage that still had
+ * entries, so the message describes the real obstacle rather than the final emptiness.
+ *
+ * The exact wording matters more than usual: these strings are what an administrator pastes
+ * into a search box, and the troubleshooting documentation quotes them verbatim.
+ *
+ * @param {object} args - Funnel state.
+ * @param {string} args.browser - Requested browser type.
+ * @param {string} [args.requestedVersion] - What the user actually asked for, which may be a
+ * keyword such as `recommended`. Never the resolved build id: quoting a resolved id back as the
+ * value of `--browser-version` sends the reader looking for a version they never set.
+ * @param {string} [args.resolvedBuildId] - The concrete build that version resolved to.
+ * @param {string} args.cacheDir - Directory that was searched.
+ * @param {string} [args.hostPlatform] - Platform this machine runs, if recognised.
+ * @param {Array<object>} args.ofType - Entries matching the requested browser type.
+ * @param {Array<object>} args.ofPlatform - Of those, the ones built for this machine.
+ * @param {Array<object>} args.usable - Of those, the ones whose executable exists.
+ *
+ * @returns {void}
+ */
+const reportEmptyFunnel = ({
+    browser,
+    requestedVersion,
+    resolvedBuildId,
+    cacheDir,
+    hostPlatform,
+    ofType,
+    ofPlatform,
+    usable,
+}) => {
+    if (ofType.length === 0) {
+        logger.debug(`No cached browsers matching type "${browser}" found`);
+        return;
+    }
+
+    if (ofPlatform.length === 0) {
+        // The highest-value message here. The connected machine is usually the administrator's
+        // Mac and the target a Windows server, so this is the most likely staging mistake -
+        // and until now the only sign of it was an unrelated-looking failure at launch.
+        logger.warn(
+            `Found ${ofType.length} cached ${browser} build(s), but none built for this machine (platform "${hostPlatform}"). ` +
+                `Cached ${browser} builds are for: ${platformsOf(ofType)}. A browser cache copied from a machine with a different operating system cannot be used. ` +
+                `Browser cache directory: ${cacheDir}`
+        );
+        return;
+    }
+
+    if (usable.length === 0) {
+        logger.warn(
+            `Found ${ofPlatform.length} cached ${browser} build(s) for this machine, but none has a usable executable. ` +
+                `The cache directory may be incomplete - for example copied without the browser binary, or left behind by a failed install. ` +
+                `Browser cache directory: ${cacheDir}`
+        );
+        return;
+    }
+
+    // Only reachable with a pinned build: without one, every usable entry matches.
+    //
+    // The version is named as the user set it, with the build it resolved to in brackets. A
+    // keyword is the normal case - `recommended` is the default - so quoting the resolved id as
+    // though it were the flag's value would describe a command line nobody typed.
+    const asked = requestedVersion
+        ? `--browser-version "${requestedVersion}"${
+              resolvedBuildId && resolvedBuildId !== requestedVersion
+                  ? ` (build ${resolvedBuildId})`
+                  : ''
+          }`
+        : `build ${resolvedBuildId}`;
+
+    // No "use --browser-version latest to accept any of them" here: since issue #878 every
+    // version, keyword included, resolves to exactly one build before the cache is searched, so
+    // `latest` would miss in precisely the same way. Naming the build ids is the only advice
+    // that actually works.
+    //
+    // `warn` rather than `error` because on a connected machine the run still succeeds by
+    // downloading. The last sentence is what makes it actionable offline, where it will not.
+    logger.warn(
+        `No cached ${browser} build matches ${asked}. ` +
+            `Cached ${browser} builds that this machine can run: ${usable.map((b) => b.buildId).join(', ')}. Set --browser-version to one of those build ids to use it instead. ` +
+            `Butler Sheet Icons will now try to download ${browser} ${resolvedBuildId}, which needs internet access. On a machine without internet access this will fail.`
+    );
+};
+
+/**
  * Detects available browsers in the following priority order:
  * 1. System browser (via PUPPETEER_EXECUTABLE_PATH environment variable)
- * 2. Cached browsers in Puppeteer cache directory
+ * 2. Cached browsers in the resolved browser cache directory
  * 3. Returns null if no browser found (caller should download)
+ *
+ * A cached browser has to survive four narrowing stages before it is offered: it must be the
+ * requested type, built for this machine's platform, have an executable that actually exists,
+ * and match the pinned build id when one was given. The first two of those were missing until
+ * issue #943, where a cache staged on macOS and mounted into a Linux container was accepted and
+ * then failed at launch with an error that named none of this.
  *
  * Version matching works on a build id that the caller has already resolved, never on the raw
  * `--browser-version` value. That is what makes a keyword mean exactly one build: before this,
@@ -98,29 +200,63 @@ export const detectAvailableBrowser = async (options, resolvedBuildId) => {
         // Priority 2: Check for cached browsers in the browser cache directory
         const browserPath = resolveBrowserCacheDir(options);
 
-        const installedBrowsers = await getInstalledBrowsers({
-            cacheDir: browserPath,
-        });
+        // The shared inventory rather than getInstalledBrowsers() directly: it already answers
+        // "can this machine run that build" as `canRunHere`, and a second copy of that rule here
+        // would drift from the one `browser list-installed` and `browser uninstall` report.
+        const installedBrowsers = await getBrowserInventory({ cacheDir: browserPath });
 
         if (installedBrowsers && installedBrowsers.length > 0) {
             logger.info(`Found ${installedBrowsers.length} cached browser(s)`);
 
-            // Filter by requested browser type if specified
-            let matchingBrowsers = installedBrowsers;
-            if (options.browser) {
-                matchingBrowsers = matchingBrowsers.filter((b) => b.browser === options.browser);
-            }
+            // A funnel rather than a single filter, because the stage that empties *is* the
+            // diagnosis. Reporting only "no usable browser found" throws away the one fact the
+            // administrator needs: whether the cache is for the wrong machine, incomplete, or
+            // simply missing the pinned build.
+            const ofType = options.browser
+                ? installedBrowsers.filter((b) => b.browser === options.browser)
+                : installedBrowsers;
 
-            const ofRequestedType = matchingBrowsers.length;
+            // `canRunHere` is computed by the inventory, which owns the compatibility rule -
+            // it is wider than equality, because 64-bit Windows runs 32-bit builds and Apple
+            // Silicon runs Intel ones. An undetectable host platform leaves every build
+            // runnable, so a machine Butler Sheet Icons does not recognise keeps working.
+            //
+            // Read here only to name the host in the diagnostic below; the decision itself is
+            // not made from it. Synchronous, despite several call sites in this codebase
+            // awaiting it.
+            const hostPlatform = detectBrowserPlatform();
+            const ofPlatform = ofType.filter((b) => {
+                if (b.canRunHere) {
+                    return true;
+                }
 
-            if (resolvedBuildId) {
-                matchingBrowsers = matchingBrowsers.filter((b) => b.buildId === resolvedBuildId);
-            } else {
-                matchingBrowsers = sortNewestFirst(matchingBrowsers, options.browser);
-            }
+                logger.verbose(
+                    `Skipping cached ${b.browser} ${b.buildId}: built for ${b.platform}, which this machine (${hostPlatform}) cannot run`
+                );
+                return false;
+            });
 
-            if (matchingBrowsers.length > 0) {
-                const browser = matchingBrowsers[0];
+            // `computeExecutablePath()` builds this path from the layout convention without
+            // ever stat-ing it, so a cache copied without its binaries - or without the
+            // `.metadata` file, which is what a tar invocation that skips dotfiles produces -
+            // yields a perfectly plausible path to nothing.
+            const usable = ofPlatform.filter((b) => {
+                if (fs.existsSync(b.executablePath)) {
+                    return true;
+                }
+
+                logger.verbose(
+                    `Skipping cached ${b.browser} ${b.buildId}: executable not found at ${b.executablePath}`
+                );
+                return false;
+            });
+
+            const matching = resolvedBuildId
+                ? usable.filter((b) => b.buildId === resolvedBuildId)
+                : sortNewestFirst(usable, options.browser);
+
+            if (matching.length > 0) {
+                const browser = matching[0];
                 logger.info(`Using cached browser: ${browser.browser} ${browser.buildId}`);
 
                 return {
@@ -129,15 +265,21 @@ export const detectAvailableBrowser = async (options, resolvedBuildId) => {
                     browser: browser.browser,
                     buildId: browser.buildId,
                 };
-            } else if (ofRequestedType > 0) {
-                // The type matched and only the build did. Saying "no browsers of type chrome"
-                // here, as this used to, sends the reader looking for the wrong problem.
-                logger.debug(
-                    `Cached "${options.browser}" browsers found, but none matching build ${resolvedBuildId}`
-                );
-            } else {
-                logger.debug(`No cached browsers matching type "${options.browser}" found`);
             }
+
+            // Report from the last stage that still had entries. The `warn` blocks fire only
+            // when the funnel has emptied - a healthy run with one stale directory beside a
+            // usable build stays quiet, because warnings that fire on success get ignored.
+            reportEmptyFunnel({
+                browser: options.browser,
+                requestedVersion: options.browserVersion,
+                resolvedBuildId,
+                cacheDir: browserPath,
+                hostPlatform,
+                ofType,
+                ofPlatform,
+                usable,
+            });
         } else {
             logger.debug('No cached browsers found');
         }

--- a/src/lib/browser/browser-inventory.js
+++ b/src/lib/browser/browser-inventory.js
@@ -10,8 +10,54 @@ import { resolveBrowserCacheDir } from './browser-paths.js';
  * @property {string} platform - Platform the build was downloaded for, e.g. `mac_arm`.
  * @property {string} path - Installation folder.
  * @property {string} executablePath - The browser binary itself.
- * @property {boolean} isCurrentPlatform - Whether this build can run on this machine.
+ * @property {boolean} isCurrentPlatform - Whether this build was made for exactly this platform.
+ * @property {boolean} canRunHere - Whether this machine can execute the build, which is a wider
+ * question than `isCurrentPlatform` - see {@link RUNNABLE_PLATFORMS}.
  */
+
+/**
+ * Build platforms each host platform can execute, beyond its own.
+ *
+ * Equality is the wrong test for "can this machine run that build", and getting it wrong is
+ * expensive in exactly the environment this matters most: rejecting a build that would have run
+ * sends an air-gapped machine to a download it cannot make.
+ *
+ * - **64-bit Windows runs 32-bit Chrome.** WOW64 has been standard for two decades. Note that
+ *   `detectBrowserPlatform()` also reports `win64` for Windows 11 on ARM, because that emulates
+ *   x64 - so this entry covers that case too.
+ * - **Apple Silicon runs Intel builds** through Rosetta 2. Rosetta is not guaranteed to be
+ *   installed, so this is optimistic; it is the same optimism that shipped before cached builds
+ *   were filtered at all, and a build that cannot start still fails at launch as it did then.
+ *
+ * Everything else is exact: a Linux host cannot run a Windows build, and an ARM Linux host
+ * cannot run an x64 one.
+ */
+const RUNNABLE_PLATFORMS = Object.freeze({
+    win64: ['win32'],
+    mac_arm: ['mac'],
+});
+
+/**
+ * Whether a cached build can be executed on the host.
+ *
+ * With no host platform detected there is no evidence a build is foreign, and claiming otherwise
+ * would label every entry unusable. Absence of evidence is reported as runnable, not as broken.
+ *
+ * @param {string} [hostPlatform] - Platform this machine runs, if it could be detected.
+ * @param {string} buildPlatform - Platform the cached build was made for.
+ *
+ * @returns {boolean} `true` when the build can run here.
+ */
+export const canRunOnHost = (hostPlatform, buildPlatform) => {
+    if (!hostPlatform) {
+        return true;
+    }
+
+    return (
+        buildPlatform === hostPlatform ||
+        (RUNNABLE_PLATFORMS[hostPlatform]?.includes(buildPlatform) ?? false)
+    );
+};
 
 /**
  * List the browsers in the cache, as plain data.
@@ -63,5 +109,10 @@ export const getBrowserInventory = async ({ cacheDir = resolveBrowserCacheDir() 
         // foreign, and claiming otherwise would label every entry "cannot run
         // here". Absence of evidence is reported as usable, not as unusable.
         isCurrentPlatform: hostPlatform ? browser.platform === hostPlatform : true,
+        // Deliberately a second field rather than a widening of the one above. They answer
+        // different questions and have different callers: `browser uninstall` picks between
+        // several builds of the same id and wants the exact host build, while detection asks
+        // only whether a build will start.
+        canRunHere: canRunOnHost(hostPlatform, browser.platform),
     }));
 };


### PR DESCRIPTION
Closes #943. Covers the remaining detection work tracked in #931, and is commit 2 of the sequencing in `docs/todo/airgap-browser-phase-1.md`.

## The problem

`detectAvailableBrowser()` matched a cached build on **browser type** and **build id** only. It never checked that the build was made for this machine, or that the browser binary was actually there. Both mistakes were accepted, logged as a confident `Using cached browser: chrome 151.0.7922.77`, and then failed at launch with an error that named none of the real cause.

#943 reproduces the first against the released 4.0.0 image: a `win64` cache mounted into a Linux container.

This matters more now than it did a week ago. `--browser-cache-dir` shipped in #1024, so administrators can point BSI at any directory — including one staged on the wrong machine.

## What changed

The cache lookup is a funnel — type → runnable here → executable present → pinned build — and it reports from **the last stage that still had entries**, because the stage that empties is the diagnosis. Only that stage warns, so a healthy cache with one stale directory beside a working build stays silent.

Runnability is deliberately **wider than equality**, which is the part most likely to be assumed wrong on review:

| Host | Build | Accepted |
| --- | --- | --- |
| `win64` | `win32` | yes — WOW64, and `detectBrowserPlatform()` reports `win64` for Windows 11 on ARM too |
| `mac_arm` | `mac` | yes — Rosetta 2 |
| `win32` | `win64` | no |
| `mac_arm` | `win64` | no |
| unknown | anything | yes — absence of evidence is not evidence |

That rule lives in `canRunOnHost()` in `browser-inventory.js` and reaches detection as `canRunHere`, so `browser list-installed` and detection cannot disagree about whether a build is usable. `isCurrentPlatform` is untouched: `browser uninstall` chooses between builds sharing a build id and wants the exact host build.

The pinned-version warning names the version **as the user set it**, with the resolved build in brackets, and no longer suggests `--browser-version latest` — since #878 every keyword resolves to exactly one build before the cache is searched, so that advice sent the reader round the same loop with a different build id.

## Verification

`npm run test:unit` green (2657 tests). Beyond the unit tests, detection was exercised against real directories on disk with the real `@puppeteer/browsers` parsing them:

| Scenario | Result |
| --- | --- |
| `win64` cache on macOS | `null` + warning naming both platforms |
| Executable never copied | `null` + "cache directory may be incomplete" |
| Intel build on Apple Silicon | accepted, no warning |
| Healthy cache | accepted, silent |
| Pin miss with default `recommended` | `--browser-version "recommended" (build 138.0.7204.94)` |

## Reviewer notes

- **Behaviour change worth a changelog line:** a cache that genuinely cannot run here is now rejected rather than accepted. On a connected machine that turns into a download; on an air-gapped one it turns a confusing launch failure into an explicit message. The compatibility table above is what keeps working setups working.
- Doc draft for the three troubleshooting entries is staged in `docs/to-doc-site/`, quoting each message verbatim.
- The design doc's §6.3 previously specified the `latest` advice that this PR removes; it is corrected in the same branch so commit 6 (`browser check`) does not inherit it.
- Not fixed here: `uninstall.interactive.js` labels builds `cannot run here` from `isCurrentPlatform`, so it will make that claim about a `win32` build on `win64`. Pre-existing, and belongs to the uninstall command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
