### PR TITLE
Make the uninstall picker name the build that will actually be removed

### DIFF
--- a/src/lib/browser/__tests__/browser_uninstall.test.js
+++ b/src/lib/browser/__tests__/browser_uninstall.test.js
@@ -218,6 +218,23 @@ describe('browserUninstall — platform handling (issue #892)', () => {
         expect(uninstall).toHaveBeenCalledWith(expect.objectContaining({ platform: 'mac_arm' }));
     });
 
+    test('falls back to a build this machine can run before an arbitrary one', async () => {
+        // No build for exactly this platform, but an Intel one that Rosetta will run. The
+        // comment on this rule has always said "prefer the build that can actually run here";
+        // without this tier the choice fell back to filesystem order and could land on the
+        // win64 build, which cannot run at all.
+        const ROSETTA = { ...LOCAL, platform: 'mac', path: '/p/mac-intel' };
+        cacheReads([FOREIGN, ROSETTA], [FOREIGN]);
+
+        const result = await browserUninstall({
+            browser: 'chrome',
+            browserVersion: '151.0.7922.77',
+        });
+
+        expect(result).toBe(true);
+        expect(uninstall).toHaveBeenCalledWith(expect.objectContaining({ platform: 'mac' }));
+    });
+
     test('says so when a build id is cached for more than one platform', async () => {
         cacheReads([FOREIGN, LOCAL], [FOREIGN]);
 

--- a/src/lib/browser/browser-selection.js
+++ b/src/lib/browser/browser-selection.js
@@ -1,0 +1,37 @@
+/**
+ * Which cached build an operation acts on when several of them match.
+ *
+ * Its own module, with no imports at all, for one reason: the rule has to be shared between
+ * `browser uninstall` and the wizard that drives it, and both of those are mocked by
+ * `browser_wizards.test.js`. Living in either one would force that suite to stub the rule, and a
+ * stub is a second implementation - which is the exact defect this module exists to prevent.
+ * Nothing mocks a module that has no behaviour worth faking.
+ */
+
+/**
+ * The build a removal targets when several platforms share one build id.
+ *
+ * `browser uninstall` can name only a browser and a build id, and removes one build per run, so
+ * something has to choose between the entries that match. Three tiers, narrowest first:
+ *
+ * 1. Built for exactly this platform - the copy most likely to be the one in use.
+ * 2. Failing that, one this machine can run at all: a 32-bit Windows build on 64-bit Windows, or
+ *    an Intel macOS build on Apple Silicon. Without this tier the choice fell through to
+ *    filesystem order and could land on a build that cannot run here while a runnable copy of the
+ *    same id sat beside it - which is not what "prefer the build that can actually run here" ever
+ *    meant.
+ * 3. Failing that, the first match. Nothing here runs, so any of them will do.
+ *
+ * The uninstall wizard's picker calls this to name the build the run will choose. A row that
+ * describes one build while the run removes another is the defect this rule exists to prevent,
+ * and a copy of the expression in the wizard would let the two drift apart silently, since
+ * nothing compares them.
+ *
+ * @param {Array<object>} matches - Inventory entries sharing a browser and build id.
+ *
+ * @returns {object} The entry to act on.
+ */
+export const buildToRemove = (matches) =>
+    matches.find((build) => build.isCurrentPlatform) ??
+    matches.find((build) => build.canRunHere) ??
+    matches[0];

--- a/src/lib/browser/browser-uninstall.js
+++ b/src/lib/browser/browser-uninstall.js
@@ -7,6 +7,7 @@ import path from 'node:path';
 import { logger, setLoggingLevel, bsiExecutablePath, isSea } from '../../globals.js';
 import { redactOptions } from '../util/redact-secrets.js';
 import { resolveLocalBrowserBuildId, VERSION_RECOMMENDED } from './browser-version.js';
+import { buildToRemove } from './browser-selection.js';
 
 /**
  * Uninstall a browser from the Butler Sheet Icons cache.
@@ -68,10 +69,7 @@ export const browserUninstall = async (options) => {
             return false;
         }
 
-        // Prefer the build that can actually run here. Previously this was
-        // whichever entry the filesystem happened to list first.
-        const browserToUninstall =
-            matches.find((browser) => browser.isCurrentPlatform) ?? matches[0];
+        const browserToUninstall = buildToRemove(matches);
 
         if (matches.length > 1) {
             logger.warn(

--- a/src/lib/commands/browser/__tests__/browser_wizards.test.js
+++ b/src/lib/commands/browser/__tests__/browser_wizards.test.js
@@ -165,6 +165,68 @@ describe('the uninstall wizard', () => {
         expect(labels[0]).toContain('cannot run here');
     });
 
+    test('offers one row per build id, not one per platform', async () => {
+        // `browser uninstall` can only name a browser and a build id, and removes one build per
+        // run. A row per platform would let an operator pick a row and watch a different build
+        // disappear, because browserUninstall resolves the ambiguity by host match.
+        getBrowserInventory.mockResolvedValue([MAC_BUILD, RUNNABLE_FOREIGN_BUILD]);
+        const runtime = scriptedRuntime({
+            _build: { browser: 'chrome', buildId: '151.0.7922.47' },
+            _review: 'cancel',
+        });
+
+        await runInteractive({ path: 'browser uninstall', runtime });
+
+        expect(runtime.asked[0].choices).toHaveLength(1);
+    });
+
+    test('names the build that will actually be removed', async () => {
+        // The representative has to be chosen the way browserUninstall chooses it, or the row
+        // describes one build and the run removes another. Listed foreign-build-first on
+        // purpose: taking entry [0] would name the win32 build here.
+        getBrowserInventory.mockResolvedValue([RUNNABLE_FOREIGN_BUILD, MAC_BUILD]);
+        const runtime = scriptedRuntime({
+            _build: { browser: 'chrome', buildId: '151.0.7922.47' },
+            _review: 'cancel',
+        });
+
+        await runInteractive({ path: 'browser uninstall', runtime });
+
+        expect(runtime.asked[0].choices[0].name).toContain('(mac_arm)');
+    });
+
+    test('says another platform is still cached, and that a re-run removes it', async () => {
+        getBrowserInventory.mockResolvedValue([MAC_BUILD, RUNNABLE_FOREIGN_BUILD]);
+        const runtime = scriptedRuntime({
+            _build: { browser: 'chrome', buildId: '151.0.7922.47' },
+            _review: 'cancel',
+        });
+
+        await runInteractive({ path: 'browser uninstall', runtime });
+
+        const label = runtime.asked[0].choices[0].name;
+        expect(label).toContain('1 other platform');
+        expect(label).toContain('re-run');
+    });
+
+    test('pluralises the other-platforms note', async () => {
+        // Two branches, and only the singular one was covered. `1 other platforms` in the case
+        // an operator is most likely to hit would otherwise ship with a green suite.
+        getBrowserInventory.mockResolvedValue([
+            MAC_BUILD,
+            RUNNABLE_FOREIGN_BUILD,
+            { ...RUNNABLE_FOREIGN_BUILD, platform: 'win64', canRunHere: false },
+        ]);
+        const runtime = scriptedRuntime({
+            _build: { browser: 'chrome', buildId: '151.0.7922.47' },
+            _review: 'cancel',
+        });
+
+        await runInteractive({ path: 'browser uninstall', runtime });
+
+        expect(runtime.asked[0].choices[0].name).toContain('2 other platforms');
+    });
+
     test('does not claim a runnable build cannot run here', async () => {
         // The regression this guards: keyed on `isCurrentPlatform`, the picker told a Windows
         // administrator that the `win32` build in their cache "cannot run here" while browser

--- a/src/lib/commands/browser/uninstall.interactive.js
+++ b/src/lib/commands/browser/uninstall.interactive.js
@@ -1,6 +1,7 @@
 import { getBrowserInventory } from '../../browser/browser-inventory.js';
 import { resolveBrowserCacheDir } from '../../browser/browser-paths.js';
 import { browserUninstall } from '../../browser/browser-uninstall.js';
+import { buildToRemove } from '../../browser/browser-selection.js';
 
 /** Key of the synthetic question that replaces the browser/version pair. */
 const BUILD = '_build';
@@ -19,16 +20,29 @@ const BUILD = '_build';
  * cache "cannot run here" while browser detection was perfectly willing to use
  * it - the picker and the run disagreeing about the same build.
  *
- * @param {object} build - An entry from the browser inventory.
+ * @param {object} build - An entry from the browser inventory: the one that will actually be
+ * removed, not merely one that shares its build id.
+ * @param {number} [cachedForPlatforms] - How many platforms this browser and build id are cached
+ * for, this one included.
  *
  * @returns {string} The label to show.
  */
-export const labelForBuild = (build) => {
+export const labelForBuild = (build, cachedForPlatforms = 1) => {
     const base = `${build.browser}  ${build.buildId}`;
 
-    return build.canRunHere
-        ? `${base}  (${build.platform})`
-        : `${base}  (built for ${build.platform} - cannot run here)`;
+    const platform = build.canRunHere
+        ? `(${build.platform})`
+        : `(built for ${build.platform} - cannot run here)`;
+
+    // Said here rather than left to the warning `browserUninstall` prints afterwards, because
+    // by then the operator has already confirmed a removal believing it was the only one.
+    const remaining = cachedForPlatforms - 1;
+    const more =
+        remaining > 0
+            ? `  - also cached for ${remaining} other platform${remaining === 1 ? '' : 's'}, re-run to remove`
+            : '';
+
+    return `${base}  ${platform}${more}`;
 };
 
 export default {
@@ -119,13 +133,43 @@ export default {
                         cacheDir: resolveBrowserCacheDir(answers),
                     });
 
-                    // Builds for other platforms stay selectable on purpose:
+                    // Builds this machine cannot run stay selectable on purpose:
                     // wanting the disk space back is a perfectly good reason to
                     // remove a browser you cannot run.
-                    return inventory.map((build) => ({
-                        name: labelForBuild(build),
-                        value: { browser: build.browser, buildId: build.buildId },
-                    }));
+                    //
+                    // One row per browser and build id, though, not one per
+                    // platform. That pair is all the command can name, and
+                    // `browserUninstall` removes one build per run - so a row
+                    // per platform would let an operator pick a row and watch a
+                    // different build disappear. The consequence, said plainly
+                    // in the label: when one build id is cached for several
+                    // platforms they come off one at a time, this machine's own
+                    // copy first, so reaching a foreign copy takes a second run.
+                    const groups = new Map();
+
+                    for (const build of inventory) {
+                        // A space is enough of a separator: neither a browser name nor a build
+                        // id can contain one, so no two distinct pairs collide.
+                        const key = `${build.browser} ${build.buildId}`;
+                        const group = groups.get(key);
+
+                        if (group) {
+                            group.push(build);
+                        } else {
+                            groups.set(key, [build]);
+                        }
+                    }
+
+                    // `buildToRemove` rather than a copy of its rule, so the row cannot come to
+                    // describe a different build than the run removes.
+                    return [...groups.values()].map((builds) => {
+                        const build = buildToRemove(builds);
+
+                        return {
+                            name: labelForBuild(build, builds.length),
+                            value: { browser: build.browser, buildId: build.buildId },
+                        };
+                    });
                 },
                 fallback: {
                     type: 'input',


### PR DESCRIPTION
Follows #1067, which made the uninstall wizard's picker label builds by whether this machine can run them. Reviewing that change surfaced a worse problem underneath it, plus a rule the code was not keeping.

## 1. The row you picked was not always the build removed

The picker offered a row per cached build, but the value it produces is only a browser and a build id — all `browser uninstall` can name. When one id was cached for two platforms, **both rows carried the identical value**, and the command resolved it by host match.

So on an Apple Silicon machine with chrome 151.0.7922.47 cached for both `mac` and `mac_arm`, an operator picking the Intel row to reclaim ~150 MB watched the arm64 build they were running disappear instead. #1067 made this easier to hit, because it removed the `cannot run here` marker that had made the two rows look different.

One row per browser and build id now, with the representative chosen by the same `buildToRemove` the command uses — not a copy of its rule — so a row cannot come to describe a different build than the run removes. Where an id is cached for several platforms the label says so, and says a re-run takes the next one.

**Consequence worth knowing:** reaching a foreign copy now takes a second run, because this machine's own copy goes first. That is the honest shape of a command that removes one build per invocation; the label states it rather than leaving the operator to wonder.

## 2. The selection rule did not keep its own promise

`browser-uninstall.js` chose `find(isCurrentPlatform) ?? matches[0]` under a comment reading *"Prefer the build that can actually run here."* Those are different rules. With chrome cached for `linux` and `mac` on Apple Silicon and no `mac_arm` copy, the choice fell to filesystem order and could remove the `linux` build while a runnable copy sat beside it.

Three tiers now — exact platform, then runnable at all (`win32` on `win64`, Intel under Rosetta), then first match — which is what the comment always said.

## Why `browser-selection.js` is a module with no imports

The rule has to be shared between the command and the wizard that drives it, and `browser_wizards.test.js` mocks **both** `browser-uninstall.js` and `browser-inventory.js` by enumerating their exports. Living in either would force that suite to stub the rule, and a stub is a second implementation — precisely the defect a shared rule prevents. Nothing mocks a module with no behaviour worth faking.

## Verification

`npm run test:unit` green (2706 tests), `npm run lint` clean. `detect_changes` reports **medium** risk: `browserUninstall` sits on five execution flows under `HandleBrowserUninstall`, expected for a change to its selection rule.

Run against a real staged cache — six entries, three rows, every row agreeing with what the command would remove:

```
chrome  120.0.0.1      (built for linux - cannot run here)            -> removes "linux"     AGREE
chrome  138.0.7204.94  (mac)  - also cached for 1 other platform      -> removes "mac"       AGREE
chrome  151.0.7922.47  (mac_arm)  - also cached for 2 other platforms -> removes "mac_arm"   AGREE
```

The middle row is item 2: no host copy exists, and it names the runnable `mac` build rather than `linux`.

## Reviewer note

An earlier revision of this branch contained a literal NUL byte in a template literal, which made the source file **binary to git** — no diff, no three-way merge, no blame, and `grep` silently skipping it. `npm run lint` exited 0 throughout. It is gone, verified by byte scan, and the rest of `src/` was swept: the only other control byte is a legitimate ANSI escape in `colour.test.js`, already marked `text` in `.gitattributes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
