### PR TITLE
Correct three things the repo says that are no longer true

### DIFF
--- a/docs/todo/airgap-browser-phase-1.md
+++ b/docs/todo/airgap-browser-phase-1.md
@@ -18,9 +18,10 @@ ship in:
 Commits 1 and 3 shipped before commit 2, inverting the order §12 argues for. That is why the
 platform filter arrived after administrators could already point `--browser-cache-dir` anywhere.
 
-**Read the source before trusting the detail here.** Two sections are known to describe a codebase
-that no longer exists: §10's call-site table predates #887, and §11.1's version gate names 3.12.0
-when the open release train is well past it. Where this document and `src/` disagree, `src/` wins.
+**Read the source before trusting the detail here.** §10 has been marked up as a historical record
+rather than instructions — the consolidation it describes happened by another route — and §11.1's
+version gate now reads 5.0.0. Both were stale for a while, which is the general hazard: where this
+document and `src/` disagree, `src/` wins.
 
 **Phase 1 in one sentence:** Butler Sheet Icons (BSI) can already run without internet access if it
 finds a browser — so let administrators tell it where the browser is, and make it honest about what
@@ -717,16 +718,24 @@ Also update `src/__tests__/butler-sheet-icons.test.js` so `browser --help` conta
 
 ## 10. Call sites to change
 
-The eight hardcoded cache-directory sites. Each currently reads:
+**Done, and by a different route than this section describes — kept only as the record of what the
+starting state was.** Do not work from the table below; it names line numbers in a layout that no
+longer exists.
 
-```js
-const browserPath = path.join(homedir(), '.cache/puppeteer');
-logger.debug(`Browser cache path: ${browserPath}`);
-```
+What actually happened: #887 consolidated the eight hardcoded
+`path.join(homedir(), '.cache/puppeteer')` sites into a single `getBrowserCacheDir()` while this
+document was being written, and #1024 then grew that module into `browser-paths.js` with the full
+tier list from §4.1. So the "replace eight sites" work described here was never done as such — the
+consolidation arrived first, and the resolver was added underneath it.
 
-Replace both lines with `const browserPath = resolveBrowserCacheDir(options);` — the resolver emits a
-strictly better debug line, so net log volume is unchanged — and drop the now-unused `path` / `homedir`
-imports where nothing else needs them.
+Where the cache directory is decided now:
+
+| Module | What it does |
+| --- | --- |
+| `src/lib/browser/browser-paths.js` | Owns every decision. `resolveBrowserCacheDir` for reading, `resolveBrowserCacheDirForWriting` for installing, `resolveExecutablePathOverride` for a named browser. |
+| `src/lib/browser/browser-inventory.js` | The one place that turns a cache directory into inspectable entries, including `canRunHere` and `hasUsableExecutable`. |
+
+The original table, for reference only — every line number in it is stale:
 
 | File | Line | Note |
 | --- | --- | --- |
@@ -738,9 +747,6 @@ imports where nothing else needs them.
 | `src/lib/browser/browser-uninstall.js` | 99 | plus the `emptyDir` fix, §8.2 |
 | `src/lib/browser/browser-list-available.js` | 169 | dead value; swap for consistency, no CLI option |
 | `src/lib/browser/browser-list-available.js` | 319 | ditto |
-
-`browser-paths.js` imports `logger` from `../../globals.js`. Every existing browser test already mocks
-that specifier, so no test gains a new mock because of this.
 
 ---
 
@@ -825,9 +831,9 @@ Content, all of it copy-pasteable rather than conceptual:
    in a deployment script.
 
 6. **A version gate** at the top: `::: warning Requires BSI X.Y.Z or later`. The next version is
-   **3.12.0** per the open release-please PR (`chore(main): release butler-sheet-icons 3.12.0`) —
-   re-check that PR at publication time rather than trusting this number, since it follows from the
-   unreleased commit types.
+   **5.0.0** per the open release-please PR — re-check that PR at publication time rather than
+   trusting this number, since it follows from the unreleased commit types and has already moved
+   once (this line said 3.12.0 while the phase 1 commits were landing).
 
 ### 11.2 `docs/to-doc-site/browser-flags-and-cache-dir.md`
 

--- a/src/lib/commands/browser/__tests__/browser_wizards.test.js
+++ b/src/lib/commands/browser/__tests__/browser_wizards.test.js
@@ -52,6 +52,10 @@ jest.unstable_mockModule('../../../browser/browser-install.js', () => ({ browser
 const { runInteractive } = await import('../../../interactive/index.js');
 const { scriptedRuntime } = await import('../../../interactive/test-helpers/scripted-runtime.js');
 
+// Both flags, because they are not the same question and the picker keys on the wider one.
+// `isCurrentPlatform` is "built for exactly this platform"; `canRunHere` is "this machine can
+// execute it", which is true for a 32-bit Windows build on 64-bit Windows and for an Intel
+// macOS build on Apple Silicon.
 const MAC_BUILD = {
     browser: 'chrome',
     buildId: '151.0.7922.47',
@@ -59,6 +63,7 @@ const MAC_BUILD = {
     path: '/cache/chrome/mac_arm-151.0.7922.47',
     executablePath: '/cache/chrome/mac_arm-151.0.7922.47/chrome',
     isCurrentPlatform: true,
+    canRunHere: true,
 };
 
 const WIN_BUILD = {
@@ -66,6 +71,22 @@ const WIN_BUILD = {
     platform: 'win64',
     path: '/cache/chrome/win64-151.0.7922.47',
     isCurrentPlatform: false,
+    canRunHere: false,
+};
+
+/**
+ * A build this machine can run even though it was not built for exactly this platform.
+ *
+ * `win32` rather than `mac`, for two reasons. It is the case `labelForBuild` documents - a 32-bit
+ * build on 64-bit Windows - and, unlike `mac`, it is not a substring of any other platform name,
+ * so an assertion on it cannot be satisfied by the wrong platform being rendered.
+ */
+const RUNNABLE_FOREIGN_BUILD = {
+    ...MAC_BUILD,
+    platform: 'win32',
+    path: '/cache/chrome/win32-151.0.7922.47',
+    isCurrentPlatform: false,
+    canRunHere: true,
 };
 
 beforeEach(() => {
@@ -142,6 +163,25 @@ describe('the uninstall wizard', () => {
         const labels = runtime.asked[0].choices.map((choice) => choice.name);
         expect(labels[0]).toContain('built for win64');
         expect(labels[0]).toContain('cannot run here');
+    });
+
+    test('does not claim a runnable build cannot run here', async () => {
+        // The regression this guards: keyed on `isCurrentPlatform`, the picker told a Windows
+        // administrator that the `win32` build in their cache "cannot run here" while browser
+        // detection was perfectly willing to launch it. The picker and the run have to agree.
+        getBrowserInventory.mockResolvedValue([RUNNABLE_FOREIGN_BUILD]);
+        const runtime = scriptedRuntime({
+            _build: { browser: 'chrome', buildId: '151.0.7922.47' },
+            _review: 'cancel',
+        });
+
+        await runInteractive({ path: 'browser uninstall', runtime });
+
+        // Asserted with the parentheses, so this cannot be satisfied by the platform appearing
+        // anywhere else in the label - including inside the "built for X" phrasing it must not use.
+        const labels = runtime.asked[0].choices.map((choice) => choice.name);
+        expect(labels[0]).toContain('(win32)');
+        expect(labels[0]).not.toContain('cannot run here');
     });
 
     test('shows the platform plainly for a build that does run here', async () => {

--- a/src/lib/commands/browser/uninstall.interactive.js
+++ b/src/lib/commands/browser/uninstall.interactive.js
@@ -12,6 +12,13 @@ const BUILD = '_build';
  * here. Repeating "mac_arm" against every row on a Mac is noise; saying it
  * against the one row that came from somewhere else is the whole point.
  *
+ * Keyed on `canRunHere`, not `isCurrentPlatform`, because the claim being made
+ * is about running the build. Those two differ: 64-bit Windows runs 32-bit
+ * builds, and Apple Silicon runs Intel ones under Rosetta. Keying on the
+ * narrower field told a Windows administrator that the `win32` build in their
+ * cache "cannot run here" while browser detection was perfectly willing to use
+ * it - the picker and the run disagreeing about the same build.
+ *
  * @param {object} build - An entry from the browser inventory.
  *
  * @returns {string} The label to show.
@@ -19,7 +26,7 @@ const BUILD = '_build';
 export const labelForBuild = (build) => {
     const base = `${build.browser}  ${build.buildId}`;
 
-    return build.isCurrentPlatform
+    return build.canRunHere
         ? `${base}  (${build.platform})`
         : `${base}  (built for ${build.platform} - cannot run here)`;
 };


### PR DESCRIPTION
Three small corrections, each one a place where the repo currently states something that is no longer true. Grouped because they are all consequences of the phase 1 air-gapped work landing (#1024, #1059, #1060, #1061), not because they are related in the code.

## 1. The uninstall wizard misreported runnable builds

The picker labelled every build not made for *exactly* this platform as `cannot run here`. That is a narrower claim than the words make, and it was wrong for the two pairings where the platforms differ but the build still runs:

| Host | Build | Picker said | Reality |
| --- | --- | --- | --- |
| `win64` | `win32` | "cannot run here" | runs (WOW64) |
| `mac_arm` | `mac` | "cannot run here" | runs (Rosetta) |

So the wizard told a Windows administrator their cached `win32` build was unusable while browser detection was perfectly willing to launch it — **the picker and the run disagreeing about the same build.**

Keyed on `canRunHere` instead of `isCurrentPlatform`. Both come from the browser inventory and answer different questions: can this machine execute the build, versus was it built for exactly this platform. Selection in `browserUninstall` deliberately keeps the narrower field, because when several platforms share a build id the exact host build is the right one to remove.

## 2. §10 of the phase 1 design doc was being read as instructions

It told the reader to replace eight hardcoded cache-directory sites, with a line number for each. That work was never done as described — #887 consolidated those sites while the document was being written, and #1024 grew the result into `browser-paths.js`. Now marked as a record of the starting state, with a note on where the decision actually lives, and the original table kept below with its line numbers called out as stale.

## 3. §11.1's version gate said 3.12.0

The release train is at 5.0.0, and that number has already moved once while the phase 1 commits were landing. The instruction to re-check it at publication time is now the emphasis rather than a footnote.

Also done outside this PR: #931's first two checkboxes ticked, since #1059 shipped them.

## Verification

`npm run test:unit` green (2701 tests), `npm run lint` clean. `gitnexus detect_changes` reports risk **low** — one production symbol touched, no affected execution flows, matching the impact analysis on `labelForBuild` (one caller, `choices()` in the same file, `epistemic: "exact"`).

The new wizard test was confirmed to **fail when the fix is reverted**, and uses a `win32` fixture rather than `mac`: it is the case the function documents, and unlike `mac` it is not a substring of another platform name, so the assertion cannot be satisfied by the wrong platform being rendered.

## Known, not fixed here

The picker's choice value drops `platform`, so when one build id exists for two platforms both rows produce the same value and `browserUninstall` resolves it by host match — meaning the row you select is not necessarily the build removed. Pre-existing, and this PR removes the label that made those rows look different. Being fixed separately, since it changes the behaviour of a destructive command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
