### PR TITLE
Recognise a browser that is already in the cache instead of trying to download it

### DIFF
--- a/docs/to-doc-site/browser-install-works-offline.md
+++ b/docs/to-doc-site/browser-install-works-offline.md
@@ -1,0 +1,104 @@
+# `browser install` now works without internet access for a browser you already have
+
+**Target pages:** `reference/browser.md` (the `browser install` entry), plus a troubleshooting entry
+in `guide/troubleshooting.md`.
+
+**Version gate:** confirm the next released version at publication time from the open release-please
+pull request, and add `::: warning Requires BSI X.Y.Z or later` to each section.
+
+---
+
+## What changed
+
+`butler-sheet-icons browser install` used to check whether the browser could be **downloaded**
+before it looked at what was already on the machine. On a server with no internet access that check
+fails, so the command reported:
+
+```
+Browser "chrome" version "..." cannot be downloaded. Please use the "list-available"
+command to check available versions
+```
+
+— about a browser that was already installed and sitting on disk. The suggested next step,
+`browser list-available`, needs internet access too, so there was no way forward.
+
+Butler Sheet Icons now looks in the browser cache first. If the browser you asked for is already
+there, it says so and stops:
+
+```
+chrome 151.0.7922.47 is already installed at
+C:\butler-sheet-icons\browser-cache\chrome\win64-151.0.7922.47. Nothing to download.
+To replace it, remove it first with "butler-sheet-icons browser uninstall
+--browser-version 151.0.7922.47".
+```
+
+No network connection is used, and no download is attempted.
+
+## Why this matters
+
+This is what lets you **confirm a staged browser on the air-gapped machine itself**. Copying a
+browser cache onto a server with no internet access is the documented way to set Butler Sheet Icons
+up in such an environment, and running `browser install` is the natural way to check the copy
+worked. Until now that check was the one thing that could not be done there.
+
+It also works with **no options at all**. `--browser-version` defaults to `recommended`, which is a
+specific browser build recorded inside Butler Sheet Icons itself rather than something it has to
+look up. So on a machine with the matching browser staged:
+
+```
+butler-sheet-icons browser install
+```
+
+completes offline. Other version settings — `latest`, `stable`, or a release channel — still need
+internet access, because Butler Sheet Icons has to ask the browser vendor which build those names
+currently mean. That lookup happens before the cache is consulted, so those settings fail offline
+even when the browser is present.
+
+## What this changes about repeated installs
+
+`browser install` used to install again every time it was run. It is now a **no-op when the
+requested build is already present**: it reports what is installed and exits successfully without
+re-downloading. If you need to replace an installed browser, uninstall it first:
+
+```
+butler-sheet-icons browser uninstall --browser-version 151.0.7922.47
+```
+
+## Three cases where it still downloads
+
+Butler Sheet Icons only skips the download when the browser in the cache is genuinely the one it
+was asked for.
+
+**A different build.** The cache holds a different version from the one requested. See the
+troubleshooting entry on version pinning — the message lists the build ids you have.
+
+**A build for a different operating system.** A cache copied from a machine running a different
+operating system cannot be used, and installing is about placing *this* machine's build, so a
+foreign build never counts as already installed. Note this is stricter than the check made when
+taking screenshots, which will accept a 32-bit Windows build on 64-bit Windows, or an Intel macOS
+build on Apple Silicon.
+
+**A folder with no browser in it.** If the build's folder exists but the browser program inside it
+is missing — an incomplete copy, or an interrupted download — you will see:
+
+```
+A cached chrome 151.0.7922.47 directory exists at
+C:\butler-sheet-icons\browser-cache\chrome\win64-151.0.7922.47, but the browser executable
+is missing from it. Butler Sheet Icons will remove that directory and install the build
+again, which needs internet access.
+```
+
+Butler Sheet Icons removes the incomplete folder itself and installs the build again, which works on
+a machine with internet access. Nothing is lost by the removal: a folder with no browser program in
+it cannot be used for anything.
+
+On an air-gapped machine the reinstall cannot succeed, so copy the browser across again, making sure
+your archiving tool includes hidden files — several skip them by default, and one of the files
+Butler Sheet Icons needs is hidden.
+
+## Note for the publishing pass
+
+Verify every message above against the implementation before publishing, and quote them verbatim.
+The `browser install` option table on `reference/browser.md` is generated — refresh it with
+`npm run docs:cli-tables` rather than editing it by hand — but the prose describing what the command
+does needs the update above.

--- a/src/lib/browser/__tests__/browser_install.test.js
+++ b/src/lib/browser/__tests__/browser_install.test.js
@@ -8,6 +8,10 @@ jest.unstable_mockModule('@puppeteer/browsers', () => ({
     detectBrowserPlatform: jest.fn(),
     canDownload: jest.fn(),
     uninstall: jest.fn(),
+    // Reached through getBrowserInventory(), which browser-install.js consults for an
+    // already-staged build before touching the network. ESM checks named exports when the
+    // module graph is linked, so omitting it fails the whole suite rather than one test.
+    getInstalledBrowsers: jest.fn().mockResolvedValue([]),
 }));
 const { install, resolveBuildId, detectBrowserPlatform, canDownload, uninstall } =
     await import('@puppeteer/browsers');

--- a/src/lib/browser/__tests__/browser_install_offline.test.js
+++ b/src/lib/browser/__tests__/browser_install_offline.test.js
@@ -11,6 +11,10 @@ jest.unstable_mockModule('@puppeteer/browsers', () => ({
     install: jest.fn(),
     resolveBuildId: jest.fn(),
     uninstall: jest.fn(),
+    // Reached through getBrowserInventory(), which browser-install.js consults for an
+    // already-staged build. Empty here: these tests are about failures on the way to a
+    // download, so nothing must short-circuit before them.
+    getInstalledBrowsers: jest.fn().mockResolvedValue([]),
 }));
 const { resolveBuildId } = await import('@puppeteer/browsers');
 

--- a/src/lib/browser/__tests__/browser_install_staged.test.js
+++ b/src/lib/browser/__tests__/browser_install_staged.test.js
@@ -1,0 +1,272 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+// `browser install` for a build that is already in the cache. The point of these tests is that
+// the whole path is reachable with no network at all: an administrator who has staged a browser
+// onto an air-gapped machine runs `browser install` to confirm it worked, and until now was told
+// the browser "cannot be downloaded" - about a browser sitting right there on disk.
+
+jest.unstable_mockModule('@puppeteer/browsers', () => ({
+    install: jest.fn(),
+    resolveBuildId: jest.fn(),
+    detectBrowserPlatform: jest.fn().mockReturnValue('mac_arm'),
+    canDownload: jest.fn().mockResolvedValue(true),
+    uninstall: jest.fn(),
+    getInstalledBrowsers: jest.fn(),
+}));
+const { install, canDownload, getInstalledBrowsers, detectBrowserPlatform, uninstall } =
+    await import('@puppeteer/browsers');
+
+// Stubbed so the reading and writing resolvers can be told apart. They differ in production only
+// for a standalone build whose primary cache is empty while the previous default location is
+// not - exactly the case where reading from the wrong one costs a 150 MB re-download.
+jest.unstable_mockModule('../browser-paths.js', () => ({
+    resolveBrowserCacheDir: jest.fn(() => '/read-here'),
+    resolveBrowserCacheDirForWriting: jest.fn(() => '/write-here'),
+    assertCacheDirWritable: jest.fn(),
+    isPermissionDenied: jest.fn(() => false),
+    unwritableCacheDirMessage: jest.fn((dir) => `cannot write to ${dir}`),
+}));
+const { assertCacheDirWritable } = await import('../browser-paths.js');
+
+jest.unstable_mockModule('puppeteer-core/internal/revisions.js', () => ({
+    PUPPETEER_REVISIONS: Object.freeze({ chrome: '150.0.7871.24' }),
+}));
+
+jest.unstable_mockModule('../../../globals.js', () => ({
+    logger: {
+        info: jest.fn(),
+        verbose: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+    },
+    setLoggingLevel: jest.fn(),
+    bsiExecutablePath: '/test/path',
+    isSea: false,
+    sleep: jest.fn().mockResolvedValue(undefined),
+}));
+const { logger } = await import('../../../globals.js');
+
+jest.unstable_mockModule('fs', () => ({
+    default: { existsSync: jest.fn() },
+    existsSync: jest.fn(),
+}));
+const fs = (await import('fs')).default;
+
+/** Inert progress bar so the install path does not write to a TTY. */
+class FakeSingleBar {
+    /**
+     * No-op stub for cli-progress SingleBar.start.
+     *
+     * @returns {void}
+     */
+    start() {}
+
+    /**
+     * No-op stub for cli-progress SingleBar.update.
+     *
+     * @returns {void}
+     */
+    update() {}
+
+    /**
+     * No-op stub for cli-progress SingleBar.stop.
+     *
+     * @returns {void}
+     */
+    stop() {}
+}
+jest.unstable_mockModule('cli-progress', () => ({
+    default: { SingleBar: FakeSingleBar, Presets: { shades_classic: {} } },
+}));
+
+const { browserInstall } = await import('../browser-install.js');
+
+const RECOMMENDED = '150.0.7871.24';
+
+/**
+ * Builds a cache entry as `@puppeteer/browsers` reports it.
+ *
+ * @param {object} [overrides] - Fields to override.
+ *
+ * @returns {object} An installed-browser-shaped entry.
+ */
+const cached = (overrides = {}) => ({
+    browser: 'chrome',
+    buildId: RECOMMENDED,
+    platform: 'mac_arm',
+    path: `/read-here/chrome/mac_arm-${RECOMMENDED}`,
+    executablePath: `/read-here/chrome/mac_arm-${RECOMMENDED}/chrome`,
+    ...overrides,
+});
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    detectBrowserPlatform.mockReturnValue('mac_arm');
+    canDownload.mockResolvedValue(true);
+    fs.existsSync.mockImplementation((candidate) => String(candidate).startsWith('/read-here/'));
+    getInstalledBrowsers.mockResolvedValue([]);
+    // `clearMocks` keeps implementations, so the rejection one test installs would otherwise
+    // make every later cleanup fail.
+    uninstall.mockResolvedValue(undefined);
+    install.mockResolvedValue({
+        browser: 'chrome',
+        buildId: RECOMMENDED,
+        executablePath: `/write-here/chrome/mac_arm-${RECOMMENDED}/chrome`,
+    });
+});
+
+const OPTIONS = { browser: 'chrome', browserVersion: 'recommended' };
+
+describe('browserInstall — a build already staged in the cache', () => {
+    test('returns the staged build without reaching the network', async () => {
+        // The assertion that matters is `canDownload` never being called. Checking only the log
+        // line would pass with the network request still happening, which is the entire defect.
+        getInstalledBrowsers.mockResolvedValue([cached()]);
+
+        const result = await browserInstall(OPTIONS);
+
+        expect(canDownload).not.toHaveBeenCalled();
+        expect(install).not.toHaveBeenCalled();
+        expect(result).toMatchObject({
+            browser: 'chrome',
+            buildId: RECOMMENDED,
+            executablePath: `/read-here/chrome/mac_arm-${RECOMMENDED}/chrome`,
+        });
+    });
+
+    test('says what it found and how to replace it', async () => {
+        // Quoted verbatim by the documentation, and the only place the operator is told that
+        // installing is now a no-op - so it has to name the way back to a reinstall.
+        getInstalledBrowsers.mockResolvedValue([cached()]);
+
+        await browserInstall(OPTIONS);
+
+        const info = logger.info.mock.calls.map(([msg]) => msg).join('\n');
+        expect(info).toContain(`chrome ${RECOMMENDED} is already installed at`);
+        expect(info).toContain('Nothing to download.');
+        expect(info).toContain('browser uninstall --browser-version');
+    });
+
+    test('falls through when the host platform cannot be detected', async () => {
+        // The inventory reports every build as `isCurrentPlatform` when there is no host
+        // platform to compare against, which is right for running a browser and wrong here:
+        // install() would throw "Unable to detect browser platform" rather than accept a foreign
+        // build, and that honest failure must not be replaced by a false "already installed".
+        detectBrowserPlatform.mockReturnValue(undefined);
+        getInstalledBrowsers.mockResolvedValue([cached({ platform: 'win64' })]);
+
+        await browserInstall(OPTIONS);
+
+        expect(install).toHaveBeenCalled();
+    });
+
+    test('looks in the reading cache directory, not the one it would install into', async () => {
+        // A standalone build whose primary cache is empty reads from the previous default
+        // location. Looking for a staged build in the write target instead would miss it and
+        // re-download ~150 MB that detection is happily using.
+        getInstalledBrowsers.mockResolvedValue([cached()]);
+
+        await browserInstall(OPTIONS);
+
+        expect(getInstalledBrowsers).toHaveBeenCalledWith({ cacheDir: '/read-here' });
+    });
+
+    test('does not require the cache directory to be writable', async () => {
+        // A browser staged onto a read-only share, or unzipped under C:\Program Files, needs no
+        // write at all when the build is already there.
+        getInstalledBrowsers.mockResolvedValue([cached()]);
+
+        await browserInstall(OPTIONS);
+
+        expect(assertCacheDirWritable).not.toHaveBeenCalled();
+    });
+
+    test('still installs into the writing directory when nothing is staged', async () => {
+        await browserInstall(OPTIONS);
+
+        expect(assertCacheDirWritable).toHaveBeenCalledWith('/write-here');
+        expect(install).toHaveBeenCalledWith(
+            expect.objectContaining({ cacheDir: '/write-here', buildId: RECOMMENDED })
+        );
+    });
+
+    test('ignores a staged build made for another platform', async () => {
+        // Unlike detection, which asks only whether a build will start, install asks whether the
+        // build it would download is already here - and it would download this platform's build.
+        getInstalledBrowsers.mockResolvedValue([cached({ platform: 'win64' })]);
+
+        await browserInstall(OPTIONS);
+
+        expect(install).toHaveBeenCalled();
+    });
+
+    test('ignores a staged build whose executable is missing, and says so', async () => {
+        // Reporting "already installed" for a folder with no browser in it would reintroduce
+        // exactly the false success that cached-browser detection just stopped producing.
+        getInstalledBrowsers.mockResolvedValue([cached()]);
+        fs.existsSync.mockReturnValue(false);
+
+        await browserInstall(OPTIONS);
+
+        expect(install).toHaveBeenCalled();
+        const warned = logger.warn.mock.calls.map(([msg]) => msg).join('\n');
+        expect(warned).toContain(RECOMMENDED);
+        expect(warned).toContain('executable');
+    });
+
+    test('clears the incomplete directory it is about to install over', async () => {
+        // install() treats a surviving install directory as an already-installed browser, skips
+        // the download and fails validation with "The browser folder exists but the executable
+        // is missing". The retry loop recovers, but only after an alarming failed attempt - and
+        // the warning above promises a reinstall, so it has to actually happen.
+        getInstalledBrowsers.mockResolvedValue([cached()]);
+        fs.existsSync.mockReturnValue(false);
+
+        await browserInstall(OPTIONS);
+
+        expect(uninstall).toHaveBeenCalledWith({
+            browser: 'chrome',
+            buildId: RECOMMENDED,
+            cacheDir: '/read-here',
+            platform: 'mac_arm',
+        });
+    });
+
+    test('installs anyway when the incomplete directory cannot be cleared', async () => {
+        // Cleanup is best effort. Letting its failure escape would replace a recoverable install
+        // with an error about a directory the operator never asked about.
+        getInstalledBrowsers.mockResolvedValue([cached()]);
+        fs.existsSync.mockReturnValue(false);
+        uninstall.mockRejectedValue(new Error('EPERM: operation not permitted'));
+
+        await expect(browserInstall(OPTIONS)).resolves.toMatchObject({ buildId: RECOMMENDED });
+    });
+
+    test('explains a staged build that is for the wrong platform', async () => {
+        getInstalledBrowsers.mockResolvedValue([cached({ platform: 'win64' })]);
+
+        await browserInstall(OPTIONS);
+
+        const verbose = logger.verbose.mock.calls.map(([msg]) => msg).join('\n');
+        expect(verbose).toContain('win64');
+        expect(verbose).toContain('mac_arm');
+    });
+
+    test('ignores a different build of the same browser', async () => {
+        getInstalledBrowsers.mockResolvedValue([cached({ buildId: '131.0.6778.204' })]);
+
+        await browserInstall(OPTIONS);
+
+        expect(install).toHaveBeenCalled();
+    });
+
+    test('does not fail the install when the cache cannot be read', async () => {
+        // The short-circuit is an optimisation over the install path, not a precondition for it.
+        // An unreadable cache must fall through to the normal install rather than abort it.
+        getInstalledBrowsers.mockRejectedValue(new Error('EACCES: permission denied'));
+
+        await expect(browserInstall(OPTIONS)).resolves.toMatchObject({ buildId: RECOMMENDED });
+        expect(install).toHaveBeenCalled();
+    });
+});

--- a/src/lib/browser/browser-detect.js
+++ b/src/lib/browser/browser-detect.js
@@ -1,5 +1,5 @@
 import { getVersionComparator, detectBrowserPlatform } from '@puppeteer/browsers';
-import { getBrowserInventory } from './browser-inventory.js';
+import { getBrowserInventory, hasUsableExecutable } from './browser-inventory.js';
 import { resolveBrowserCacheDir } from './browser-paths.js';
 import fs from 'fs';
 
@@ -236,12 +236,10 @@ export const detectAvailableBrowser = async (options, resolvedBuildId) => {
                 return false;
             });
 
-            // `computeExecutablePath()` builds this path from the layout convention without
-            // ever stat-ing it, so a cache copied without its binaries - or without the
-            // `.metadata` file, which is what a tar invocation that skips dotfiles produces -
-            // yields a perfectly plausible path to nothing.
+            // Shared with `browser install`, so the two cannot disagree about whether a cached
+            // build is real - see hasUsableExecutable().
             const usable = ofPlatform.filter((b) => {
-                if (fs.existsSync(b.executablePath)) {
+                if (hasUsableExecutable(b)) {
                     return true;
                 }
 

--- a/src/lib/browser/browser-install.js
+++ b/src/lib/browser/browser-install.js
@@ -2,9 +2,11 @@ import { install, detectBrowserPlatform, canDownload, uninstall } from '@puppete
 import {
     assertCacheDirWritable,
     isPermissionDenied,
+    resolveBrowserCacheDir,
     resolveBrowserCacheDirForWriting,
     unwritableCacheDirMessage,
 } from './browser-paths.js';
+import { getBrowserInventory, hasUsableExecutable } from './browser-inventory.js';
 import cliProgress from 'cli-progress';
 
 import { logger, setLoggingLevel, bsiExecutablePath, isSea, sleep } from '../../globals.js';
@@ -13,11 +15,121 @@ import { resolveBrowserVersion } from './browser-version.js';
 import { alreadyReported } from '../util/reported-error.js';
 
 /**
+ * Finds a build already in the cache that makes downloading unnecessary.
+ *
+ * This is what lets an administrator confirm a staged browser *on the air-gapped machine itself*,
+ * which is the first thing they will try. Without it `browser install` runs `canDownload()` first
+ * and reports that a browser sitting right there on disk "cannot be downloaded".
+ *
+ * Three decisions worth stating, because each one is a way this could quietly be wrong:
+ *
+ * - **The reading resolver, not the writing one.** They differ for a standalone build whose
+ *   primary cache is empty while the previous default location still holds browsers. Looking in
+ *   the write target would miss a browser that detection is happily using, and re-download
+ *   ~150 MB - the exact outcome the legacy fallback exists to prevent.
+ * - **An exact platform match against the platform this install would download for**, rather
+ *   than the inventory's `canRunHere`. Detection asks whether a build will start, so it accepts
+ *   a 32-bit build on 64-bit Windows. Install asks whether the build it would otherwise fetch is
+ *   already here, and that is a narrower question. It is also why `isCurrentPlatform` is not
+ *   used: that field reports every build as current when the host platform cannot be detected,
+ *   which is the right answer for "can I run this" and the wrong one here - `install()` would
+ *   throw `Unable to detect browser platform` rather than accept a foreign build, so a
+ *   `platform` of `undefined` must match nothing and fall through to that honest failure.
+ * - **The executable has to exist.** Reporting "already installed" for a directory with no
+ *   browser in it would reintroduce the false success that cached-browser detection stopped
+ *   producing in issue #943.
+ *
+ * @param {object} options - Options object, carrying `browser` and any cache directory override.
+ * @param {string} buildId - The exact build the caller is about to install.
+ * @param {string} [platform] - Platform this install would download for. Passed in rather than
+ * detected again here, so the platform named in the log and the one matched against are one value.
+ *
+ * @returns {Promise<object|null>} The staged build's inventory entry, or `null` to install.
+ */
+const findStagedBuild = async (options, buildId, platform) => {
+    const cacheDir = resolveBrowserCacheDir(options);
+
+    let inventory;
+    try {
+        inventory = await getBrowserInventory({ cacheDir });
+    } catch (err) {
+        // A short-circuit over the install path, not a precondition for it: an unreadable cache
+        // must fall through to a normal install rather than abort one that would have worked.
+        logger.debug(`Could not read the browser cache at ${cacheDir}: ${err?.message ?? err}`);
+        return null;
+    }
+
+    const sameBuild = inventory.filter(
+        (build) => build.browser === options.browser && build.buildId === buildId
+    );
+
+    // Every decline gets a line. Without them an administrator who staged a browser watches the
+    // download start with nothing anywhere in the log saying why their copy was not accepted.
+    if (sameBuild.length === 0) {
+        logger.debug(
+            `No cached ${options.browser} ${buildId} found in ${cacheDir}; it will be installed.`
+        );
+        return null;
+    }
+
+    const staged = sameBuild.find((build) => build.platform === platform);
+
+    if (!staged) {
+        logger.verbose(
+            `Cached ${options.browser} ${buildId} is present in ${cacheDir} but built for ${sameBuild
+                .map((build) => build.platform)
+                .join(', ')}, not "${platform}". Installing the build for this machine instead.`
+        );
+        return null;
+    }
+
+    if (!hasUsableExecutable(staged)) {
+        logger.warn(
+            `A cached ${options.browser} ${buildId} directory exists at ${staged.path}, but the browser executable is missing from it. ` +
+                `Butler Sheet Icons will remove that directory and install the build again, which needs internet access.`
+        );
+
+        // Removed here rather than left for install() to trip over. `install()` treats an
+        // existing install directory as an already-installed browser, so it skips the download
+        // and fails validation with "The browser folder exists but the executable is missing" -
+        // the retry loop below recovers from that, but only after a failed attempt the operator
+        // has to read past. Clearing it up front makes the warning above true, and loses
+        // nothing: the directory has no browser in it.
+        try {
+            await uninstall({ browser: options.browser, buildId, cacheDir, platform });
+        } catch (err) {
+            // Never let cleanup mask the install that follows.
+            logger.debug(
+                `Could not clear the incomplete install directory: ${err?.message ?? err}`
+            );
+        }
+
+        return null;
+    }
+
+    return staged;
+};
+
+/**
  * Install a browser into the Puppeteer cache directory.
  *
  * Downloads and unpacks the browser while showing a progress bar, and returns the installed
  * browser metadata on success. The version is interpreted by `resolveBrowserVersion`, which is the
  * only place in Butler Sheet Icons that reads a `--browser-version` value.
+ *
+ * **Installing is a no-op when the requested build is already staged in the cache.** That case
+ * returns without touching the network, which is what lets an administrator confirm a staged
+ * browser on an air-gapped machine - see `findStagedBuild`. It also means this function no longer
+ * reinstalls over the top of an existing build; there is no `--force` yet, so removing the build
+ * with `browser uninstall` is the way to replace one.
+ *
+ * The returned object therefore comes from one of two places, and callers must not depend on
+ * which: an `InstalledBrowser` instance from `@puppeteer/browsers` after a real install, or a
+ * plain inventory entry from {@link getBrowserInventory} for an already-staged build. Both carry
+ * `browser`, `buildId`, `platform`, `path` and `executablePath`; only the latter carries the
+ * inventory's own fields. Prefer the returned `executablePath` over recomputing one, because a
+ * staged build may have been found in the previous default cache location rather than the
+ * directory this function would have installed into.
  *
  * Failure is signalled by throwing, never by a falsy return value: the single `return` is
  * guarded by `if (!browser) throw lastError;`. Callers that need to add context to a failure
@@ -35,7 +147,7 @@ import { alreadyReported } from '../util/reported-error.js';
  * single run to one resolution, so the build that is installed is the same one the cache was
  * searched for.
  *
- * @returns {Promise<object>} Resolves with the installed browser metadata from `@puppeteer/browsers` (`browser`, `buildId`, `executablePath`, ...).
+ * @returns {Promise<object>} Resolves with the installed browser metadata (`browser`, `buildId`, `executablePath`, ...), whether it was just installed or already staged.
  *
  * @throws {Error} If required options are missing, the version cannot be resolved, the build is unavailable, or the install fails.
  */
@@ -67,10 +179,6 @@ export const browserInstall = async (options, _command, resolvedBuildId) => {
         // previous default location still installs beside its own executable.
         const browserPath = resolveBrowserCacheDirForWriting(options);
 
-        // Checked before the version lookup and the download, so a binary unzipped somewhere
-        // unwritable fails in one second with an explanation rather than after 150 MB.
-        assertCacheDirWritable(browserPath);
-
         const platform = await detectBrowserPlatform();
         logger.verbose(`Detected browser platform: ${platform}`);
 
@@ -92,6 +200,33 @@ export const browserInstall = async (options, _command, resolvedBuildId) => {
         logger.info(
             `Resolved browser build id: "${buildId}" for browser "${options.browser}" version "${options.browserVersion}" on platform "${platform}"`
         );
+
+        // Before anything that needs the network, and before the cache is required to be
+        // writable: a build already staged here needs neither.
+        //
+        // Note this makes `browser install` a no-op when the build is present, where it used to
+        // reinstall unconditionally. There is no --force yet; add one only if someone needs to
+        // reinstall over the top.
+        const staged = await findStagedBuild(options, buildId, platform);
+
+        if (staged) {
+            logger.info(
+                `${options.browser} ${buildId} is already installed at ${staged.path}. Nothing to download. ` +
+                    `To replace it, remove it first with "butler-sheet-icons browser uninstall --browser-version ${buildId}".`
+            );
+            return staged;
+        }
+
+        // Checked after the staged-build lookup but before the download, so a binary unzipped
+        // somewhere unwritable fails with an explanation rather than after 150 MB, while a
+        // browser already staged into a read-only cache still works.
+        //
+        // This used to run before the version lookup, which cost one round trip but did surface
+        // an unwritable directory even when that lookup failed. It no longer does: offline, a
+        // `--browser-version stable` run now reports only the version-service failure, and the
+        // unwritable cache is found on the next attempt. The default `recommended` resolves from
+        // a constant, so it reaches this line without a network call either way.
+        assertCacheDirWritable(browserPath);
 
         // Ensure browser can be downloaded
         const canDownloadBrowser = await canDownload({

--- a/src/lib/browser/browser-inventory.js
+++ b/src/lib/browser/browser-inventory.js
@@ -1,4 +1,5 @@
 import { getInstalledBrowsers, detectBrowserPlatform } from '@puppeteer/browsers';
+import fs from 'fs';
 
 import { logger } from '../../globals.js';
 import { resolveBrowserCacheDir } from './browser-paths.js';
@@ -38,10 +39,31 @@ const RUNNABLE_PLATFORMS = Object.freeze({
 });
 
 /**
+ * Whether a cache entry actually has a browser behind it.
+ *
+ * `computeExecutablePath()` derives this path from the layout convention without ever stat-ing
+ * it, so a cache copied without its binaries - or without the `.metadata` file, which is what a
+ * tar invocation that skips dotfiles produces - yields a perfectly plausible path to nothing.
+ *
+ * Shared rather than repeated at each call site because the answer has to be the same for every
+ * caller: `browser install` reporting a build as already present while detection refuses to use
+ * it, or the reverse, is worse than either answer on its own. Issue #931 may yet widen this to
+ * check the executable bit on POSIX, and that must land in one place.
+ *
+ * @param {object} build - An entry from the browser inventory.
+ *
+ * @returns {boolean} `true` when the browser binary is on disk.
+ */
+export const hasUsableExecutable = (build) => fs.existsSync(build.executablePath);
+
+/**
  * Whether a cached build can be executed on the host.
  *
  * With no host platform detected there is no evidence a build is foreign, and claiming otherwise
  * would label every entry unusable. Absence of evidence is reported as runnable, not as broken.
+ *
+ * Note this is the right rule for *using* a browser, and the wrong one for deciding whether the
+ * build a download would fetch is already present - see `findStagedBuild` in browser-install.js.
  *
  * @param {string} [hostPlatform] - Platform this machine runs, if it could be detected.
  * @param {string} buildPlatform - Platform the cached build was made for.

--- a/src/lib/browser/browser-launch.js
+++ b/src/lib/browser/browser-launch.js
@@ -210,11 +210,20 @@ export const resolveBrowserExecutablePath = async (options) => {
     // the install cannot pick a different build than the cache was searched for.
     const browserInstallResult = await browserInstall(options, undefined, requestedBuildId);
 
-    const executablePath = computeExecutablePath({
-        browser: browserInstallResult.browser,
-        buildId: browserInstallResult.buildId,
-        cacheDir: browserPath,
-    });
+    // The path browserInstall() reports, in preference to deriving one. Deriving it from
+    // `browserPath` assumes the browser ended up in the directory this function would install
+    // into, and that is not guaranteed: browserInstall() returns without downloading when the
+    // build is already staged, and it looks for a staged build through the *reading* resolver,
+    // which still honours the previous default cache location. Recomputing would then name a
+    // path in an empty directory. The fallback keeps older callers and doubles working when the
+    // result carries no path of its own.
+    const executablePath =
+        browserInstallResult.executablePath ??
+        computeExecutablePath({
+            browser: browserInstallResult.browser,
+            buildId: browserInstallResult.buildId,
+            cacheDir: browserPath,
+        });
 
     logger.info(`Browser downloaded successfully`);
 

--- a/src/lib/commands/browser/__tests__/browser_wizards.test.js
+++ b/src/lib/commands/browser/__tests__/browser_wizards.test.js
@@ -34,6 +34,10 @@ jest.unstable_mockModule('../../../../globals.js', () => ({
 
 jest.unstable_mockModule('../../../browser/browser-inventory.js', () => ({
     getBrowserInventory,
+    // Not used by the wizards, but browser-detect.js and browser-install.js both import it from
+    // here, and ESM checks named exports across the whole linked graph - so omitting it fails
+    // this suite before a single test runs, with no test failure to point at the cause.
+    hasUsableExecutable: jest.fn(() => true),
 }));
 jest.unstable_mockModule('../../../browser/browser-uninstall.js', () => ({
     browserUninstall,


### PR DESCRIPTION
Commit 5 of the sequencing in `docs/todo/airgap-browser-phase-1.md`, and the last cheap win before route A1 (`--browser-executable-path`). Follows #1059.

## The problem

`browser install` ran `canDownload()` — a network request — before it looked at what was already on the machine. On a server with no internet access:

```
Browser "chrome" version "..." cannot be downloaded. Please use the
"list-available" command to check available versions
```

…about a browser already sitting in the cache. The suggested next step, `list-available`, needs the network too, so there was no way forward.

That made **confirming a staged browser on the air-gapped machine itself** — the first thing an administrator tries — the one thing that could not be done there. The capability was always present: `install()` needs no network for a build already unpacked; BSI's own precheck was the only obstacle.

## What changed

The cache is consulted first, before the network and before the cache directory is required to be writable. Three things decide whether a staged build counts, and each is a way this could quietly have been wrong:

| Decision | Why not the obvious alternative |
| --- | --- |
| Looked up through the **reading** resolver | The writing resolver skips the legacy cache location. Looking there would miss a browser detection is happily using and re-download ~150 MB |
| Platform must **equal** the platform this install would fetch | Narrower than detection's `canRunHere`, which accepts a 32-bit build on 64-bit Windows. Also why `isCurrentPlatform` is unused: it reports every build as current when the host platform is undetectable, where install must fall through to `install()`'s honest failure |
| Executable must **exist** | Otherwise "already installed" for an empty folder — the false success #943 was about |

`browser-launch.js` now prefers the path `browserInstall` reports over recomputing one from the writing directory, which would name a file that isn't there when the staged build came from the legacy location.

## The headline

`--browser-version` defaults to `recommended`, which resolves from a compile-time constant. So on a machine with the matching browser staged, this completes **with no network at all**:

```
butler-sheet-icons browser install
```

Other keywords (`latest`, `stable`, channels) still need the vendor's version service, which runs before the cache is reached.

## Verification

`npm run test:unit` green (2670 tests). Beyond that, run against real cache directories with no mocks, using build `99.0.1234.56` — which **does not exist upstream**, so any network call fails the run:

| Scenario | Result |
| --- | --- |
| Staged build, nonexistent upstream | returned in **1 ms** |
| Default `--browser-version`, staged | returned in **1 ms** — no flags, no network |
| Staged in a read-only cache | returned in 1 ms |
| Directory present, executable missing | warned, cleared the directory, fell through (293 ms) |
| Staged for another platform | explained at verbose, fell through (148 ms) |

The 1 ms versus 148–293 ms gap is the network round-trip being skipped.

## Reviewer notes

- **Behaviour change worth a changelog line:** `browser install` is now a no-op when the requested build is present, where it used to reinstall unconditionally. No `--force`; the message names `browser uninstall` as the way to replace a build.
- **New deleting behaviour, deliberate:** a build directory with no executable in it is removed before reinstalling. It is the same `uninstall()` the retry loop already performed one failed attempt later, it is wrapped so a failure cannot mask the install, and such a directory is unusable by definition.
- `assertCacheDirWritable` moved after the version lookup so a browser staged into a read-only cache works. The cost — an unwritable directory is no longer reported when the version lookup fails first — is recorded in the comment.
- Doc draft staged in `docs/to-doc-site/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
