### PR TITLE
Make GitNexus answer correctly from a linked worktree

### DIFF
--- a/.claude/skills/generated/browser/SKILL.md
+++ b/.claude/skills/generated/browser/SKILL.md
@@ -1,91 +1,95 @@
 ---
 name: browser
-description: "Skill for the Browser area of butler-sheet-icons. 43 symbols across 23 files."
+description: "Skill for the Browser area of butler-sheet-icons. 92 symbols across 40 files."
 ---
 
 # Browser
 
-43 symbols | 23 files | Cohesion: 84%
+92 symbols | 40 files | Cohesion: 70%
 
 ## When to Use
 
 - Working with code in `src/`
-- Understanding how launchBrowserForApp, resolveBrowserVersion, assertInteractiveCapable work
+- Understanding how browserListAvailable, browserUninstall, qscloudListCollections work
 - Modifying browser-related functionality
 
 ## Key Files
 
 | File | Symbols |
 |------|---------|
-| `src/lib/browser/browser-launch.js` | logUnusableBrowser, watchForUnexpectedDisconnect, launchBrowserForApp, detectDocker, buildBrowserArgs (+2) |
-| `src/lib/browser/browser-version.js` | normalizeVersionKeyword, assertExplicitVersionIsWellFormed, markLookupFailure, logVersionLookupFailure, resolveBrowserVersion |
-| `src/lib/browser/browser-list-available.js` | extractVersions, mapPlatformToChrome, fetchAvailableVersions, browserListAvailable, getMostRecentUsableChromeBuildId |
+| `src/lib/browser/browser-paths.js` | resolveBrowserCacheDir, unwritableCacheDirMessage, isPermissionDenied, nearestExistingAncestor, assertCacheDirWritable (+6) |
+| `src/lib/browser/browser-version.js` | describeBrowserVersionOption, isVersionKeyword, isVersionLookupFailure, resolveLocalBrowserBuildId, assertBrowserIsSupported (+5) |
+| `src/lib/browser/browser-launch.js` | resolveRequestedBuildId, resolveBrowserExecutablePath, detectDocker, buildBrowserArgs, logUnusableBrowser (+3) |
+| `src/lib/browser/browser-list-available.js` | browserListAvailable, logVersionHistoryFailure, extractVersions, mapPlatformToChrome, fetchAvailableVersions |
+| `src/lib/commands/browser/uninstall.interactive.js` | run, labelForBuild, precheck, choices |
+| `src/lib/interactive/launch.js` | suppliedEntries, presetOptionsFrom, presetSourcesFrom, launchInteractive |
 | `src/lib/util/image-dir.js` | createAppImageDir, logPermissionAdvice, isProbablyContainer |
-| `src/lib/util/reported-error.js` | markReported, alreadyReported |
-| `src/globals.js` | getLoggingLevel, setLoggingLevel |
+| `src/lib/commands/helpers.js` | parsePositiveInteger, collectPositiveIntegers, buildBrowserCacheDirOption |
 | `src/lib/browser/browser-uninstall.js` | browserUninstall, browserUninstallAll |
-| `src/lib/browser/browser-detect.js` | sortNewestFirst, detectAvailableBrowser |
-| `src/lib/interactive/tty.js` | assertInteractiveCapable |
-| `src/lib/browser/browser-installed.js` | browserInstalled |
+| `src/lib/commands/browser/install.js` | handleBrowserInstall, buildBrowserInstallCommand |
 
 ## Entry Points
 
 Start here when exploring this area:
 
-- **`launchBrowserForApp`** (Function) — `src/lib/browser/browser-launch.js:287`
-- **`resolveBrowserVersion`** (Function) — `src/lib/browser/browser-version.js:354`
-- **`assertInteractiveCapable`** (Function) — `src/lib/interactive/tty.js:121`
-- **`createAppImageDir`** (Function) — `src/lib/util/image-dir.js:32`
-- **`markReported`** (Function) — `src/lib/util/reported-error.js:32`
+- **`browserListAvailable`** (Function) — `src/lib/browser/browser-list-available.js:190`
+- **`browserUninstall`** (Function) — `src/lib/browser/browser-uninstall.js:27`
+- **`qscloudListCollections`** (Function) — `src/lib/cloud/cloud-collections.js:21`
+- **`qscloudCreateThumbnails`** (Function) — `src/lib/cloud/cloud-create-thumbnails.js:36`
+- **`qscloudRemoveSheetIcons`** (Function) — `src/lib/cloud/cloud-remove-sheet-icons.js:166`
 
 ## Key Symbols
 
 | Symbol | Type | File | Line |
 |--------|------|------|------|
-| `launchBrowserForApp` | Function | `src/lib/browser/browser-launch.js` | 287 |
-| `resolveBrowserVersion` | Function | `src/lib/browser/browser-version.js` | 354 |
-| `assertInteractiveCapable` | Function | `src/lib/interactive/tty.js` | 121 |
-| `createAppImageDir` | Function | `src/lib/util/image-dir.js` | 32 |
-| `markReported` | Function | `src/lib/util/reported-error.js` | 32 |
-| `browserInstalled` | Function | `src/lib/browser/browser-installed.js` | 17 |
-| `browserUninstall` | Function | `src/lib/browser/browser-uninstall.js` | 24 |
-| `browserUninstallAll` | Function | `src/lib/browser/browser-uninstall.js` | 138 |
-| `qscloudListCollections` | Function | `src/lib/cloud/cloud-collections.js` | 19 |
-| `qscloudCreateThumbnails` | Function | `src/lib/cloud/cloud-create-thumbnails.js` | 35 |
-| `withQuietLogging` | Function | `src/lib/interactive/quiet.js` | 27 |
-| `qseowCreateThumbnails` | Function | `src/lib/qseow/qseow-create-thumbnails.js` | 30 |
-| `buildInteractiveCommand` | Function | `src/lib/interactive/interactive-command.js` | 112 |
-| `description` | Function | `src/lib/interactive/theme.js` | 54 |
-| `fetchAvailableVersions` | Function | `src/lib/browser/browser-list-available.js` | 146 |
-| `browserListAvailable` | Function | `src/lib/browser/browser-list-available.js` | 197 |
-| `getMostRecentUsableChromeBuildId` | Function | `src/lib/browser/browser-list-available.js` | 335 |
-| `choices` | Function | `src/lib/commands/browser/install.interactive.js` | 51 |
+| `browserListAvailable` | Function | `src/lib/browser/browser-list-available.js` | 190 |
+| `browserUninstall` | Function | `src/lib/browser/browser-uninstall.js` | 27 |
+| `qscloudListCollections` | Function | `src/lib/cloud/cloud-collections.js` | 21 |
+| `qscloudCreateThumbnails` | Function | `src/lib/cloud/cloud-create-thumbnails.js` | 36 |
+| `qscloudRemoveSheetIcons` | Function | `src/lib/cloud/cloud-remove-sheet-icons.js` | 166 |
+| `qscloudTestConnection` | Function | `src/lib/cloud/cloud-test-connection.js` | 31 |
+| `run` | Function | `src/lib/commands/browser/uninstall.interactive.js` | 155 |
+| `probe` | Function | `src/lib/commands/qscloud/create-sheet-thumbnails.interactive.js` | 104 |
+| `run` | Function | `src/lib/commands/qscloud/create-sheet-thumbnails.interactive.js` | 241 |
+| `run` | Function | `src/lib/commands/qseow/create-sheet-thumbnails.interactive.js` | 273 |
+| `runCommand` | Function | `src/lib/commands/run-command.js` | 26 |
+| `presetOptionsFrom` | Function | `src/lib/interactive/launch.js` | 58 |
+| `presetSourcesFrom` | Function | `src/lib/interactive/launch.js` | 75 |
+| `launchInteractive` | Function | `src/lib/interactive/launch.js` | 91 |
+| `qseowCreateThumbnails` | Function | `src/lib/qseow/qseow-create-thumbnails.js` | 31 |
+| `qseowRemoveSheetIcons` | Function | `src/lib/qseow/qseow-remove-sheet-icons.js` | 135 |
+| `toAppIdList` | Function | `src/lib/util/app-ids.js` | 23 |
+| `redactOptions` | Function | `src/lib/util/redact-secrets.js` | 149 |
 | `alreadyReported` | Function | `src/lib/util/reported-error.js` | 47 |
-| `detectAvailableBrowser` | Function | `src/lib/browser/browser-detect.js` | 61 |
+| `runOverApps` | Function | `src/lib/util/run-over-apps.js` | 36 |
 
 ## Execution Flows
 
 | Flow | Type | Steps |
 |------|------|-------|
-| `EveryLeafCommand → Description` | cross_community | 4 |
-| `BrowserListAvailable → GetErrorCategory` | cross_community | 4 |
-| `BrowserListAvailable → MarkReported` | cross_community | 4 |
-| `Choices → GetErrorCategory` | cross_community | 4 |
-| `Choices → MarkReported` | cross_community | 4 |
-| `GetMostRecentUsableChromeBuildId → GetErrorCategory` | cross_community | 4 |
-| `GetMostRecentUsableChromeBuildId → MarkReported` | cross_community | 4 |
-| `ResolveBrowserVersion → MarkReported` | intra_community | 3 |
-| `ResolveBrowserVersion → GetErrorCategory` | cross_community | 3 |
-| `LaunchBrowserForApp → LogUnusableBrowser` | intra_community | 3 |
+| `QseowRemoveSheetIcons → SafeString` | cross_community | 7 |
+| `QseowCreateThumbnails → SafeString` | cross_community | 7 |
+| `QseowRemoveSheetIcons → SafeRead` | cross_community | 6 |
+| `RunInteractive → ParsePositiveInteger` | cross_community | 6 |
+| `RunInteractive → DescribeBrowserVersionOption` | cross_community | 6 |
+| `RunInteractive → BuildBrowserCacheDirOption` | cross_community | 6 |
+| `QscloudRemoveSheetIcons → SafeString` | cross_community | 6 |
+| `HandleCloudCreateSheetThumbnails → SafeRead` | cross_community | 6 |
+| `HandleCloudCreateSheetThumbnails → Walk` | cross_community | 6 |
+| `Content → ParsePositiveInteger` | cross_community | 6 |
 
 ## Connected Areas
 
 | Area | Connections |
 |------|-------------|
-| Util | 2 calls |
+| Util | 18 calls |
+| Qseow | 4 calls |
+| Interactive | 4 calls |
+| Cloud | 3 calls |
 
 ## How to Explore
 
-1. `gitnexus_context({name: "launchBrowserForApp"})` — see callers and callees
-2. `gitnexus_query({query: "browser"})` — find related execution flows
+1. `context({name: "browserListAvailable"})` — see callers and callees
+2. `query({search_query: "browser"})` — find related execution flows
 3. Read key files listed above for implementation details
+4. `explain({target: "<file or symbol>"})` — persisted taint findings (source→sink data flows), when indexed with `--pdg`

--- a/.claude/skills/generated/cloud/SKILL.md
+++ b/.claude/skills/generated/cloud/SKILL.md
@@ -1,85 +1,74 @@
 ---
 name: cloud
-description: "Skill for the Cloud area of butler-sheet-icons. 17 symbols across 12 files."
+description: "Skill for the Cloud area of butler-sheet-icons. 13 symbols across 7 files."
 ---
 
 # Cloud
 
-17 symbols | 12 files | Cohesion: 77%
+13 symbols | 7 files | Cohesion: 86%
 
 ## When to Use
 
 - Working with code in `src/`
-- Understanding how browserInstall, deleteCloudAppThumbnail, processCloudApp work
+- Understanding how listCollections, listApps, listAppsByCollection work
 - Modifying cloud-related functionality
 
 ## Key Files
 
 | File | Symbols |
 |------|---------|
+| `src/lib/cloud/cloud-apps.js` | appsFromItems, listCollections, listApps, listAppsByCollection |
 | `src/lib/cloud/cloud-repo-request.js` | bufferToStream, makeRequest, request |
-| `src/lib/util/socket-keepalive.js` | attachSocketKeepalive, stop |
-| `src/lib/cloud/cloud-remove-sheet-icons.js` | removeSheetIconsCloudApp, qscloudRemoveSheetIcons |
-| `src/lib/qseow/qseow-remove-sheet-icons.js` | removeSheetIconsQSEoWApp, qseowRemoveSheetIcons |
-| `src/globals.js` | sleep |
-| `src/lib/browser/browser-install.js` | browserInstall |
-| `src/lib/cloud/cloud-delete-thumbnails.js` | deleteCloudAppThumbnail |
-| `src/lib/cloud/process-cloud-app.js` | processCloudApp |
-| `src/lib/cloud/sheet-screenshot.js` | takeSheetScreenshot |
-| `src/lib/cloud/cloud-updatesheets.js` | qscloudUpdateSheetThumbnails |
+| `src/lib/commands/qscloud/create-sheet-thumbnails.interactive.js` | choices, resolve |
+| `src/lib/cloud/cloud-collections.js` | qscloudVerifyCollectionExists |
+| `src/lib/cloud/saas-response.js` | saasGetList |
+| `src/lib/interactive/labels.js` | labelForCollection |
+| `src/lib/cloud/cloud-repo.js` | qlikSaas |
 
 ## Entry Points
 
 Start here when exploring this area:
 
-- **`browserInstall`** (Function) — `src/lib/browser/browser-install.js:34`
-- **`deleteCloudAppThumbnail`** (Function) — `src/lib/cloud/cloud-delete-thumbnails.js:10`
-- **`processCloudApp`** (Function) — `src/lib/cloud/process-cloud-app.js:33`
-- **`takeSheetScreenshot`** (Function) — `src/lib/cloud/sheet-screenshot.js:19`
-- **`attachSocketKeepalive`** (Function) — `src/lib/util/socket-keepalive.js:38`
+- **`listCollections`** (Function) — `src/lib/cloud/cloud-apps.js:85`
+- **`listApps`** (Function) — `src/lib/cloud/cloud-apps.js:112`
+- **`listAppsByCollection`** (Function) — `src/lib/cloud/cloud-apps.js:139`
+- **`qscloudVerifyCollectionExists`** (Function) — `src/lib/cloud/cloud-collections.js:133`
+- **`saasGetList`** (Function) — `src/lib/cloud/saas-response.js:39`
 
 ## Key Symbols
 
 | Symbol | Type | File | Line |
 |--------|------|------|------|
-| `browserInstall` | Function | `src/lib/browser/browser-install.js` | 34 |
-| `deleteCloudAppThumbnail` | Function | `src/lib/cloud/cloud-delete-thumbnails.js` | 10 |
-| `processCloudApp` | Function | `src/lib/cloud/process-cloud-app.js` | 33 |
-| `takeSheetScreenshot` | Function | `src/lib/cloud/sheet-screenshot.js` | 19 |
-| `attachSocketKeepalive` | Function | `src/lib/util/socket-keepalive.js` | 38 |
-| `stop` | Function | `src/lib/util/socket-keepalive.js` | 48 |
-| `qscloudRemoveSheetIcons` | Function | `src/lib/cloud/cloud-remove-sheet-icons.js` | 171 |
-| `qscloudUpdateSheetThumbnails` | Function | `src/lib/cloud/cloud-updatesheets.js` | 36 |
-| `qseowRemoveSheetIcons` | Function | `src/lib/qseow/qseow-remove-sheet-icons.js` | 140 |
-| `assertAllProcessed` | Function | `src/lib/util/sheet-list.js` | 337 |
-| `sleep` | Function | `src/globals.js` | 291 |
-| `removeSheetIconsCloudApp` | Function | `src/lib/cloud/cloud-remove-sheet-icons.js` | 35 |
-| `removeSheetIconsQSEoWApp` | Function | `src/lib/qseow/qseow-remove-sheet-icons.js` | 35 |
+| `listCollections` | Function | `src/lib/cloud/cloud-apps.js` | 85 |
+| `listApps` | Function | `src/lib/cloud/cloud-apps.js` | 112 |
+| `listAppsByCollection` | Function | `src/lib/cloud/cloud-apps.js` | 139 |
+| `qscloudVerifyCollectionExists` | Function | `src/lib/cloud/cloud-collections.js` | 133 |
+| `saasGetList` | Function | `src/lib/cloud/saas-response.js` | 39 |
+| `choices` | Function | `src/lib/commands/qscloud/create-sheet-thumbnails.interactive.js` | 152 |
+| `resolve` | Function | `src/lib/commands/qscloud/create-sheet-thumbnails.interactive.js` | 171 |
+| `labelForCollection` | Function | `src/lib/interactive/labels.js` | 43 |
+| `appsFromItems` | Function | `src/lib/cloud/cloud-apps.js` | 22 |
 | `bufferToStream` | Function | `src/lib/cloud/cloud-repo-request.js` | 59 |
 | `makeRequest` | Function | `src/lib/cloud/cloud-repo-request.js` | 75 |
-| `request` | Function | `src/lib/cloud/cloud-repo-request.js` | 143 |
+| `request` | Function | `src/lib/cloud/cloud-repo-request.js` | 149 |
 | `qlikSaas` | Function | `src/lib/cloud/cloud-repo.js` | 19 |
 
 ## Execution Flows
 
 | Flow | Type | Steps |
 |------|------|-------|
-| `ProcessCloudApp → Sleep` | intra_community | 3 |
-| `QscloudRemoveSheetIcons → AssertAllProcessed` | intra_community | 3 |
-| `QseowLogout → Sleep` | cross_community | 3 |
-| `QseowRemoveSheetIcons → AssertAllProcessed` | intra_community | 3 |
-| `QlikSaas → BufferToStream` | intra_community | 3 |
-| `QlikSaas → MakeRequest` | intra_community | 3 |
+| `QscloudVerifyCollectionExists → SafeString` | cross_community | 6 |
+| `QscloudVerifyCollectionExists → SafeRead` | cross_community | 5 |
 
 ## Connected Areas
 
 | Area | Connections |
 |------|-------------|
-| Browser | 4 calls |
-| Util | 1 calls |
+| Util | 2 calls |
 
 ## How to Explore
 
-1. `gitnexus_context({name: "browserInstall"})` — see callers and callees
-2. `gitnexus_query({query: "cloud"})` — find related execution flows
+1. `context({name: "listCollections"})` — see callers and callees
+2. `query({search_query: "cloud"})` — find related execution flows
 3. Read key files listed above for implementation details
+4. `explain({target: "<file or symbol>"})` — persisted taint findings (source→sink data flows), when indexed with `--pdg`

--- a/.claude/skills/generated/diag/SKILL.md
+++ b/.claude/skills/generated/diag/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: diag
-description: "Skill for the Diag area of butler-sheet-icons. 11 symbols across 1 files."
+description: "Skill for the Diag area of butler-sheet-icons. 10 symbols across 1 files."
 ---
 
 # Diag
 
-11 symbols | 1 files | Cohesion: 100%
+10 symbols | 1 files | Cohesion: 95%
 
 ## When to Use
 
@@ -17,7 +17,7 @@ description: "Skill for the Diag area of butler-sheet-icons. 11 symbols across 1
 
 | File | Symbols |
 |------|---------|
-| `scripts/diag/browser-flag-probe.mjs` | parseArgs, capture, lastDisplayTransition, captureHostState, deadline (+6) |
+| `scripts/diag/browser-flag-probe.mjs` | parseArgs, capture, lastDisplayTransition, captureHostState, deadline (+5) |
 
 ## Key Symbols
 
@@ -28,7 +28,6 @@ description: "Skill for the Diag area of butler-sheet-icons. 11 symbols across 1
 | `lastDisplayTransition` | Function | `scripts/diag/browser-flag-probe.mjs` | 123 |
 | `captureHostState` | Function | `scripts/diag/browser-flag-probe.mjs` | 138 |
 | `deadline` | Function | `scripts/diag/browser-flag-probe.mjs` | 168 |
-| `cancel` | Function | `scripts/diag/browser-flag-probe.mjs` | 173 |
 | `withDeadline` | Function | `scripts/diag/browser-flag-probe.mjs` | 185 |
 | `sampleWedgedProcess` | Function | `scripts/diag/browser-flag-probe.mjs` | 211 |
 | `runTrial` | Function | `scripts/diag/browser-flag-probe.mjs` | 244 |
@@ -39,13 +38,19 @@ description: "Skill for the Diag area of butler-sheet-icons. 11 symbols across 1
 
 | Flow | Type | Steps |
 |------|------|-------|
-| `Main → Capture` | intra_community | 5 |
-| `Main → Deadline` | intra_community | 4 |
-| `Main → Cancel` | intra_community | 4 |
-| `Main → SampleWedgedProcess` | intra_community | 3 |
+| `Main → Configured` | cross_community | 5 |
+| `Main → GetDefaultBrowserCacheDir` | cross_community | 5 |
+| `Main → CountCachedBuilds` | cross_community | 5 |
+
+## Connected Areas
+
+| Area | Connections |
+|------|-------------|
+| Browser | 1 calls |
 
 ## How to Explore
 
-1. `gitnexus_context({name: "parseArgs"})` — see callers and callees
-2. `gitnexus_query({query: "diag"})` — find related execution flows
+1. `context({name: "parseArgs"})` — see callers and callees
+2. `query({search_query: "diag"})` — find related execution flows
 3. Read key files listed above for implementation details
+4. `explain({target: "<file or symbol>"})` — persisted taint findings (source→sink data flows), when indexed with `--pdg`

--- a/.claude/skills/generated/docs/SKILL.md
+++ b/.claude/skills/generated/docs/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: docs
+description: "Skill for the Docs area of butler-sheet-icons. 13 symbols across 1 files."
+---
+
+# Docs
+
+13 symbols | 1 files | Cohesion: 88%
+
+## When to Use
+
+- Working with code in `src/`
+- Understanding how renderTable, line, renderOptionTable work
+- Modifying docs-related functionality
+
+## Key Files
+
+| File | Symbols |
+|------|---------|
+| `src/lib/docs/cli-option-tables.js` | blockBody, renderTable, line, renderOptionTable, commandAt (+8) |
+
+## Entry Points
+
+Start here when exploring this area:
+
+- **`renderTable`** (Function) — `src/lib/docs/cli-option-tables.js:251`
+- **`line`** (Function) — `src/lib/docs/cli-option-tables.js:258`
+- **`renderOptionTable`** (Function) — `src/lib/docs/cli-option-tables.js:276`
+- **`commandAt`** (Function) — `src/lib/docs/cli-option-tables.js:305`
+- **`content`** (Function) — `src/lib/docs/cli-option-tables.js:348`
+
+## Key Symbols
+
+| Symbol | Type | File | Line |
+|--------|------|------|------|
+| `renderTable` | Function | `src/lib/docs/cli-option-tables.js` | 251 |
+| `line` | Function | `src/lib/docs/cli-option-tables.js` | 258 |
+| `renderOptionTable` | Function | `src/lib/docs/cli-option-tables.js` | 276 |
+| `commandAt` | Function | `src/lib/docs/cli-option-tables.js` | 305 |
+| `content` | Function | `src/lib/docs/cli-option-tables.js` | 348 |
+| `renderBlock` | Function | `src/lib/docs/cli-option-tables.js` | 371 |
+| `escapeCell` | Function | `src/lib/docs/cli-option-tables.js` | 75 |
+| `codeCell` | Function | `src/lib/docs/cli-option-tables.js` | 106 |
+| `formatDefault` | Function | `src/lib/docs/cli-option-tables.js` | 128 |
+| `formatDescription` | Function | `src/lib/docs/cli-option-tables.js` | 157 |
+| `deriveExample` | Function | `src/lib/docs/cli-option-tables.js` | 182 |
+| `optionRowsFor` | Function | `src/lib/docs/cli-option-tables.js` | 202 |
+| `blockBody` | Function | `src/lib/docs/cli-option-tables.js` | 26 |
+
+## Execution Flows
+
+| Flow | Type | Steps |
+|------|------|-------|
+| `Content → ParsePositiveInteger` | cross_community | 6 |
+| `Content → EscapeCell` | cross_community | 5 |
+| `Content → CodeCell` | cross_community | 5 |
+| `Content → DescribeBrowserVersionOption` | cross_community | 5 |
+| `Content → BuildBrowserCacheDirOption` | cross_community | 5 |
+| `Content → BuildCloudListCollectionsCommand` | cross_community | 5 |
+| `Content → BuildCloudRemoveSheetIconsCommand` | cross_community | 5 |
+| `Run → DeriveExample` | cross_community | 5 |
+| `Run → CodeCell` | cross_community | 5 |
+| `Run → Line` | cross_community | 5 |
+
+## Connected Areas
+
+| Area | Connections |
+|------|-------------|
+| Qscloud | 1 calls |
+
+## How to Explore
+
+1. `context({name: "renderTable"})` — see callers and callees
+2. `query({search_query: "docs"})` — find related execution flows
+3. Read key files listed above for implementation details
+4. `explain({target: "<file or symbol>"})` — persisted taint findings (source→sink data flows), when indexed with `--pdg`

--- a/.claude/skills/generated/interactive/SKILL.md
+++ b/.claude/skills/generated/interactive/SKILL.md
@@ -1,80 +1,93 @@
 ---
 name: interactive
-description: "Skill for the Interactive area of butler-sheet-icons. 44 symbols across 10 files."
+description: "Skill for the Interactive area of butler-sheet-icons. 113 symbols across 26 files."
 ---
 
 # Interactive
 
-44 symbols | 10 files | Cohesion: 98%
+113 symbols | 26 files | Cohesion: 77%
 
 ## When to Use
 
 - Working with code in `src/`
-- Understanding how askQuestions, runInteractive, runMenu work
+- Understanding how openingOn, appSourceQuestion, resolvesToApps work
 - Modifying interactive-related functionality
 
 ## Key Files
 
 | File | Symbols |
 |------|---------|
-| `src/lib/interactive/self-test.js` | heading, formatCapabilities, renderStaticReport, runPromptGallery, runSelfTest (+6) |
-| `src/lib/interactive/ask-questions.js` | resolveChoices, configFor, askQuestions, hasDefault, select (+5) |
-| `src/lib/interactive/theme.js` | help, answer, message, defaultAnswer |
-| `src/lib/interactive/to-cli-options.js` | matchesDeclaredDefault, tokensFor, emissionsFor, notEmitted |
-| `src/lib/interactive/prompt-runtime.js` | loadPrompts, ask, write |
-| `src/lib/interactive/interactive-command.js` | runSelfTestUnlessCancelled, runWizardUnlessCancelled, handleInteractive |
-| `src/lib/interactive/mandatory-relaxation.js` | commandAndAncestors, relaxMandatoryOptionsIfInteractive, relax |
-| `src/lib/interactive/option-introspect.js` | typeForOption, defaultForOption, specFromOption |
-| `src/lib/interactive/index.js` | review, runInteractive |
-| `src/lib/interactive/menu.js` | runMenu |
+| `src/lib/interactive/ask-questions.js` | assertNeedsAreSatisfiable, describeSupplied, describePassedCheck, describeFailedCheck, configFor (+12) |
+| `src/lib/interactive/spec-ops.js` | openingOn, appSourceQuestion, resolvesToApps, appPickerQuestion, typedAppQuestion (+11) |
+| `src/lib/interactive/self-test.js` | readWindowsCodePage, heading, formatCapabilities, formatSymbolMatrix, frames (+8) |
+| `src/lib/interactive/merge-env-file.js` | toLines, dominantEol, opensQuote, closesQuote, findClosingLine (+2) |
+| `src/lib/interactive/option-introspect.js` | isTrueFalseOption, splitDescription, typeForOption, defaultForOption, specFromOption (+1) |
+| `src/lib/interactive/to-cli-options.js` | tokensFor, emissionsFor, notEmitted, matchesDeclaredDefault, tokensFrom (+1) |
+| `src/lib/interactive/render-env-file.js` | quoteEnvValue, savable, isSecret, assign, envAssignments (+1) |
+| `src/lib/interactive/index.js` | review, runInteractive, checkOnly, upFront, nameOf |
+| `src/lib/interactive/mandatory-relaxation.js` | wantsInteractive, commandAndAncestors, relaxMandatoryOptionsIfInteractive, relax |
+| `src/lib/interactive/symbols.js` | getSymbols, isUnicodeCapable, tableBorderName |
 
 ## Entry Points
 
 Start here when exploring this area:
 
-- **`askQuestions`** (Function) — `src/lib/interactive/ask-questions.js:196`
-- **`runInteractive`** (Function) — `src/lib/interactive/index.js:72`
-- **`runMenu`** (Function) — `src/lib/interactive/menu.js:24`
-- **`formatCapabilities`** (Function) — `src/lib/interactive/self-test.js:152`
-- **`renderStaticReport`** (Function) — `src/lib/interactive/self-test.js:283`
+- **`openingOn`** (Function) — `src/lib/interactive/spec-ops.js:112`
+- **`appSourceQuestion`** (Function) — `src/lib/interactive/spec-ops.js:176`
+- **`resolvesToApps`** (Function) — `src/lib/interactive/spec-ops.js:217`
+- **`appPickerQuestion`** (Function) — `src/lib/interactive/spec-ops.js:259`
+- **`typedAppQuestion`** (Function) — `src/lib/interactive/spec-ops.js:331`
 
 ## Key Symbols
 
 | Symbol | Type | File | Line |
 |--------|------|------|------|
-| `askQuestions` | Function | `src/lib/interactive/ask-questions.js` | 196 |
-| `runInteractive` | Function | `src/lib/interactive/index.js` | 72 |
-| `runMenu` | Function | `src/lib/interactive/menu.js` | 24 |
+| `openingOn` | Function | `src/lib/interactive/spec-ops.js` | 112 |
+| `appSourceQuestion` | Function | `src/lib/interactive/spec-ops.js` | 176 |
+| `resolvesToApps` | Function | `src/lib/interactive/spec-ops.js` | 217 |
+| `appPickerQuestion` | Function | `src/lib/interactive/spec-ops.js` | 259 |
+| `typedAppQuestion` | Function | `src/lib/interactive/spec-ops.js` | 331 |
+| `gate` | Function | `src/lib/interactive/spec-ops.js` | 354 |
+| `gatedBy` | Function | `src/lib/interactive/spec-ops.js` | 387 |
+| `inSections` | Function | `src/lib/interactive/spec-ops.js` | 415 |
+| `headingFor` | Function | `src/lib/interactive/spec-ops.js` | 417 |
+| `rank` | Function | `src/lib/interactive/spec-ops.js` | 424 |
+| `readWindowsCodePage` | Function | `src/lib/interactive/self-test.js` | 39 |
 | `formatCapabilities` | Function | `src/lib/interactive/self-test.js` | 152 |
-| `renderStaticReport` | Function | `src/lib/interactive/self-test.js` | 283 |
-| `runSelfTest` | Function | `src/lib/interactive/self-test.js` | 364 |
-| `help` | Function | `src/lib/interactive/theme.js` | 48 |
-| `formatPalette` | Function | `src/lib/interactive/self-test.js` | 250 |
-| `answer` | Function | `src/lib/interactive/theme.js` | 44 |
-| `message` | Function | `src/lib/interactive/theme.js` | 45 |
-| `defaultAnswer` | Function | `src/lib/interactive/theme.js` | 47 |
-| `emissionsFor` | Function | `src/lib/interactive/to-cli-options.js` | 105 |
-| `notEmitted` | Function | `src/lib/interactive/to-cli-options.js` | 107 |
-| `relaxMandatoryOptionsIfInteractive` | Function | `src/lib/interactive/mandatory-relaxation.js` | 92 |
-| `relax` | Function | `src/lib/interactive/mandatory-relaxation.js` | 100 |
-| `specFromOption` | Function | `src/lib/interactive/option-introspect.js` | 140 |
-| `collectCapabilities` | Function | `src/lib/interactive/self-test.js` | 74 |
 | `formatSymbolMatrix` | Function | `src/lib/interactive/self-test.js` | 185 |
 | `frames` | Function | `src/lib/interactive/self-test.js` | 188 |
-| `resolveChoices` | Function | `src/lib/interactive/ask-questions.js` | 53 |
+| `formatPalette` | Function | `src/lib/interactive/self-test.js` | 250 |
+| `renderStaticReport` | Function | `src/lib/interactive/self-test.js` | 283 |
+| `runSelfTest` | Function | `src/lib/interactive/self-test.js` | 368 |
+| `getSymbols` | Function | `src/lib/interactive/symbols.js` | 87 |
+| `buildTheme` | Function | `src/lib/interactive/theme.js` | 29 |
+| `createPalette` | Function | `src/lib/util/colour.js` | 62 |
 
 ## Execution Flows
 
 | Flow | Type | Steps |
 |------|------|-------|
-| `RunInteractive → LoadPrompts` | intra_community | 4 |
-| `RunSelfTest → LoadPrompts` | intra_community | 4 |
-| `AskQuestions → LoadPrompts` | intra_community | 3 |
-| `RunInteractive → Write` | intra_community | 3 |
-| `RunMenu → LoadPrompts` | intra_community | 3 |
+| `RunInteractive → ParsePositiveInteger` | cross_community | 6 |
+| `RunInteractive → DescribeBrowserVersionOption` | cross_community | 6 |
+| `RunInteractive → BuildBrowserCacheDirOption` | cross_community | 6 |
+| `HandleCloudCreateSheetThumbnails → Walk` | cross_community | 6 |
+| `RunInteractive → BuildCloudListCollectionsCommand` | cross_community | 5 |
+| `RunInteractive → BuildCloudRemoveSheetIconsCommand` | cross_community | 5 |
+| `RunSelfTest → IsUnicodeCapable` | cross_community | 5 |
+| `HandleCloudCreateSheetThumbnails → IsUnicodeCapable` | cross_community | 5 |
+| `HandleCloudCreateSheetThumbnails → IsInteractiveOption` | cross_community | 5 |
+| `HandleQseowCreateSheetThumbnails → IsUnicodeCapable` | cross_community | 5 |
+
+## Connected Areas
+
+| Area | Connections |
+|------|-------------|
+| Browser | 3 calls |
+| Qscloud | 1 calls |
 
 ## How to Explore
 
-1. `gitnexus_context({name: "askQuestions"})` — see callers and callees
-2. `gitnexus_query({query: "interactive"})` — find related execution flows
+1. `context({name: "openingOn"})` — see callers and callees
+2. `query({search_query: "interactive"})` — find related execution flows
 3. Read key files listed above for implementation details
+4. `explain({target: "<file or symbol>"})` — persisted taint findings (source→sink data flows), when indexed with `--pdg`

--- a/.claude/skills/generated/qscloud/SKILL.md
+++ b/.claude/skills/generated/qscloud/SKILL.md
@@ -1,29 +1,26 @@
 ---
 name: qscloud
-description: "Skill for the Qscloud area of butler-sheet-icons. 9 symbols across 7 files."
+description: "Skill for the Qscloud area of butler-sheet-icons. 6 symbols across 4 files."
 ---
 
 # Qscloud
 
-9 symbols | 7 files | Cohesion: 81%
+6 symbols | 4 files | Cohesion: 63%
 
 ## When to Use
 
 - Working with code in `src/`
-- Understanding how everyLeafCommand, walk work
+- Understanding how everyLeafCommand, walk, leafCommandAt work
 - Modifying qscloud-related functionality
 
 ## Key Files
 
 | File | Symbols |
 |------|---------|
-| `src/lib/commands/helpers.js` | parsePositiveInteger, collectPositiveIntegers |
-| `src/lib/interactive/command-tree.js` | everyLeafCommand, walk |
-| `src/lib/commands/qscloud/create-sheet-thumbnails.js` | buildCloudCreateSheetThumbnailsCommand |
+| `src/lib/interactive/command-tree.js` | everyLeafCommand, walk, leafCommandAt |
 | `src/lib/commands/qscloud/index.js` | buildQscloudCommand |
 | `src/lib/commands/qscloud/list-collections.js` | buildCloudListCollectionsCommand |
 | `src/lib/commands/qscloud/remove-sheet-icons.js` | buildCloudRemoveSheetIconsCommand |
-| `src/lib/commands/qseow/index.js` | buildQseowCommand |
 
 ## Entry Points
 
@@ -31,6 +28,7 @@ Start here when exploring this area:
 
 - **`everyLeafCommand`** (Function) — `src/lib/interactive/command-tree.js:26`
 - **`walk`** (Function) — `src/lib/interactive/command-tree.js:29`
+- **`leafCommandAt`** (Function) — `src/lib/interactive/command-tree.js:57`
 
 ## Key Symbols
 
@@ -38,29 +36,35 @@ Start here when exploring this area:
 |--------|------|------|------|
 | `everyLeafCommand` | Function | `src/lib/interactive/command-tree.js` | 26 |
 | `walk` | Function | `src/lib/interactive/command-tree.js` | 29 |
-| `parsePositiveInteger` | Function | `src/lib/commands/helpers.js` | 16 |
-| `collectPositiveIntegers` | Function | `src/lib/commands/helpers.js` | 78 |
-| `buildCloudCreateSheetThumbnailsCommand` | Function | `src/lib/commands/qscloud/create-sheet-thumbnails.js` | 35 |
+| `leafCommandAt` | Function | `src/lib/interactive/command-tree.js` | 57 |
 | `buildQscloudCommand` | Function | `src/lib/commands/qscloud/index.js` | 10 |
 | `buildCloudListCollectionsCommand` | Function | `src/lib/commands/qscloud/list-collections.js` | 24 |
 | `buildCloudRemoveSheetIconsCommand` | Function | `src/lib/commands/qscloud/remove-sheet-icons.js` | 25 |
-| `buildQseowCommand` | Function | `src/lib/commands/qseow/index.js` | 36 |
 
 ## Execution Flows
 
 | Flow | Type | Steps |
 |------|------|-------|
-| `EveryLeafCommand → ParsePositiveInteger` | intra_community | 5 |
-| `EveryLeafCommand → Description` | cross_community | 4 |
+| `RunInteractive → ParsePositiveInteger` | cross_community | 6 |
+| `RunInteractive → DescribeBrowserVersionOption` | cross_community | 6 |
+| `RunInteractive → BuildBrowserCacheDirOption` | cross_community | 6 |
+| `HandleCloudCreateSheetThumbnails → Walk` | cross_community | 6 |
+| `Content → ParsePositiveInteger` | cross_community | 6 |
+| `RunInteractive → BuildCloudListCollectionsCommand` | cross_community | 5 |
+| `RunInteractive → BuildCloudRemoveSheetIconsCommand` | cross_community | 5 |
+| `Content → DescribeBrowserVersionOption` | cross_community | 5 |
+| `Content → BuildBrowserCacheDirOption` | cross_community | 5 |
+| `Content → BuildCloudListCollectionsCommand` | cross_community | 5 |
 
 ## Connected Areas
 
 | Area | Connections |
 |------|-------------|
-| Browser | 5 calls |
+| Browser | 3 calls |
 
 ## How to Explore
 
-1. `gitnexus_context({name: "everyLeafCommand"})` — see callers and callees
-2. `gitnexus_query({query: "qscloud"})` — find related execution flows
+1. `context({name: "everyLeafCommand"})` — see callers and callees
+2. `query({search_query: "qscloud"})` — find related execution flows
 3. Read key files listed above for implementation details
+4. `explain({target: "<file or symbol>"})` — persisted taint findings (source→sink data flows), when indexed with `--pdg`

--- a/.claude/skills/generated/qseow/SKILL.md
+++ b/.claude/skills/generated/qseow/SKILL.md
@@ -1,79 +1,90 @@
 ---
 name: qseow
-description: "Skill for the Qseow area of butler-sheet-icons. 16 symbols across 9 files."
+description: "Skill for the Qseow area of butler-sheet-icons. 28 symbols across 17 files."
 ---
 
 # Qseow
 
-16 symbols | 9 files | Cohesion: 82%
+28 symbols | 17 files | Cohesion: 76%
 
 ## When to Use
 
 - Working with code in `src/`
-- Understanding how qrsGetList, qseowProcessApp, qseowUpdateSheetThumbnails work
+- Understanding how resolve, listApps, determineSheetExcludeStatus work
 - Modifying qseow-related functionality
 
 ## Key Files
 
 | File | Symbols |
 |------|---------|
+| `src/lib/qseow/qrs-filter.js` | qrsFilterValue, toFilterValueList, qrsFilterAnyOf, qrsPathWithFilter |
 | `src/lib/qseow/qseow-logout.js` | qpsUserPath, logoutViaApi, logoutViaHub, qseowLogout |
+| `src/lib/commands/qseow/create-sheet-thumbnails.interactive.js` | resolve, listApps |
+| `src/lib/qseow/qseow-app-lookup.js` | listAppsByTag, listAllApps |
 | `src/lib/qseow/qseow-process-app.js` | getSheetsTaggedWith, qseowProcessApp |
-| `src/lib/util/errors.js` | QseowError, CertError |
-| `src/lib/qseow/qseow-certificates.js` | exists, qseowVerifyCertificatesExist |
 | `src/lib/qseow/qseow-enigma.js` | readCert, createSocket |
+| `src/lib/util/socket-keepalive.js` | attachSocketKeepalive, stop |
+| `src/lib/qseow/determine-sheet-exclude-status.js` | determineSheetExcludeStatus |
 | `src/lib/qseow/qrs-response.js` | qrsGetList |
-| `src/lib/qseow/qseow-updatesheets.js` | qseowUpdateSheetThumbnails |
-| `src/lib/qseow/qseow-upload.js` | qseowUploadToContentLibrary |
-| `src/lib/util/cert.js` | getCertFilePaths |
+| `src/lib/qseow/qseow-contentlibrary.js` | qseowVerifyContentLibraryExists |
 
 ## Entry Points
 
 Start here when exploring this area:
 
-- **`qrsGetList`** (Function) — `src/lib/qseow/qrs-response.js:28`
-- **`qseowProcessApp`** (Function) — `src/lib/qseow/qseow-process-app.js:115`
-- **`qseowUpdateSheetThumbnails`** (Function) — `src/lib/qseow/qseow-updatesheets.js:33`
-- **`qseowUploadToContentLibrary`** (Function) — `src/lib/qseow/qseow-upload.js:32`
-- **`qseowVerifyCertificatesExist`** (Function) — `src/lib/qseow/qseow-certificates.js:49`
+- **`resolve`** (Function) — `src/lib/commands/qseow/create-sheet-thumbnails.interactive.js:176`
+- **`listApps`** (Function) — `src/lib/commands/qseow/create-sheet-thumbnails.interactive.js:188`
+- **`determineSheetExcludeStatus`** (Function) — `src/lib/qseow/determine-sheet-exclude-status.js:16`
+- **`qrsFilterValue`** (Function) — `src/lib/qseow/qrs-filter.js:35`
+- **`toFilterValueList`** (Function) — `src/lib/qseow/qrs-filter.js:49`
 
 ## Key Symbols
 
 | Symbol | Type | File | Line |
 |--------|------|------|------|
 | `QseowError` | Class | `src/lib/util/errors.js` | 91 |
-| `CertError` | Class | `src/lib/util/errors.js` | 43 |
+| `resolve` | Function | `src/lib/commands/qseow/create-sheet-thumbnails.interactive.js` | 176 |
+| `listApps` | Function | `src/lib/commands/qseow/create-sheet-thumbnails.interactive.js` | 188 |
+| `determineSheetExcludeStatus` | Function | `src/lib/qseow/determine-sheet-exclude-status.js` | 16 |
+| `qrsFilterValue` | Function | `src/lib/qseow/qrs-filter.js` | 35 |
+| `toFilterValueList` | Function | `src/lib/qseow/qrs-filter.js` | 49 |
+| `qrsFilterAnyOf` | Function | `src/lib/qseow/qrs-filter.js` | 78 |
+| `qrsPathWithFilter` | Function | `src/lib/qseow/qrs-filter.js` | 102 |
 | `qrsGetList` | Function | `src/lib/qseow/qrs-response.js` | 28 |
-| `qseowProcessApp` | Function | `src/lib/qseow/qseow-process-app.js` | 115 |
-| `qseowUpdateSheetThumbnails` | Function | `src/lib/qseow/qseow-updatesheets.js` | 33 |
-| `qseowUploadToContentLibrary` | Function | `src/lib/qseow/qseow-upload.js` | 32 |
-| `qseowVerifyCertificatesExist` | Function | `src/lib/qseow/qseow-certificates.js` | 49 |
-| `getCertFilePaths` | Function | `src/lib/util/cert.js` | 18 |
-| `qseowLogout` | Function | `src/lib/qseow/qseow-logout.js` | 140 |
-| `createSocket` | Function | `src/lib/qseow/qseow-enigma.js` | 76 |
-| `getSheetsTaggedWith` | Function | `src/lib/qseow/qseow-process-app.js` | 46 |
-| `exists` | Function | `src/lib/qseow/qseow-certificates.js` | 21 |
-| `qpsUserPath` | Function | `src/lib/qseow/qseow-logout.js` | 21 |
-| `logoutViaApi` | Function | `src/lib/qseow/qseow-logout.js` | 32 |
-| `logoutViaHub` | Function | `src/lib/qseow/qseow-logout.js` | 74 |
-| `readCert` | Function | `src/lib/qseow/qseow-enigma.js` | 16 |
+| `listAppsByTag` | Function | `src/lib/qseow/qseow-app-lookup.js` | 48 |
+| `listAllApps` | Function | `src/lib/qseow/qseow-app-lookup.js` | 90 |
+| `qseowVerifyContentLibraryExists` | Function | `src/lib/qseow/qseow-contentlibrary.js` | 18 |
+| `qseowProcessApp` | Function | `src/lib/qseow/qseow-process-app.js` | 117 |
+| `setupQseowQrsConnection` | Function | `src/lib/qseow/qseow-qrs.js` | 16 |
+| `getQseowHubSelectors` | Function | `src/lib/qseow/qseow-selectors.js` | 105 |
+| `qseowUploadToContentLibrary` | Function | `src/lib/qseow/qseow-upload.js` | 33 |
+| `isSheetTagged` | Function | `src/lib/util/sheet-list.js` | 137 |
+| `createSocket` | Function | `src/lib/cloud/cloud-enigma.js` | 44 |
+| `createSocket` | Function | `src/lib/qseow/qseow-enigma.js` | 77 |
+| `attachSocketKeepalive` | Function | `src/lib/util/socket-keepalive.js` | 38 |
 
 ## Execution Flows
 
 | Flow | Type | Steps |
 |------|------|-------|
-| `QseowLogout → QpsUserPath` | intra_community | 3 |
-| `QseowLogout → Sleep` | cross_community | 3 |
+| `QseowUploadToContentLibrary → SafeString` | cross_community | 6 |
+| `QseowUploadToContentLibrary → SafeRead` | cross_community | 5 |
+| `QseowProcessApp → IsProbablyContainer` | cross_community | 4 |
+| `HandleQseowCreateSheetThumbnails → SetupQseowQrsConnection` | cross_community | 4 |
+| `HandleQseowCreateSheetThumbnails → QrsPathWithFilter` | cross_community | 4 |
+| `QseowCreateThumbnails → QrsFilterValue` | cross_community | 4 |
+| `QseowCreateThumbnails → QseowError` | cross_community | 4 |
 
 ## Connected Areas
 
 | Area | Connections |
 |------|-------------|
-| Cloud | 3 calls |
-| Browser | 1 calls |
+| Util | 11 calls |
+| Browser | 3 calls |
 
 ## How to Explore
 
-1. `gitnexus_context({name: "qrsGetList"})` — see callers and callees
-2. `gitnexus_query({query: "qseow"})` — find related execution flows
+1. `context({name: "resolve"})` — see callers and callees
+2. `query({search_query: "qseow"})` — find related execution flows
 3. Read key files listed above for implementation details
+4. `explain({target: "<file or symbol>"})` — persisted taint findings (source→sink data flows), when indexed with `--pdg`

--- a/.claude/skills/generated/scripts/SKILL.md
+++ b/.claude/skills/generated/scripts/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: scripts
+description: "Skill for the Scripts area of butler-sheet-icons. 10 symbols across 3 files."
+---
+
+# Scripts
+
+10 symbols | 3 files | Cohesion: 91%
+
+## When to Use
+
+- Working with code in `scripts/`
+- Understanding how updateGeneratedBlocks, knownCommandPaths work
+- Modifying scripts-related functionality
+
+## Key Files
+
+| File | Symbols |
+|------|---------|
+| `scripts/docs-cli-tables.js` | parseArgs, valueFor, loadExamples, readText, main (+1) |
+| `src/lib/docs/cli-option-tables.js` | updateGeneratedBlocks, knownCommandPaths |
+| `scripts/gitnexus.js` | clearCachedNpxInstall, main |
+
+## Entry Points
+
+Start here when exploring this area:
+
+- **`updateGeneratedBlocks`** (Function) — `src/lib/docs/cli-option-tables.js:345`
+- **`knownCommandPaths`** (Function) — `src/lib/docs/cli-option-tables.js:379`
+
+## Key Symbols
+
+| Symbol | Type | File | Line |
+|--------|------|------|------|
+| `updateGeneratedBlocks` | Function | `src/lib/docs/cli-option-tables.js` | 345 |
+| `knownCommandPaths` | Function | `src/lib/docs/cli-option-tables.js` | 379 |
+| `parseArgs` | Function | `scripts/docs-cli-tables.js` | 56 |
+| `valueFor` | Function | `scripts/docs-cli-tables.js` | 66 |
+| `loadExamples` | Function | `scripts/docs-cli-tables.js` | 127 |
+| `readText` | Function | `scripts/docs-cli-tables.js` | 156 |
+| `main` | Function | `scripts/docs-cli-tables.js` | 174 |
+| `run` | Function | `scripts/docs-cli-tables.js` | 197 |
+| `clearCachedNpxInstall` | Function | `scripts/gitnexus.js` | 83 |
+| `main` | Function | `scripts/gitnexus.js` | 117 |
+
+## Execution Flows
+
+| Flow | Type | Steps |
+|------|------|-------|
+| `Run → ParsePositiveInteger` | cross_community | 5 |
+| `Run → DescribeBrowserVersionOption` | cross_community | 5 |
+| `Run → BuildBrowserCacheDirOption` | cross_community | 5 |
+| `Run → BuildCloudListCollectionsCommand` | cross_community | 5 |
+| `Run → BuildCloudRemoveSheetIconsCommand` | cross_community | 5 |
+| `Run → DeriveExample` | cross_community | 5 |
+| `Run → CodeCell` | cross_community | 5 |
+| `Run → Line` | cross_community | 5 |
+| `Run → Walk` | cross_community | 5 |
+
+## Connected Areas
+
+| Area | Connections |
+|------|-------------|
+| Docs | 1 calls |
+| Qscloud | 1 calls |
+
+## How to Explore
+
+1. `context({name: "updateGeneratedBlocks"})` — see callers and callees
+2. `query({search_query: "scripts"})` — find related execution flows
+3. Read key files listed above for implementation details
+4. `explain({target: "<file or symbol>"})` — persisted taint findings (source→sink data flows), when indexed with `--pdg`

--- a/.claude/skills/generated/util/SKILL.md
+++ b/.claude/skills/generated/util/SKILL.md
@@ -1,91 +1,93 @@
 ---
 name: util
-description: "Skill for the Util area of butler-sheet-icons. 47 symbols across 13 files."
+description: "Skill for the Util area of butler-sheet-icons. 71 symbols across 27 files."
 ---
 
 # Util
 
-47 symbols | 13 files | Cohesion: 89%
+71 symbols | 27 files | Cohesion: 85%
 
 ## When to Use
 
 - Working with code in `src/`
-- Understanding how redactValue, redactOptions, redactSensitivePatterns work
+- Understanding how closeBrowserQuietly, deleteCloudAppThumbnail, setupEnigmaConnection work
 - Modifying util-related functionality
 
 ## Key Files
 
 | File | Symbols |
 |------|---------|
-| `src/lib/util/fatal-handlers.js` | toError, logFatalLine, exitOnce, armWatchdog, handleFatal (+5) |
+| `src/lib/util/fatal-handlers.js` | toError, isBrokenPipeError, logFatalLine, exitOnce, armWatchdog (+9) |
+| `src/lib/util/env-check.js` | isMissing, describePlain, toHex, formatSecret, checkEnv (+2) |
+| `src/lib/util/log-error.js` | logError, safeString, safeRead, describeValue, describeError (+1) |
+| `src/lib/util/sheet-list.js` | getSheetList, sortSheetsByRank, describeCloseEvent, runOverSheets, saveIfChanged (+1) |
 | `src/lib/util/crash-dump.js` | envBool, parseMaxDumps, buildTimestampForFilename, sanitizeStackTrace, resolveCrashDir (+1) |
-| `src/lib/util/log-error.js` | logErrorWithLevel, logError, logWarn, logInfo, logVerbose (+1) |
-| `src/lib/util/env-check.js` | isMissing, present, toHex, formatSecret, checkEnv (+1) |
-| `src/lib/util/redact-secrets.js` | isSecretKey, isProseWord, redactValue, redactOptions, redactSensitivePatterns |
-| `src/lib/util/errors.js` | BsiError, EnigmaError, CloudError |
-| `src/lib/util/sheet-list.js` | isSessionLevelFailure, describeCloseEvent, runOverSheets |
-| `src/globals.js` | sanitizeLogValue, sanitizeFormat |
+| `src/lib/util/errors.js` | BsiError, CertError, EnigmaError, CloudError |
+| `src/lib/util/redact-secrets.js` | isSecretKey, isProseWord, redactValue, redactSensitivePatterns |
+| `src/globals.js` | sleep, sanitizeLogValue, sanitizeFormat |
+| `src/lib/qseow/qseow-certificates.js` | exists, qseowVerifyCertificatesExist |
 | `src/lib/util/error-categorizer.js` | getErrorCategory, getErrorMetadata |
-| `src/lib/cloud/cloud-test-connection.js` | qscloudTestConnection |
 
 ## Entry Points
 
 Start here when exploring this area:
 
-- **`redactValue`** (Function) — `src/lib/util/redact-secrets.js:112`
-- **`redactOptions`** (Function) — `src/lib/util/redact-secrets.js:149`
-- **`redactSensitivePatterns`** (Function) — `src/lib/util/redact-secrets.js:160`
-- **`onUncaughtException`** (Function) — `src/lib/util/fatal-handlers.js:277`
-- **`onUnhandledRejection`** (Function) — `src/lib/util/fatal-handlers.js:291`
+- **`closeBrowserQuietly`** (Function) — `src/lib/browser/browser-launch.js:481`
+- **`deleteCloudAppThumbnail`** (Function) — `src/lib/cloud/cloud-delete-thumbnails.js:10`
+- **`setupEnigmaConnection`** (Function) — `src/lib/cloud/cloud-enigma.js:19`
+- **`qscloudUpdateSheetThumbnails`** (Function) — `src/lib/cloud/cloud-updatesheets.js:37`
+- **`qscloudUploadToApp`** (Function) — `src/lib/cloud/cloud-upload.js:30`
 
 ## Key Symbols
 
 | Symbol | Type | File | Line |
 |--------|------|------|------|
 | `BsiError` | Class | `src/lib/util/errors.js` | 26 |
+| `CertError` | Class | `src/lib/util/errors.js` | 43 |
 | `EnigmaError` | Class | `src/lib/util/errors.js` | 59 |
 | `CloudError` | Class | `src/lib/util/errors.js` | 75 |
-| `redactValue` | Function | `src/lib/util/redact-secrets.js` | 112 |
-| `redactOptions` | Function | `src/lib/util/redact-secrets.js` | 149 |
-| `redactSensitivePatterns` | Function | `src/lib/util/redact-secrets.js` | 160 |
-| `onUncaughtException` | Function | `src/lib/util/fatal-handlers.js` | 277 |
-| `onUnhandledRejection` | Function | `src/lib/util/fatal-handlers.js` | 291 |
-| `qscloudTestConnection` | Function | `src/lib/cloud/cloud-test-connection.js` | 31 |
-| `qscloudUploadToApp` | Function | `src/lib/cloud/cloud-upload.js` | 29 |
+| `closeBrowserQuietly` | Function | `src/lib/browser/browser-launch.js` | 481 |
+| `deleteCloudAppThumbnail` | Function | `src/lib/cloud/cloud-delete-thumbnails.js` | 10 |
+| `setupEnigmaConnection` | Function | `src/lib/cloud/cloud-enigma.js` | 19 |
+| `qscloudUpdateSheetThumbnails` | Function | `src/lib/cloud/cloud-updatesheets.js` | 37 |
+| `qscloudUploadToApp` | Function | `src/lib/cloud/cloud-upload.js` | 30 |
+| `determineSheetExcludeStatus` | Function | `src/lib/cloud/determine-sheet-exclude-status.js` | 27 |
+| `processCloudApp` | Function | `src/lib/cloud/process-cloud-app.js` | 34 |
+| `takeSheetScreenshot` | Function | `src/lib/cloud/sheet-screenshot.js` | 19 |
+| `probe` | Function | `src/lib/commands/qseow/create-sheet-thumbnails.interactive.js` | 131 |
+| `qseowVerifyCertificatesExist` | Function | `src/lib/qseow/qseow-certificates.js` | 50 |
+| `setupEnigmaConnection` | Function | `src/lib/qseow/qseow-enigma.js` | 38 |
+| `qseowUpdateSheetThumbnails` | Function | `src/lib/qseow/qseow-updatesheets.js` | 34 |
+| `getCertFilePaths` | Function | `src/lib/util/cert.js` | 18 |
+| `withEngineSession` | Function | `src/lib/util/engine-session.js` | 56 |
 | `getEnigmaSchema` | Function | `src/lib/util/enigma-util.js` | 45 |
-| `writeCrashDump` | Function | `src/lib/util/crash-dump.js` | 203 |
-| `logError` | Function | `src/lib/util/log-error.js` | 77 |
-| `logWarn` | Function | `src/lib/util/log-error.js` | 88 |
-| `logInfo` | Function | `src/lib/util/log-error.js` | 99 |
-| `logVerbose` | Function | `src/lib/util/log-error.js` | 110 |
-| `logDebug` | Function | `src/lib/util/log-error.js` | 121 |
-| `getErrorCategory` | Function | `src/lib/util/error-categorizer.js` | 32 |
-| `getErrorMetadata` | Function | `src/lib/util/error-categorizer.js` | 81 |
-| `isSessionLevelFailure` | Function | `src/lib/util/sheet-list.js` | 190 |
+| `logError` | Function | `src/lib/util/log-error.js` | 160 |
 
 ## Execution Flows
 
 | Flow | Type | Steps |
 |------|------|-------|
-| `OnUncaughtException → IsProseWord` | cross_community | 5 |
-| `OnUnhandledRejection → IsProseWord` | cross_community | 5 |
-| `BrowserListAvailable → GetErrorCategory` | cross_community | 4 |
-| `BrowserListAvailable → MarkReported` | cross_community | 4 |
-| `OnUncaughtException → ExitOnce` | intra_community | 4 |
-| `OnUncaughtException → EnvBool` | cross_community | 4 |
-| `OnUncaughtException → ParseMaxDumps` | cross_community | 4 |
-| `OnUncaughtException → SanitizeStackTrace` | cross_community | 4 |
-| `OnUnhandledRejection → ExitOnce` | intra_community | 4 |
-| `OnUnhandledRejection → EnvBool` | cross_community | 4 |
+| `QseowRemoveSheetIcons → SafeString` | cross_community | 7 |
+| `QseowCreateThumbnails → SafeString` | cross_community | 7 |
+| `Probe → SafeString` | cross_community | 7 |
+| `ProcessCloudApp → SafeString` | cross_community | 6 |
+| `QseowRemoveSheetIcons → SafeRead` | cross_community | 6 |
+| `QscloudRemoveSheetIcons → SafeString` | cross_community | 6 |
+| `HandleCloudCreateSheetThumbnails → SafeRead` | cross_community | 6 |
+| `QseowCreateThumbnails → SafeRead` | cross_community | 6 |
+| `QscloudCreateThumbnails → SafeString` | cross_community | 6 |
+| `QscloudListCollections → SafeString` | cross_community | 6 |
 
 ## Connected Areas
 
 | Area | Connections |
 |------|-------------|
-| Browser | 2 calls |
+| Qseow | 4 calls |
+| Browser | 4 calls |
 
 ## How to Explore
 
-1. `gitnexus_context({name: "redactValue"})` — see callers and callees
-2. `gitnexus_query({query: "util"})` — find related execution flows
+1. `context({name: "closeBrowserQuietly"})` — see callers and callees
+2. `query({search_query: "util"})` — find related execution flows
 3. Read key files listed above for implementation details
+4. `explain({target: "<file or symbol>"})` — persisted taint findings (source→sink data flows), when indexed with `--pdg`

--- a/.claude/skills/gitnexus/gitnexus-cli/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-cli/SKILL.md
@@ -5,14 +5,16 @@ description: "Use when the user needs to run GitNexus CLI commands like analyze/
 
 # GitNexus CLI Commands
 
-All commands work via `npx` — no global install required.
+Commands below use `node .gitnexus/run.cjs <command>` — the project-local runner `gitnexus analyze` drops next to the index. It auto-selects an available runner at call time (global `gitnexus`, else `pnpm dlx`, else `npx`), so no package-manager assumption and no global install is required.
+
+> **Not analyzed yet, or `node .gitnexus/run.cjs` reports `Cannot find module`** (the gitignored runner is absent — e.g. a fresh clone or `git clean`)? (Re)generate it with `npx gitnexus analyze` from the project root. On **npm 11.x**, if `npx` crashes during install (`node.target is null`), install once with `npm i -g gitnexus` (then `gitnexus analyze`) or use `pnpm --allow-build=@ladybugdb/core --allow-build=gitnexus --allow-build=tree-sitter dlx gitnexus@latest analyze`. See [#1939](https://github.com/abhigyanpatwari/GitNexus/issues/1939).
 
 ## Commands
 
 ### analyze — Build or refresh the index
 
 ```bash
-npx gitnexus analyze
+node .gitnexus/run.cjs analyze
 ```
 
 Run from the project root. This parses all source files, builds the knowledge graph, writes it to `.gitnexus/`, and generates CLAUDE.md / AGENTS.md context files.
@@ -22,13 +24,14 @@ Run from the project root. This parses all source files, builds the knowledge gr
 | `--force`      | Force full re-index even if up to date                           |
 | `--embeddings` | Enable embedding generation for semantic search (off by default) |
 | `--drop-embeddings` | Drop existing embeddings on rebuild. By default, an `analyze` without `--embeddings` preserves them. |
+| `--pdg` | Build the program-dependence layers used by `explain` and `pdg_query` (taint, CDG, and REACHING_DEF). |
 
 **When to run:** First time in a project, after major code changes, or when `gitnexus://repo/{name}/context` reports the index is stale. In Claude Code, a PostToolUse hook detects staleness after `git commit` and `git merge` and notifies the agent to run `analyze` — the hook does not run analyze itself, to avoid blocking the agent for up to 120s and risking KuzuDB corruption on timeout.
 
 ### status — Check index freshness
 
 ```bash
-npx gitnexus status
+node .gitnexus/run.cjs status
 ```
 
 Shows whether the current repo has a GitNexus index, when it was last updated, and symbol/relationship counts. Use this to check if re-indexing is needed.
@@ -36,7 +39,7 @@ Shows whether the current repo has a GitNexus index, when it was last updated, a
 ### clean — Delete the index
 
 ```bash
-npx gitnexus clean
+node .gitnexus/run.cjs clean
 ```
 
 Deletes the `.gitnexus/` directory and unregisters the repo from the global registry. Use before re-indexing if the index is corrupt or after removing GitNexus from a project.
@@ -49,7 +52,7 @@ Deletes the `.gitnexus/` directory and unregisters the repo from the global regi
 ### wiki — Generate documentation from the graph
 
 ```bash
-npx gitnexus wiki
+node .gitnexus/run.cjs wiki
 ```
 
 Generates repository documentation from the knowledge graph using an LLM. Requires an API key (saved to `~/.gitnexus/config.json` on first use).
@@ -66,7 +69,7 @@ Generates repository documentation from the knowledge graph using an LLM. Requir
 ### list — Show all indexed repos
 
 ```bash
-npx gitnexus list
+node .gitnexus/run.cjs list
 ```
 
 Lists all repositories registered in `~/.gitnexus/registry.json`. The MCP `list_repos` tool provides the same information.

--- a/.claude/skills/gitnexus/gitnexus-debugging/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-debugging/SKILL.md
@@ -16,23 +16,23 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 ## Workflow
 
 ```
-1. gitnexus_query({query: "<error or symptom>"})            → Find related execution flows
-2. gitnexus_context({name: "<suspect>"})                    → See callers/callees/processes
+1. query({search_query: "<error or symptom>"})            → Find related execution flows
+2. context({name: "<suspect>"})                    → See callers/callees/processes
 3. READ gitnexus://repo/{name}/process/{name}                → Trace execution flow
-4. gitnexus_cypher({query: "MATCH path..."})                 → Custom traces if needed
+4. cypher({statement: "MATCH path..."})                 → Custom traces if needed
 ```
 
-> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
 
 ## Checklist
 
 ```
 - [ ] Understand the symptom (error message, unexpected behavior)
-- [ ] gitnexus_query for error text or related code
+- [ ] query for error text or related code
 - [ ] Identify the suspect function from returned processes
-- [ ] gitnexus_context to see callers and callees
+- [ ] context to see callers and callees
 - [ ] Trace execution flow via process resource if applicable
-- [ ] gitnexus_cypher for custom call chain traces if needed
+- [ ] cypher for custom call chain traces if needed
 - [ ] Read source files to confirm root cause
 ```
 
@@ -40,46 +40,58 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 
 | Symptom              | GitNexus Approach                                          |
 | -------------------- | ---------------------------------------------------------- |
-| Error message        | `gitnexus_query` for error text → `context` on throw sites |
+| Error message        | `query` for error text → `context` on throw sites |
 | Wrong return value   | `context` on the function → trace callees for data flow    |
 | Intermittent failure | `context` → look for external calls, async deps            |
 | Performance issue    | `context` → find symbols with many callers (hot paths)     |
 | Recent regression    | `detect_changes` to see what your changes affect           |
+| "How does A reach B?" | `trace` between the two symbols — shortest call chain in one call |
 
 ## Tools
 
-**gitnexus_query** — find code related to error:
+**query** — find code related to error:
 
 ```
-gitnexus_query({query: "payment validation error"})
+query({search_query: "payment validation error"})
 → Processes: CheckoutFlow, ErrorHandling
 → Symbols: validatePayment, handlePaymentError, PaymentException
 ```
 
-**gitnexus_context** — full context for a suspect:
+**context** — full context for a suspect:
 
 ```
-gitnexus_context({name: "validatePayment"})
+context({name: "validatePayment"})
 → Incoming calls: processCheckout, webhookHandler
 → Outgoing calls: verifyCard, fetchRates (external API!)
 → Processes: CheckoutFlow (step 3/7)
 ```
 
-**gitnexus_cypher** — custom call chain traces:
+**cypher** — custom call chain traces:
 
 ```cypher
 MATCH path = (a)-[:CodeRelation {type: 'CALLS'}*1..2]->(b:Function {name: "validatePayment"})
 RETURN [n IN nodes(path) | n.name] AS chain
 ```
 
+**trace** — shortest call chain between two symbols ("how does A reach B?"), one call instead of chaining `context` hops:
+
+```
+trace({ from: "processCheckout", to: "fetchRates" })
+→ status: ok, hopCount: 3
+→ hops: processCheckout → validatePayment → verifyCard → fetchRates
+→ edges: CALLS (1.0), CALLS (0.95), CALLS (1.0)
+```
+
+When no path exists, `trace` reports the furthest reachable node — exactly where the chain breaks (dynamic dispatch, reflection, or an external boundary).
+
 ## Example: "Payment endpoint returns 500 intermittently"
 
 ```
-1. gitnexus_query({query: "payment error handling"})
+1. query({search_query: "payment error handling"})
    → Processes: CheckoutFlow, ErrorHandling
    → Symbols: validatePayment, handlePaymentError
 
-2. gitnexus_context({name: "validatePayment"})
+2. context({name: "validatePayment"})
    → Outgoing calls: verifyCard, fetchRates (external API!)
 
 3. READ gitnexus://repo/my-app/process/CheckoutFlow

--- a/.claude/skills/gitnexus/gitnexus-exploring/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-exploring/SKILL.md
@@ -18,20 +18,20 @@ description: "Use when the user asks how code works, wants to understand archite
 ```
 1. READ gitnexus://repos                          → Discover indexed repos
 2. READ gitnexus://repo/{name}/context             → Codebase overview, check staleness
-3. gitnexus_query({query: "<what you want to understand>"})  → Find related execution flows
-4. gitnexus_context({name: "<symbol>"})            → Deep dive on specific symbol
+3. query({search_query: "<what you want to understand>"})  → Find related execution flows
+4. context({name: "<symbol>"})            → Deep dive on specific symbol
 5. READ gitnexus://repo/{name}/process/{name}      → Trace full execution flow
 ```
 
-> If step 2 says "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If step 2 says "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
 
 ## Checklist
 
 ```
 - [ ] READ gitnexus://repo/{name}/context
-- [ ] gitnexus_query for the concept you want to understand
+- [ ] query for the concept you want to understand
 - [ ] Review returned processes (execution flows)
-- [ ] gitnexus_context on key symbols for callers/callees
+- [ ] context on key symbols for callers/callees
 - [ ] READ process resource for full execution traces
 - [ ] Read source files for implementation details
 ```
@@ -47,18 +47,18 @@ description: "Use when the user asks how code works, wants to understand archite
 
 ## Tools
 
-**gitnexus_query** — find execution flows related to a concept:
+**query** — find execution flows related to a concept:
 
 ```
-gitnexus_query({query: "payment processing"})
+query({search_query: "payment processing"})
 → Processes: CheckoutFlow, RefundFlow, WebhookHandler
 → Symbols grouped by flow with file locations
 ```
 
-**gitnexus_context** — 360-degree view of a symbol:
+**context** — 360-degree view of a symbol:
 
 ```
-gitnexus_context({name: "validateUser"})
+context({name: "validateUser"})
 → Incoming calls: loginHandler, apiMiddleware
 → Outgoing calls: checkToken, getUserById
 → Processes: LoginFlow (step 2/5), TokenRefresh (step 1/3)
@@ -68,10 +68,10 @@ gitnexus_context({name: "validateUser"})
 
 ```
 1. READ gitnexus://repo/my-app/context       → 918 symbols, 45 processes
-2. gitnexus_query({query: "payment processing"})
+2. query({search_query: "payment processing"})
    → CheckoutFlow: processPayment → validateCard → chargeStripe
    → RefundFlow: initiateRefund → calculateRefund → processRefund
-3. gitnexus_context({name: "processPayment"})
+3. context({name: "processPayment"})
    → Incoming: checkoutHandler, webhookHandler
    → Outgoing: validateCard, chargeStripe, saveTransaction
 4. Read src/payments/processor.ts for implementation details

--- a/.claude/skills/gitnexus/gitnexus-guide/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-guide/SKILL.md
@@ -15,7 +15,7 @@ For any task involving code understanding, debugging, impact analysis, or refact
 2. **Match your task to a skill below** and **read that skill file**
 3. **Follow the skill's workflow and checklist**
 
-> If step 1 warns the index is stale, run `npx gitnexus analyze` in the terminal first.
+> If step 1 warns the index is stale, run `node .gitnexus/run.cjs analyze` in the terminal first.
 
 ## Skills
 
@@ -35,10 +35,82 @@ For any task involving code understanding, debugging, impact analysis, or refact
 | `query`          | Process-grouped code intelligence — execution flows related to a concept |
 | `context`        | 360-degree symbol view — categorized refs, processes it participates in  |
 | `impact`         | Symbol blast radius — what breaks at depth 1/2/3 with confidence         |
+| `trace`          | Shortest path between two symbols — "how does A reach B?" in one call     |
 | `detect_changes` | Git-diff impact — what do your current changes affect                    |
 | `rename`         | Multi-file coordinated rename with confidence-tagged edits               |
 | `cypher`         | Raw graph queries (read `gitnexus://repo/{name}/schema` first)           |
-| `list_repos`     | Discover indexed repos                                                   |
+| `explain`        | Persisted taint findings — source→sink data flows (needs `analyze --pdg`) |
+| `pdg_query`      | Control/data dependence — what gates X (CDG) / where Y flows (REACHING_DEF); needs `analyze --pdg` |
+| `check`          | Check graph invariants such as circular imports                          |
+| `route_map`      | API route map — which components/hooks fetch which endpoints, and the handler files that serve them |
+| `shape_check`    | Response-shape drift — keys each route returns vs keys its consumers access (flags MISMATCH) |
+| `api_impact`     | Pre-change report for an API route — consumers, middleware, shape mismatches, risk level |
+| `tool_map`       | MCP/RPC tool definitions and the files that handle them                  |
+| `group_list`     | List configured multi-repo groups, or one group's config                 |
+| `group_sync`     | Rebuild a group's Contract Registry (cross-repo HTTP contract links); run after `group.yaml` changes or member re-index |
+| `list_repos`     | Discover indexed repos (paginated — `limit`/`offset`)                    |
+
+### Paginating `list_repos`
+
+`list_repos` is paginated so a large registry is not truncated by MCP/LLM token limits. It takes optional `limit` (default **50**, max **200**) and `offset`, and returns:
+
+```jsonc
+{
+  "repositories": [
+    { "name": "...", "path": "...", "indexedAt": "...", "lastCommit": "...", "stats": { } }
+  ],
+  "pagination": {
+    "total": 437,
+    "limit": 50,
+    "offset": 0,
+    "returned": 50,
+    "hasMore": true,
+    "nextOffset": 50
+  }
+}
+```
+
+To enumerate **every** repository, keep calling with `offset` set to `pagination.nextOffset` until `hasMore` is `false`:
+
+```text
+list_repos {}               → repos 1–50,    nextOffset 50,  hasMore true
+list_repos { offset: 50 }   → repos 51–100,  nextOffset 100, hasMore true
+…
+list_repos { offset: 400 }  → repos 401–437,                 hasMore false   (done)
+```
+
+Notes: `offset` ≥ `total` returns an empty page (with `total` still reported). Out-of-range or malformed `limit`/`offset` (non-integer, `limit` outside `[1, 200]`, `offset < 0`) are rejected with a clear error — `limit` above the max is rejected, not silently capped. The order is deterministic (lower-cased name, then path), so paging never skips or duplicates an entry while the registry is unchanged.
+
+### Taint findings (`explain`)
+
+`explain` returns taint findings recorded by `gitnexus analyze --pdg` — intra-procedural `TAINTED` edges plus cross-function `TAINT_PATH` hops where the interprocedural taint phase found a function-level source→sink chain. Each finding includes a sink category (command-injection, code-injection, path-traversal, sql-injection, xss), source/sink lines, and the ordered hop path with the variable carried on each hop.
+
+- `explain {}` — enumerate all findings for the repo (bounded by `limit`, deterministic order)
+- `explain { target: "src/vuln.ts" }` — findings in a file (suffix path match accepted)
+- `explain { target: "runUserCommand" }` — findings in a function (resolved like `context`; ambiguous names return ranked candidates)
+
+A repo indexed without `--pdg` returns a clear "no taint layer" note. Caveats: closure/callback, property/field, and implicit flows are not modeled, and interprocedural findings are function-level `TAINT_PATH` hops rather than statement-level path proof, so the absence of a finding is **not** proof of safety. `SANITIZES` (sanitizer-kill) edges are queryable via `cypher`.
+
+### Control & data dependence (`pdg_query`)
+
+`pdg_query` reads the control/data-dependence layers `gitnexus analyze --pdg` records (CDG + REACHING_DEF, basic-block granular) — the control/data analog of `explain`. It is **always anchored** (a `target` file path or symbol, resolved like `context`) and has two modes:
+
+- `pdg_query { mode: "controls", target: "..." }` — CDG: "under what condition does X run?". Each edge is a controlling predicate block → dependent block with the branch sense (`'T'`/`'F'`) in `reason`; an edge into an early `return`/`throw` is flagged `guard: true` (guard-clause discovery — the sense depends on the predicate, so don't filter guards by a fixed label).
+- `pdg_query { mode: "flows", target: "...", variable?: "..." }` — REACHING_DEF def→use edges within the function; pass `variable` to trace one binding.
+
+A repo indexed without `--pdg` returns a "no PDG layer" note (or "status unknown" when the layer can't be confirmed). Intra-procedural only — cross-function flow is taint's domain (`explain`). The raw CDG/REACHING_DEF edges are also queryable via `cypher`. See the `gitnexus-pdg-query` skill for the full query surface.
+
+### Shortest path between two symbols (`trace`)
+
+`trace` answers "how does A reach B?" in one call — the shortest directed path over `CALLS` (plus `HAS_METHOD`, so a class-rooted trace descends into its methods) instead of chaining 3–8 `context`/`impact` hops by hand.
+
+- `trace { from: "validateUser", to: "executeQuery" }` — shortest path between two symbols.
+- Disambiguate common names with `from_uid`/`to_uid` (zero-ambiguity) or `from_file`/`to_file`; an ambiguous name returns ranked candidates.
+- `maxDepth` (default 10, max 30) bounds the search; `includeTests` (default false) lets the traversal pass through test-file symbols.
+
+Returns ordered `hops` (each `{ name, filePath, startLine }`) and an aligned `edges[]` of `{ relType, confidence }`, so call hops and containment (`HAS_METHOD`) hops stay distinguishable. When no path exists it reports the **furthest** reachable node (where the chain breaks) and sets `truncated: true` if a traversal cap was hit first. Every result carries a `status`: `ok` / `no_path` / `ambiguous` / `not_found` / `error`.
+
+Cross-repo (experimental): pass `repo: "@groupName"` to trace across a group's member repos — the path may cross **one** `ContractLink` boundary (reported as a `CONTRACT_LINK` hop with the bridged contract in `crossings[]`). Omit `to` entirely to follow `from`'s outgoing HTTP call to whatever provider endpoint it lands on. Groups are configured via `group_list` / `group_sync`.
 
 ## Resources Reference
 
@@ -55,8 +127,10 @@ Lightweight reads (~100-500 tokens) for navigation:
 
 ## Graph Schema
 
-**Nodes:** File, Function, Class, Interface, Method, Community, Process
-**Edges (via CodeRelation.type):** CALLS, IMPORTS, EXTENDS, IMPLEMENTS, DEFINES, MEMBER_OF, STEP_IN_PROCESS
+**Nodes:** File, Folder, Function, Class, Interface, Method, CodeElement, Community, Process, Route, Tool, plus language-specific types (Struct, Enum, Trait, Impl, Namespace, Module, …) and BasicBlock (`--pdg` indexes only). The full node list lives in `gitnexus://repo/{name}/schema`.
+**Edges (via CodeRelation.type):** CALLS, IMPORTS, EXTENDS, IMPLEMENTS, DEFINES, CONTAINS, MEMBER_OF, HAS_METHOD, HAS_PROPERTY, ACCESSES, METHOD_OVERRIDES, METHOD_IMPLEMENTS, STEP_IN_PROCESS, HANDLES_ROUTE, FETCHES, HANDLES_TOOL, ENTRY_POINT_OF, WRAPS, QUERIES, INJECTS, plus `--pdg`-only types (CFG, REACHING_DEF, TAINTED, SANITIZES, TAINT_PATH, CDG — zero rows on a default index).
+
+Read `gitnexus://repo/{name}/schema` before writing Cypher — it is the authoritative schema for the indexed repo.
 
 ```cypher
 MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "myFunc"})

--- a/.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
@@ -17,22 +17,22 @@ description: "Use when the user wants to know what will break if they change som
 ## Workflow
 
 ```
-1. gitnexus_impact({target: "X", direction: "upstream"})  → What depends on this
+1. impact({target: "X", direction: "upstream"})  → What depends on this
 2. READ gitnexus://repo/{name}/processes                   → Check affected execution flows
-3. gitnexus_detect_changes()                               → Map current git changes to affected flows
+3. detect_changes()                               → Map current git changes to affected flows
 4. Assess risk and report to user
 ```
 
-> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
 
 ## Checklist
 
 ```
-- [ ] gitnexus_impact({target, direction: "upstream"}) to find dependents
+- [ ] impact({target, direction: "upstream"}) to find dependents
 - [ ] Review d=1 items first (these WILL BREAK)
 - [ ] Check high-confidence (>0.8) dependencies
 - [ ] READ processes to check affected execution flows
-- [ ] gitnexus_detect_changes() for pre-commit check
+- [ ] detect_changes() for pre-commit check
 - [ ] Assess risk level and report to user
 ```
 
@@ -55,10 +55,10 @@ description: "Use when the user wants to know what will break if they change som
 
 ## Tools
 
-**gitnexus_impact** — the primary tool for symbol blast radius:
+**impact** — the primary tool for symbol blast radius:
 
 ```
-gitnexus_impact({
+impact({
   target: "validateUser",
   direction: "upstream",
   minConfidence: 0.8,
@@ -73,10 +73,10 @@ gitnexus_impact({
   - authRouter (src/routes/auth.ts:22) [CALLS, 95%]
 ```
 
-**gitnexus_detect_changes** — git-diff based impact analysis:
+**detect_changes** — git-diff based impact analysis:
 
 ```
-gitnexus_detect_changes({scope: "staged"})
+detect_changes({scope: "staged"})
 
 → Changed: 5 symbols in 3 files
 → Affected: LoginFlow, TokenRefresh, APIMiddlewarePipeline
@@ -86,7 +86,7 @@ gitnexus_detect_changes({scope: "staged"})
 ## Example: "What breaks if I change validateUser?"
 
 ```
-1. gitnexus_impact({target: "validateUser", direction: "upstream"})
+1. impact({target: "validateUser", direction: "upstream"})
    → d=1: loginHandler, apiMiddleware (WILL BREAK)
    → d=2: authRouter, sessionManager (LIKELY AFFECTED)
 

--- a/.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md
@@ -16,78 +16,78 @@ description: "Use when the user wants to rename, extract, split, move, or restru
 ## Workflow
 
 ```
-1. gitnexus_impact({target: "X", direction: "upstream"})  → Map all dependents
-2. gitnexus_query({query: "X"})                            → Find execution flows involving X
-3. gitnexus_context({name: "X"})                           → See all incoming/outgoing refs
+1. impact({target: "X", direction: "upstream"})  → Map all dependents
+2. query({search_query: "X"})                            → Find execution flows involving X
+3. context({name: "X"})                           → See all incoming/outgoing refs
 4. Plan update order: interfaces → implementations → callers → tests
 ```
 
-> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
 
 ## Checklists
 
 ### Rename Symbol
 
 ```
-- [ ] gitnexus_rename({symbol_name: "oldName", new_name: "newName", dry_run: true}) — preview all edits
-- [ ] Review graph edits (high confidence) and ast_search edits (review carefully)
-- [ ] If satisfied: gitnexus_rename({..., dry_run: false}) — apply edits
-- [ ] gitnexus_detect_changes() — verify only expected files changed
+- [ ] rename({symbol_name: "oldName", new_name: "newName", dry_run: true}) — preview all edits
+- [ ] Review graph edits (high confidence) and text_search edits (review carefully)
+- [ ] If satisfied: rename({..., dry_run: false}) — apply edits
+- [ ] detect_changes() — verify only expected files changed
 - [ ] Run tests for affected processes
 ```
 
 ### Extract Module
 
 ```
-- [ ] gitnexus_context({name: target}) — see all incoming/outgoing refs
-- [ ] gitnexus_impact({target, direction: "upstream"}) — find all external callers
+- [ ] context({name: target}) — see all incoming/outgoing refs
+- [ ] impact({target, direction: "upstream"}) — find all external callers
 - [ ] Define new module interface
 - [ ] Extract code, update imports
-- [ ] gitnexus_detect_changes() — verify affected scope
+- [ ] detect_changes() — verify affected scope
 - [ ] Run tests for affected processes
 ```
 
 ### Split Function/Service
 
 ```
-- [ ] gitnexus_context({name: target}) — understand all callees
+- [ ] context({name: target}) — understand all callees
 - [ ] Group callees by responsibility
-- [ ] gitnexus_impact({target, direction: "upstream"}) — map callers to update
+- [ ] impact({target, direction: "upstream"}) — map callers to update
 - [ ] Create new functions/services
 - [ ] Update callers
-- [ ] gitnexus_detect_changes() — verify affected scope
+- [ ] detect_changes() — verify affected scope
 - [ ] Run tests for affected processes
 ```
 
 ## Tools
 
-**gitnexus_rename** — automated multi-file rename:
+**rename** — automated multi-file rename:
 
 ```
-gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
 → 12 edits across 8 files
-→ 10 graph edits (high confidence), 2 ast_search edits (review)
+→ 10 graph edits (high confidence), 2 text_search edits (review)
 → Changes: [{file_path, edits: [{line, old_text, new_text, confidence}]}]
 ```
 
-**gitnexus_impact** — map all dependents first:
+**impact** — map all dependents first:
 
 ```
-gitnexus_impact({target: "validateUser", direction: "upstream"})
+impact({target: "validateUser", direction: "upstream"})
 → d=1: loginHandler, apiMiddleware, testUtils
 → Affected Processes: LoginFlow, TokenRefresh
 ```
 
-**gitnexus_detect_changes** — verify your changes after refactoring:
+**detect_changes** — verify your changes after refactoring:
 
 ```
-gitnexus_detect_changes({scope: "all"})
+detect_changes({scope: "all"})
 → Changed: 8 files, 12 symbols
 → Affected processes: LoginFlow, TokenRefresh
 → Risk: MEDIUM
 ```
 
-**gitnexus_cypher** — custom reference queries:
+**cypher** — custom reference queries:
 
 ```cypher
 MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "validateUser"})
@@ -98,24 +98,24 @@ RETURN caller.name, caller.filePath ORDER BY caller.filePath
 
 | Risk Factor         | Mitigation                                |
 | ------------------- | ----------------------------------------- |
-| Many callers (>5)   | Use gitnexus_rename for automated updates |
+| Many callers (>5)   | Use rename for automated updates |
 | Cross-area refs     | Use detect_changes after to verify scope  |
-| String/dynamic refs | gitnexus_query to find them               |
+| String/dynamic refs | query to find them               |
 | External/public API | Version and deprecate properly            |
 
 ## Example: Rename `validateUser` to `authenticateUser`
 
 ```
-1. gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
-   → 12 edits: 10 graph (safe), 2 ast_search (review)
+1. rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+   → 12 edits: 10 graph (safe), 2 text_search (review)
    → Files: validator.ts, login.ts, middleware.ts, config.json...
 
-2. Review ast_search edits (config.json: dynamic reference!)
+2. Review text_search edits (config.json: dynamic reference!)
 
-3. gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: false})
+3. rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: false})
    → Applied 12 edits across 8 files
 
-4. gitnexus_detect_changes({scope: "all"})
+4. detect_changes({scope: "all"})
    → Affected: LoginFlow, TokenRefresh
    → Risk: MEDIUM — run tests for these flows
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,18 +14,27 @@ This project is indexed by GitNexus as **butler-sheet-icons**. Use the GitNexus 
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST pass `repo: "butler-sheet-icons"` on every GitNexus tool call.** GitNexus never infers the repository from the working directory, and this machine has several indexed, so a call that omits `repo` fails with `Multiple repositories indexed` — identically in the canonical checkout and in a worktree. Omitting it is the single most common reason GitNexus looks broken.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream", repo: "butler-sheet-icons"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes({repo: "butler-sheet-icons"})` before committing** to verify your changes only affect expected symbols and execution flows.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept", repo: "butler-sheet-icons"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName", repo: "butler-sheet-icons"})`.
 
 ## Never Do
 
 - NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph. From a worktree, see the exception below.
 - NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## In a linked worktree
+
+Most work here happens in a worktree under `.claude/worktrees/`. Three things behave differently, and none of them announce themselves.
+
+- **The graph describes the canonical checkout at its last index — `main`, not your branch.** `impact`, `context` and `query` answer "as of `main`": correct for the blast radius of changing existing code, blind to code your branch has just added. This is by design — `scripts/gitnexus-reindex.sh` skips linked worktrees, and the work reaches the index when the branch is merged.
+- **`gitnexus_rename` with `dry_run: false` writes to the canonical checkout, not to your worktree.** It resolves every path against the indexed repo root, so it edits files outside your branch. Use `dry_run: true` to get the reference list, then apply the edits yourself in the worktree. This is the one exception to the find-and-replace rule above.
+- **`gitnexus_detect_changes` reads the worktree only on GitNexus ≥ 1.6.6.** Earlier versions diffed the canonical checkout instead and answered "No changes detected" for every change made in a worktree — a mandated safety check that silently passed. See `docs/README.gitnexus.md`.
 
 ## Resources
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,9 +57,13 @@ Most work here happens in a worktree under `.claude/worktrees/`. Three things be
 | Index, status, clean, wiki CLI commands      | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md`             |
 | Work in the Cloud area                       | `.claude/skills/generated/cloud/SKILL.md`                   |
 | Work in the Browser area                     | `.claude/skills/generated/browser/SKILL.md`                 |
+| Work in the Interactive area                 | `.claude/skills/generated/interactive/SKILL.md`             |
 | Work in the Qscloud area                     | `.claude/skills/generated/qscloud/SKILL.md`                 |
 | Work in the Qseow area                       | `.claude/skills/generated/qseow/SKILL.md`                   |
 | Work in the Util area                        | `.claude/skills/generated/util/SKILL.md`                    |
+| Work in the Diag area                        | `.claude/skills/generated/diag/SKILL.md`                    |
+| Work in the Docs area                        | `.claude/skills/generated/docs/SKILL.md`                    |
+| Work in the Scripts area                     | `.claude/skills/generated/scripts/SKILL.md`                 |
 
 <!-- gitnexus:end -->
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,18 +14,27 @@ This project is indexed by GitNexus as **butler-sheet-icons**. Use the GitNexus 
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST pass `repo: "butler-sheet-icons"` on every GitNexus tool call.** GitNexus never infers the repository from the working directory, and this machine has several indexed, so a call that omits `repo` fails with `Multiple repositories indexed` — identically in the canonical checkout and in a worktree. Omitting it is the single most common reason GitNexus looks broken.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream", repo: "butler-sheet-icons"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes({repo: "butler-sheet-icons"})` before committing** to verify your changes only affect expected symbols and execution flows.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept", repo: "butler-sheet-icons"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName", repo: "butler-sheet-icons"})`.
 
 ## Never Do
 
 - NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph. From a worktree, see the exception below.
 - NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## In a linked worktree
+
+Most work here happens in a worktree under `.claude/worktrees/`. Three things behave differently, and none of them announce themselves.
+
+- **The graph describes the canonical checkout at its last index — `main`, not your branch.** `impact`, `context` and `query` answer "as of `main`": correct for the blast radius of changing existing code, blind to code your branch has just added. This is by design — `scripts/gitnexus-reindex.sh` skips linked worktrees, and the work reaches the index when the branch is merged.
+- **`gitnexus_rename` with `dry_run: false` writes to the canonical checkout, not to your worktree.** It resolves every path against the indexed repo root, so it edits files outside your branch. Use `dry_run: true` to get the reference list, then apply the edits yourself in the worktree. This is the one exception to the find-and-replace rule above.
+- **`gitnexus_detect_changes` reads the worktree only on GitNexus ≥ 1.6.6.** Earlier versions diffed the canonical checkout instead and answered "No changes detected" for every change made in a worktree — a mandated safety check that silently passed. See `docs/README.gitnexus.md`.
 
 ## Resources
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,8 @@ Most work here happens in a worktree under `.claude/worktrees/`. Three things be
 | Work in the Qseow area                       | `.claude/skills/generated/qseow/SKILL.md`                   |
 | Work in the Util area                        | `.claude/skills/generated/util/SKILL.md`                    |
 | Work in the Diag area                        | `.claude/skills/generated/diag/SKILL.md`                    |
+| Work in the Docs area                        | `.claude/skills/generated/docs/SKILL.md`                    |
+| Work in the Scripts area                     | `.claude/skills/generated/scripts/SKILL.md`                 |
 
 <!-- gitnexus:end -->
 

--- a/docs/README.gitnexus.md
+++ b/docs/README.gitnexus.md
@@ -56,6 +56,28 @@ const ANALYZE_FLAGS = ['--no-stats', '--skip-agents-md'];
 
 `--skip-agents-md` is load-bearing, not cosmetic. See the top of this file for what happens without it.
 
+## The MCP tools run a different install
+
+The wrapper governs *indexing*. It does not govern the `gitnexus_*` tools an agent calls: those are served by a **globally installed** GitNexus, registered in `~/.claude.json` as
+
+```json
+"gitnexus": { "command": "/Users/<user>/.nvm/versions/node/<version>/bin/gitnexus", "args": ["mcp"] }
+```
+
+Claude Code spawns one of those per session, with the session's working directory. Two consequences:
+
+- **The pin and the MCP server drift independently.** Bumping `GITNEXUS_VERSION` changes what `npm run gitnexus:*` runs and nothing else — the tools keep running whatever is installed globally. Upgrade both together. The global install is per nvm node version, and the path in `~/.claude.json` names the one that actually matters.
+- **A pin the global install cannot satisfy breaks the npm scripts outright.** GitNexus is in no `node_modules`, so with nothing in the npx cache `npx --no-install gitnexus@<pin>` resolves the copy on `PATH` — the global one — and only when its version matches the pin, which the wrapper writes as an exact spec. Bump the pin past the global install and every `npm run gitnexus:*` dies with `npx canceled due to missing packages`; the re-index hook then prints its "not installed" line and skips, so the index quietly stops being maintained without any command failing. Upgrade the global install alongside the pin, or run `npm run gitnexus:install` to cache the pinned version explicitly.
+- **A global upgrade needs `--allow-scripts=@ladybugdb/core`**, for the same reason the npx path does. npm 12 blocks install scripts by default, and without that one `gitnexus --version` still prints a version while every real query dies with `LadybugDB native binary (lbugjs.node) is missing`. The binary ships in the tarball; only the step that moves it into place is blocked, so an install that already went wrong is repaired without re-downloading anything:
+
+    ```bash
+    node <prefix>/lib/node_modules/gitnexus/node_modules/@ladybugdb/core/install.js
+    ```
+
+    The other blocked scripts do not matter here. The tree-sitter grammars and `onnxruntime-node` ship prebuilt binaries for this platform, and GitNexus's own postinstall only activates vendored grammars for languages this repo does not contain.
+
+Like the hook fix below, this is machine-local: another machine needs the same treatment.
+
 ## The managed block is now hand-maintained
 
 Because `--skip-agents-md` is always passed, the block between `<!-- gitnexus:start -->` and `<!-- gitnexus:end -->` in `CLAUDE.md` and `AGENTS.md` is no longer regenerated. Edit it by hand when it needs to change.
@@ -88,6 +110,18 @@ On a stale index after a `git commit`, `merge`, `rebase`, `cherry-pick` or `pull
 It is also worktree-aware. A linked worktree under `.claude/worktrees/` never carries its own `.gitnexus/`, so the hook resolves the index to the canonical checkout — and therefore reads `HEAD` from that checkout too, not from the worktree. Comparing a worktree branch's `HEAD` against an index built from the canonical checkout marked the index stale on every commit made on a branch, and re-indexing would not have cleared it, because the index describes the canonical checkout either way. The warning now fires when the index is genuinely behind what it indexes, and names the canonical directory so the suggested command is runnable as written.
 
 **This fix is machine-local.** The hook sits outside the repository, so a fresh clone on another machine gets a stock hook and the old advice with it. Re-apply it there, or set `GITNEXUS_HOOK_CLI_PATH` and copy the fork across.
+
+## Worktrees
+
+Most agent work in this repo happens in a linked worktree under `.claude/worktrees/`. GitNexus is usable there, but three things behave differently and none of them announce themselves. `CLAUDE.md` and `AGENTS.md` carry the short version; this is the reasoning.
+
+A fourth thing looks like a worktree problem and is not: `Multiple repositories indexed` fails identically in the canonical checkout. GitNexus resolves the repository from the `repo` parameter alone — never from the working directory — so every tool call has to name it. That is one line in the managed block, not a worktree issue.
+
+**The graph describes the canonical checkout.** A linked worktree carries no `.gitnexus/` of its own, and the re-index hook skips it deliberately — see [Automatic re-indexing](#automatic-re-indexing). So `impact`, `context` and `query` answer as of `main` at its last index: the right answer for the blast radius of changing existing code, the wrong one for code the branch has just added. The work reaches the index when the branch is merged.
+
+**`detect_changes` needed GitNexus ≥ 1.6.6.** Before that it ran `git diff` in the indexed repo root — the canonical checkout — regardless of where it was called from. Since agents work in worktrees and the canonical checkout is normally clean, the answer was "No changes detected", and the managed block mandates that check before every commit. A required safety check that always passes is worse than no check at all, which is why the pin moved to 1.6.9. Upstream fixed it in 1.6.6 with `resolveWorktreeCwd`.
+
+**`rename` still has that shape as of 1.6.9.** It resolves every path against the indexed repo root — for the reads, for the ripgrep sweep, and for the final `writeFile`. Called with `dry_run: false` from a worktree it edits the canonical checkout instead of your branch. Use `dry_run: true` for the reference list and apply the edits by hand until upstream extends `resolveWorktreeCwd` to cover it.
 
 ## Version pinning
 

--- a/docs/README.gitnexus.md
+++ b/docs/README.gitnexus.md
@@ -50,7 +50,7 @@ There is also an internal `check` subcommand that reports through its exit code 
 The pinned version and the analyze flags are defined there exactly once, so there is no second copy to keep in sync:
 
 ```js
-const GITNEXUS_VERSION = '1.6.5';
+const GITNEXUS_VERSION = '1.6.9';
 const ANALYZE_FLAGS = ['--no-stats', '--skip-agents-md'];
 ```
 

--- a/scripts/gitnexus.js
+++ b/scripts/gitnexus.js
@@ -30,7 +30,7 @@ import { join } from 'node:path';
  * This constant is the only place the version appears. It matches the pin in butler-sos;
  * bump both together.
  */
-const GITNEXUS_VERSION = '1.6.5';
+const GITNEXUS_VERSION = '1.6.9';
 
 /**
  * Flags shared by every `analyze` run.


### PR DESCRIPTION
Most work in this repo happens in a linked worktree under `.claude/worktrees/`, where GitNexus appeared to be blind. Investigation found two unrelated problems, and only one of them was about worktrees.

## The ambiguity was never a worktree problem

`Multiple repositories indexed` fails identically in the canonical checkout — verified by running the same command from both. `resolveRepoFromCache()` does no working-directory matching at all, so with several repos registered, any call omitting `repo:` fails everywhere. Every tool example in the managed block now passes `repo: "butler-sheet-icons"`.

## What was worktree-specific was silent

Up to 1.6.5, `detect_changes` ran `git diff` with `cwd` set to the indexed repo root — the canonical checkout — regardless of which worktree called it. A dirty worktree against a clean `main` always read as "No changes detected", and the managed block mandates that check before every commit. A required safety check that always passes is worse than no check.

Upstream fixed this in 1.6.6 with `resolveWorktreeCwd`, hence the pin bump to 1.6.9.

**Verified:** with the canonical checkout clean, an edit to `resolveBrowserCacheDir` in a worktree is now reported, where 1.6.5 reported nothing.

## Two limits that remain, now written down

- `gitnexus_rename` with `dry_run: false` still resolves every path against the indexed repo root as of 1.6.9, so from a worktree it writes to the canonical checkout. Confirmed at the `fs.writeFile` call site.
- The graph describes the canonical checkout at its last index — `main`, not your branch. This is by design; `scripts/gitnexus-reindex.sh` skips linked worktrees deliberately, and that behaviour is unchanged here.

## Also recorded

The `gitnexus_*` tools are served by a separate global install registered in `~/.claude.json`, not by the pinned copy the wrapper runs — the docs never mentioned this. The two are coupled: `npx --no-install` resolves the global copy from `PATH` only when its version matches the pin, so a pin ahead of the global install makes every `npm run gitnexus:*` fail while the re-index hook skips silently.

## Commits

- `build:` pin 1.6.5 → 1.6.9
- `docs:` the worktree contract, the `repo:` convention, the global install
- `chore:` skill files regenerated on 1.6.9, plus rows for the two new areas it derives (Docs, Scripts)

Note the global install must be upgraded separately on each machine; the pin alone does not change what agents call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)