### PR TITLE
Point Butler Sheet Icons at a browser that is already installed on the server

### DIFF
--- a/docs/to-doc-site/point-at-an-installed-browser.md
+++ b/docs/to-doc-site/point-at-an-installed-browser.md
@@ -1,0 +1,124 @@
+# Use a browser that is already installed on the server
+
+**Target pages:** a new section on `guide/concepts/browser-detection-and-environment-variables.md`,
+option table refreshes on `reference/qseow.md` and `reference/qscloud.md`, and one troubleshooting
+entry. This is also the first half of the air-gapped runbook — if that page is being written in the
+same pass, this content belongs there as "Route A".
+
+**Version gate:** confirm the next released version at publication time from the open release-please
+pull request.
+
+---
+
+## What changed
+
+Butler Sheet Icons can now be told exactly which browser to use:
+
+```
+butler-sheet-icons qseow create-sheet-thumbnails --browser-executable-path "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe" ...
+```
+
+or, for a scheduled task where editing the command line is awkward, the same value as an environment
+variable:
+
+```
+BSI_BROWSER_EXECUTABLE_PATH=C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe
+```
+
+Butler Sheet Icons then uses that browser and neither downloads nor manages one.
+
+## Why you might want this
+
+**No internet access.** Getting a browser onto an isolated server is the whole difficulty of running
+Butler Sheet Icons there. If the server already has a suitable browser — and Windows Server usually
+does — this sidesteps the problem entirely, with nothing to copy across.
+
+**Change control.** In estates where software is deployed centrally, a tool that downloads its own
+browser is awkward to approve. Pointing at a browser your normal deployment process installed and
+patches keeps Butler Sheet Icons out of that conversation.
+
+**Disk space and time.** The browser Butler Sheet Icons downloads is around 150 MB per machine, and
+it is downloaded again for each new version.
+
+## Which browsers work
+
+Any Chromium-based browser. On Windows Server that means **Microsoft Edge**, which is installed by
+default on current builds, or **Google Chrome**. Both are Chromium underneath and both work with
+Butler Sheet Icons unmodified.
+
+Typical locations:
+
+| Browser | Usual path on 64-bit Windows |
+| --- | --- |
+| Microsoft Edge | `C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe` |
+| Google Chrome | `C:\Program Files\Google\Chrome\Application\chrome.exe` |
+
+Confirm the real path before using it rather than trusting the table — installers vary, and both
+vendors have moved these over the years.
+
+If the server has no browser at all, both vendors publish **offline enterprise installers** designed
+for exactly this: downloaded once on a connected machine, then distributed internally through your
+normal software deployment process.
+
+| Browser | Where |
+| --- | --- |
+| Microsoft Edge | [Microsoft Edge for Business download](https://www.microsoft.com/en-us/edge/business/download) |
+| Google Chrome | [Chrome Enterprise download](https://chromeenterprise.google/download/) |
+
+Link to those landing pages rather than to a versioned installer, and note that Butler Sheet Icons
+does not update a browser installed this way — its patching stays with your normal process, which is
+worth stating plainly because a browser on a Sense server is a security-review item.
+
+## An important difference from the old environment variable
+
+Butler Sheet Icons has always honoured `PUPPETEER_EXECUTABLE_PATH`, and it still does. The new option
+differs in one deliberate way:
+
+- **`--browser-executable-path` is a promise.** If the file is not there, the run **stops** with an
+  error naming the path. Butler Sheet Icons does not quietly download a different browser instead.
+- **`PUPPETEER_EXECUTABLE_PATH` is a hint.** If the file is not there, Butler Sheet Icons warns and
+  carries on looking, exactly as before.
+
+The difference is intentional. Naming a browser through a Butler Sheet Icons option states what you
+want to happen; running some other browser instead is precisely the surprise a change-controlled
+environment cannot tolerate. An environment variable inherited from a container image or a shell
+profile is a much weaker signal, and many existing setups rely on it falling through.
+
+When the file is missing, you will see:
+
+```
+--browser-executable-path is set to "D:\browsers\chrome.exe" but no such file exists on this
+machine. Butler Sheet Icons will not fall back to downloading a browser when an executable path
+has been given explicitly. Correct the path, or remove the option to let Butler Sheet Icons find
+a browser itself.
+```
+
+## Precedence
+
+When more than one is set, Butler Sheet Icons uses the first of these that names a file:
+
+1. `--browser-executable-path` / `BSI_BROWSER_EXECUTABLE_PATH`
+2. `PUPPETEER_EXECUTABLE_PATH`
+3. A browser in the browser cache
+4. A browser it downloads
+
+An empty value means "not set" at every level, so `BSI_BROWSER_EXECUTABLE_PATH=` in a unit file or
+`-e PUPPETEER_EXECUTABLE_PATH=""` in Docker both mean "ignore this and look further down the list".
+
+**Docker users:** the official image sets `PUPPETEER_EXECUTABLE_PATH` to its built-in browser.
+Setting `BSI_BROWSER_EXECUTABLE_PATH` overrides that, which is how you point a container at a
+different browser.
+
+## What `--browser-version` does when a browser is named
+
+Nothing — the named browser is used as it is. If you asked for a specific build, Butler Sheet Icons
+warns that the setting is being overridden, so the two settings cannot silently disagree. Version
+keywords such as `recommended` do not produce that warning, because they are Butler Sheet Icons'
+own choice rather than yours.
+
+## Note for the publishing pass
+
+Verify the flag names, the environment variable names and the error message against the
+implementation before publishing, and quote the message verbatim. The option tables on the reference
+pages are generated — refresh them with `npm run docs:cli-tables` rather than typing the new option
+in by hand.

--- a/docs/to-doc-site/two-renamed-messages.md
+++ b/docs/to-doc-site/two-renamed-messages.md
@@ -1,0 +1,82 @@
+# Two log messages were renamed — corrections to already-published pages
+
+**This page is not a new topic.** It is a correction list: two messages quoted verbatim on pages
+that are **already live** have changed wording, and the live pages now quote text Butler Sheet Icons
+no longer emits.
+
+Both were changed by the work that added `--browser-executable-path`. Neither is a behaviour change
+on its own — only the wording moved — but both are quoted as literal sample output, which is exactly
+the case where a stale quote does damage: administrators search for the string they saw.
+
+---
+
+## 1. The version-override warning
+
+**Page to fix:** `guide/advanced/docker.md` — staged originally as
+`docs/to-doc-site/done/done_docker-browser-management-section-is-wrong.md`, which quotes this
+message in two places.
+
+**What the page currently shows:**
+
+```
+warn: PUPPETEER_EXECUTABLE_PATH overrides --browser-version "121.0.6167.85": the browser at
+/usr/bin/chromium-browser will be used instead. Unset PUPPETEER_EXECUTABLE_PATH to use the
+requested build.
+```
+
+**What Butler Sheet Icons now emits:**
+
+```
+warn: The browser executable from PUPPETEER_EXECUTABLE_PATH overrides --browser-version
+"121.0.6167.85": the browser at /usr/bin/chromium-browser will be used instead. Unset
+PUPPETEER_EXECUTABLE_PATH to use the requested build.
+```
+
+The message had to name *which* setting was winning, because there are now two that can: the new
+`--browser-executable-path` / `BSI_BROWSER_EXECUTABLE_PATH`, and the long-standing
+`PUPPETEER_EXECUTABLE_PATH`. When the new option is what won, the same message reads:
+
+```
+warn: The browser executable from --browser-executable-path / BSI_BROWSER_EXECUTABLE_PATH
+overrides --browser-version "121.0.6167.85": the browser at C:\Program Files\Google\Chrome\
+Application\chrome.exe will be used instead. Remove --browser-executable-path /
+BSI_BROWSER_EXECUTABLE_PATH to use the requested build.
+```
+
+While updating that page, it is worth adding a line pointing Docker users at
+`BSI_BROWSER_EXECUTABLE_PATH` as the way to override the browser the image ships with — it takes
+precedence over the image's own `PUPPETEER_EXECUTABLE_PATH`.
+
+## 2. The browser failure wrapper
+
+**Page to fix:** `guide/advanced/crash-dumps.md` — staged originally as
+`docs/to-doc-site/done/done_crash-dump-files.md`, which shows this message twice in an annotated
+crash-dump example, once bare and once as `QseowError: ...`.
+
+**What the page currently shows:**
+
+```
+Failed to install a browser for QSEoW app a3e0f5d2-000a-464f-998d-33d333b175d7
+```
+
+**What Butler Sheet Icons now emits:**
+
+```
+Could not obtain a browser for QSEoW app a3e0f5d2-000a-464f-998d-33d333b175d7
+```
+
+The old wording claimed an install had been attempted. That is no longer true in general: with
+`--browser-executable-path` set to a file that does not exist, the run stops before any download is
+considered, and telling the reader an install failed sent them looking for a network problem they
+did not have. The same rename applies to the Qlik Sense Cloud form of the message
+(`... for Qlik Sense Cloud app <id>`).
+
+Crash-dump documentation is read while someone is comparing strings against a real dump, so this one
+matters more than its size suggests.
+
+## Note for the publishing pass
+
+Check both pages for any other occurrence of either string before publishing — the quotes above are
+the ones found in the staging files, and the live pages may have picked up more during editing. The
+`done_` staging files themselves are history and should be left alone; this page is the record of
+what changed.

--- a/src/lib/browser/__tests__/browser_detect.test.js
+++ b/src/lib/browser/__tests__/browser_detect.test.js
@@ -579,16 +579,23 @@ describe('detectAvailableBrowser — an explicitly named browser', () => {
 
 describe('detectAvailableBrowser — system browser', () => {
     test('prefers PUPPETEER_EXECUTABLE_PATH and does not consult the cache', async () => {
-        process.env.PUPPETEER_EXECUTABLE_PATH = '/usr/bin/chromium-browser';
+        // Compared and asserted through `path.resolve`, never against the literal. The resolver
+        // resolves a configured path, and `path.resolve('/usr/bin/chromium-browser')` is
+        // `C:\usr\bin\chromium-browser` on Windows - so a hardcoded POSIX comparison here
+        // matched nothing there, detection fell through to the cache, and this test failed on
+        // the Windows runner alone.
+        const configuredPath = '/usr/bin/chromium-browser';
+        const resolvedPath = path.resolve(configuredPath);
+
+        process.env.PUPPETEER_EXECUTABLE_PATH = configuredPath;
         fs.existsSync.mockImplementation(
-            (candidate) =>
-                candidate === '/usr/bin/chromium-browser' || String(candidate).startsWith('/cache/')
+            (candidate) => candidate === resolvedPath || String(candidate).startsWith('/cache/')
         );
 
         const result = await detectAvailableBrowser({ browser: 'chrome' });
 
         expect(result).toEqual({
-            executablePath: '/usr/bin/chromium-browser',
+            executablePath: resolvedPath,
             source: 'system',
             browser: 'chrome',
             buildId: 'system-installed',

--- a/src/lib/browser/__tests__/browser_detect.test.js
+++ b/src/lib/browser/__tests__/browser_detect.test.js
@@ -42,6 +42,7 @@ jest.unstable_mockModule('fs', () => ({
 const fs = (await import('fs')).default;
 
 const { detectAvailableBrowser } = await import('../browser-detect.js');
+const { BrowserNotFoundError } = await import('../../util/errors.js');
 
 // These are ambient and leak between test files, so capture and restore them around every
 // test rather than assuming they start unset. PUPPETEER_CACHE_DIR joined the list when the
@@ -449,6 +450,130 @@ describe('detectAvailableBrowser — no resolved build id (offline fallback)', (
         const result = await detectAvailableBrowser({ browser: 'chrome' });
 
         expect(result.buildId).toBe('151.0.7922.109');
+    });
+});
+
+describe('detectAvailableBrowser — an explicitly named browser', () => {
+    test('prefers --browser-executable-path over PUPPETEER_EXECUTABLE_PATH', async () => {
+        // Which is also how a container user overrides the browser the Docker image sets.
+        process.env.PUPPETEER_EXECUTABLE_PATH = '/usr/bin/chromium';
+        fs.existsSync.mockReturnValue(true);
+
+        const result = await detectAvailableBrowser({
+            browser: 'chrome',
+            browserExecutablePath: '/opt/edge',
+        });
+
+        expect(result.executablePath).toBe(path.resolve('/opt/edge'));
+        expect(result.source).toBe('system');
+    });
+
+    test('throws when an explicitly named executable is missing', async () => {
+        // The asymmetry with PUPPETEER_EXECUTABLE_PATH is deliberate: naming a path with a
+        // Butler Sheet Icons option states an intent, and downloading a different browser
+        // instead is a compliance problem in a regulated estate - and offline, a guaranteed
+        // failure reported as something else entirely.
+        fs.existsSync.mockReturnValue(false);
+
+        await expect(
+            detectAvailableBrowser({ browser: 'chrome', browserExecutablePath: '/nope/chrome' })
+        ).rejects.toThrow(BrowserNotFoundError);
+    });
+
+    test('never consults the cache when an explicit executable is missing', async () => {
+        fs.existsSync.mockReturnValue(false);
+        getInstalledBrowsers.mockResolvedValue([cachedBrowser('chrome', '138.0.7204.94')]);
+
+        await detectAvailableBrowser({
+            browser: 'chrome',
+            browserExecutablePath: '/nope/chrome',
+        }).catch(() => undefined);
+
+        expect(getInstalledBrowsers).not.toHaveBeenCalled();
+    });
+
+    test('names the path and the way out when an explicit executable is missing', async () => {
+        fs.existsSync.mockReturnValue(false);
+
+        const err = await detectAvailableBrowser({
+            browser: 'chrome',
+            browserExecutablePath: '/nope/chrome',
+        }).catch((caught) => caught);
+
+        expect(err.message).toContain('/nope/chrome');
+        expect(err.message).toContain('--browser-executable-path');
+    });
+
+    test('does not also log the failure it is throwing', async () => {
+        // `logError` renders an error together with its whole cause chain, so the caller that
+        // attaches the app context prints this message in full. Logging it here as well is how
+        // one failure ends up described twice - the symptom issue #785 is about.
+        fs.existsSync.mockReturnValue(false);
+
+        await detectAvailableBrowser({
+            browser: 'chrome',
+            browserExecutablePath: '/nope/chrome',
+        }).catch(() => undefined);
+
+        expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    test('quotes a relative path as it was written, not as it resolved', async () => {
+        // An operator hunting through a unit file cannot find an absolute path they never typed.
+        process.env.PUPPETEER_EXECUTABLE_PATH = 'browsers/chrome';
+        fs.existsSync.mockReturnValue(false);
+        getInstalledBrowsers.mockResolvedValue([]);
+
+        await detectAvailableBrowser({ browser: 'chrome' });
+
+        const warned = logger.warn.mock.calls.map(([msg]) => msg).join('\n');
+        expect(warned).toContain('"browsers/chrome"');
+    });
+
+    test.each([
+        [
+            '--browser-executable-path',
+            { browserExecutablePath: '/opt/edge' },
+            'Remove --browser-executable-path',
+        ],
+        ['PUPPETEER_EXECUTABLE_PATH', {}, 'Unset PUPPETEER_EXECUTABLE_PATH'],
+    ])(
+        'warns that %s overrides an exact --browser-version, and names what to remove',
+        async (_label, extra, remedy) => {
+            // Untested until now, and the wording is quoted verbatim by a published doc page.
+            process.env.PUPPETEER_EXECUTABLE_PATH = '/opt/edge';
+            fs.existsSync.mockReturnValue(true);
+
+            await detectAvailableBrowser({
+                browser: 'chrome',
+                browserVersion: '121.0.6167.85',
+                ...extra,
+            });
+
+            const warned = logger.warn.mock.calls.map(([msg]) => msg).join('\n');
+            expect(warned).toContain('overrides --browser-version "121.0.6167.85"');
+            expect(warned).toContain(remedy);
+        }
+    );
+
+    test('says nothing about a version keyword being overridden', async () => {
+        // A keyword is Butler Sheet Icons' own choice, so overriding it is unremarkable.
+        process.env.PUPPETEER_EXECUTABLE_PATH = '/opt/edge';
+        fs.existsSync.mockReturnValue(true);
+
+        await detectAvailableBrowser({ browser: 'chrome', browserVersion: 'recommended' });
+
+        expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    test('still falls through to the cache when PUPPETEER_EXECUTABLE_PATH is missing', async () => {
+        // Unchanged legacy behaviour, and the Docker documentation depends on it.
+        process.env.PUPPETEER_EXECUTABLE_PATH = '/nope/chromium';
+        getInstalledBrowsers.mockResolvedValue([cachedBrowser('chrome', '138.0.7204.94')]);
+
+        const result = await detectAvailableBrowser({ browser: 'chrome' });
+
+        expect(result.source).toBe('cache');
     });
 });
 

--- a/src/lib/browser/__tests__/browser_launch.test.js
+++ b/src/lib/browser/__tests__/browser_launch.test.js
@@ -29,6 +29,7 @@ jest.unstable_mockModule('../browser-detect.js', () => ({
     detectAvailableBrowser: jest.fn(),
 }));
 const { detectAvailableBrowser } = await import('../browser-detect.js');
+const { BrowserNotFoundError } = await import('../../util/errors.js');
 
 jest.unstable_mockModule('../browser-install.js', () => ({
     browserInstall: jest.fn(),
@@ -355,8 +356,29 @@ describe('launchBrowserForApp', () => {
 
         await expect(launchBrowserForApp(OPTIONS, CONTEXT)).rejects.toThrow(TestError);
         await expect(launchBrowserForApp(OPTIONS, CONTEXT)).rejects.toThrow(
-            'Failed to install a browser for test app test-app-id'
+            'Could not obtain a browser for test app test-app-id'
         );
+        expect(puppeteer.launch).not.toHaveBeenCalled();
+    });
+
+    test('lets a refusal from detection through, without attempting an install', async () => {
+        // detectAvailableBrowser's outer catch turns any failure into `null`, and only an
+        // `instanceof BsiError` re-throw keeps a deliberate refusal - an explicitly named
+        // --browser-executable-path that does not exist - from becoming a silent download.
+        // That is invisible inside browser-detect's own suite: it is only observable here.
+        const refusal = new BrowserNotFoundError(
+            '--browser-executable-path is set to "/nope/chrome" but no such file exists on this machine.'
+        );
+        detectAvailableBrowser.mockRejectedValue(refusal);
+
+        const err = await launchBrowserForApp(OPTIONS, CONTEXT).catch((caught) => caught);
+
+        expect(err).toBeInstanceOf(TestError);
+        expect(err.message).toBe('Could not obtain a browser for test app test-app-id');
+        // The specific reason travels as the cause, which is what logError renders after the
+        // app context. Losing it would leave the operator with only "could not obtain".
+        expect(err.cause).toBe(refusal);
+        expect(browserInstall).not.toHaveBeenCalled();
         expect(puppeteer.launch).not.toHaveBeenCalled();
     });
 

--- a/src/lib/browser/__tests__/browser_paths.test.js
+++ b/src/lib/browser/__tests__/browser_paths.test.js
@@ -103,11 +103,14 @@ const testOnPosix = process.platform === 'win32' ? test.skip : test;
 const SAVED_ENV = {
     BSI_BROWSER_CACHE_DIR: process.env.BSI_BROWSER_CACHE_DIR,
     PUPPETEER_CACHE_DIR: process.env.PUPPETEER_CACHE_DIR,
+    BSI_BROWSER_EXECUTABLE_PATH: process.env.BSI_BROWSER_EXECUTABLE_PATH,
+    PUPPETEER_EXECUTABLE_PATH: process.env.PUPPETEER_EXECUTABLE_PATH,
 };
 
 beforeEach(() => {
-    delete process.env.BSI_BROWSER_CACHE_DIR;
-    delete process.env.PUPPETEER_CACHE_DIR;
+    for (const name of Object.keys(SAVED_ENV)) {
+        delete process.env[name];
+    }
 });
 
 afterEach(() => {
@@ -556,5 +559,114 @@ describe('assertCacheDirWritable', () => {
             // Restored so the afterEach cleanup can remove it.
             fs.chmodSync(parent, 0o700);
         }
+    });
+});
+
+describe('the browser executable override', () => {
+    test('is absent when nothing names one', async () => {
+        const { paths } = await loadPaths();
+
+        expect(paths.resolveExecutablePathOverride({})).toBeNull();
+        expect(paths.resolveExecutablePathOverride(undefined)).toBeNull();
+    });
+
+    test('takes --browser-executable-path, and marks it explicit', async () => {
+        const { paths } = await loadPaths();
+
+        expect(
+            paths.resolveExecutablePathOverride({ browserExecutablePath: '/opt/chrome' })
+        ).toEqual({
+            path: path.resolve('/opt/chrome'),
+            configuredValue: '/opt/chrome',
+            source: 'option',
+            explicit: true,
+        });
+    });
+
+    test('falls back to PUPPETEER_EXECUTABLE_PATH, and does not mark it explicit', async () => {
+        // The `explicit` flag is load-bearing: a path named with a Butler Sheet Icons option is
+        // a stated intent and a missing file is fatal, while a stale inherited environment
+        // variable is a much weaker signal that thousands of Docker setups rely on falling
+        // through.
+        process.env.PUPPETEER_EXECUTABLE_PATH = '/usr/bin/chromium';
+        const { paths } = await loadPaths();
+
+        expect(paths.resolveExecutablePathOverride({})).toEqual({
+            path: path.resolve('/usr/bin/chromium'),
+            configuredValue: '/usr/bin/chromium',
+            source: 'puppeteer-env',
+            explicit: false,
+        });
+    });
+
+    test('prefers the option over PUPPETEER_EXECUTABLE_PATH', async () => {
+        // Which also means it outranks the value the Docker image sets - that is how a
+        // container user overrides the embedded Chromium, and it has to be documented.
+        process.env.PUPPETEER_EXECUTABLE_PATH = '/usr/bin/chromium';
+        const { paths } = await loadPaths();
+
+        expect(
+            paths.resolveExecutablePathOverride({ browserExecutablePath: '/opt/chrome' }).path
+        ).toBe(path.resolve('/opt/chrome'));
+    });
+
+    test('reads BSI_BROWSER_EXECUTABLE_PATH as the option', async () => {
+        // Commander puts the environment value on the same option property, so this is really
+        // a check that nothing downstream cares which of the two the operator used.
+        const { paths } = await loadPaths();
+
+        expect(paths.resolveExecutablePathOverride({ browserExecutablePath: '/from/env' })).toEqual(
+            {
+                path: path.resolve('/from/env'),
+                configuredValue: '/from/env',
+                source: 'option',
+                explicit: true,
+            }
+        );
+    });
+
+    test.each([
+        ['an empty string', ''],
+        ['whitespace', '   '],
+    ])('treats %s as unset at every tier', async (_label, value) => {
+        // `PUPPETEER_EXECUTABLE_PATH=""` meaning "ignore this" is a documented idiom for Docker
+        // users; breaking it would be a regression, and Commander hands a bare
+        // `BSI_BROWSER_EXECUTABLE_PATH=` line through as an empty string too.
+        process.env.PUPPETEER_EXECUTABLE_PATH = value;
+        const { paths } = await loadPaths();
+
+        expect(paths.resolveExecutablePathOverride({ browserExecutablePath: value })).toBeNull();
+    });
+
+    test('resolves a relative path against the working directory', async () => {
+        const { paths } = await loadPaths();
+
+        expect(
+            paths.resolveExecutablePathOverride({ browserExecutablePath: './chrome' }).path
+        ).toBe(path.resolve('./chrome'));
+    });
+});
+
+describe('the configured value a message should quote', () => {
+    test('is the value as written, not as resolved', async () => {
+        // A relative path printed back absolute is a string the operator cannot find in the
+        // unit file or Dockerfile they are searching.
+        const { paths } = await loadPaths();
+
+        const override = paths.resolveExecutablePathOverride({
+            browserExecutablePath: 'browsers/chrome',
+        });
+
+        expect(override.configuredValue).toBe('browsers/chrome');
+        expect(override.path).toBe(path.resolve('browsers/chrome'));
+    });
+
+    test('is trimmed, so surrounding whitespace never reaches a message', async () => {
+        const { paths } = await loadPaths();
+
+        expect(
+            paths.resolveExecutablePathOverride({ browserExecutablePath: '  /opt/chrome  ' })
+                .configuredValue
+        ).toBe('/opt/chrome');
     });
 });

--- a/src/lib/browser/browser-detect.js
+++ b/src/lib/browser/browser-detect.js
@@ -1,6 +1,12 @@
 import { getVersionComparator, detectBrowserPlatform } from '@puppeteer/browsers';
 import { getBrowserInventory, hasUsableExecutable } from './browser-inventory.js';
-import { resolveBrowserCacheDir } from './browser-paths.js';
+import {
+    EXECUTABLE_SOURCE_LABELS,
+    EXECUTABLE_SOURCE_REMOVAL,
+    resolveBrowserCacheDir,
+    resolveExecutablePathOverride,
+} from './browser-paths.js';
+import { BrowserNotFoundError, BsiError } from '../util/errors.js';
 import fs from 'fs';
 
 import { logger } from '../../globals.js';
@@ -166,35 +172,64 @@ const reportEmptyFunnel = ({
  */
 export const detectAvailableBrowser = async (options, resolvedBuildId) => {
     try {
-        // Priority 1: Check for system browser via PUPPETEER_EXECUTABLE_PATH
-        if (process.env.PUPPETEER_EXECUTABLE_PATH) {
-            const systemBrowserPath = process.env.PUPPETEER_EXECUTABLE_PATH;
+        // Priority 1: a browser the administrator named, by option or environment variable.
+        const override = resolveExecutablePathOverride(options);
 
-            // Verify the path exists
-            if (fs.existsSync(systemBrowserPath)) {
-                logger.info(`Found system browser at: ${systemBrowserPath}`);
-                logger.info('Using system browser (PUPPETEER_EXECUTABLE_PATH is set)');
+        if (override) {
+            const label = EXECUTABLE_SOURCE_LABELS[override.source];
+
+            if (fs.existsSync(override.path)) {
+                logger.info(`Found system browser at: ${override.path}`);
+                logger.info(`Using system browser (${label})`);
 
                 // Asking for a specific build and silently getting a different one is worth a
                 // warning: the version was requested deliberately, and this path ignores it.
                 // A keyword is Butler Sheet Icons' own choice, so overriding it is unremarkable.
                 if (options.browserVersion && !isVersionKeyword(options.browserVersion)) {
                     logger.warn(
-                        `PUPPETEER_EXECUTABLE_PATH overrides --browser-version "${options.browserVersion}": the browser at ${systemBrowserPath} will be used instead. Unset PUPPETEER_EXECUTABLE_PATH to use the requested build.`
+                        `The browser executable ${label} overrides --browser-version "${options.browserVersion}": the browser at ${override.path} will be used instead. ` +
+                            `${EXECUTABLE_SOURCE_REMOVAL[override.source]} to use the requested build.`
                     );
                 }
 
                 return {
-                    executablePath: systemBrowserPath,
+                    executablePath: override.path,
                     source: 'system',
                     browser: options.browser,
                     buildId: 'system-installed',
                 };
-            } else {
-                logger.warn(
-                    `PUPPETEER_EXECUTABLE_PATH is set to "${systemBrowserPath}" but file does not exist`
+            }
+
+            // The file is not there. What happens next depends entirely on how firmly it was
+            // named, and the two cases are deliberately different.
+            if (override.explicit) {
+                // Named through a Butler Sheet Icons option, so this is a stated intent that
+                // cannot be met. Downloading some other browser instead would be a compliance
+                // problem in a regulated Qlik estate, and on an air-gapped machine it is a
+                // failure reported as something unrelated.
+                //
+                // Thrown without being logged here, and deliberately so. `logError` renders an
+                // error together with its whole `cause` chain, so the caller that attaches the
+                // app context prints this message in full anyway - logging it here as well is
+                // how the same failure ends up described twice, which is the symptom issue #785
+                // was about. `markReported` does not help: the wrapper is a new error, and
+                // `logError` does not consult the marker.
+                throw new BrowserNotFoundError(
+                    `--browser-executable-path is set to "${override.configuredValue}" but no such file exists on this machine. ` +
+                        `Butler Sheet Icons will not fall back to downloading a browser when an executable path has been given explicitly. ` +
+                        `Correct the path, or remove the option to let Butler Sheet Icons find a browser itself.`
                 );
             }
+
+            // A stale PUPPETEER_EXECUTABLE_PATH inherited from a container image or a shell is
+            // a much weaker signal, and falling through to the cache is what the Docker
+            // documentation tells people to rely on. Unchanged on purpose.
+            //
+            // The value is quoted as the operator set it, not as it resolved: a relative path
+            // printed back absolute is one they cannot find in their unit file.
+            logger.warn(
+                `PUPPETEER_EXECUTABLE_PATH is set to "${override.configuredValue}" but file does not exist`
+            );
         }
 
         // Priority 2: Check for cached browsers in the browser cache directory
@@ -286,6 +321,14 @@ export const detectAvailableBrowser = async (options, resolvedBuildId) => {
         logger.debug('No system or cached browser available - download will be required');
         return null;
     } catch (err) {
+        // This catch exists so that a cache that cannot be read degrades into "download one"
+        // rather than taking the run down. A Butler Sheet Icons error is the opposite case: it
+        // was raised on purpose, by code that had already decided the run must not continue, so
+        // swallowing it here would turn a deliberate refusal into a silent download.
+        if (err instanceof BsiError) {
+            throw err;
+        }
+
         logger.error(`Error detecting available browser: ${err.message}`);
         if (err.stack) {
             logger.debug(err.stack);

--- a/src/lib/browser/browser-launch.js
+++ b/src/lib/browser/browser-launch.js
@@ -1,5 +1,9 @@
 import puppeteer from 'puppeteer-core';
-import { resolveBrowserCacheDirForWriting } from './browser-paths.js';
+import fs from 'fs';
+import {
+    resolveBrowserCacheDirForWriting,
+    resolveExecutablePathOverride,
+} from './browser-paths.js';
 import { computeExecutablePath } from '@puppeteer/browsers';
 
 import { logger } from '../../globals.js';
@@ -168,6 +172,10 @@ const resolveRequestedBuildId = async (options) => {
  * browser that cannot be driven is otherwise reported as an anonymous protocol failure with
  * nothing tying it to `--browser-version` (issue #878).
  *
+ * @throws {import('../util/errors.js').BrowserNotFoundError} If `--browser-executable-path` names
+ * a file that does not exist. Raised before any download is attempted, so it is not an install
+ * failure - which is why the caller wrapping this says "could not obtain" rather than "failed to
+ * install".
  * @throws {Error} If no browser is available and the install fails. Callers are expected to wrap
  * this in a platform-specific typed error carrying the app id.
  */
@@ -177,7 +185,21 @@ export const resolveBrowserExecutablePath = async (options) => {
     // back to the previous default location.
     const browserPath = resolveBrowserCacheDirForWriting(options);
 
-    const { buildId: requestedBuildId, resolveError } = await resolveRequestedBuildId(options);
+    // A browser named by the operator, and actually present, decides everything: detection will
+    // return it whatever version was asked for. Resolving the version first would then be a
+    // network round trip whose answer is discarded - and on the air-gapped machine this option
+    // exists for, it is a lookup that fails slowly and logs two warnings about a build nobody
+    // is going to download.
+    //
+    // Only when the file is really there. A named path that is missing still needs the resolved
+    // build id: an explicit one is about to throw, and a stale PUPPETEER_EXECUTABLE_PATH falls
+    // through to the cache, where a pinned version must still match exactly (issue #878).
+    const namedBrowser = resolveExecutablePathOverride(options);
+    const namedBrowserExists = Boolean(namedBrowser && fs.existsSync(namedBrowser.path));
+
+    const { buildId: requestedBuildId, resolveError } = namedBrowserExists
+        ? { buildId: undefined, resolveError: undefined }
+        : await resolveRequestedBuildId(options);
 
     logger.info(`Checking for available browsers...`);
     const browserInfo = await detectAvailableBrowser(options, requestedBuildId);
@@ -373,7 +395,11 @@ export const launchBrowserForApp = async (options, { appId, logPrefix, appLabel,
     try {
         browserInfo = await resolveBrowserExecutablePath(options);
     } catch (err) {
-        throw new ErrorClass(`Failed to install a browser for ${appLabel} ${appId}`, {
+        // "Could not obtain", not "Failed to install": nothing necessarily tried to install.
+        // An explicitly named --browser-executable-path that does not exist fails here without
+        // a download ever being attempted, and reporting that as an install failure sends the
+        // reader looking for a network problem they do not have.
+        throw new ErrorClass(`Could not obtain a browser for ${appLabel} ${appId}`, {
             cause: err,
         });
     }

--- a/src/lib/browser/browser-paths.js
+++ b/src/lib/browser/browser-paths.js
@@ -59,6 +59,30 @@ export const SOURCE_LABELS = Object.freeze({
 });
 
 /**
+ * Human-readable phrase for each way the browser executable can be named.
+ *
+ * Separate from {@link SOURCE_LABELS} rather than sharing its `option` and `puppeteer-env`
+ * keys, because the two answer different questions and print different variable names. A
+ * message that said "from --browser-cache-dir" about an executable would be actively wrong.
+ */
+export const EXECUTABLE_SOURCE_LABELS = Object.freeze({
+    option: 'from --browser-executable-path / BSI_BROWSER_EXECUTABLE_PATH',
+    'puppeteer-env': 'from PUPPETEER_EXECUTABLE_PATH',
+});
+
+/**
+ * How to stop each source winning, phrased as the start of a sentence.
+ *
+ * A remedy that says "remove that setting" makes the reader work out which of two possible
+ * settings was meant. Naming it is what makes the line copy-pasteable, which is the whole
+ * point of putting a remedy in a log message.
+ */
+export const EXECUTABLE_SOURCE_REMOVAL = Object.freeze({
+    option: 'Remove --browser-executable-path / BSI_BROWSER_EXECUTABLE_PATH',
+    'puppeteer-env': 'Unset PUPPETEER_EXECUTABLE_PATH',
+});
+
+/**
  * The cache directory Butler Sheet Icons has always used.
  *
  * Built with `path.join(homedir(), '.cache', 'puppeteer')`, which is byte-identical to the
@@ -317,6 +341,64 @@ export const resolveBrowserCacheDirForWriting = (options) => {
     });
 
     return described.primaryCacheDir;
+};
+
+/**
+ * The browser executable an administrator has named, if any.
+ *
+ * Two tiers, and the order between them matters more than it looks:
+ *
+ * 1. `--browser-executable-path` / `BSI_BROWSER_EXECUTABLE_PATH`
+ * 2. `PUPPETEER_EXECUTABLE_PATH`
+ *
+ * `explicit` is what separates them, and it is load-bearing rather than decorative. A path
+ * named through a Butler Sheet Icons option is a stated intent: if the file is not there,
+ * quietly downloading some other browser instead is a compliance problem in a regulated Qlik
+ * estate and, on an air-gapped machine, a guaranteed failure with a misleading error. A
+ * `PUPPETEER_EXECUTABLE_PATH` inherited from a container image or a developer shell is a far
+ * weaker signal, and thousands of existing setups depend on it falling through to the cache.
+ * `detectAvailableBrowser` acts on that distinction; this function only records it.
+ *
+ * The option outranking `PUPPETEER_EXECUTABLE_PATH` also means it outranks the value the
+ * official Docker image sets. That is intended - it is how a container user points Butler
+ * Sheet Icons at a different browser - and it is documented.
+ *
+ * Read here rather than through Commander for the same reasons `PUPPETEER_CACHE_DIR` is:
+ * `Option.env()` holds one variable name, and Commander has a single environment precedence
+ * level, so "BSI_ beats PUPPETEER_" is not expressible there.
+ *
+ * `configuredValue` is the value as the operator wrote it, and messages quote that rather than
+ * `path`. The two differ for a relative path, and quoting the resolved one back at someone
+ * hunting through a unit file for a string they never typed helps nobody.
+ *
+ * @param {object} [options] - Options bag as Commander produces it.
+ * @param {string} [options.browserExecutablePath] - Path named by the administrator.
+ *
+ * @returns {{path: string, configuredValue: string, source: string, explicit: boolean}|null}
+ * The override, or `null` when nothing names one.
+ */
+export const resolveExecutablePathOverride = (options) => {
+    /**
+     * One tier of the lookup.
+     *
+     * @param {string} [value] - Raw configured value.
+     * @param {string} source - Which setting it came from.
+     * @param {boolean} explicit - Whether it was named through a Butler Sheet Icons option.
+     *
+     * @returns {object|null} The override for this tier, or `null` when it is unset.
+     */
+    const tier = (value, source, explicit) => {
+        const resolved = configured(value);
+
+        return resolved
+            ? { path: resolved, configuredValue: value.trim(), source, explicit }
+            : null;
+    };
+
+    return (
+        tier(options?.browserExecutablePath, 'option', true) ??
+        tier(process.env.PUPPETEER_EXECUTABLE_PATH, 'puppeteer-env', false)
+    );
 };
 
 /**

--- a/src/lib/cloud/__tests__/process_cloud_app.test.js
+++ b/src/lib/cloud/__tests__/process_cloud_app.test.js
@@ -594,9 +594,7 @@ describe('process-cloud-app.js — puppeteer launch and click options', () => {
         ).rejects.toThrow();
 
         const logged = logger.error.mock.calls.map((call) => String(call[0])).join('\n');
-        expect(logged).toContain(
-            'Failed to install a browser for Qlik Sense Cloud app test-app-id'
-        );
+        expect(logged).toContain('Could not obtain a browser for Qlik Sense Cloud app test-app-id');
         expect(puppeteer.launch).not.toHaveBeenCalled();
     });
 });

--- a/src/lib/commands/__tests__/commands.test.js
+++ b/src/lib/commands/__tests__/commands.test.js
@@ -1343,3 +1343,68 @@ describe('option keys match the property names the code reads (issue #890)', () 
         });
     });
 });
+
+describe('--browser-executable-path (issue #929)', () => {
+    // Only the two commands that launch a browser. `browser install` deliberately does not
+    // carry it: pointing at an executable is the alternative to installing one, so the option
+    // would be a knob that does nothing there.
+    const carriers = [
+        ['qseow create-sheet-thumbnails', () => thumbnailCommand(buildQseowCommand())],
+        ['qscloud create-sheet-thumbnails', () => thumbnailCommand(buildQscloudCommand())],
+    ];
+
+    test.each(carriers)('%s carries the option', (_name, build) => {
+        const option = build().options.find((opt) => opt.long === '--browser-executable-path');
+
+        expect(option).toBeDefined();
+    });
+
+    test.each(carriers)('%s reads the shared environment variable', (_name, build) => {
+        const option = build().options.find((opt) => opt.long === '--browser-executable-path');
+
+        expect(option.envVar).toBe('BSI_BROWSER_EXECUTABLE_PATH');
+    });
+
+    test.each(carriers)('%s leaves the tiers to the resolver', (_name, build) => {
+        // A Commander default would make the value always truthy, so PUPPETEER_EXECUTABLE_PATH
+        // would never be consulted.
+        const option = build().options.find((opt) => opt.long === '--browser-executable-path');
+
+        expect(option.defaultValue).toBeUndefined();
+    });
+
+    test.each(carriers)('%s accepts a set-but-empty environment variable', (_name, build) => {
+        // Same reasoning as the cache directory: `PUPPETEER_EXECUTABLE_PATH=""` meaning
+        // "ignore this" is a documented Docker idiom, and an argParser would turn the
+        // equivalent BSI_ line into a hard CLI error instead of a no-op.
+        const option = build().options.find((opt) => opt.long === '--browser-executable-path');
+
+        expect(option.parseArg).toBeUndefined();
+
+        const saved = process.env.BSI_BROWSER_EXECUTABLE_PATH;
+        process.env.BSI_BROWSER_EXECUTABLE_PATH = '';
+
+        try {
+            const parent = new Command();
+            parent.exitOverride();
+            parent.addOption(option);
+
+            expect(() => parent.parse(['node', 'test'])).not.toThrow();
+            expect(parent.opts().browserExecutablePath).toBe('');
+        } finally {
+            if (saved === undefined) {
+                delete process.env.BSI_BROWSER_EXECUTABLE_PATH;
+            } else {
+                process.env.BSI_BROWSER_EXECUTABLE_PATH = saved;
+            }
+        }
+    });
+
+    test('browser install does not carry it', () => {
+        const option = buildBrowserInstallCommand().options.find(
+            (opt) => opt.long === '--browser-executable-path'
+        );
+
+        expect(option).toBeUndefined();
+    });
+});

--- a/src/lib/commands/helpers.js
+++ b/src/lib/commands/helpers.js
@@ -145,4 +145,32 @@ const buildBrowserCacheDirOption = () =>
         'Directory where Butler Sheet Icons keeps downloaded browsers. Defaults to a "browser-cache" folder next to the Butler Sheet Icons executable for standalone builds, and to the .cache/puppeteer folder in the current user\'s home directory otherwise.'
     ).env('BSI_BROWSER_CACHE_DIR');
 
-export { parsePositiveInteger, collectPositiveIntegers, collectAppIds, buildBrowserCacheDirOption };
+/**
+ * The `--browser-executable-path` option, for the commands that launch a browser.
+ *
+ * A factory for the same reason as {@link buildBrowserCacheDirOption}: Commander stores parsed
+ * values on the Option object, so commands cannot share one instance.
+ *
+ * The environment variable is shared across commands rather than per-command prefixed, because
+ * where the browser is installed is a property of the machine, not of one command.
+ *
+ * Neither a `.default()` nor an `argParser`, for the reasons spelled out on the cache directory
+ * option: the tiers below this one live in the resolver, and Commander runs `parseArg` on
+ * environment values too, so rejecting the empty string would turn `PUPPETEER_EXECUTABLE_PATH=""`
+ * - a documented Docker idiom - into a hard CLI error.
+ *
+ * @returns {Option} A new `--browser-executable-path` option.
+ */
+const buildBrowserExecutablePathOption = () =>
+    new Option(
+        '--browser-executable-path <path>',
+        'Full path to a browser executable to use, for example a Microsoft Edge or Google Chrome already installed on this machine. Butler Sheet Icons then neither downloads nor manages a browser. Takes precedence over PUPPETEER_EXECUTABLE_PATH. If the file does not exist the run stops rather than downloading a browser instead.'
+    ).env('BSI_BROWSER_EXECUTABLE_PATH');
+
+export {
+    parsePositiveInteger,
+    collectPositiveIntegers,
+    collectAppIds,
+    buildBrowserCacheDirOption,
+    buildBrowserExecutablePathOption,
+};

--- a/src/lib/commands/qscloud/__tests__/qscloud_wizard.test.js
+++ b/src/lib/commands/qscloud/__tests__/qscloud_wizard.test.js
@@ -699,6 +699,7 @@ describe('progressive disclosure', () => {
                 browserVersion: 'recommended',
                 browserPageTimeout: '90',
                 browserCacheDir: '',
+                browserExecutablePath: '',
                 headless: true,
             })
         );
@@ -710,6 +711,7 @@ describe('progressive disclosure', () => {
         // Behind the advanced gate rather than in the main flow: most runs never name a
         // browser cache directory, and an unplaced key would be asked last and ungated.
         expect(runtime.asked.map((a) => a.key)).toContain('browserCacheDir');
+        expect(runtime.asked.map((a) => a.key)).toContain('browserExecutablePath');
     });
 
     test('never asks for the log level up front', async () => {

--- a/src/lib/commands/qscloud/create-sheet-thumbnails.interactive.js
+++ b/src/lib/commands/qscloud/create-sheet-thumbnails.interactive.js
@@ -45,6 +45,7 @@ const ADVANCED_KEYS = [
     'browserVersion',
     'browserPageTimeout',
     'browserCacheDir',
+    'browserExecutablePath',
     'headless',
 ];
 

--- a/src/lib/commands/qscloud/create-sheet-thumbnails.js
+++ b/src/lib/commands/qscloud/create-sheet-thumbnails.js
@@ -12,6 +12,7 @@ import {
     collectPositiveIntegers,
     collectAppIds,
     buildBrowserCacheDirOption,
+    buildBrowserExecutablePathOption,
 } from '../helpers.js';
 import { toAppIdList } from '../../util/app-ids.js';
 import { addInteractiveOption } from '../../interactive/interactive-option.js';
@@ -277,7 +278,8 @@ const buildCloudCreateSheetThumbnailsCommand = () => {
                 .default('90')
                 .env('BSI_BROWSER_PAGE_TIMEOUT')
         )
-        .addOption(buildBrowserCacheDirOption());
+        .addOption(buildBrowserCacheDirOption())
+        .addOption(buildBrowserExecutablePathOption());
 
     addInteractiveOption(command);
 

--- a/src/lib/commands/qseow/__tests__/qseow_wizard.test.js
+++ b/src/lib/commands/qseow/__tests__/qseow_wizard.test.js
@@ -926,6 +926,7 @@ describe('progressive disclosure', () => {
                 browserVersion: 'recommended',
                 browserPageTimeout: '90',
                 browserCacheDir: '',
+                browserExecutablePath: '',
             })
         );
 
@@ -937,6 +938,7 @@ describe('progressive disclosure', () => {
         // Behind the advanced gate rather than in the main flow: most runs never name a
         // browser cache directory, and an unplaced key would be asked last and ungated.
         expect(asked).toContain('browserCacheDir');
+        expect(asked).toContain('browserExecutablePath');
     });
 });
 

--- a/src/lib/commands/qseow/create-sheet-thumbnails.interactive.js
+++ b/src/lib/commands/qseow/create-sheet-thumbnails.interactive.js
@@ -69,6 +69,7 @@ const ADVANCED_KEYS = [
     'browserVersion',
     'browserPageTimeout',
     'browserCacheDir',
+    'browserExecutablePath',
 ];
 
 /** Which section each question belongs under, in the order the sections run. */

--- a/src/lib/commands/qseow/index.js
+++ b/src/lib/commands/qseow/index.js
@@ -13,6 +13,7 @@ import {
     collectPositiveIntegers,
     collectAppIds,
     buildBrowserCacheDirOption,
+    buildBrowserExecutablePathOption,
 } from '../helpers.js';
 import { toAppIdList } from '../../util/app-ids.js';
 import { addInteractiveOption } from '../../interactive/interactive-option.js';
@@ -372,7 +373,8 @@ const buildQseowCommand = () => {
                 .default('90')
                 .env('BSI_BROWSER_PAGE_TIMEOUT')
         )
-        .addOption(buildBrowserCacheDirOption());
+        .addOption(buildBrowserCacheDirOption())
+        .addOption(buildBrowserExecutablePathOption());
 
     addInteractiveOption(qseow.commands[0]);
 

--- a/src/lib/qseow/__tests__/qseow_process_app.test.js
+++ b/src/lib/qseow/__tests__/qseow_process_app.test.js
@@ -581,7 +581,7 @@ describe('qseow-process-app.js — puppeteer launch and click options', () => {
         await expect(qseowProcessApp('test-app-id', defaultOptions)).rejects.toThrow();
 
         const logged = logger.error.mock.calls.map((call) => String(call[0])).join('\n');
-        expect(logged).toContain('Failed to install a browser for QSEoW app test-app-id');
+        expect(logged).toContain('Could not obtain a browser for QSEoW app test-app-id');
         expect(puppeteer.launch).not.toHaveBeenCalled();
     });
 

--- a/src/lib/util/errors.js
+++ b/src/lib/util/errors.js
@@ -87,6 +87,26 @@ export class CloudError extends BsiError {
 }
 
 /**
+ * No usable browser could be obtained, and Butler Sheet Icons will not look further.
+ *
+ * Thrown only where continuing would contradict something the operator asked for - today,
+ * an explicitly named `--browser-executable-path` that does not exist. A browser merely being
+ * absent is not this error: detection returns `null` for that, and the caller downloads one.
+ */
+export class BrowserNotFoundError extends BsiError {
+    /**
+     * Construct a browser-not-found error.
+     *
+     * @param {string} message - Human-readable error message.
+     * @param {object} [options] - Standard `Error` options.
+     */
+    constructor(message, options = {}) {
+        super(message, options);
+        this.name = 'BrowserNotFoundError';
+    }
+}
+
+/**
  * QSEoW processing failure (sheet exclude status, app processing, etc.).
  */
 export class QseowError extends BsiError {


### PR DESCRIPTION
Closes #929 (air-gapped route A1). Commit 4 of the sequencing in `docs/todo/airgap-browser-phase-1.md`; only `browser check` remains after this.

## Why this is the cheapest air-gapped route

Getting a browser onto an isolated server is the entire difficulty of running BSI there. Windows Server ships Microsoft Edge on current builds, so for most QSEoW sites there is already a usable browser on the machine — there is just no way to say so. This adds one:

```
butler-sheet-icons qseow create-sheet-thumbnails \
  --browser-executable-path "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe" ...
```

Nothing to copy across, nothing downloaded, nothing for BSI to manage or patch.

## The one decision worth reviewing

`--browser-executable-path` / `BSI_BROWSER_EXECUTABLE_PATH` sits above `PUPPETEER_EXECUTABLE_PATH`, and the two behave **differently when the file is missing**:

| Setting | File missing |
| --- | --- |
| `--browser-executable-path` | **run stops** with `BrowserNotFoundError` |
| `PUPPETEER_EXECUTABLE_PATH` | warns, falls through to the cache — unchanged |

Naming a browser through a BSI option states an intent that cannot be met; quietly downloading a different browser instead is a compliance problem in a regulated Qlik estate, and offline it is a guaranteed failure reported as something unrelated. An inherited `PUPPETEER_EXECUTABLE_PATH` is a much weaker signal, and the Docker documentation depends on it falling through. Both tiers resolve in one place, `resolveExecutablePathOverride`, which records which setting won and whether it was explicit.

## Knock-ons, each a consequence rather than a drive-by

- **`detectAvailableBrowser`'s outer catch** turned every failure into `null`, which would have swallowed the refusal. It now re-throws BSI-typed errors and still degrades unrecognised ones into "download instead".
- **The refusal is thrown unlogged.** `logError` renders an error with its whole cause chain, so the caller attaching the app id prints it in full; logging it here too is how one failure gets described twice (#785).
- **`Failed to install a browser for <app>` → `Could not obtain a browser for <app>`.** Nothing necessarily tried to install any more.
- **The version lookup is skipped when a named browser exists.** Resolving `stable` first was a network round trip whose answer is discarded — and on an air-gapped machine, two alarming warnings about a build nobody was going to download.
- **Messages quote what the operator wrote.** `path.resolve('D:\browsers\chrome.exe')` on macOS yields a nonsense POSIX path, and a relative path echoed back absolute is a string they cannot find in their unit file.

## Verification

`npm run test:unit` green (2700 tests). Beyond that, detection was run against real files with no mocks — option-with-file, option-without-file, option vs `PUPPETEER_`, `PUPPETEER_` missing, and empty-means-unset all behaved as designed, and every message quoted in the doc drafts was confirmed against real output.

## Reviewer notes

- **Second commit is a documentation correction, not new content.** Two messages this PR renames are quoted verbatim on pages that are already live (the Docker page and the crash-dumps page). `docs/to-doc-site/two-renamed-messages.md` names both pages with before/after. The `done_` staging files are deliberately untouched.
- The wizards carry the option too. #1057's prompt contract made that unavoidable rather than optional — 90 tests failed until it was declared, which is the contract working.
- `gitnexus_detect_changes` could not run before the commit as CLAUDE.md asks: the MCP server disconnected mid-session. The caller sweep was done by grep instead — `resolveBrowserExecutablePath` has one production caller, in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
