### PR TITLE
Archive the six doc drafts published to the doc site next branch

### DIFF
--- a/docs/to-doc-site/done/done_browser-cache-checked-before-use.md
+++ b/docs/to-doc-site/done/done_browser-cache-checked-before-use.md
@@ -148,3 +148,37 @@ the list in the message is guaranteed to match what you have.
 Verify each message above against the current implementation before publishing, and quote it
 **verbatim** — administrators search for these strings, so a paraphrase on the doc site is worse
 than no entry at all.
+
+<!--
+PUBLISHED to `next` on 2026-08-14, butler-sheet-icons-docs PR #93. Version gate 5.0.0,
+read from release-please PR #974. All three messages verified fragment-by-fragment against
+src/lib/browser/browser-detect.js, in both directions.
+
+Published to:
+  - guide/troubleshooting.md - new "A cached browser was rejected" entry
+    (#a-cached-browser-was-rejected), holding all three messages
+  - guide/concepts/browser-detection-and-environment-variables.md - section 2 rewritten,
+    plus a warning on Strategy 3
+
+CORRECTION to this draft, do not trust the text above:
+
+  - "Pointing Butler Sheet Icons at a browser with PUPPETEER_EXECUTABLE_PATH is unaffected"
+    was written before --browser-executable-path existed. Both settings bypass these
+    checks, and the published pages name both. See point-at-an-installed-browser.md.
+
+THREE THINGS WERE ALREADY WRONG ON THE LIVE SITE and were fixed in the same PR. They are
+not this draft's fault, but they were the same fact, so they could not be left standing
+next to it:
+
+  - The cached-browser section said a cached browser matches on TWO checks. It is four.
+  - It said `--browser-version latest` is the default and that any cached build is then
+    accepted. The default is `recommended`, and since issue #878 every keyword resolves to
+    exactly one build before the cache is searched. The whole `"latest" means "anything
+    cached"` tip callout was false and was replaced. Note guide/concepts/browser-management.md
+    had this right already - the site contradicted itself.
+  - The Strategy 3 staging example installed with `--browser-version latest`, which resolves
+    to whatever is newest that day and so cannot match the `recommended` build the target
+    machine looks for. That example produced the exact third failure this draft documents.
+    Now uses `recommended`.
+-->
+

--- a/docs/to-doc-site/done/done_browser-install-works-offline.md
+++ b/docs/to-doc-site/done/done_browser-install-works-offline.md
@@ -102,3 +102,46 @@ Verify every message above against the implementation before publishing, and quo
 The `browser install` option table on `reference/browser.md` is generated — refresh it with
 `npm run docs:cli-tables` rather than editing it by hand — but the prose describing what the command
 does needs the update above.
+
+<!--
+PUBLISHED to `next` on 2026-08-14, butler-sheet-icons-docs PR #94. Version gate 5.0.0,
+read from release-please PR #974. Both messages verified fragment-by-fragment against
+src/lib/browser/browser-install.js, in both directions.
+
+Published to:
+  - reference/browser.md - new "Installing a browser that is already there" section
+    (#install-already-present), plus the "Available Commands" table row
+  - guide/concepts/browser-detection-and-environment-variables.md - the `browser install`
+    row of the internet-access table
+  - guide/troubleshooting.md - the same row in the offline-commands table, plus a callout
+
+CORRECTION to this draft, do not trust the text above. The section "Why this matters" says
+the settings that still need internet are "latest, stable, or a release channel". That list
+is wrong in BOTH directions. Established by execution, not by reading: stub net.connect,
+tls.connect and dns.lookup, then call resolveBrowserVersion for each value.
+
+  recommended (default)          resolves OFFLINE
+  full build id 151.0.7922.47    resolves OFFLINE  <- draft implied it does not
+  stable / latest / beta         needs network
+  build prefix 151.0.7922        needs network     <- draft omitted
+  milestone 151                  needs network     <- draft omitted
+
+Practical consequence: an administrator staging an exact build CAN verify it offline. The
+draft's prose would have talked them out of trying.
+
+Note the doc site already had this matrix correct, under "What --browser-version costs on an
+offline machine". The published pages link to it rather than adding a fourth copy.
+
+Beware when re-testing: blocking only node:http/https or globalThis.fetch does NOT block
+@puppeteer/browsers. Both of those attempts appeared to prove every value resolved offline.
+Block at the socket layer.
+
+ALSO FIXED, already wrong on the live site: three places stated `browser install` always
+needs internet access, and the concepts page gave the removed download-precheck as the
+reason. A staging example using `--browser-version latest` was corrected too - same defect
+as the one found while publishing browser-cache-checked-before-use.md, different page.
+
+UNRELATED, not a docs issue: resolveBrowserVersion returns `usedNetwork: true` for a full
+build id even though that path touches no network. Not user-visible today.
+-->
+

--- a/docs/to-doc-site/done/done_closed-output-pipe-when-another-program-reads-the-output.md
+++ b/docs/to-doc-site/done/done_closed-output-pipe-when-another-program-reads-the-output.md
@@ -64,3 +64,36 @@ unchanged, and the `| head -12` example is still correct.
 - Verified on macOS. A real shell pipe reports the reader leaving one way in every one of 30 runs;
   captured output intermittently reports it another way, and that case was still writing crash
   reports. Checked across 120 runs after the fix, including runs that took the intermittent path.
+
+<!--
+PUBLISHED to `next` on 2026-08-14, butler-sheet-icons-docs PR #97.
+
+This draft was ACCURATE - nothing in it needed correcting. It correctly judged that the site
+already covered the `| head` case and that this belonged as an extension of the existing
+section rather than a new page, so the published change is five lines.
+
+No second version gate was added. The section already carries "Requires BSI 5.0.0 or later",
+and this ships in 5.0.0 too - confirmed from release-please PR #974, as the draft asked.
+Confirmed too that the troubleshooting entry and the exit-code-141 reference entry needed no
+change.
+
+Published to:
+  - guide/advanced/crash-dumps.md, section #a-closed-output-pipe-is-not-a-crash
+
+THE CLAIM THAT NEEDS PROTECTING, if this area is ever refactored: the new bullet
+"A lost connection to Qlik Sense still produces a crash report" is only true because
+fatal-handlers.js keeps TWO different error-code sets:
+
+  STREAM_BROKEN_PIPE_CODES   = EPIPE, ERR_STREAM_DESTROYED, ENOTCONN, ECONNRESET
+  BACKSTOP_BROKEN_PIPE_CODES = EPIPE, ERR_STREAM_DESTROYED
+
+The wide set is what makes captured output quiet. The backstop excludes ECONNRESET and
+ENOTCONN precisely so a Qlik Sense connection reset by the far end keeps its crash dump.
+Merging the two sets "for simplicity" would silently make the published bullet false.
+
+METHOD NOTE for the next publishing pass: Cloudflare Pages propagates unevenly across edge
+nodes. A single successful fetch of the preview URL is NOT proof a page is live - during this
+pass one node served the new page while others still served the old, which briefly looked like
+a successful verification. Fetch with cache-busting until several consecutive responses agree.
+-->
+

--- a/docs/to-doc-site/done/done_point-at-an-installed-browser.md
+++ b/docs/to-doc-site/done/done_point-at-an-installed-browser.md
@@ -122,3 +122,41 @@ Verify the flag names, the environment variable names and the error message agai
 implementation before publishing, and quote the message verbatim. The option tables on the reference
 pages are generated — refresh them with `npm run docs:cli-tables` rather than typing the new option
 in by hand.
+
+<!--
+PUBLISHED to `next` on 2026-08-14, butler-sheet-icons-docs PR #95. Version gate 5.0.0,
+read from release-please PR #974. Every message verified fragment-by-fragment against
+browser-detect.js and browser-paths.js, in both directions.
+
+This draft was ACCURATE. Precedence, the promise-vs-hint distinction, empty-value handling
+and the error text all matched the implementation. Two things it did not say:
+
+  - The option is only on `qseow create-sheet-thumbnails` and `qscloud create-sheet-thumbnails`.
+    Confirmed against the Commander definitions, not assumed.
+  - Publishing it required RENUMBERING the browser detection order on the concepts page, from
+    three tiers to four.
+
+THE RENUMBERING BROKE TWO LIVE LINKS, and this is the part worth remembering. The heading
+"### 2. Cached browser (medium priority)" generated the anchor
+`#_2-cached-browser-medium-priority`, which guide/troubleshooting.md and
+guide/concepts/browser-management.md both linked to. Inserting a tier renamed it. VitePress
+`docs:build` does NOT validate #fragments, so both would have shipped as dead links with a
+green build.
+
+Both were repointed, and all four headings now carry stable custom anchors:
+#browser-you-named, #puppeteer-executable-path-browser, #cached-browser, #download-browser.
+Use those, and add a custom anchor to any new numbered heading, rather than relying on the
+generated one.
+
+Published to:
+  - guide/concepts/browser-detection-and-environment-variables.md - detection order, Strategy 2
+    rewritten (#use-a-browser-already-installed-on-the-server), new BSI_BROWSER_EXECUTABLE_PATH
+    env var entry, summary
+  - guide/troubleshooting.md - new #browser-executable-path-missing entry
+  - reference/qseow.md, reference/qscloud.md - option tables regenerated with docs:cli-tables
+
+NOT done, deliberately: the page's "Thumbnail generation examples" still use
+PUPPETEER_EXECUTABLE_PATH. They are not wrong - that variable still works - and converting
+them all is a larger rewrite than this draft called for.
+-->
+

--- a/docs/to-doc-site/done/done_two-renamed-messages.md
+++ b/docs/to-doc-site/done/done_two-renamed-messages.md
@@ -80,3 +80,38 @@ Check both pages for any other occurrence of either string before publishing —
 the ones found in the staging files, and the live pages may have picked up more during editing. The
 `done_` staging files themselves are history and should be left alone; this page is the record of
 what changed.
+
+<!--
+PUBLISHED to `next` on 2026-08-14, butler-sheet-icons-docs PR #96. All quotes verified
+fragment-by-fragment against browser-detect.js, browser-paths.js and browser-launch.js, in
+both directions.
+
+TWO CORRECTIONS to this draft. Do not trust its target list.
+
+  1. WRONG PAGE for the version-override warning. This draft says
+     guide/advanced/docker.md, "which quotes this message in two places". The string is
+     NOT on docker.md at all. It is on docs/examples/browser-management.md, ONCE.
+     Following the draft literally would have edited nothing and left the stale quote live.
+
+  2. A THIRD RENAMED MESSAGE the draft does not mention:
+        old: info: Using system browser (PUPPETEER_EXECUTABLE_PATH is set)
+        new: info: Using system browser (from PUPPETEER_EXECUTABLE_PATH)
+     The suffix is EXECUTABLE_SOURCE_LABELS in browser-paths.js, the same table that
+     reworded the override warning - so it changed for the same reason and was missed.
+     It was on guide/advanced/docker.md, inside the block that page presents as PROOF an
+     air-gapped run never reached the internet. All five lines of that block were checked;
+     the other four are correct.
+
+The lesson is the one this draft states and then does not itself follow: sweep the site for
+the string, do not trust a draft's list of where it appears.
+
+Published to:
+  - docs/examples/browser-management.md - override warning + a "wording changed" callout
+  - guide/advanced/crash-dumps.md - both occurrences, + a callout so older dumps still match
+  - guide/advanced/docker.md - the system-browser line, + BSI_BROWSER_EXECUTABLE_PATH added
+    to "If you do not want the embedded browser", which previously offered only the
+    mounted-cache route
+
+Verified on the deployed site that the old strings appear zero times in sample output.
+-->
+

--- a/docs/to-doc-site/done/done_windows-binary-signed-again.md
+++ b/docs/to-doc-site/done/done_windows-binary-signed-again.md
@@ -4,19 +4,24 @@
 
 **Suggested target pages:** the troubleshooting page (a "Windows warns about the publisher" symptom), and wherever the site covers downloading and installing the Windows binary. This is a short addition to existing pages rather than a page of its own.
 
-::: warning Version gate to be filled in at publication
-The version that first carries the restored signature is not yet decided — it is whatever release ships after this change. Set the gate before publishing; do not guess it.
+::: warning Requires Butler Sheet Icons 5.0.0 or later
+5.0.0 is the first release to carry the restored signature. Earlier downloads are unaffected by
+everything on this page.
 :::
 
 ## What changed
 
-Butler Sheet Icons' Windows executable carries a digital signature again. The certificate is issued by Certum to the project's maintainer as an open source developer, so the publisher shown by Windows is:
+From 5.0.0, Butler Sheet Icons' Windows executable carries a digital signature again. It is a
+proper, commercial code signing certificate issued by Certum.
 
-> **Open Source Developer Karl Göran Sander**
+The certificate is issued to an individual open source developer rather than to a company, so the
+publisher name Windows shows you is a person's name, not "Ptarmigan Labs". That is normal for open
+source projects and does not affect what the signature guarantees. You can read the exact publisher
+string out of any signed release yourself — see [Checking the signature
+yourself](#checking-the-signature-yourself) below.
 
-That is the name on the certificate rather than a company name, which is normal for open source projects and does not affect what the signature guarantees.
-
-The previous certificate expired shortly before version 4.0.0, and the versions released in between — **4.0.0 and 4.1.0** — shipped without any signature at all.
+The previous certificate expired shortly before version 4.0.0, and the versions released in
+between — **4.0.0 and 4.1.0** — shipped without any signature at all.
 
 Nothing about how Butler Sheet Icons works has changed. This affects only how Windows treats the file.
 
@@ -61,12 +66,16 @@ You can also right-click the file, choose **Properties**, and look at the **Digi
 
 | | |
 |---|---|
-| Subject | `CN=Open Source Developer Karl Göran Sander, O=Open Source Developer, L=Saltsjö-Duvnäs, S=Stockholm, C=SE` |
 | Issuer | `CN=Certum Code Signing 2021 CA, O=Asseco Data Systems S.A., C=PL` |
 | Thumbprint | `1674DF1C6EAD6DB9D816705CD230281B87A1C97E` |
 | Valid | 2026-08-12 to 2027-08-12 |
 
-None of this is confidential. The certificate is embedded in every signed release, so anyone holding a download can read it out; publishing it here only saves you the step.
+The thumbprint is the value that actually confirms the publisher, and it is the one to compare. The
+subject line — which names the individual the certificate was issued to — is printed by the commands
+above from the release you already hold, so there is no need to reproduce it here.
+
+None of this is confidential: the certificate is embedded in every signed release, so anyone holding
+a download can read all of it out.
 
 Two things that surprise people:
 
@@ -95,26 +104,69 @@ A valid signature proves the publisher, not the download source. Always download
 If you are running 4.0.0 or 4.1.0, upgrading to the current release is the fix. No configuration change is needed on your side — download the newer release as usual.
 
 <!--
-DRAFT - do not publish until a signed release actually exists.
+PUBLISHED to `next` on 2026-08-14, butler-sheet-icons-docs PR #98.
 
-Verified against the signing host on 2026-08-12 (scripts/diag/win-signing-check.ps1):
+*** THE RELEASE-TIME CONDITION BELOW IS STILL OPEN. It could not be discharged at
+*** publication because 5.0.0 has not been cut yet. Do NOT merge `next` to `main`
+*** without it. See "THE ONE CONDITION" further down.
 
-  - Publisher name is "Open Source Developer Karl Göran Sander", NOT "Ptarmigan Labs".
-    An earlier draft of this page said Ptarmigan Labs throughout and was wrong. The
-    certificate is an individual open source developer certificate, subject
-    CN=Open Source Developer Karl Göran Sander, O=Open Source Developer,
-    L=Saltsjö-Duvnäs, S=Stockholm, C=SE.
+Published to:
+  - reference/security.md - the Windows section (#windows-code-signing), previously a single
+    sentence, now the full treatment
+  - guide/installation.md - Windows platform notes, now version-qualified
+  - guide/troubleshooting.md - new #windows-publisher-warning symptom table
+
+The edit that set the 5.0.0 gate and removed the certificate holder's name was recovered from
+an uncommitted working tree in the worktree .claude/worktrees/github-actions-failure-99713f
+and committed as part of the archive. It had never been committed anywhere.
+
+NOT VERIFIED AT PUBLICATION, and the highest-risk item on the page: the thumbprint, the issuer
+string and the validity dates. WIN_CODESIGN_THUMBPRINT is a repository secret, so it is masked
+in workflow logs and absent from the repo - there was no independent source to check against.
+Those three values are the draft's own, from the 2026-08-12 signing-host run. Re-confirm them
+as part of the release-time check.
+
+What WAS verified independently: 4.1.0 shipped 2026-08-11 and the certificate was issued
+2026-08-12, so no released version can carry it. The "4.0.0 and 4.1.0 unsigned, 5.0.0 first
+signed" claim therefore holds without relying on the draft.
+
+ALSO CORRECTED, already wrong on the live site: both reference/security.md and
+guide/installation.md stated flatly that the Windows binary is signed, with no version
+qualification. For anyone on 4.0.0 or 4.1.0 that was misleading - their download is unsigned
+and the site gave them no way to know that was expected.
+
+Original draft note follows.
+
+---
+
+Verified against the signing host on 2026-08-12 (scripts/diag/win-signing-check.ps1), and
+re-confirmed on 2026-08-14 from the insiders-build log for main@5674fa8, which printed the
+same subject and "Certificate valid until 2027-08-12":
+
+  - The certificate is an individual open source developer certificate, NOT one issued to
+    Ptarmigan Labs. An earlier draft of this page said Ptarmigan Labs throughout and was
+    wrong.
   - Issuer is CN=Certum Code Signing 2021 CA, valid 2026-08-12 to 2027-08-12.
 
-Still to confirm before publishing:
+The certificate holder's name is deliberately NOT printed on this page. The doc site removed
+it from the security page on 2026-08-13 (butler-sheet-icons-docs ded6c35, "docs: drop the
+certificate holder's name from the Windows signing note"), and reinstating it here - with the
+locality, no less - would undo that decision. Everything an administrator needs still works:
+the thumbprint is what confirms the publisher, and the PowerShell snippets read the exact
+subject out of the release they already hold. Do not add the subject back without checking
+that the earlier decision has changed.
 
-  - The list of unsigned versions. 4.0.0 and 4.1.0 are unsigned. Whether any later
-    release is also unsigned depends on when this change ships - check the releases
-    page and update.
-  - Set the version gate at the top.
-  - Re-check the certificate table against the live certificate. The thumbprint in it
-    was read off the signing host on 2026-08-12 and matches the WIN_CODESIGN_THUMBPRINT
-    secret; confirm both still agree at publication.
+Resolved:
+
+  - Version gate is 5.0.0, confirmed by the maintainer.
+  - Unsigned versions are 4.0.0 and 4.1.0. 5.0.0 is signed.
+
+THE ONE CONDITION: Windows signing can fail silently in a way that still produces a release.
+On 2026-08-13 every insiders build was red for about 23 hours because the SimplySign session
+had expired, and the signing precheck reported the certificate as usable anyway. This page
+tells administrators the download is signed, so before `next` is merged to `main` at release
+time, confirm the published 5.0.0 Windows binary really does carry a signature -
+Get-AuthenticodeSignature on the actual release asset, not the CI log.
 
 MAINTENANCE, and the reason this page is not fire-and-forget: it publishes the
 certificate thumbprint, so it goes stale the moment the certificate is renewed - due


### PR DESCRIPTION
All six pending drafts in `docs/to-doc-site/` have been published to the doc site `next` branch and approved. This archives them into `done/` with the `done_` prefix, per the workflow in `docs/to-doc-site/README.md`.

`docs/to-doc-site/` now contains only its `README.md`.

## What was published

| Draft | Doc site PR | Landed on |
| --- | --- | --- |
| `browser-cache-checked-before-use.md` | [#93](https://github.com/ptarmiganlabs/butler-sheet-icons-docs/pull/93) | troubleshooting, browser-detection concepts |
| `browser-install-works-offline.md` | [#94](https://github.com/ptarmiganlabs/butler-sheet-icons-docs/pull/94) | reference/browser, concepts, troubleshooting |
| `point-at-an-installed-browser.md` | [#95](https://github.com/ptarmiganlabs/butler-sheet-icons-docs/pull/95) | concepts, troubleshooting, qseow + qscloud tables |
| `two-renamed-messages.md` | [#96](https://github.com/ptarmiganlabs/butler-sheet-icons-docs/pull/96) | examples/browser-management, crash-dumps, docker |
| `closed-output-pipe-…md` | [#97](https://github.com/ptarmiganlabs/butler-sheet-icons-docs/pull/97) | crash-dumps |
| `windows-binary-signed-again.md` | [#98](https://github.com/ptarmiganlabs/butler-sheet-icons-docs/pull/98) | reference/security, installation, troubleshooting |

Everything went to `next` only. `main` on the doc site is untouched, and reaches the public site when `next` is merged at release time.

## Each archived file gained a publication note

Recording where the content landed and — where it applies — what the draft got **wrong**, so a later reader of `done/` does not trust it. Four drafts contained errors:

- **`browser-cache-checked-before-use.md`** — its `PUPPETEER_EXECUTABLE_PATH` sentence predates `--browser-executable-path`.
- **`browser-install-works-offline.md`** — its list of version values needing a network lookup was wrong in *both* directions. The note carries the corrected matrix and the socket-level test that established it, plus a warning that the two obvious ways to block the network silently pass.
- **`point-at-an-installed-browser.md`** — accurate, but publishing it renumbered the detection order and broke two live anchors. The note records the stable custom anchors that now exist.
- **`two-renamed-messages.md`** — named a page that never contained the string it wanted fixed, and missed a third renamed message.

## ⚠️ One open item

`done_windows-binary-signed-again.md` carries a **release-time condition that is still open**: before the doc site's `next` is merged to `main`, confirm the published 5.0.0 Windows binary really is signed, using `Get-AuthenticodeSignature` on the actual release asset rather than the CI log. Windows signing failed silently for ~23 hours on 2026-08-13 while the precheck reported the certificate as usable.

The certificate thumbprint, issuer and validity dates on that page could **not** be verified at publication — `WIN_CODESIGN_THUMBPRINT` is a repository secret, so it is masked in workflow logs and absent from the repo. Re-confirm them in the same check.

## Note

This branch also carries the previously-uncommitted edit to `windows-binary-signed-again.md` recovered from the `github-actions-failure-99713f` worktree — it set the 5.0.0 gate and removed the certificate holder's name and home locality, and had never been committed anywhere.

Documentation staging only. No source, test, or build changes.