### PR TITLE
Add a browser check command so an air-gapped server can be diagnosed without a production run

### DIFF
--- a/docs/to-doc-site/browser-check-command.md
+++ b/docs/to-doc-site/browser-check-command.md
@@ -1,0 +1,360 @@
+# `browser check`: find out whether a server can take screenshots
+
+**Status:** new command, not yet on the doc site.
+**Suggested target pages:** a new section under `/reference/browser`, plus a link from the air-gapped installation guide and from the troubleshooting pages.
+
+> **Note for the publishing pass.** Every message string, log line and remediation sentence below was captured from a real run of the command. Only the environment-specific values — paths, user names, the machine's platform and browser build ids — have been changed to a plausible Windows Server example, since the audience runs Qlik Sense on Windows and the capture machine was a Mac. Do not reword the message text: administrators search for it verbatim.
+
+---
+
+## What it is
+
+`butler-sheet-icons browser check` answers one question: **will a real thumbnail run work on this machine?**
+
+It answers it without contacting Qlik Sense, without changing anything, and without making a single network request. It is safe to run on a production Qlik Sense server at any time, and safe to give to a customer as the first troubleshooting step.
+
+Until now, the only way to find out whether a Butler Sheet Icons installation could actually drive a browser was to run a full thumbnail job against a production Qlik Sense environment and see what happened. On a server with no internet access — which is most Qlik Sense servers in regulated organisations — a browser problem showed up as a failure late in the run, with an error message that said nothing about browsers.
+
+Run it like this:
+
+```
+butler-sheet-icons browser check
+```
+
+## What it checks
+
+Five things, in the order they matter:
+
+1. **The machine and the account.** Which operating system, which user Butler Sheet Icons is running as, where that user's home directory is, and which directory the command was started from.
+2. **The browser executable**, if you have configured one with `--browser-executable-path` or the `BSI_BROWSER_EXECUTABLE_PATH` environment variable. Is it where you said it is?
+3. **The browser cache** — where it is, whether this account can read it, whether it will be consulted at all, and which browser builds are in it. Each build is reported as usable or not usable, with the reason.
+4. **The selection** — which browser a real run would actually pick, and where it is.
+5. **The launch test** — the selected browser is started and asked for its version number, then closed again. No web page is opened and nothing is navigated to.
+
+The last one is the point. A browser file being in the right place proves much less than the browser actually starting: antivirus software, missing system libraries and browser builds that Butler Sheet Icons cannot drive all produce a browser that looks perfectly fine on disk and fails the moment it is used.
+
+## How to read the output
+
+The output has two parts, and telling them apart saves confusion.
+
+**The report** starts at the line `Butler Sheet Icons browser check` and runs to the end of the output — the `Result:` line, and the numbered `Next steps:` that follow it when the run failed. Paste all of it into a support request.
+
+**Above the report** are a few lines from the steps the command runs on the way there — the Butler Sheet Icons version, and then the browser-detection step's own log output. Those are shared with a real thumbnail run: they are exactly what a real run prints at that point, which is deliberate, because it means the check reproduces what you would see in a failing job.
+
+That has one consequence worth knowing about in advance. When no staged browser matches, the detection step prints this:
+
+```
+warn: No cached chrome build matches --browser-version "recommended" (build 151.0.7922.71). Cached chrome builds that this machine can run: 151.0.7922.138. Set --browser-version to one of those build ids to use it instead. Butler Sheet Icons will now try to download chrome 151.0.7922.71, which needs internet access. On a machine without internet access this will fail.
+```
+
+**`browser check` does not download anything, and does not make that request.** That sentence describes what a *real thumbnail run* would do next, because the same detection step is shared with the run. The check stops there and reports; nothing after that line reaches the network.
+
+## The exit code
+
+`browser check` sets the exit code, so it can be used as a gate in a deployment script:
+
+- **0** — a browser was found and, unless you passed `--skip-launch`, started successfully.
+- **1** — no usable browser was found, the browser could not be started, or a setting is wrong in a way that would stop a real run.
+
+For example, in a PowerShell deployment script on a Qlik Sense server:
+
+```powershell
+.\butler-sheet-icons.exe browser check
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Butler Sheet Icons cannot take screenshots on this server. See the output above."
+    exit 1
+}
+```
+
+## A healthy server
+
+This is what a working server looks like. Note that the command reports facts even when everything is fine — that is deliberate, because it is what lets you rule things out, and it makes the output useful to paste into a support request.
+
+```
+info: Butler Sheet Icons browser check
+info: Environment
+info:     Platform            : win32 x64 (Puppeteer platform "win64")
+info:     Running as user     : svc_qlik
+info:     Home directory      : C:\Users\svc_qlik
+info:     Working directory   : C:\butler-sheet-icons
+info:     Standalone binary   : true
+info: Browser executable
+info:     Configured          : no
+info: Browser cache
+info:     Source              : default location next to the Butler Sheet Icons executable
+info:     Directory           : C:\butler-sheet-icons\browser-cache
+info:     Directory exists    : yes
+info:     In use              : yes
+info:     Cached builds       : 1
+info:         chrome 151.0.7922.71     platform=win64     executable present   usable
+info: Selection
+info:     Requested           : chrome recommended (build 151.0.7922.71)
+info:     Would use           : cached browser (chrome 151.0.7922.71)
+info:     Executable          : C:\butler-sheet-icons\browser-cache\chrome\win64-151.0.7922.71\chrome-win64\chrome.exe
+info: Launch test
+info:     Launched            : yes
+info:     Reported version    : Chrome/151.0.7922.71
+info: Note: these findings are best-effort. Butler Sheet Icons reports what it can observe on this
+info: machine, and cannot see everything about your environment - group policy, antivirus, proxy rules
+info: and Qlik Sense itself are all invisible to it. Review suggested commands before running them on a
+info: production server.
+info: Result: OK - Butler Sheet Icons can take screenshots on this machine without internet access.
+```
+
+Three lines here are worth more attention than they look:
+
+**`Running as user`, `Home directory` and `Working directory`.** If Butler Sheet Icons runs as a Windows scheduled task under the LocalSystem account, the home directory is `C:\Windows\system32\config\systemprofile` and the working directory is `C:\Windows\system32` — not the folder you installed it in. A browser cache staged into your own user profile is invisible to that account, and a `.env` file placed beside the executable is never read. Both symptoms are baffling until you see these three lines.
+
+**`In use`.** When you have configured a browser executable and that file exists, the browser cache is never consulted. The line then reads `no (an executable path is configured, so the cache is not consulted)`, which tells you the cache directory setting is being ignored on purpose rather than silently failing.
+
+**The best-effort note.** It appears on every run and cannot be switched off. Butler Sheet Icons is reasoning from what it can observe on one machine; it cannot see group policy, antivirus rules, proxy configuration, or anything about your Qlik Sense installation itself.
+
+## A server that cannot take screenshots
+
+```
+info: Butler Sheet Icons browser check
+info: Environment
+info:     Platform            : win32 x64 (Puppeteer platform "win64")
+info:     Running as user     : svc_qlik
+info:     Home directory      : C:\Windows\system32\config\systemprofile
+info:     Working directory   : C:\Windows\system32
+info:     Standalone binary   : true
+info: Browser executable
+info:     Configured          : no
+info: Browser cache
+info:     Source              : from --browser-cache-dir / BSI_BROWSER_CACHE_DIR
+info:     Directory           : D:\qlik\bsi-browser-cache
+info:     Directory exists    : yes
+info:     In use              : yes
+info:     Cached builds       : 1
+info:         chrome 151.0.7922.71     platform=mac_arm   executable present   not usable (built for another platform)
+error:     The cache at D:\qlik\bsi-browser-cache holds 1 chrome build(s), for mac_arm. This machine is win64. A browser cache copied from a machine with a different operating system cannot be used.
+info: Selection
+info:     Requested           : chrome recommended (build 151.0.7922.71)
+info:     Would use           : nothing - a browser would have to be downloaded
+info: Note: these findings are best-effort. Butler Sheet Icons reports what it can observe on this
+info: machine, and cannot see everything about your environment - group policy, antivirus, proxy rules
+info: and Qlik Sense itself are all invisible to it. Review suggested commands before running them on a
+info: production server.
+error: Result: FAILED - the cached browsers were built for a different operating system
+error: Next steps:
+error:     1. Stage the browser from a machine running the same operating system as this one, and copy that machine's browser cache directory here.
+error:        butler-sheet-icons.exe browser install --browser chrome --browser-version recommended
+error:     2. Or, if Chrome or Edge is already installed on this machine, point Butler Sheet Icons at it with --browser-executable-path or BSI_BROWSER_EXECUTABLE_PATH.
+```
+
+This is the most common air-gapped staging mistake, and the report names it exactly: the browser was downloaded on a Mac and copied to a Windows server. A browser build is compiled for one operating system and cannot run on another. **Always stage the browser from a machine running the same operating system as the target server.**
+
+Read the failure output in three parts:
+
+- The **`error:` lines within the report** say what was observed, with the actual values — which directory, which builds, which platform.
+- The **`Result: FAILED` line** names the single most important problem in one sentence.
+- The **`Next steps`** are ordered, and the first one is the one to try.
+
+The suggested commands are shown for the operating system you are on: PowerShell commands on Windows, shell commands on macOS and Linux. Steps are never repeated: when one problem explains another, only the one you can act on carries advice.
+
+## Other things it catches
+
+### A browser executable path that points nowhere
+
+If you set `--browser-executable-path` or `BSI_BROWSER_EXECUTABLE_PATH` to a file that does not exist, Butler Sheet Icons deliberately stops rather than quietly downloading a different browser instead. This is the single most useful thing `browser check` catches, because it means an explicit setting is wrong:
+
+```
+info: Browser executable
+info:     Source              : from --browser-executable-path / BSI_BROWSER_EXECUTABLE_PATH
+info:     Path                : D:\Chrome\chrome.exe
+info:     Exists              : no
+error:     --browser-executable-path / BSI_BROWSER_EXECUTABLE_PATH is set to "D:\Chrome\chrome.exe", and no such file exists on this machine. Butler Sheet Icons will not fall back to downloading a browser when an executable path has been given explicitly, so every thumbnail run will stop here.
+info: Browser cache
+info:     Source              : default location next to the Butler Sheet Icons executable
+info:     Directory           : C:\butler-sheet-icons\browser-cache
+info:     Directory exists    : yes
+info:     In use              : no (an executable path is configured but missing, so detection stops before the cache)
+...
+error: Result: FAILED - the configured browser executable does not exist
+error: Next steps:
+error:     1. Correct the path so it names a browser that exists on this machine, or remove the setting to let Butler Sheet Icons find a browser itself. On Windows, Google Chrome is usually at C:\Program Files\Google\Chrome\Application\chrome.exe and Microsoft Edge at C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe.
+```
+
+Note the `In use` line: because the path was given explicitly and is missing, Butler Sheet Icons stops there and never looks in the cache at all. Staging a browser into that cache would not help until the path is corrected or removed.
+
+### A browser cache this account cannot read
+
+The one that looks like an empty cache and is not. A cache staged by an administrator, under a Windows scheduled task running as LocalSystem, is often unreadable by the account Butler Sheet Icons actually runs as:
+
+```
+info: Browser cache
+info:     Source              : from --browser-cache-dir / BSI_BROWSER_CACHE_DIR
+info:     Directory           : D:\qlik\bsi-browser-cache
+info:     Directory exists    : yes
+info:     In use              : yes
+info:     Cached builds       : 0
+error:     Butler Sheet Icons could not read D:\qlik\bsi-browser-cache. Whatever browsers are staged there, this account cannot see them, so a real run would behave as though the cache were empty. The error was: EPERM: operation not permitted, scandir 'D:\qlik\bsi-browser-cache\chrome'
+...
+error: Result: FAILED - the browser cache directory could not be read
+error: Next steps:
+error:     1. Check that the account this runs as (svc_qlik) can read D:\qlik\bsi-browser-cache and everything under it. A cache staged from an administrator's own profile is the usual cause - under a Windows scheduled task Butler Sheet Icons often runs as LocalSystem, not as the person who staged it.
+error:     2. Or move the browser cache somewhere the service account can read, and point Butler Sheet Icons at it with --browser-cache-dir or BSI_BROWSER_CACHE_DIR.
+```
+
+Read this together with the `Running as user` line in the Environment block. Those two lines together are usually the whole diagnosis.
+
+### A browser version that is not the one you staged
+
+If the cache holds a browser but not the exact build being asked for, `browser check` says so and tells you which build ids you do have:
+
+```
+info: Selection
+info:     Requested           : chrome recommended (build 151.0.7922.71)
+info:     Would use           : nothing - the requested build would have to be downloaded
+error:     chrome recommended (build 151.0.7922.71) was requested, and C:\butler-sheet-icons\browser-cache holds no such build. It does hold 1 build(s) this machine can run: chrome 151.0.7922.138. A real run would try to download the requested build, which needs internet access.
+...
+error: Result: FAILED - the requested browser build is not in the cache, although other builds are
+error: Next steps:
+error:     1. Use one of the builds already on this machine: set --browser-version to 151.0.7922.138, or set the matching BSI_*_BROWSER_VERSION environment variable.
+error:        butler-sheet-icons.exe browser check --browser-version 151.0.7922.138
+error:     2. Or, on a machine with internet access and the same operating system as this one, install the requested build and copy the browser cache directory here.
+error:        butler-sheet-icons.exe browser install --browser chrome --browser-version recommended
+```
+
+This matters because Butler Sheet Icons asks for one specific browser build, not "any browser". Staging a browser today and upgrading Butler Sheet Icons next month can leave you with a cache that is full and still unusable — and the fix is usually step 1, not a new download.
+
+### A cache holding a different browser
+
+The default cache directory is shared with any other tool on the machine that uses the same browser library, so it can fill up with builds Butler Sheet Icons never looks at. Those are reported as present but not usable:
+
+```
+info:     Cached builds       : 1
+info:         chrome-headless-shell 151.0.7922.71 platform=win64     executable present   not usable (a chrome-headless-shell build, not the chrome build this run needs)
+```
+
+Run with `--loglevel verbose` to see the summary of each check as well as its facts, which states the same conclusion in a sentence:
+
+```
+verbose:     The browser cache holds no chrome builds
+```
+
+### A browser that starts but cannot be driven
+
+Some browser builds start perfectly well and then stop responding to the first command sent to them. The report distinguishes this from a browser that never started, because the fix is completely different — a different build, not an antivirus exclusion:
+
+```
+info: Launch test
+info:     Launched            : yes
+info:     Responded           : no
+info:     Build               : 151.0.7922.71
+error:     The browser at C:\butler-sheet-icons\browser-cache\chrome\win64-151.0.7922.71\chrome-win64\chrome.exe started and then stopped responding on the first command sent to it. The process is fine; this build cannot be driven. A real run fails the same way, part-way through a sheet. The error was: Protocol error (Browser.getVersion): Session closed.
+error: Result: FAILED - the browser starts but cannot be driven by Butler Sheet Icons
+```
+
+### A browser that starts, but far too slowly
+
+This one passes and still tells you something. If starting the browser takes longer than Butler Sheet Icons allows for, the check reports it as a warning while still returning exit code 0:
+
+```
+warn:     Starting the browser took 92s, longer than the 30s launch timeout allows for. It worked this time, so this check passes - but a real run can exceed the timeout on the same machine and fail with an error naming none of this.
+```
+
+On Windows this is almost always antivirus or endpoint protection scanning a browser executable it has not seen before. Excluding the Butler Sheet Icons browser cache directory from real-time scanning avoids it. Worth acting on: a run that is merely slow today is a run that fails intermittently tomorrow.
+
+### Which `--browser-version` values work offline
+
+Not every way of naming a browser version survives on a server with no internet access, and `browser check` treats them differently because a real thumbnail run does.
+
+| What you set | Offline | Reported as |
+| --- | --- | --- |
+| `recommended` (the default) | Works. Resolves from a value built into Butler Sheet Icons. | nothing to report |
+| A full build id, e.g. `151.0.7922.77` | Works. Names one build, no lookup needed. | nothing to report |
+| `stable`, `beta`, `dev`, `canary` | Works, but you may get a different build than a connected machine would. Butler Sheet Icons falls back to the newest suitable build already staged. | a warning |
+| A milestone or partial id, e.g. `151` or `151.0.7922` | **Does not work.** There is no fallback for this form, so a real run stops with a lookup error before it looks at the cache. | a failure |
+
+That last row is worth reading twice, because it is the surprising one — a partial version looks more precise than `stable`, and offline it is the one that cannot work:
+
+```
+info:     Requested           : chrome 151
+info:     Would use           : cached browser (chrome 151.0.7922.138)
+info:     Requested version   : 151
+error:     --browser-version "151" names a milestone or a partial build id, and turning that into a single build is the browser vendor's lookup. Butler Sheet Icons does not fall back to a cached build for this form - only for keywords such as "recommended" and "stable" - so a real run on a machine without internet access stops with a lookup error before it looks at the cache at all. Whatever this check reports about the browser here, a run with this setting cannot start offline.
+...
+error: Result: FAILED - the requested browser version can only be resolved over the internet
+```
+
+Note the report still shows which browser it *would* have used. That is not a contradiction: the browser is there and is fine — the version setting is what stops the run.
+
+A floating keyword is only a warning, because a real run does fall back to what is staged:
+
+```
+warn:     --browser-version "stable" names whichever build is newest at the time it runs, which can only be resolved over the internet. This check did not make that call, so it accepted the newest suitable build already present instead. A real run on a machine with internet access may therefore choose a different build than the one reported here.
+```
+
+### A cache copied without the browser binaries
+
+Some copy tools skip hidden files by default. A browser cache copied that way looks complete — the folders are all there — but the browser itself is missing:
+
+```
+info:     Cached builds       : 1
+info:         chrome 151.0.7922.71     platform=win64     executable MISSING   not usable (executable not found on disk)
+error:     1 of 1 cached chrome build(s) in D:\qlik\bsi-browser-cache have no browser binary where one should be: chrome 151.0.7922.71 (expected at D:\qlik\bsi-browser-cache\chrome\win64-151.0.7922.71\chrome-win64\chrome.exe). The cache directory is incomplete - copied without the browser binary, or left behind by a failed install.
+...
+error: Result: FAILED - cached browsers are missing their executable files
+error: Next steps:
+error:     1. Copy the browser cache directory again, preserving hidden files - a tar or robocopy invocation that skips dotfiles leaves the .metadata file behind and produces exactly this.
+error:     2. Or install the browser again on a machine with internet access, and copy the whole cache directory here.
+error:        butler-sheet-icons.exe browser install --browser chrome --browser-version recommended
+```
+
+## Options
+
+<!-- generated:cli-options browser check -->
+
+| Option                             | Environment Variable            | Description                                                                                                                                                                                                                                                                                                                                                                         | Default       | Example            |
+| ---------------------------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- | ------------------ |
+| `--log-level, --loglevel <level>`  | `BSI_BROWSER_C_LOG_LEVEL`       | Log level (choices: error, warn, info, verbose, debug, silly)                                                                                                                                                                                                                                                                                                                       | `info`        | `--loglevel error` |
+| `--browser <browser>`              | `BSI_BROWSER_C_BROWSER`         | Browser to check for. Only "chrome" is supported. (choices: chrome)                                                                                                                                                                                                                                                                                                                 | `chrome`      | `--browser chrome` |
+| `--browser-version <version>`      | `BSI_BROWSER_C_BROWSER_VERSION` | Browser build to check for. Either a keyword - "recommended" for the build Butler Sheet Icons is tested with, "stable" for the newest stable release, or a release channel such as "beta" - or an exact version: a milestone ("151"), a build prefix ("151.0.7922") or a full build id ("151.0.7922.77"). Use "butler-sheet-icons browser list-available" to see what is available. | `recommended` | -                  |
+| `--browser-cache-dir <directory>`  | `BSI_BROWSER_CACHE_DIR`         | Directory where Butler Sheet Icons keeps downloaded browsers. Defaults to a "browser-cache" folder next to the Butler Sheet Icons executable for standalone builds, and to the .cache/puppeteer folder in the current user's home directory otherwise.                                                                                                                              | -             | -                  |
+| `--browser-executable-path <path>` | `BSI_BROWSER_EXECUTABLE_PATH`   | Full path to a browser executable to use, for example a Microsoft Edge or Google Chrome already installed on this machine. Butler Sheet Icons then neither downloads nor manages a browser. Takes precedence over PUPPETEER_EXECUTABLE_PATH. If the file does not exist the run stops rather than downloading a browser instead.                                                    | -             | -                  |
+| `--headless <true\|false>`         | `BSI_BROWSER_C_HEADLESS`        | Headless (=not visible) browser (true, false)                                                                                                                                                                                                                                                                                                                                       | `true`        | -                  |
+| `--skip-launch [true\|false]`      | `BSI_BROWSER_C_SKIP_LAUNCH`     | Find a browser but do not start it. Faster, and useful where starting a browser is not allowed - but it leaves the most valuable part of the check undone.                                                                                                                                                                                                                          | `false`       | -                  |
+| `-h, --help`                       | -                               | display help for command                                                                                                                                                                                                                                                                                                                                                            | -             | `-h`               |
+
+<!-- /generated:cli-options -->
+
+Pass the same browser options you use for your real thumbnail runs. If your `qseow create-sheet-thumbnails` command sets `--browser-cache-dir`, set it here too — otherwise the check reports on a different browser cache than the one your real runs use, and a pass here proves nothing about them.
+
+`--headless false` is worth trying if headless runs behave oddly: starting a visible browser on a server with no display is a genuinely different test, and it fails in a way a headless launch does not.
+
+**Both true/false options accept the same words, and refuse anything else.** `true`, `1`, `yes` and `on` all mean on; `false`, `0`, `no` and `off` all mean off; case does not matter. A value neither list recognises is rejected with an error rather than quietly guessed at, so a typo in a scheduled task shows up as a failed command instead of a silently different test:
+
+```
+error: option '--headless <true|false>' argument 'maybe' is invalid. "maybe" is not a true/false value. Use one of: true, 1, yes, on - or false, 0, no, off.
+```
+
+`--skip-launch` can be written as a bare flag or with a value: `--skip-launch`, `--skip-launch true` and `BSI_BROWSER_C_SKIP_LAUNCH=true` all skip the launch test, while `--skip-launch false` and `BSI_BROWSER_C_SKIP_LAUNCH=false` run it. An environment variable set but left empty — `BSI_BROWSER_C_SKIP_LAUNCH=` — means "unset", so the option keeps its default.
+
+When the launch test is skipped, the result line says so rather than claiming more than was checked:
+
+```
+info: Result: OK - a browser was found on this machine. It was not started, so whether it runs here is untested.
+```
+
+## What it deliberately does not do
+
+- **It makes no network requests of its own.** This is a hard rule, not a side effect: a diagnostic that hangs waiting for a DNS lookup on an air-gapped server is worse than no diagnostic at all. The check never downloads a browser and never contacts the browser vendor, even when the report says a real run would have to. See [How to read the output](#how-to-read-the-output) for the one log line that can look otherwise.
+
+  One consequence is visible in the report. Working out which build `--browser-version stable` or `--browser-version 151` refers to is a lookup only the browser vendor can answer, so the check does not make it — and how much that matters depends on which of the two you wrote. See [Which `--browser-version` values work offline](#which-browser-version-values-work-offline) below.
+
+  `--browser-version recommended` — the default — needs no lookup at all, which is why it is the default.
+
+- **It never contacts Qlik Sense.** It tells you nothing about whether your certificates, virtual proxy or credentials are correct.
+- **It changes nothing.** It installs nothing, downloads nothing and deletes nothing.
+- **It does not open a web page.** The browser is started, asked for its version, and closed.
+
+## When to run it
+
+- **After installing Butler Sheet Icons on a new server**, before scheduling anything.
+- **After staging a browser** on an air-gapped server, to confirm the copy worked — this is the step that used to require a full production thumbnail run.
+- **As the same account the scheduled task uses.** Running it as yourself proves very little about a task that runs as LocalSystem; the `Running as user` line is there to make that difference visible.
+- **As the first step when a thumbnail run fails.** If `browser check` passes, the browser is not your problem, and you can look at Qlik Sense connectivity instead.
+- **In a deployment script**, as a gate.
+- **When opening a support issue.** Paste the whole output, including the lines above the report. It is the single most useful thing you can attach to a browser-related bug report: it says what operating system, which account, which directories, which browser builds and whether the browser starts.

--- a/src/__tests__/butler-sheet-icons.test.js
+++ b/src/__tests__/butler-sheet-icons.test.js
@@ -158,6 +158,12 @@ describe('butler-sheet-icons CLI', () => {
         expect(result.status).toBe(0);
         expect(result.stdout).toContain('list-available');
     });
+
+    test('should handle browser check command', () => {
+        const result = execCLI(['browser', '--help']);
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('check');
+    });
 });
 
 /** Printed by the child once the handlers are installed, to prove it got that far. */
@@ -604,6 +610,7 @@ describe('adding interactive mode changes nothing that already worked', () => {
             'uninstall-all',
             'list-installed',
             'list-available',
+            'check',
         ]) {
             expect(result.stdout).toContain(leaf);
         }

--- a/src/lib/browser/__tests__/browser_check.test.js
+++ b/src/lib/browser/__tests__/browser_check.test.js
@@ -1,0 +1,652 @@
+import { jest, test, expect, describe, beforeEach, afterEach } from '@jest/globals';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * `browser check` - the worker.
+ *
+ * Two properties are load-bearing beyond the individual assertions.
+ *
+ * **It must not touch the network.** `browserInstall` and `canDownload` are mocked here purely so
+ * that reaching them can be asserted against. A doctor that hangs on a DNS timeout on an
+ * air-gapped server is worse than no doctor, and the way that regression would arrive is somebody
+ * swapping `detectAvailableBrowser()` for `resolveBrowserExecutablePath()`, which falls through to
+ * an install.
+ *
+ * **The best-effort disclaimer is emitted on both paths.** Nothing breaks if it quietly disappears
+ * in a refactor, which is exactly why it needs a test rather than a code comment.
+ */
+
+const loggerMock = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    verbose: jest.fn(),
+    debug: jest.fn(),
+};
+
+jest.unstable_mockModule('../../../globals.js', () => ({
+    logger: loggerMock,
+    setLoggingLevel: jest.fn(),
+    // browser-paths.js gates the standalone cache location on this, and ESM checks named exports
+    // when the module graph is linked, so leaving it out is a hard error rather than an undefined.
+    isSea: false,
+    bsiExecutablePath: '/opt/bsi',
+    appVersion: 'test-version',
+}));
+
+jest.unstable_mockModule('@puppeteer/browsers', () => ({
+    canDownload: jest.fn().mockResolvedValue(true),
+    computeExecutablePath: jest.fn(),
+    detectBrowserPlatform: jest.fn().mockReturnValue('win64'),
+    getInstalledBrowsers: jest.fn().mockResolvedValue([]),
+    getVersionComparator: jest.fn(),
+    install: jest.fn(),
+    resolveBuildId: jest.fn(),
+    uninstall: jest.fn(),
+}));
+
+jest.unstable_mockModule('../browser-detect.js', () => ({
+    detectAvailableBrowser: jest.fn(),
+}));
+
+jest.unstable_mockModule('../browser-inventory.js', () => ({
+    getBrowserInventory: jest.fn().mockResolvedValue([]),
+    hasUsableExecutable: jest.fn().mockReturnValue(true),
+    canRunOnHost: jest.fn().mockReturnValue(true),
+}));
+
+jest.unstable_mockModule('../browser-install.js', () => ({
+    browserInstall: jest.fn(),
+}));
+
+const launchMock = jest.fn();
+jest.unstable_mockModule('puppeteer-core', () => ({
+    default: { launch: launchMock },
+}));
+
+const { canDownload } = await import('@puppeteer/browsers');
+const { detectAvailableBrowser } = await import('../browser-detect.js');
+const { getBrowserInventory, hasUsableExecutable } = await import('../browser-inventory.js');
+const { browserInstall } = await import('../browser-install.js');
+const { browserCheck } = await import('../browser-check.js');
+const { BEST_EFFORT_DISCLAIMER } = await import('../../doctor/render-report.js');
+
+/** A cached build the host can run, with its binary present. */
+const CACHED_BUILD = {
+    browser: 'chrome',
+    buildId: '138.0.7204.94',
+    platform: 'win64',
+    path: '/cache/chrome/win64-138.0.7204.94',
+    executablePath: '/cache/chrome/win64-138.0.7204.94/chrome',
+    isCurrentPlatform: true,
+    canRunHere: true,
+};
+
+/**
+ * A browser handle that answers a version query.
+ *
+ * @param {object} [overrides] - Methods to replace on the default handle.
+ *
+ * @returns {object} A stand-in for a Puppeteer browser.
+ */
+const fakeBrowser = (overrides = {}) => ({
+    version: jest.fn().mockResolvedValue('Chrome/138.0.7204.94'),
+    close: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+});
+
+/**
+ * Every line the logger was given, at any level, joined.
+ *
+ * @returns {string} The logged output.
+ */
+const loggedText = () =>
+    [loggerMock.info, loggerMock.warn, loggerMock.error, loggerMock.verbose, loggerMock.debug]
+        .flatMap((fn) => fn.mock.calls.map(([line]) => String(line)))
+        .join('\n');
+
+/**
+ * Options with a cache directory, so no test depends on this machine's real one.
+ *
+ * @param {object} [extra] - Extra options to merge in.
+ *
+ * @returns {object} An options bag.
+ */
+const options = (extra = {}) => ({
+    browser: 'chrome',
+    browserVersion: 'recommended',
+    headless: 'true',
+    browserCacheDir: path.join(os.tmpdir(), 'bsi-browser-check-test'),
+    ...extra,
+});
+
+let savedPuppeteerCacheDir;
+let savedPuppeteerExecutablePath;
+
+beforeEach(() => {
+    // Both are ambient and behaviour-affecting: a developer shell or a CI image may have them set,
+    // and browser-paths.js reads them directly rather than through Commander.
+    savedPuppeteerCacheDir = process.env.PUPPETEER_CACHE_DIR;
+    savedPuppeteerExecutablePath = process.env.PUPPETEER_EXECUTABLE_PATH;
+    delete process.env.PUPPETEER_CACHE_DIR;
+    delete process.env.PUPPETEER_EXECUTABLE_PATH;
+
+    getBrowserInventory.mockResolvedValue([]);
+    hasUsableExecutable.mockReturnValue(true);
+    launchMock.mockResolvedValue(fakeBrowser());
+});
+
+afterEach(() => {
+    if (savedPuppeteerCacheDir === undefined) {
+        delete process.env.PUPPETEER_CACHE_DIR;
+    } else {
+        process.env.PUPPETEER_CACHE_DIR = savedPuppeteerCacheDir;
+    }
+
+    if (savedPuppeteerExecutablePath === undefined) {
+        delete process.env.PUPPETEER_EXECUTABLE_PATH;
+    } else {
+        process.env.PUPPETEER_EXECUTABLE_PATH = savedPuppeteerExecutablePath;
+    }
+});
+
+describe('a machine that can take screenshots', () => {
+    test('reports ok when a named executable exists and the browser launches', async () => {
+        detectAvailableBrowser.mockResolvedValue({
+            executablePath: '/usr/bin/chromium',
+            source: 'system',
+            browser: 'chrome',
+            buildId: 'system-installed',
+        });
+
+        const report = await browserCheck(options({ browserExecutablePath: process.execPath }));
+
+        expect(report.ok).toBe(true);
+        expect(report.launched).toBe(true);
+        expect(report.browserVersion).toBe('Chrome/138.0.7204.94');
+        expect(report.wouldDownload).toBe(false);
+        expect(report.selection).toEqual({
+            source: 'system',
+            executablePath: '/usr/bin/chromium',
+            browser: 'chrome',
+            buildId: 'system-installed',
+        });
+    });
+
+    test('launches with the production arguments and headless setting', async () => {
+        detectAvailableBrowser.mockResolvedValue({
+            executablePath: '/usr/bin/chromium',
+            source: 'system',
+            browser: 'chrome',
+            buildId: 'system-installed',
+        });
+
+        await browserCheck(options({ headless: 'false' }));
+
+        const [launchOptions] = launchMock.mock.calls[0];
+
+        // Resolving a path proves far less than starting the process, and starting it with
+        // different arguments than a real run proves less again.
+        expect(launchOptions.executablePath).toBe('/usr/bin/chromium');
+        expect(launchOptions.headless).toBe(false);
+        expect(launchOptions.args).toContain('--no-sandbox');
+        expect(launchOptions.args).toContain('--ignore-certificate-errors');
+    });
+
+    test('closes the browser even when the version query fails', async () => {
+        const browser = fakeBrowser({
+            version: jest.fn().mockRejectedValue(new Error('Session closed')),
+        });
+        launchMock.mockResolvedValue(browser);
+        detectAvailableBrowser.mockResolvedValue({
+            executablePath: '/usr/bin/chromium',
+            source: 'system',
+            browser: 'chrome',
+            buildId: 'system-installed',
+        });
+
+        const report = await browserCheck(options());
+
+        expect(browser.close).toHaveBeenCalledTimes(1);
+        expect(report.ok).toBe(false);
+        expect(report.launchError).toContain('Session closed');
+
+        // Issue #878, and the reason the launch is tracked in two phases: this browser started
+        // perfectly well. Reporting it as one that "could not be started" led with antivirus
+        // advice while the actual fix - a different build - sat underneath it.
+        expect(report.findings.map((finding) => finding.id)).toContain('BSI-BROWSER-020');
+        expect(report.findings.map((finding) => finding.id)).not.toContain('BSI-BROWSER-015');
+    });
+
+    test('a browser that never starts is reported as a start failure, not a driving failure', async () => {
+        launchMock.mockRejectedValue(new Error('Failed to launch the browser process!'));
+        detectAvailableBrowser.mockResolvedValue({
+            executablePath: '/usr/bin/chromium',
+            source: 'system',
+            browser: 'chrome',
+            buildId: 'system-installed',
+        });
+
+        const report = await browserCheck(options());
+
+        expect(report.ok).toBe(false);
+        expect(report.findings.map((finding) => finding.id)).toContain('BSI-BROWSER-015');
+        expect(report.findings.map((finding) => finding.id)).not.toContain('BSI-BROWSER-020');
+    });
+
+    test('an error carrying no message still says something', async () => {
+        // `err?.message ?? String(err)` kept an empty string, because '' is neither null nor
+        // undefined - producing "starting it failed: " and a launchError a JSON consumer reads as
+        // absent while ok is false.
+        launchMock.mockRejectedValue(new Error(''));
+        detectAvailableBrowser.mockResolvedValue({
+            executablePath: '/usr/bin/chromium',
+            source: 'system',
+            browser: 'chrome',
+            buildId: 'system-installed',
+        });
+
+        const report = await browserCheck(options());
+
+        expect(report.launchError).toBeTruthy();
+    });
+
+    test('--skip-launch resolves a browser without starting one', async () => {
+        detectAvailableBrowser.mockResolvedValue({
+            executablePath: '/usr/bin/chromium',
+            source: 'system',
+            browser: 'chrome',
+            buildId: 'system-installed',
+        });
+
+        const report = await browserCheck(options({ skipLaunch: true }));
+
+        expect(launchMock).not.toHaveBeenCalled();
+        expect(report.launched).toBe(false);
+        // Still a pass: a browser was found, and the administrator asked not to start it.
+        expect(report.ok).toBe(true);
+    });
+});
+
+describe('the four ways this command could wrongly report OK', () => {
+    // Every test here is a route by which `browser check` exited 0 on a machine where a real run
+    // fails. That is the one thing this command must never do: it is documented as a deployment
+    // gate, so a false pass is worse than no command at all.
+
+    test('a --browser-version a real run would reject fails the check', async () => {
+        // The catch-all in resolveBuildIdOffline used to treat any unrecognised value as a
+        // floating keyword - "accept the newest cached build, emit a warning" - and warnings do
+        // not fail the run. Meanwhile resolveBrowserVersion() throws for the same value, so the
+        // real thumbnail run died on the very misconfiguration the check was run to catch.
+        getBrowserInventory.mockResolvedValue([CACHED_BUILD]);
+        detectAvailableBrowser.mockResolvedValue({
+            executablePath: CACHED_BUILD.executablePath,
+            source: 'cache',
+            browser: 'chrome',
+            buildId: CACHED_BUILD.buildId,
+        });
+
+        const report = await browserCheck(options({ browserVersion: 'garbage' }));
+
+        expect(report.ok).toBe(false);
+        expect(report.findings.map((finding) => finding.id)).toContain('BSI-BROWSER-018');
+        expect(loggedText()).toContain('garbage');
+    });
+
+    test('a milestone pin fails, because a real run cannot resolve it offline', async () => {
+        // "151" is an explicit pin that browser install and browser uninstall both accept, so it
+        // was first reported as a warning alongside `stable`. That was still a false OK: a failed
+        // lookup only degrades to a cached build for keywords, and isVersionKeyword('151') is
+        // false - so an air-gapped run throws before it reaches the cache. Its own finding, and an
+        // error.
+        getBrowserInventory.mockResolvedValue([CACHED_BUILD]);
+        detectAvailableBrowser.mockResolvedValue({
+            executablePath: CACHED_BUILD.executablePath,
+            source: 'cache',
+            browser: 'chrome',
+            buildId: CACHED_BUILD.buildId,
+        });
+
+        const report = await browserCheck(options({ browserVersion: '151' }));
+
+        const pin = report.findings.find((finding) => finding.id === 'BSI-BROWSER-022');
+
+        expect(pin).toBeDefined();
+        expect(pin.severity).toBe('error');
+        expect(pin.detail).not.toContain('names whichever build is newest');
+        expect(pin.detail).toContain('151');
+        expect(report.ok).toBe(false);
+        // And it is not confused with the floating-keyword warning, which describes a different
+        // consequence and would send the reader somewhere else.
+        expect(report.findings.map((finding) => finding.id)).not.toContain('BSI-BROWSER-013');
+    });
+
+    test('a floating keyword is still only a warning, because a real run degrades', async () => {
+        getBrowserInventory.mockResolvedValue([CACHED_BUILD]);
+        detectAvailableBrowser.mockResolvedValue({
+            executablePath: CACHED_BUILD.executablePath,
+            source: 'cache',
+            browser: 'chrome',
+            buildId: CACHED_BUILD.buildId,
+        });
+
+        const report = await browserCheck(options({ browserVersion: 'stable' }));
+
+        expect(report.findings.find((finding) => finding.id === 'BSI-BROWSER-013').severity).toBe(
+            'warning'
+        );
+        expect(report.ok).toBe(true);
+    });
+
+    test('an unsupported browser is named as the problem, not the version', async () => {
+        // getRecommendedBuildId throws for a browser Butler Sheet Icons cannot drive, and the
+        // catch used to overwrite the version form with INVALID while leaving requestedVersion as
+        // 'recommended'. The report then said `--browser-version "recommended" is neither a
+        // keyword nor a build id` - false, and it sends the administrator to change the one
+        // setting that was correct.
+        detectAvailableBrowser.mockResolvedValue(null);
+
+        const report = await browserCheck(options({ browser: 'firefox' }));
+
+        expect(report.ok).toBe(false);
+
+        const ids = report.findings.map((finding) => finding.id);
+
+        expect(ids).toContain('BSI-BROWSER-023');
+        expect(ids).not.toContain('BSI-BROWSER-018');
+
+        const unsupported = report.findings.find((f) => f.id === 'BSI-BROWSER-023');
+
+        expect(unsupported.detail).toContain('firefox');
+        expect(unsupported.detail).not.toContain('neither a keyword nor a build id');
+    });
+
+    test('an unreadable browser cache is a finding, and the report still prints', async () => {
+        // The cache directory is read with no try/catch, so an EACCES or ENOTDIR killed the whole
+        // command: no Environment block, no cache location, not even the disclaimer. That is the
+        // LocalSystem case this command exists to diagnose - a cache staged by an administrator
+        // and read by a service account.
+        const denied = new Error("EACCES: permission denied, scandir '/cache/chrome'");
+        denied.code = 'EACCES';
+        getBrowserInventory.mockRejectedValue(denied);
+        detectAvailableBrowser.mockResolvedValue(null);
+
+        const report = await browserCheck(options());
+
+        expect(report.ok).toBe(false);
+        expect(report.findings.map((finding) => finding.id)).toContain('BSI-BROWSER-019');
+        // The facts that make the diagnosis, all of which used to be lost.
+        expect(loggedText()).toContain('Environment');
+        expect(loggedText()).toContain('Running as user');
+        expect(loggedText()).toContain(BEST_EFFORT_DISCLAIMER[0]);
+        expect(loggedText()).toContain('permission denied');
+    });
+
+    test('cached builds of another browser are not counted as usable', async () => {
+        // getBrowserInventory returns every browser in the cache directory, but detection filters
+        // by the requested type first. Reasoning over the unfiltered list made the check name
+        // chrome-headless-shell build ids in its remediation - a command that fails identically -
+        // while the cache check reported "Cached browsers match this machine".
+        getBrowserInventory.mockResolvedValue([
+            { ...CACHED_BUILD, browser: 'chrome-headless-shell' },
+        ]);
+        detectAvailableBrowser.mockResolvedValue(null);
+
+        const report = await browserCheck(options());
+
+        expect(report.ok).toBe(false);
+        expect(report.cachedBrowsers[0]).toEqual(
+            expect.objectContaining({
+                browser: 'chrome-headless-shell',
+                usable: false,
+                reason: expect.stringContaining('chrome'),
+            })
+        );
+        // The remediation must not offer a build detection will never look at.
+        const steps = report.findings.flatMap((finding) =>
+            finding.remediation.map((step) => `${step.text} ${step.command?.bash ?? ''}`)
+        );
+        expect(steps.join('\n')).not.toContain(CACHED_BUILD.buildId);
+    });
+
+    test('detection is given the normalised browser, so it filters by type', async () => {
+        // Every other consumer normalises with `options.browser ?? 'chrome'`; detection got the
+        // raw bag, and it drops its type filter entirely when `options.browser` is absent. With a
+        // cache holding only chrome-headless-shell, `browserCheck({})` selected a build the render
+        // path cannot drive and exited 0 - while the same report said the cache held no chrome.
+        getBrowserInventory.mockResolvedValue([
+            { ...CACHED_BUILD, browser: 'chrome-headless-shell' },
+        ]);
+        detectAvailableBrowser.mockResolvedValue(null);
+
+        await browserCheck({ browserCacheDir: path.join(os.tmpdir(), 'bsi-browser-check-test') });
+
+        expect(detectAvailableBrowser).toHaveBeenCalledWith(
+            expect.objectContaining({ browser: 'chrome' }),
+            expect.anything(),
+            expect.anything()
+        );
+    });
+
+    test('the browser cache is read once, so the report cannot contradict the verdict', async () => {
+        // gatherContext read the inventory and then detection read it again, independently. The
+        // report described snapshot 1 while the verdict came from snapshot 2, so a build removed
+        // between them (an antivirus quarantine, a concurrent uninstall) produced a report that
+        // listed a build as usable and simultaneously said it was missing.
+        getBrowserInventory.mockResolvedValue([CACHED_BUILD]);
+        detectAvailableBrowser.mockResolvedValue(null);
+
+        await browserCheck(options());
+
+        expect(getBrowserInventory).toHaveBeenCalledTimes(1);
+
+        // And the single snapshot is what detection was asked to reason about.
+        const [, , extra] = detectAvailableBrowser.mock.calls[0];
+        expect(extra.inventory).toHaveLength(1);
+        expect(extra.inventory[0].buildId).toBe(CACHED_BUILD.buildId);
+    });
+
+    test('nothing usable stays an error when no other check explained why', async () => {
+        // The selection check used to demote itself to info whenever the cache held any build,
+        // predicting that a cache check had already raised the error. That prediction held only
+        // while `usable` meant exactly `canRunHere && executableExists`, so a build unusable for
+        // any third reason left every check reporting OK and the command exiting 0 on a machine
+        // that cannot take a screenshot.
+        //
+        // An empty cache is the case that reaches BSI-BROWSER-011 with nothing to supersede it:
+        // the platform check reports an empty cache as information, so if 011 did not stand as an
+        // error, nothing in the report would be one.
+        //
+        // Asserting `ok === false` alone is not enough, and an earlier version of this test made
+        // exactly that mistake - it built a cache whose build was usable, took the
+        // BSI-BROWSER-017 branch instead, and still passed when 011 was mutated to `info`. The
+        // severity of the specific finding is what has to be pinned.
+        getBrowserInventory.mockResolvedValue([]);
+        detectAvailableBrowser.mockResolvedValue(null);
+
+        const report = await browserCheck(options());
+        const nothingUsable = report.findings.find((finding) => finding.id === 'BSI-BROWSER-011');
+
+        expect(nothingUsable).toBeDefined();
+        expect(nothingUsable.severity).toBe('error');
+        expect(nothingUsable.remediation.length).toBeGreaterThan(0);
+        expect(report.ok).toBe(false);
+
+        // And it is the only thing failing the run, so the assertion above cannot be satisfied by
+        // some unrelated error standing in for it.
+        expect(
+            report.findings.filter((finding) => finding.severity === 'error').map((f) => f.id)
+        ).toEqual(['BSI-BROWSER-011']);
+    });
+});
+
+describe('a machine that cannot', () => {
+    test('reports a download would be needed, without reaching the network', async () => {
+        detectAvailableBrowser.mockResolvedValue(null);
+
+        const report = await browserCheck(options());
+
+        expect(report.ok).toBe(false);
+        expect(report.wouldDownload).toBe(true);
+        expect(report.launched).toBe(false);
+
+        // The regression this guards: swapping detectAvailableBrowser() for
+        // resolveBrowserExecutablePath() would reach both of these.
+        expect(browserInstall).not.toHaveBeenCalled();
+        expect(canDownload).not.toHaveBeenCalled();
+        expect(launchMock).not.toHaveBeenCalled();
+    });
+
+    test('a --browser-executable-path that does not exist is a finding, not a crash', async () => {
+        const { BrowserNotFoundError } = await import('../../util/errors.js');
+
+        // Since #1061 detection throws for an explicitly named path that is missing, rather than
+        // returning null. Reporting that is arguably the most valuable thing this command does:
+        // it means somebody's explicit configuration is wrong.
+        detectAvailableBrowser.mockRejectedValue(
+            new BrowserNotFoundError(
+                '--browser-executable-path is set to "D:\\nope\\chrome.exe" but no such file exists on this machine.'
+            )
+        );
+
+        const report = await browserCheck(
+            options({ browserExecutablePath: 'D:\\nope\\chrome.exe' })
+        );
+
+        expect(report.ok).toBe(false);
+        expect(report.selection).toBeNull();
+        expect(report.executableOverride).toEqual(
+            expect.objectContaining({ exists: false, source: 'option' })
+        );
+        expect(report.findings.map((finding) => finding.id)).toContain('BSI-BROWSER-002');
+        expect(loggedText()).toContain('no such file exists on this machine');
+    });
+
+    test('lists a wrong-platform cached build as unusable, and says why', async () => {
+        getBrowserInventory.mockResolvedValue([
+            { ...CACHED_BUILD, platform: 'mac_arm', isCurrentPlatform: false, canRunHere: false },
+        ]);
+        detectAvailableBrowser.mockResolvedValue(null);
+
+        const report = await browserCheck(options());
+
+        expect(report.cachedBrowsers).toEqual([
+            expect.objectContaining({
+                browser: 'chrome',
+                buildId: '138.0.7204.94',
+                platform: 'mac_arm',
+                executableExists: true,
+                usable: false,
+                reason: expect.stringContaining('another platform'),
+            }),
+        ]);
+    });
+
+    test('lists a cached build whose binary is missing as unusable', async () => {
+        getBrowserInventory.mockResolvedValue([CACHED_BUILD]);
+        hasUsableExecutable.mockReturnValue(false);
+        detectAvailableBrowser.mockResolvedValue(null);
+
+        const report = await browserCheck(options());
+
+        expect(report.cachedBrowsers[0]).toEqual(
+            expect.objectContaining({
+                executableExists: false,
+                usable: false,
+                reason: expect.stringContaining('executable'),
+            })
+        );
+    });
+});
+
+describe('the best-effort disclaimer', () => {
+    // §15.7. It is not suppressible, it appears once, and it appears whatever the outcome - an
+    // administrator who only ever sees a healthy machine is exactly the one who needs to know the
+    // limits of what was checked.
+    test('is printed on the success path', async () => {
+        detectAvailableBrowser.mockResolvedValue({
+            executablePath: '/usr/bin/chromium',
+            source: 'system',
+            browser: 'chrome',
+            buildId: 'system-installed',
+        });
+
+        const report = await browserCheck(options());
+
+        expect(report.ok).toBe(true);
+        expect(loggedText()).toContain(BEST_EFFORT_DISCLAIMER[0]);
+    });
+
+    test('is printed on the failure path', async () => {
+        detectAvailableBrowser.mockResolvedValue(null);
+
+        const report = await browserCheck(options());
+
+        expect(report.ok).toBe(false);
+        expect(loggedText()).toContain(BEST_EFFORT_DISCLAIMER[0]);
+    });
+
+    test('is carried in the returned data as well as printed', async () => {
+        detectAvailableBrowser.mockResolvedValue(null);
+
+        const report = await browserCheck(options());
+
+        expect(report.disclaimer).toEqual(BEST_EFFORT_DISCLAIMER);
+    });
+
+    test('appears exactly once', async () => {
+        detectAvailableBrowser.mockResolvedValue(null);
+
+        await browserCheck(options());
+
+        const occurrences = loggedText()
+            .split('\n')
+            .filter((line) => line.includes(BEST_EFFORT_DISCLAIMER[0])).length;
+
+        expect(occurrences).toBe(1);
+    });
+});
+
+describe('the machine facts', () => {
+    test('are reported so the LocalSystem trap is a one-glance diagnosis', async () => {
+        detectAvailableBrowser.mockResolvedValue(null);
+
+        const report = await browserCheck(options());
+
+        expect(report.nodePlatform).toBe(process.platform);
+        expect(report.arch).toBe(process.arch);
+        expect(report.hostPlatform).toBe('win64');
+        expect(report.homeDir).toBe(os.homedir());
+        expect(report.cwd).toBe(process.cwd());
+        expect(report.isSea).toBe(false);
+        expect(typeof report.user).toBe('string');
+    });
+
+    test('name the cache directory that was actually searched', async () => {
+        detectAvailableBrowser.mockResolvedValue(null);
+
+        const cacheDir = path.join(os.tmpdir(), 'bsi-browser-check-test');
+        const report = await browserCheck(options({ browserCacheDir: cacheDir }));
+
+        // Compared through path.resolve on both sides: a POSIX literal would pass on macOS and
+        // Linux and fail only on the Windows runner.
+        expect(report.cacheDir).toBe(path.resolve(cacheDir));
+        expect(report.cacheDirSource).toBe('option');
+    });
+
+    test('say that the cache is not consulted when an executable is named', async () => {
+        detectAvailableBrowser.mockResolvedValue({
+            executablePath: process.execPath,
+            source: 'system',
+            browser: 'chrome',
+            buildId: 'system-installed',
+        });
+
+        const report = await browserCheck(options({ browserExecutablePath: process.execPath }));
+
+        // Without this line administrators file bugs about a cache directory that "does nothing".
+        expect(report.cacheDirUsed).toBe(false);
+        expect(loggedText()).toContain('an executable path is configured');
+    });
+});

--- a/src/lib/browser/browser-check.js
+++ b/src/lib/browser/browser-check.js
@@ -1,0 +1,500 @@
+import fs from 'node:fs';
+import puppeteer from 'puppeteer-core';
+import { detectBrowserPlatform } from '@puppeteer/browsers';
+
+import { logger, setLoggingLevel } from '../../globals.js';
+import { redactOptions } from '../util/redact-secrets.js';
+import {
+    describeBrowserCacheDir,
+    resolveExecutablePathOverride,
+    SOURCE_LABELS,
+    EXECUTABLE_SOURCE_LABELS,
+} from './browser-paths.js';
+import { getBrowserInventory, hasUsableExecutable } from './browser-inventory.js';
+import { detectAvailableBrowser } from './browser-detect.js';
+import {
+    BROWSER_LAUNCH_TIMEOUT_MS,
+    BROWSER_PROTOCOL_TIMEOUT_MS,
+    buildBrowserArgs,
+} from './browser-launch.js';
+import {
+    classifyBrowserVersion,
+    getRecommendedBuildId,
+    VERSION_FORM,
+    VERSION_RECOMMENDED,
+} from './browser-version.js';
+import { parseHeadlessOption } from '../util/headless-option.js';
+import { buildBaseContext } from '../doctor/context.js';
+import { checksForAreas } from '../doctor/checks/index.js';
+import { runChecks, allFindings } from '../doctor/run-checks.js';
+import { renderReport, BEST_EFFORT_DISCLAIMER } from '../doctor/render-report.js';
+
+/**
+ * `browser check` - can this machine take screenshots?
+ *
+ * Answers that without touching Qlik Sense, so it is safe to hand to a customer as the first
+ * troubleshooting step and safe to script into a deployment check.
+ *
+ * Two constraints shape everything here, and neither is negotiable.
+ *
+ * **It must not touch the network.** `detectAvailableBrowser()` is called directly, never
+ * `resolveBrowserExecutablePath()` - the latter falls through to `browserInstall()` and
+ * `canDownload()`, which makes a network request. A doctor that hangs on a DNS timeout on an
+ * air-gapped server is worse than no doctor at all. The same rule is why the requested version is
+ * resolved locally or not at all: `stable` and the release channels need the vendor's version
+ * service, and this command will not call it.
+ *
+ * **It does launch the browser.** Resolving a path proves far less than starting the process, so
+ * unless `--skip-launch` is given the selected browser is started with the production arguments
+ * and asked for its version. No page is opened, nothing is navigated to, and Qlik Sense is never
+ * contacted.
+ *
+ * The facts are gathered here; the reasoning lives in the checks under `src/lib/doctor/checks/`
+ * and the formatting in the shared renderer. That split is what makes the next diagnostic one new
+ * file and one registry line rather than a rewrite of a command people already depend on.
+ */
+
+/**
+ * The areas of the check registry this command runs.
+ *
+ * Exported so `checks.test.js` can assert that every registered check is actually selected by it,
+ * rather than restating the list and proving only that two copies agree. A check whose `area` does
+ * not match one of these vanishes from the report with no warning at all.
+ */
+export const BROWSER_CHECK_AREAS = Object.freeze(['environment', 'browser']);
+
+/**
+ * Interprets `--browser-version` without making a single network request.
+ *
+ * The form is classified by `classifyBrowserVersion`, which is the same function
+ * `assertExplicitVersionIsWellFormed` uses on the real run's path - so this command cannot accept
+ * a value a real run rejects, which it used to: an unrecognised value was treated as a floating
+ * keyword, `browser check` exited 0, and the thumbnail run then died with
+ * "Invalid --browser-version".
+ *
+ * Only two forms can be turned into a build id offline: `recommended`, which resolves from a
+ * constant compiled into puppeteer-core, and a full build id, which needs no resolution at all.
+ * The rest return no build id, which tells detection to accept the newest suitable cached build,
+ * and carry their form so the report can say *why* the pin was not checked rather than implying it
+ * was honoured.
+ *
+ * @param {object} options - Options bag carrying `browser` and `browserVersion`.
+ *
+ * @returns {{buildId: string|undefined, versionForm: string, requestedVersion: string, requested: string}}
+ * What to match against the cache, the form the version takes, the version as the user gave it,
+ * and how to describe the whole request.
+ */
+const resolveBuildIdOffline = (options) => {
+    const browser = options.browser ?? 'chrome';
+    // `||` rather than `??`: an empty string means "unset" here, exactly as
+    // `parseBrowserVersionValue` treats it, so a bare `BSI_BROWSER_C_BROWSER_VERSION=` line in a
+    // unit file lands on the default instead of being classified as invalid.
+    const version = options.browserVersion || VERSION_RECOMMENDED;
+    const versionForm = classifyBrowserVersion(version);
+    const base = { versionForm, requestedVersion: version };
+
+    if (versionForm === VERSION_FORM.RECOMMENDED) {
+        try {
+            const buildId = getRecommendedBuildId(browser);
+
+            return { ...base, buildId, requested: `${browser} ${version} (build ${buildId})` };
+        } catch (err) {
+            // Only reachable for a browser Butler Sheet Icons does not support, which Commander's
+            // `.choices()` already refuses - so this covers a worker called directly.
+            //
+            // Reported as an unsupported *browser*, not as a malformed version. Overwriting the
+            // version form with INVALID here made the report say `--browser-version "recommended"
+            // is neither a keyword nor a build id` - false, and it sent the administrator to
+            // change the one setting that was correct.
+            logger.debug(`Could not resolve the recommended build: ${err?.message ?? err}`);
+
+            return {
+                ...base,
+                buildId: undefined,
+                browserError: err instanceof Error ? err.message : String(err),
+                requested: `${browser} ${version}`,
+            };
+        }
+    }
+
+    if (versionForm === VERSION_FORM.BUILD_ID) {
+        return { ...base, buildId: version, requested: `${browser} ${version}` };
+    }
+
+    return { ...base, buildId: undefined, requested: `${browser} ${version}` };
+};
+
+/**
+ * Why a cached build cannot be used, or `undefined` when it can.
+ *
+ * The order matters. Browser type first, because detection filters on it before anything else, so
+ * a `chrome-headless-shell` build is invisible to a `chrome` run however runnable it looks - and
+ * reporting it as usable made the report offer build ids in remediation commands that fail
+ * identically. Platform next, because a build made for another operating system is unusable
+ * whether or not its binary is present.
+ *
+ * This function is the sole definition of "usable" that the checks reason about, and the checks
+ * must stay able to explain every reason it can return: an unusable build whose reason no check
+ * reports would otherwise leave the run with no error. `browser-selection.js` names the findings
+ * that cover these reasons in its `supersededBy`, and the runner demotes it only when one of them
+ * actually fired - so a new reason added here fails safe rather than silently passing.
+ *
+ * @param {object} build - An inventory entry, with `executableExists` already computed.
+ * @param {string} requestedBrowser - The browser type a real run would look for.
+ *
+ * @returns {string|undefined} The reason, in the words the report prints.
+ */
+const unusableReason = (build, requestedBrowser) => {
+    if (requestedBrowser && build.browser !== requestedBrowser) {
+        return `a ${build.browser} build, not the ${requestedBrowser} build this run needs`;
+    }
+
+    if (!build.canRunHere) {
+        return 'built for another platform';
+    }
+
+    if (!build.executableExists) {
+        return 'executable not found on disk';
+    }
+
+    return undefined;
+};
+
+/**
+ * Starts the selected browser and asks it for its version.
+ *
+ * The production `buildBrowserArgs()` and `parseHeadlessOption()`, and the production timeouts, so
+ * that a pass here means the same thing a real run means. `--headless` earns its place for the
+ * same reason: a headed launch on a display-less server is a genuinely different test.
+ *
+ * The browser is closed in a `finally`. An unclosed browser holds hundreds of megabytes and, in
+ * the test suite, hangs the run.
+ *
+ * Two phases, reported separately. `started` says the process came up; `ok` says it also answered.
+ * A build that starts and then dies on the first command is issue #878, and its remedy - a
+ * different build - has nothing to do with the remedy for a process that never started. Folding
+ * them into one flag produced a finding that told an administrator their browser "could not be
+ * started" about a browser that had started perfectly well.
+ *
+ * `elapsedMs` is measured for the same reason `launchBrowserForApp` measures it: `timeout` bounds
+ * the wait for the debugging endpoint, not the process creation before it, and on Windows that
+ * creation blocks the event loop. A launch that succeeds slowly is invisible to every timeout
+ * there is, so the duration has to be carried out of here for a check to judge.
+ *
+ * `performance.now()` rather than `Date.now()`: this measures a duration on machines - virtualised
+ * Sense servers - where an NTP step correction mid-launch is routine, and a wall clock that jumps
+ * would invent a stall or hide one behind a negative elapsed time.
+ *
+ * @param {object} options - Options bag; `headless` is read from it.
+ * @param {string} executablePath - The browser to start.
+ *
+ * @returns {Promise<{attempted: boolean, started: boolean, ok: boolean, version: string|null, error: string|null, skipped: boolean, elapsedMs: number}>}
+ * What happened.
+ */
+const tryLaunch = async (options, executablePath) => {
+    const result = {
+        attempted: true,
+        started: false,
+        ok: false,
+        version: null,
+        error: null,
+        skipped: false,
+        elapsedMs: 0,
+    };
+    const headless = parseHeadlessOption(options.headless);
+    const args = await buildBrowserArgs();
+
+    logger.verbose(`Starting ${executablePath} to check that it runs on this machine`);
+
+    let browser;
+    const startedAt = performance.now();
+
+    try {
+        browser = await puppeteer.launch({
+            timeout: BROWSER_LAUNCH_TIMEOUT_MS,
+            protocolTimeout: BROWSER_PROTOCOL_TIMEOUT_MS,
+            acceptInsecureCerts: true,
+            executablePath,
+            headless,
+            args,
+        });
+
+        // Recorded between the two calls, which is the whole point of the split: everything after
+        // this line is the browser refusing to be driven rather than refusing to start.
+        result.started = true;
+        result.elapsedMs = performance.now() - startedAt;
+
+        // The cheapest possible round trip to the browser, and exactly the `Browser.getVersion`
+        // call seen failing in issue #878: a build Puppeteer cannot drive launches perfectly well
+        // and then dies on the first command sent to it.
+        result.version = await browser.version();
+        result.ok = true;
+    } catch (err) {
+        // `||`, not `??`: an Error carrying an empty message is not `null`, so `??` kept it and
+        // produced a finding that named nothing at all.
+        result.error = (err instanceof Error ? err.message : String(err)) || String(err);
+
+        if (!result.started) {
+            result.elapsedMs = performance.now() - startedAt;
+        }
+    } finally {
+        if (browser) {
+            try {
+                await browser.close();
+            } catch (err) {
+                logger.debug(`Could not close the browser after the check: ${err?.message ?? err}`);
+            }
+        }
+    }
+
+    return result;
+};
+
+/**
+ * Reads the browser cache, turning a failure into a fact rather than an exception.
+ *
+ * This guard is the difference between a diagnosis and nothing at all. `getInstalledBrowsers()`
+ * runs `readdirSync` on each browser subdirectory, so a cache that is unreadable (EACCES on a
+ * directory staged by another account) or malformed (ENOTDIR where a file sits in place of a
+ * browser folder) throws. Unguarded, that rejected out of `gatherContext` and the command printed
+ * one error line and exited - no Environment block, no cache location, not even the best-effort
+ * disclaimer.
+ *
+ * An unreadable cache staged by an administrator and read by a service account is precisely the
+ * LocalSystem trap this command exists to expose, so it has to be reported *by* the report.
+ * `detectAvailableBrowser` already degrades the same failure to "download one" (browser-detect.js),
+ * which is why the run continues to a selection verdict rather than stopping here.
+ *
+ * @param {string} cacheDir - Cache directory to read.
+ * @param {string} requestedBrowser - Browser type a real run would look for.
+ *
+ * @returns {Promise<{inventory: object[], builds: object[], readError: string|undefined}>} The
+ * inventory exactly as read (handed to detection so it reasons about this same snapshot), the same
+ * builds annotated for the report, or empty lists and the reason they could not be read.
+ */
+const readCache = async (cacheDir, requestedBrowser) => {
+    try {
+        const inventory = await getBrowserInventory({ cacheDir });
+
+        return {
+            inventory,
+            builds: inventory.map((build) => {
+                const withExistence = { ...build, executableExists: hasUsableExecutable(build) };
+                const reason = unusableReason(withExistence, requestedBrowser);
+
+                return { ...withExistence, usable: !reason, reason };
+            }),
+            readError: undefined,
+        };
+    } catch (err) {
+        const readError = err instanceof Error ? err.message : String(err);
+
+        logger.debug(`Could not read the browser cache at ${cacheDir}: ${readError}`);
+
+        // An empty inventory rather than none: detection is handed this snapshot too, and it must
+        // see the same "nothing here" the report describes rather than going and reading again.
+        return { inventory: [], builds: [], readError };
+    }
+};
+
+/**
+ * Gathers every fact the browser checks reason about.
+ *
+ * All of the input/output lives here, so each check stays a pure function of what this produced -
+ * which is what makes them testable against a fabricated context, with no filesystem and no
+ * browser.
+ *
+ * @param {object} options - Resolved CLI options.
+ *
+ * @returns {Promise<object>} The check context.
+ */
+const gatherContext = async (options) => {
+    const hostPlatform = detectBrowserPlatform();
+
+    // The pure describer rather than `resolveBrowserCacheDir()`: this command prints where the
+    // cache is as part of its report, and the resolver's own announcement would say the same
+    // thing twice in different words.
+    const described = describeBrowserCacheDir(options);
+    const rawOverride = resolveExecutablePathOverride(options);
+    const override = rawOverride
+        ? {
+              ...rawOverride,
+              sourceLabel: EXECUTABLE_SOURCE_LABELS[rawOverride.source],
+              exists: fs.existsSync(rawOverride.path),
+          }
+        : null;
+
+    // Whether the cache is consulted at all, following `detectAvailableBrowser` exactly. Two ways
+    // it is not, and they are different enough to be worth telling apart in the report:
+    //
+    // - a named executable that is present wins outright, and detection returns it;
+    // - a named executable that is *explicitly* configured and missing stops detection, so the
+    //   cache is never reached either.
+    //
+    // A stale PUPPETEER_EXECUTABLE_PATH is the third case and does fall through, which is why
+    // `explicit` is tested rather than just "an override exists". None of this is decoration:
+    // without it the report says the cache is in use when nothing will read it, and an
+    // administrator goes and re-stages a browser that was never the problem.
+    const notConsultedReason = (() => {
+        if (override?.exists) {
+            return 'an executable path is configured, so the cache is not consulted';
+        }
+
+        if (override?.explicit) {
+            return 'an executable path is configured but missing, so detection stops before the cache';
+        }
+
+        return undefined;
+    })();
+    const cacheInUse = !notConsultedReason;
+
+    // Normalised once, here, and used for every subsequent decision. `detectAvailableBrowser` was
+    // the one consumer still handed the raw bag, and it drops its browser-type filter entirely
+    // when `options.browser` is absent - so `browserCheck({})` selected a chrome-headless-shell
+    // build the render path cannot drive, while the same report said the cache held no chrome.
+    const requestedBrowser = options.browser ?? 'chrome';
+    const resolvedOptions = { ...options, browser: requestedBrowser };
+
+    const { inventory, builds, readError } = await readCache(described.cacheDir, requestedBrowser);
+
+    const { buildId, versionForm, requestedVersion, requested, browserError } =
+        resolveBuildIdOffline(resolvedOptions);
+
+    let selection = null;
+    let detectionError = null;
+
+    try {
+        // The reading taken above, rather than letting detection take its own. One snapshot means
+        // the cache this report describes is the cache this verdict came from.
+        selection = await detectAvailableBrowser(resolvedOptions, buildId, {
+            cacheDir: described.cacheDir,
+            inventory,
+        });
+    } catch (err) {
+        // Since #1061 detection throws when an explicitly named executable path does not exist,
+        // rather than returning null. That is a finding, not a crash: it is arguably the most
+        // valuable thing this command can catch, because it means somebody's explicit
+        // configuration is wrong.
+        detectionError = err;
+    }
+
+    const launch =
+        selection && !options.skipLaunch
+            ? await tryLaunch(options, selection.executablePath)
+            : {
+                  attempted: false,
+                  started: false,
+                  ok: false,
+                  version: null,
+                  error: null,
+                  skipped: Boolean(selection && options.skipLaunch),
+                  elapsedMs: 0,
+              };
+
+    return {
+        ...buildBaseContext(options, { hostPlatform }),
+        cache: {
+            dir: described.cacheDir,
+            source: described.source,
+            sourceLabel: SOURCE_LABELS[described.source],
+            exists: fs.existsSync(described.cacheDir),
+            inUse: cacheInUse,
+            notConsultedReason,
+            legacyInUse: described.source === 'legacy',
+            builds,
+            readError,
+        },
+        executableOverride: override,
+        detection: {
+            selection,
+            error: detectionError,
+            wouldDownload: !selection && !detectionError,
+            requested,
+            requestedVersion,
+            versionForm,
+            browserError,
+            resolvedBuildId: buildId,
+        },
+        launch,
+    };
+};
+
+/**
+ * Runs the browser diagnostic and reports on it.
+ *
+ * Returns structured data as well as printing a report, so tests assert on values rather than on
+ * log strings, and so a future `--output json` has something to serialise.
+ *
+ * @param {object} [options] - Options bag as Commander produces it.
+ * @param {string} [options.browser] - Browser to check for. `chrome` is the only supported value.
+ * @param {string} [options.browserVersion] - Build to look for. Resolved locally or not at all.
+ * @param {string} [options.browserCacheDir] - Cache directory to search.
+ * @param {string} [options.browserExecutablePath] - A browser executable to use instead.
+ * @param {boolean|string} [options.headless] - Whether to start the browser headless.
+ * @param {boolean} [options.skipLaunch] - Find a browser but do not start it.
+ * @param {string} [options.loglevel] - Log level.
+ *
+ * @returns {Promise<object>} The report. `ok` is `false` when a real run would fail on this
+ * machine; every command handler turns that into the process exit code, and nothing here touches
+ * process state.
+ */
+export const browserCheck = async (options = {}) => {
+    setLoggingLevel(options.loglevel);
+
+    logger.verbose('Starting browser check');
+    logger.debug(`Options: ${JSON.stringify(redactOptions(options), null, 2)}`);
+
+    const ctx = await gatherContext(options);
+    const results = await runChecks(checksForAreas(BROWSER_CHECK_AREAS), ctx);
+    const findings = allFindings(results);
+
+    const ok = renderReport({
+        heading: 'Butler Sheet Icons browser check',
+        results,
+        // Qualified when the browser was never started, because "can take screenshots" is a
+        // stronger claim than a skipped launch supports.
+        okMessage: ctx.launch.skipped
+            ? 'a browser was found on this machine. It was not started, so whether it runs here is untested.'
+            : 'Butler Sheet Icons can take screenshots on this machine without internet access.',
+    });
+
+    return {
+        ok,
+        hostPlatform: ctx.host.hostPlatform,
+        nodePlatform: ctx.host.nodePlatform,
+        arch: ctx.host.arch,
+        user: ctx.host.user,
+        homeDir: ctx.host.homeDir,
+        cwd: ctx.host.cwd,
+        isSea: ctx.host.isSea,
+        executableOverride: ctx.executableOverride
+            ? {
+                  path: ctx.executableOverride.path,
+                  source: ctx.executableOverride.source,
+                  exists: ctx.executableOverride.exists,
+              }
+            : null,
+        cacheDir: ctx.cache.dir,
+        cacheDirSource: ctx.cache.source,
+        cacheDirExists: ctx.cache.exists,
+        cacheDirUsed: ctx.cache.inUse,
+        legacyCacheDirInUse: ctx.cache.legacyInUse,
+        cachedBrowsers: ctx.cache.builds.map((build) => ({
+            browser: build.browser,
+            buildId: build.buildId,
+            platform: build.platform,
+            executablePath: build.executablePath,
+            executableExists: build.executableExists,
+            usable: build.usable,
+            reason: build.reason,
+        })),
+        selection: ctx.detection.selection,
+        wouldDownload: ctx.detection.wouldDownload,
+        launched: ctx.launch.ok,
+        browserVersion: ctx.launch.version,
+        launchError: ctx.launch.error,
+        findings,
+        results,
+        disclaimer: BEST_EFFORT_DISCLAIMER,
+    };
+};

--- a/src/lib/browser/browser-detect.js
+++ b/src/lib/browser/browser-detect.js
@@ -166,11 +166,19 @@ const reportEmptyFunnel = ({
  * @param {string} [resolvedBuildId] - Concrete build id from `resolveBrowserVersion`. When omitted,
  * any cached build of the requested type is acceptable and the newest is chosen - the fallback used
  * when a machine is offline and the requested keyword could not be resolved.
+ * @param {object} [snapshot] - A cache reading the caller has already taken.
+ * @param {string} [snapshot.cacheDir] - The directory that reading came from.
+ * @param {Array<object>} [snapshot.inventory] - The builds found there, from `getBrowserInventory`.
+ * Supplying both makes detection reason about the caller's snapshot instead of taking its own.
+ * `browser check` needs that: it prints the cache contents *and* reports what detection chose, and
+ * with two independent readings a build removed between them produced a report that listed a build
+ * as usable and, four lines later, said it was missing. It also halves the filesystem work, which
+ * on a Windows server means half as many opens for on-access antivirus to scan.
  *
  * @returns {Promise<object|null>} Browser info object, or `null` if no browser was found.
  * Returns an object with `executablePath`, `source` (`'system'` or `'cache'`), `browser`, and `buildId`.
  */
-export const detectAvailableBrowser = async (options, resolvedBuildId) => {
+export const detectAvailableBrowser = async (options, resolvedBuildId, snapshot = {}) => {
     try {
         // Priority 1: a browser the administrator named, by option or environment variable.
         const override = resolveExecutablePathOverride(options);
@@ -232,13 +240,21 @@ export const detectAvailableBrowser = async (options, resolvedBuildId) => {
             );
         }
 
-        // Priority 2: Check for cached browsers in the browser cache directory
-        const browserPath = resolveBrowserCacheDir(options);
+        // Priority 2: Check for cached browsers in the browser cache directory.
+        //
+        // A caller's snapshot wins when it supplies one, so that what it reported and what this
+        // decided cannot disagree. Both fields are required together: a directory without its
+        // reading, or a reading without the directory it came from, would put a path in the log
+        // that does not describe the builds being judged.
+        const reuseSnapshot = Boolean(snapshot.inventory && snapshot.cacheDir);
+        const browserPath = reuseSnapshot ? snapshot.cacheDir : resolveBrowserCacheDir(options);
 
         // The shared inventory rather than getInstalledBrowsers() directly: it already answers
         // "can this machine run that build" as `canRunHere`, and a second copy of that rule here
         // would drift from the one `browser list-installed` and `browser uninstall` report.
-        const installedBrowsers = await getBrowserInventory({ cacheDir: browserPath });
+        const installedBrowsers = reuseSnapshot
+            ? snapshot.inventory
+            : await getBrowserInventory({ cacheDir: browserPath });
 
         if (installedBrowsers && installedBrowsers.length > 0) {
             logger.info(`Found ${installedBrowsers.length} cached browser(s)`);

--- a/src/lib/browser/browser-version.js
+++ b/src/lib/browser/browser-version.js
@@ -100,6 +100,63 @@ export const isVersionKeyword = (browserVersion) =>
 const EXPLICIT_VERSION_PATTERNS = [/^\d+$/, /^\d+\.\d+\.\d+$/, /^\d+\.\d+\.\d+\.\d+$/];
 
 /**
+ * What a `--browser-version` value is, and - the part callers actually need - whether it can be
+ * turned into a build id without asking the vendor.
+ *
+ * This exists because `browser check` must answer "which build would a real run use?" **without
+ * touching the network**, and the honest answer differs per form. Before it existed, that command
+ * carried its own copy of the build-id regex and treated everything else as a floating keyword,
+ * so `--browser-version garbage` passed the check and killed the real run, and `--browser-version
+ * 151` - an explicit pin - was described to the user as a value that floats.
+ *
+ * One classifier rather than a predicate per form, so the doctor and the resolver cannot hold
+ * different opinions about the same string. {@link assertExplicitVersionIsWellFormed} is built on
+ * it too.
+ */
+export const VERSION_FORM = Object.freeze({
+    /** `recommended`. Resolves from a constant compiled into puppeteer-core; no lookup. */
+    RECOMMENDED: 'recommended',
+    /** A full build id such as `151.0.7922.77`. Names exactly one build; no lookup. */
+    BUILD_ID: 'build-id',
+    /** A milestone (`151`) or build prefix (`151.0.7922`). An explicit pin, but resolving it to a build needs the vendor's version service. */
+    PARTIAL: 'partial',
+    /** `stable`, the `latest` alias, or a release channel. Whatever is newest at the time it runs. */
+    FLOATING: 'floating',
+    /** Not a form Butler Sheet Icons accepts at all. */
+    INVALID: 'invalid',
+});
+
+/**
+ * Classifies a `--browser-version` value. Pure: no logging, no network, no throwing.
+ *
+ * @param {string} browserVersion - Raw value from the command line or environment.
+ *
+ * @returns {string} One of {@link VERSION_FORM}.
+ */
+export const classifyBrowserVersion = (browserVersion) => {
+    if (browserVersion === VERSION_RECOMMENDED) {
+        return VERSION_FORM.RECOMMENDED;
+    }
+
+    if (isVersionKeyword(browserVersion)) {
+        return VERSION_FORM.FLOATING;
+    }
+
+    if (typeof browserVersion !== 'string') {
+        return VERSION_FORM.INVALID;
+    }
+
+    // Checked before the partial forms so a full build id is never reported as needing a lookup.
+    if (/^\d+\.\d+\.\d+\.\d+$/.test(browserVersion)) {
+        return VERSION_FORM.BUILD_ID;
+    }
+
+    return EXPLICIT_VERSION_PATTERNS.some((pattern) => pattern.test(browserVersion))
+        ? VERSION_FORM.PARTIAL
+        : VERSION_FORM.INVALID;
+};
+
+/**
  * Browsers Butler Sheet Icons knows how to resolve a version for.
  *
  * Chrome, and only Chrome: the render path speaks the Chrome DevTools Protocol and passes a
@@ -242,7 +299,8 @@ const normalizeVersionKeyword = (browserVersion) => {
  * @throws {Error} If the value is neither a keyword nor a plausible build id.
  */
 const assertExplicitVersionIsWellFormed = (browser, browserVersion) => {
-    if (EXPLICIT_VERSION_PATTERNS.some((pattern) => pattern.test(browserVersion))) {
+    // Through the shared classifier, so `browser check` cannot accept a value this rejects.
+    if (classifyBrowserVersion(browserVersion) !== VERSION_FORM.INVALID) {
         return;
     }
 

--- a/src/lib/commands/__tests__/commands.test.js
+++ b/src/lib/commands/__tests__/commands.test.js
@@ -77,6 +77,10 @@ const mockBrowserListAvailablePromise = jest.unstable_mockModule(
     })
 );
 
+const mockBrowserCheckPromise = jest.unstable_mockModule('../../browser/browser-check.js', () => ({
+    browserCheck: jest.fn().mockResolvedValue({ ok: true, findings: [] }),
+}));
+
 let logger;
 let qseowCreateThumbnails;
 let qscloudCreateThumbnails;
@@ -87,6 +91,7 @@ let browserInstall;
 let browserUninstall;
 let browserUninstallAll;
 let browserListAvailable;
+let browserCheck;
 let parsePositiveInteger;
 let collectPositiveIntegers;
 let collectAppIds;
@@ -105,6 +110,8 @@ let handleBrowserListAvailable;
 let buildBrowserInstallCommand;
 let buildBrowserUninstallCommand;
 let buildBrowserListAvailableCommand;
+let handleBrowserCheck;
+let buildBrowserCheckCommand;
 
 beforeAll(async () => {
     await Promise.all([
@@ -117,6 +124,7 @@ beforeAll(async () => {
         mockBrowserInstallPromise,
         mockBrowserUninstallPromise,
         mockBrowserListAvailablePromise,
+        mockBrowserCheckPromise,
     ]);
     ({ logger } = await import('../../../globals.js'));
     ({ qseowCreateThumbnails } = await import('../../qseow/qseow-create-thumbnails.js'));
@@ -143,6 +151,8 @@ beforeAll(async () => {
     ({ handleBrowserInstall, buildBrowserInstallCommand } = await import('../browser/install.js'));
     ({ handleBrowserListAvailable, buildBrowserListAvailableCommand } =
         await import('../browser/list-available.js'));
+    ({ browserCheck } = await import('../../browser/browser-check.js'));
+    ({ handleBrowserCheck, buildBrowserCheckCommand } = await import('../browser/check.js'));
 });
 
 describe('parsePositiveInteger', () => {
@@ -376,6 +386,7 @@ describe('--browser-cache-dir (issue #1024)', () => {
         ['browser list-installed', () => browserCommand('list-installed')],
         ['browser uninstall', () => buildBrowserUninstallCommand()],
         ['browser uninstall-all', () => browserCommand('uninstall-all')],
+        ['browser check', () => browserCommand('check')],
         ['qseow create-sheet-thumbnails', () => thumbnailCommand(buildQseowCommand())],
         ['qscloud create-sheet-thumbnails', () => thumbnailCommand(buildQscloudCommand())],
     ];
@@ -907,6 +918,7 @@ describe('browser commands', () => {
                 'uninstall-all',
                 'install',
                 'list-available',
+                'check',
             ])
         );
     });
@@ -951,6 +963,189 @@ describe('browser commands', () => {
         expect(errors).toContain('Could not list available browsers.');
         expect(errors.join('\n')).not.toContain('BROWSER MAIN 10');
         expect(errors.join('\n')).not.toContain('at ');
+    });
+
+    describe('check', () => {
+        test('delegates to browserCheck', async () => {
+            const options = { browser: 'chrome', browserVersion: 'recommended' };
+
+            await handleBrowserCheck(options, {});
+
+            expect(browserCheck).toHaveBeenCalledWith(options);
+        });
+
+        // §7.4. `browser check` is meant to be a gate in a deployment script on the Sense server,
+        // so the outcome has to reach the shell. `process.exitCode`, never `process.exit()`: the
+        // latter would cut winston off mid-flush and lose the report that explains the exit code.
+        test('a healthy machine leaves the exit code alone', async () => {
+            browserCheck.mockResolvedValueOnce({ ok: true, findings: [] });
+
+            await handleBrowserCheck({}, {});
+
+            expect(process.exitCode).toBeUndefined();
+        });
+
+        test('a failing check exits 1', async () => {
+            browserCheck.mockResolvedValueOnce({ ok: false, findings: [] });
+
+            await handleBrowserCheck({}, {});
+
+            expect(process.exitCode).toBe(1);
+        });
+
+        test('a thrown check exits 1 rather than reporting success', async () => {
+            browserCheck.mockRejectedValueOnce(new Error('bad'));
+
+            await handleBrowserCheck({}, {});
+
+            expect(process.exitCode).toBe(1);
+        });
+
+        test('carries the options a real run would use', () => {
+            // A doctor that reports OK under different settings than the real run is worse than
+            // no doctor. Every option here changes which browser a thumbnail run would pick, or
+            // how it would be started.
+            const declared = buildBrowserCheckCommand().options.map((opt) => opt.long);
+
+            expect(declared).toEqual(
+                expect.arrayContaining([
+                    '--browser',
+                    '--browser-version',
+                    '--browser-cache-dir',
+                    '--browser-executable-path',
+                    '--headless',
+                    '--skip-launch',
+                ])
+            );
+        });
+
+        test('--skip-launch is stored under skipLaunch and defaults to false', () => {
+            const option = buildBrowserCheckCommand().options.find(
+                (opt) => opt.long === '--skip-launch'
+            );
+
+            expect(option.attributeName()).toBe('skipLaunch');
+            expect(option.defaultValue).toBe(false);
+        });
+
+        test('bare --skip-launch still turns it on', () => {
+            const opts = parseOptionInIsolation(buildBrowserCheckCommand(), '--skip-launch', []);
+
+            expect(opts.skipLaunch).toBe(true);
+        });
+
+        // The trap this closes: as a no-argument flag, Commander set skipLaunch on the mere
+        // PRESENCE of the environment variable and never read its value, so
+        // BSI_BROWSER_C_SKIP_LAUNCH=false turned skip-launch ON. The deployment gate then exited 0
+        // having never started a browser - the most valuable part of the check - and the generated
+        // doc table, which lists the variable with default `false`, invites exactly that line.
+        test.each([
+            ['false', false],
+            ['FALSE', false],
+            ['0', false],
+            ['no', false],
+            ['', false],
+            ['true', true],
+            ['1', true],
+            ['yes', true],
+        ])('BSI_BROWSER_C_SKIP_LAUNCH=%s parses to %s', (value, expected) => {
+            const saved = process.env.BSI_BROWSER_C_SKIP_LAUNCH;
+            process.env.BSI_BROWSER_C_SKIP_LAUNCH = value;
+
+            try {
+                const command = buildBrowserCheckCommand();
+                command.exitOverride();
+                command.parse([], { from: 'user' });
+
+                expect(command.opts().skipLaunch).toBe(expected);
+            } finally {
+                if (saved === undefined) {
+                    delete process.env.BSI_BROWSER_C_SKIP_LAUNCH;
+                } else {
+                    process.env.BSI_BROWSER_C_SKIP_LAUNCH = saved;
+                }
+            }
+        });
+
+        // A stray word after the flag used to be swallowed as its value and quietly parsed to
+        // false, so `browser check --skip-launch oops` ran the full check with the flag the
+        // operator typed silently discarded - and no diagnostic. As a bare flag Commander's arity
+        // check caught that; making the argument optional removed it, so the parser has to.
+        test.each(['oops', 'maybe', 'yes-please'])(
+            '--skip-launch %s is refused rather than silently ignored',
+            (value) => {
+                // Commander converts an argParser's InvalidArgumentError into its own
+                // CommanderError, so the assertion is on the message the operator sees.
+                expect(() =>
+                    parseOptionInIsolation(buildBrowserCheckCommand(), '--skip-launch', [value])
+                ).toThrow(/is not a true\/false value/);
+            }
+        );
+
+        test('--headless reads the same vocabulary as --skip-launch', () => {
+            // Two boolean options on one command accepted different words: `--headless off` ran
+            // headless while `--skip-launch off` worked. The doc page recommends `--headless` for
+            // exactly the case a silent coercion to headless would hide.
+            for (const [value, expected] of [
+                ['false', false],
+                ['FALSE', false],
+                ['off', false],
+                ['no', false],
+                ['0', false],
+                ['true', true],
+                ['on', true],
+            ]) {
+                const opts = parseOptionInIsolation(buildBrowserCheckCommand(), '--headless', [
+                    value,
+                ]);
+
+                expect({ value, headless: opts.headless }).toEqual({ value, headless: expected });
+            }
+        });
+
+        test('--headless rejects a value it cannot interpret', () => {
+            expect(() =>
+                parseOptionInIsolation(buildBrowserCheckCommand(), '--headless', ['maybe'])
+            ).toThrow(/is not a true\/false value/);
+        });
+
+        test('an empty BSI_BROWSER_C_HEADLESS means unset, not headed', () => {
+            // Empty means "unset" everywhere else in this codebase, and --headless defaults to
+            // true - so a bare `BSI_BROWSER_C_HEADLESS=` line must leave it headless rather than
+            // flipping it.
+            const saved = process.env.BSI_BROWSER_C_HEADLESS;
+            process.env.BSI_BROWSER_C_HEADLESS = '';
+
+            try {
+                const command = buildBrowserCheckCommand();
+                command.exitOverride();
+                command.parse([], { from: 'user' });
+
+                expect(command.opts().headless).toBe(true);
+            } finally {
+                if (saved === undefined) {
+                    delete process.env.BSI_BROWSER_C_HEADLESS;
+                } else {
+                    process.env.BSI_BROWSER_C_HEADLESS = saved;
+                }
+            }
+        });
+
+        test('--skip-launch false on the command line means do not skip', () => {
+            const opts = parseOptionInIsolation(buildBrowserCheckCommand(), '--skip-launch', [
+                'false',
+            ]);
+
+            expect(opts.skipLaunch).toBe(false);
+        });
+
+        test('offers no wizard flag, matching the interactive registry', () => {
+            // registry.test.js asserts the other direction; this is the half that fails inside
+            // this file if -i is ever added without a wizard behind it.
+            const flags = buildBrowserCheckCommand().options.map((opt) => opt.short);
+
+            expect(flags).not.toContain('-i');
+        });
     });
 
     test.each([
@@ -1110,6 +1305,7 @@ describe('option keys match the property names the code reads (issue #890)', () 
         ['browser list-installed', () => sub(buildBrowserCommand(), 'list-installed')],
         ['browser uninstall', () => sub(buildBrowserCommand(), 'uninstall')],
         ['browser uninstall-all', () => sub(buildBrowserCommand(), 'uninstall-all')],
+        ['browser check', () => sub(buildBrowserCommand(), 'check')],
     ];
 
     /**
@@ -1345,12 +1541,17 @@ describe('option keys match the property names the code reads (issue #890)', () 
 });
 
 describe('--browser-executable-path (issue #929)', () => {
-    // Only the two commands that launch a browser. `browser install` deliberately does not
-    // carry it: pointing at an executable is the alternative to installing one, so the option
-    // would be a knob that does nothing there.
+    // Only the commands that launch a browser. `browser install` deliberately does not carry it:
+    // pointing at an executable is the alternative to installing one, so the option would be a
+    // knob that does nothing there. `browser check` carries it because a configuration it cannot
+    // see is a configuration it cannot diagnose.
     const carriers = [
         ['qseow create-sheet-thumbnails', () => thumbnailCommand(buildQseowCommand())],
         ['qscloud create-sheet-thumbnails', () => thumbnailCommand(buildQscloudCommand())],
+        [
+            'browser check',
+            () => buildBrowserCommand().commands.find((cmd) => cmd.name() === 'check'),
+        ],
     ];
 
     test.each(carriers)('%s carries the option', (_name, build) => {

--- a/src/lib/commands/browser/check.js
+++ b/src/lib/commands/browser/check.js
@@ -1,0 +1,133 @@
+import { Command, Option } from 'commander';
+import { logger, appVersion } from '../../../globals.js';
+import { browserCheck } from '../../browser/browser-check.js';
+import {
+    VERSION_RECOMMENDED,
+    describeBrowserVersionOption,
+    parseBrowserVersionValue,
+} from '../../browser/browser-version.js';
+import { runCommand } from '../run-command.js';
+import { buildBrowserCacheDirOption, buildBrowserExecutablePathOption } from '../helpers.js';
+import { booleanOptionParser } from '../../util/boolean-option.js';
+
+/**
+ * Commander action that checks whether this machine can take screenshots.
+ *
+ * **The exit code is the point.** `browser check` is meant to be a gate in a deployment script on
+ * a Sense server, so the outcome has to reach the shell: `0` when a browser was found and, unless
+ * `--skip-launch`, launched; `1` when it was not, or the launch failed.
+ *
+ * That is expressed by returning `ok` from inside `runCommand`, which is the repo's single place
+ * for turning a command's verdict into `process.exitCode`. Three properties of that route matter,
+ * and none of them are incidental:
+ *
+ * - It sets `process.exitCode` rather than calling `process.exit()`, so winston flushes the report
+ *   that explains the exit code. A hard exit would truncate it.
+ * - It sets it here, in the handler. The worker returns data and never touches process state,
+ *   which is what lets the same worker back a future `doctor check` and a `--output json` mode.
+ * - A thrown worker is reported as a failure too, rather than escaping to the top-level
+ *   `uncaughtException` handler and being written out as a crash dump. A machine without a browser
+ *   is an operational finding, not a crash.
+ *
+ * @param {object} [options] - CLI options describing the browser, cache directory and launch
+ * behaviour. Defaults to `{}`. Commander passes its own `Command` as a second argument, which
+ * this handler has no use for - the worker takes only the options bag.
+ *
+ * @returns {Promise<boolean>} Whether the machine passed.
+ */
+const handleBrowserCheck = async (options = {}) => {
+    logger.info(`App version: ${appVersion}`);
+
+    return runCommand('BROWSER MAIN 11', async () => {
+        const report = await browserCheck(options);
+
+        // The worker has already printed the report, including the reason for a failure and the
+        // steps that fix it. Returning `ok` is all runCommand needs to set the exit code.
+        return report.ok;
+    });
+};
+
+/**
+ * Builds the "browser check" command.
+ *
+ * Every option here changes which browser a real run would pick, or how it would be started. A
+ * doctor that reports OK under different settings than the run it is meant to predict is worse
+ * than no doctor, which is why `--browser-cache-dir`, `--browser-executable-path` and `--headless`
+ * are all carried rather than left to their defaults.
+ *
+ * No `-i`: there is nothing to ask. Recorded in `NOT_INTERACTIVE` in the interactive registry,
+ * which is where a command with no wizard has to declare itself.
+ *
+ * @returns {import('commander').Command} Configured check command.
+ */
+const buildBrowserCheckCommand = () => {
+    const command = new Command('check');
+
+    command
+        .description(
+            'Check whether this machine can take sheet screenshots, without contacting Qlik Sense.\nReports where the browser cache is, which cached browsers can run here, which browser a real run would use, and whether it starts.\nMakes no network requests, and exits 1 when a real run would fail on this machine - so it can be used as a gate in a deployment script.'
+        )
+        .action(handleBrowserCheck)
+        .addOption(
+            new Option('--log-level, --loglevel <level>', 'Log level')
+                .choices(['error', 'warn', 'info', 'verbose', 'debug', 'silly'])
+                .default('info')
+                .env('BSI_BROWSER_C_LOG_LEVEL')
+        )
+        .addOption(
+            // Chrome only: the render path speaks the Chrome DevTools Protocol. The option is
+            // carried so the check accepts the same command line the other browser commands do.
+            new Option('--browser <browser>', 'Browser to check for. Only "chrome" is supported.')
+                .choices(['chrome'])
+                .default('chrome')
+                .env('BSI_BROWSER_C_BROWSER')
+        )
+        .addOption(
+            // Same `'' -> recommended` normalisation the other browser commands apply, so a bare
+            // `BSI_BROWSER_C_BROWSER_VERSION=` line in a unit file means "unset" rather than an
+            // error - and so the check cannot report OK under different pin semantics than a real
+            // run would use.
+            new Option('--browser-version <version>', describeBrowserVersionOption('check for'))
+                .default(VERSION_RECOMMENDED)
+                .argParser(parseBrowserVersionValue)
+                .env('BSI_BROWSER_C_BROWSER_VERSION')
+        )
+        .addOption(buildBrowserCacheDirOption())
+        .addOption(buildBrowserExecutablePathOption())
+        .addOption(
+            // A headed launch on a display-less server is a genuinely different test from a
+            // headless one, which is what earns this option its place on a diagnostic.
+            // Parsed here rather than left to `parseHeadlessOption` at the point of use. That
+            // helper accepts only the exact strings 'true'/'false' and quietly returns `true` for
+            // everything else, so `--headless off` and `BSI_BROWSER_C_HEADLESS=0` ran headless -
+            // a false negative in the one option whose stated purpose is to catch a
+            // headless-only failure. An empty value means unset, and unset here is the default.
+            new Option('--headless <true|false>', 'Headless (=not visible) browser (true, false)')
+                .default(true)
+                .argParser(booleanOptionParser({ whenEmpty: true }))
+                .env('BSI_BROWSER_C_HEADLESS')
+        )
+        .addOption(
+            // The argument is optional, not absent, and that is load-bearing. Declared as a bare
+            // flag, Commander sets it from the mere *presence* of BSI_BROWSER_C_SKIP_LAUNCH and
+            // never reads the value - so `BSI_BROWSER_C_SKIP_LAUNCH=false` turned skip-launch on,
+            // and the deployment gate passed having never started a browser. With an optional
+            // argument the value reaches `argParser`, which Commander also runs on environment
+            // values, so `--skip-launch false` and `BSI_BROWSER_C_SKIP_LAUNCH=false` agree.
+            //
+            // Bare `--skip-launch` still means true: Commander stores boolean `true` for an
+            // optional-argument option supplied without a value, and the parser passes booleans
+            // through untouched.
+            new Option(
+                '--skip-launch [true|false]',
+                'Find a browser but do not start it. Faster, and useful where starting a browser is not allowed - but it leaves the most valuable part of the check undone.'
+            )
+                .default(false)
+                .argParser(booleanOptionParser({ whenEmpty: false }))
+                .env('BSI_BROWSER_C_SKIP_LAUNCH')
+        );
+
+    return command;
+};
+
+export { buildBrowserCheckCommand, handleBrowserCheck };

--- a/src/lib/commands/browser/index.js
+++ b/src/lib/commands/browser/index.js
@@ -4,6 +4,7 @@ import { buildBrowserUninstallCommand } from './uninstall.js';
 import { buildBrowserUninstallAllCommand } from './uninstall-all.js';
 import { buildBrowserInstallCommand } from './install.js';
 import { buildBrowserListAvailableCommand } from './list-available.js';
+import { buildBrowserCheckCommand } from './check.js';
 
 /**
  * Builds the "browser" command namespace and wires up the install/list/uninstall sub-commands.
@@ -18,6 +19,7 @@ const buildBrowserCommand = () => {
     browser.addCommand(buildBrowserUninstallAllCommand());
     browser.addCommand(buildBrowserInstallCommand());
     browser.addCommand(buildBrowserListAvailableCommand());
+    browser.addCommand(buildBrowserCheckCommand());
 
     return browser;
 };

--- a/src/lib/doctor/__tests__/checks.test.js
+++ b/src/lib/doctor/__tests__/checks.test.js
@@ -1,0 +1,1547 @@
+import { jest, test, expect, describe } from '@jest/globals';
+
+import { CHECKS } from '../checks/index.js';
+import { runChecks, RUNNER_ERROR_ID, SKIP_NETWORK, SKIP_NOT_APPLICABLE } from '../run-checks.js';
+import { SEVERITY } from '../findings.js';
+
+/**
+ * The check contract (§15.3 of `docs/todo/airgap-browser-phase-1.md`).
+ *
+ * Two things are tested here, and they answer different questions.
+ *
+ * The **runner** guarantees are cheap now and expensive to retrofit: one broken check must never
+ * take down the report, a `needsNetwork` check must never run on an air-gapped host unless it was
+ * asked for, and a finding id must be unique across the whole registry - checked at the moment an
+ * id is introduced rather than after it has shipped in somebody's log.
+ *
+ * The **per-check** tests are what make the contract worth having: every check is a pure function
+ * of a fabricated `ctx`, so its findings can be asserted without a filesystem, a browser or a
+ * network. A check that cannot be tested this way has reached out to the world, which is the one
+ * thing the contract forbids.
+ */
+
+/**
+ * A cached build that this machine can run, shaped exactly as the gatherer produces one.
+ *
+ * `usable` and `reason` are computed by the worker rather than by a check, so a fabricated build
+ * has to carry them - a fixture that omitted them would let a check pass here while reading
+ * `undefined` in production.
+ */
+const HEALTHY_BUILD = Object.freeze({
+    browser: 'chrome',
+    buildId: '138.0.7204.94',
+    platform: 'win64',
+    executablePath: 'C:\\bsi\\browser-cache\\chrome\\win64-138.0.7204.94\\chrome.exe',
+    executableExists: true,
+    canRunHere: true,
+    usable: true,
+    reason: undefined,
+});
+
+/** A cache holding nothing. */
+const EMPTY_CACHE = Object.freeze({
+    dir: 'C:\\bsi\\browser-cache',
+    source: 'standalone',
+    sourceLabel: 'default location next to the Butler Sheet Icons executable',
+    exists: false,
+    inUse: true,
+    notConsultedReason: undefined,
+    builds: [],
+});
+
+/**
+ * A fabricated check context, healthy unless overridden.
+ *
+ * Nested objects are replaced wholesale rather than merged: a test that says the cache is empty
+ * should not silently inherit a build list from the healthy default.
+ *
+ * @param {object} [overrides] - Top-level keys to replace.
+ *
+ * @returns {object} A context object shaped as the gatherer produces one.
+ */
+const ctxWith = (overrides = {}) => ({
+    options: { browser: 'chrome', browserVersion: 'recommended', headless: true },
+    env: {},
+    host: {
+        hostPlatform: 'win64',
+        nodePlatform: 'win32',
+        arch: 'x64',
+        user: 'svc_qlik',
+        homeDir: 'C:\\Windows\\system32\\config\\systemprofile',
+        cwd: 'C:\\Windows\\system32',
+        isSea: true,
+    },
+    cache: {
+        dir: 'C:\\bsi\\browser-cache',
+        source: 'standalone',
+        sourceLabel: 'default location next to the Butler Sheet Icons executable',
+        exists: true,
+        inUse: true,
+        notConsultedReason: undefined,
+        builds: [HEALTHY_BUILD],
+    },
+    executableOverride: null,
+    detection: {
+        selection: {
+            source: 'cache',
+            executablePath: HEALTHY_BUILD.executablePath,
+            browser: 'chrome',
+            buildId: HEALTHY_BUILD.buildId,
+        },
+        error: null,
+        wouldDownload: false,
+        requested: 'chrome recommended',
+        requestedVersion: 'recommended',
+        versionForm: 'recommended',
+        resolvedBuildId: HEALTHY_BUILD.buildId,
+    },
+    launch: {
+        attempted: true,
+        // `started` is separate from `ok` on purpose: a browser that starts and then dies on the
+        // first command is a different diagnosis with different advice (issue #878).
+        started: true,
+        ok: true,
+        version: 'Chrome/138.0.7204.94',
+        error: null,
+        skipped: false,
+        elapsedMs: 850,
+    },
+    logger: { debug: jest.fn() },
+    ...overrides,
+});
+
+/**
+ * The registered check with a given id.
+ *
+ * @param {string} id - Check id.
+ *
+ * @returns {object} The check module's exported check object.
+ */
+const checkById = (id) => {
+    const check = CHECKS.find((entry) => entry.id === id);
+
+    if (!check) {
+        throw new Error(
+            `No check registered with id "${id}". Registered: ${CHECKS.map((c) => c.id).join(', ')}.`
+        );
+    }
+
+    return check;
+};
+
+/**
+ * Runs one check against a context and returns its findings.
+ *
+ * @param {string} id - Check id.
+ * @param {object} ctx - The context to run against.
+ *
+ * @returns {Promise<object[]>} The findings it produced.
+ */
+const findingsOf = async (id, ctx) => checkById(id).run(ctx);
+
+/**
+ * The scenarios every check is held to.
+ *
+ * Data rather than a `describe` per check, because the last test in this file compares the ids
+ * actually emitted here against the ids each check declares. A branch left untested therefore
+ * fails rather than going unnoticed, which is what stops `findingIds` from rotting into a list
+ * nobody maintains.
+ */
+const SCENARIOS = [
+    {
+        check: 'environment',
+        name: 'reports the machine facts',
+        ctx: ctxWith(),
+        ids: ['BSI-ENV-001'],
+        severities: [SEVERITY.INFO],
+    },
+    {
+        check: 'browser-executable-override',
+        name: 'nothing configured, so the cache decides',
+        ctx: ctxWith(),
+        ids: ['BSI-BROWSER-004'],
+        severities: [SEVERITY.OK],
+    },
+    {
+        check: 'browser-executable-override',
+        name: 'an explicit path that exists',
+        ctx: ctxWith({
+            executableOverride: {
+                path: 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+                configuredValue: 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+                source: 'option',
+                sourceLabel: 'from --browser-executable-path / BSI_BROWSER_EXECUTABLE_PATH',
+                explicit: true,
+                exists: true,
+            },
+        }),
+        ids: ['BSI-BROWSER-001'],
+        severities: [SEVERITY.OK],
+    },
+    {
+        check: 'browser-executable-override',
+        name: 'an explicit path that does not exist is an error, not a crash',
+        ctx: ctxWith({
+            executableOverride: {
+                path: 'D:\\nope\\chrome.exe',
+                configuredValue: 'D:\\nope\\chrome.exe',
+                source: 'option',
+                sourceLabel: 'from --browser-executable-path / BSI_BROWSER_EXECUTABLE_PATH',
+                explicit: true,
+                exists: false,
+            },
+        }),
+        ids: ['BSI-BROWSER-002'],
+        severities: [SEVERITY.ERROR],
+    },
+    {
+        check: 'browser-executable-override',
+        name: 'a stale PUPPETEER_EXECUTABLE_PATH only warns, because it falls through',
+        ctx: ctxWith({
+            executableOverride: {
+                path: '/usr/bin/chromium-browser',
+                configuredValue: '/usr/bin/chromium-browser',
+                source: 'puppeteer-env',
+                sourceLabel: 'from PUPPETEER_EXECUTABLE_PATH',
+                explicit: false,
+                exists: false,
+            },
+        }),
+        ids: ['BSI-BROWSER-003'],
+        severities: [SEVERITY.WARNING],
+    },
+    {
+        check: 'browser-cache-platform',
+        name: 'a cached build this machine can run',
+        ctx: ctxWith(),
+        ids: ['BSI-BROWSER-005'],
+        severities: [SEVERITY.OK],
+    },
+    {
+        check: 'browser-cache-platform',
+        name: 'every cached build was made for another operating system',
+        // No selection: these scenarios describe a cache that WAS the deciding factor, which is
+        // what makes its faults failures. With a browser selected they are warnings - see the
+        // "a cache problem that did not stop the run" tests.
+        nothingSelected: true,
+        ctx: ctxWith({
+            cache: {
+                dir: 'C:\\bsi\\browser-cache',
+                source: 'option',
+                sourceLabel: 'from --browser-cache-dir / BSI_BROWSER_CACHE_DIR',
+                exists: true,
+                inUse: true,
+                notConsultedReason: undefined,
+                builds: [
+                    {
+                        ...HEALTHY_BUILD,
+                        platform: 'mac_arm',
+                        canRunHere: false,
+                        usable: false,
+                        reason: 'built for another platform',
+                    },
+                ],
+            },
+        }),
+        ids: ['BSI-BROWSER-006'],
+        severities: [SEVERITY.ERROR],
+    },
+    {
+        check: 'browser-cache-platform',
+        name: 'an empty cache is not an error on its own',
+        ctx: ctxWith({ cache: EMPTY_CACHE }),
+        ids: ['BSI-BROWSER-007'],
+        severities: [SEVERITY.INFO],
+    },
+    {
+        check: 'browser-cache-platform',
+        // ~/.cache/puppeteer is shared with any other Puppeteer install on the host, which stages
+        // chrome-headless-shell beside chrome. Those builds are real, runnable and irrelevant:
+        // detection filters on the browser type before anything else.
+        name: 'a cache holding only another browser is reported as such',
+        ctx: ctxWith({
+            cache: {
+                ...EMPTY_CACHE,
+                exists: true,
+                builds: [
+                    {
+                        ...HEALTHY_BUILD,
+                        browser: 'chrome-headless-shell',
+                        usable: false,
+                        reason: 'a chrome-headless-shell build, not the chrome build this run needs',
+                    },
+                ],
+            },
+        }),
+        ids: ['BSI-BROWSER-007'],
+        severities: [SEVERITY.INFO],
+    },
+    {
+        check: 'browser-cache-platform',
+        // The LocalSystem symptom: a cache staged from an administrator's profile that the
+        // service account cannot open. This used to reject out of the gatherer and take the whole
+        // report with it - no environment block, no cache directory, no disclaimer.
+        name: 'an unreadable cache is an error the report survives',
+        // No selection: these scenarios describe a cache that WAS the deciding factor, which is
+        // what makes its faults failures. With a browser selected they are warnings - see the
+        // "a cache problem that did not stop the run" tests.
+        nothingSelected: true,
+        ctx: ctxWith({
+            cache: {
+                ...EMPTY_CACHE,
+                exists: true,
+                readError: "EACCES: permission denied, scandir 'D:\\bsi\\cache\\chrome'",
+            },
+        }),
+        ids: ['BSI-BROWSER-019'],
+        severities: [SEVERITY.ERROR],
+    },
+    {
+        check: 'browser-cache-executable',
+        name: 'every cached build has its binary',
+        ctx: ctxWith(),
+        ids: ['BSI-BROWSER-008'],
+        severities: [SEVERITY.OK],
+    },
+    {
+        check: 'browser-cache-executable',
+        name: 'a cache copied without its binaries',
+        // No selection: these scenarios describe a cache that WAS the deciding factor, which is
+        // what makes its faults failures. With a browser selected they are warnings - see the
+        // "a cache problem that did not stop the run" tests.
+        nothingSelected: true,
+        ctx: ctxWith({
+            cache: {
+                dir: 'D:\\bsi\\cache',
+                source: 'option',
+                sourceLabel: 'from --browser-cache-dir / BSI_BROWSER_CACHE_DIR',
+                exists: true,
+                inUse: true,
+                notConsultedReason: undefined,
+                builds: [
+                    {
+                        ...HEALTHY_BUILD,
+                        executableExists: false,
+                        usable: false,
+                        reason: 'executable not found on disk',
+                    },
+                ],
+            },
+        }),
+        ids: ['BSI-BROWSER-009'],
+        severities: [SEVERITY.ERROR],
+    },
+    {
+        check: 'browser-selection',
+        name: 'a browser was selected',
+        ctx: ctxWith(),
+        ids: ['BSI-BROWSER-010'],
+        severities: [SEVERITY.OK],
+    },
+    {
+        check: 'browser-selection',
+        name: 'nothing local at all, so a real run would download',
+        ctx: ctxWith({
+            cache: EMPTY_CACHE,
+            detection: {
+                selection: null,
+                error: null,
+                wouldDownload: true,
+                requested: 'chrome recommended',
+                resolvedBuildId: '138.0.7204.94',
+                pinCheckedOffline: true,
+            },
+        }),
+        ids: ['BSI-BROWSER-011'],
+        severities: [SEVERITY.ERROR],
+    },
+    {
+        check: 'browser-selection',
+        // Always an error here, whatever the cache holds. Demotion is the runner's job, driven by
+        // a cause that is actually present - see the supersession tests. Deciding it here, from
+        // the shape of the cache, is what let `browser check` exit 0 on a machine that could not
+        // take a screenshot.
+        name: 'nothing usable is an error even when a cache check will explain it',
+        ctx: ctxWith({
+            cache: {
+                dir: 'D:\\bsi\\cache',
+                source: 'option',
+                sourceLabel: 'from --browser-cache-dir / BSI_BROWSER_CACHE_DIR',
+                exists: true,
+                inUse: true,
+                notConsultedReason: undefined,
+                builds: [
+                    {
+                        ...HEALTHY_BUILD,
+                        platform: 'win64',
+                        canRunHere: false,
+                        usable: false,
+                        reason: 'built for another platform',
+                    },
+                ],
+            },
+            detection: {
+                selection: null,
+                error: null,
+                wouldDownload: true,
+                requested: 'chrome recommended',
+                requestedVersion: 'recommended',
+                versionForm: 'recommended',
+                resolvedBuildId: '138.0.7204.94',
+            },
+        }),
+        ids: ['BSI-BROWSER-011'],
+        severities: [SEVERITY.ERROR],
+    },
+    {
+        check: 'browser-selection',
+        // It names the cache findings that would explain it, so the runner can demote it rather
+        // than the check guessing.
+        name: 'nothing usable names the causes that would explain it',
+        ctx: ctxWith({
+            cache: { ...EMPTY_CACHE },
+            detection: {
+                selection: null,
+                error: null,
+                wouldDownload: true,
+                requested: 'chrome recommended',
+                requestedVersion: 'recommended',
+                versionForm: 'recommended',
+                resolvedBuildId: '138.0.7204.94',
+            },
+        }),
+        ids: ['BSI-BROWSER-011'],
+        severities: [SEVERITY.ERROR],
+        supersededBy: ['BSI-BROWSER-006', 'BSI-BROWSER-009', 'BSI-BROWSER-019'],
+    },
+    {
+        check: 'browser-selection',
+        // Reproduced on a real machine while building this command: the cache held
+        // chrome 151.0.7922.138 and the recommended pin was 151.0.7922.71. The advice that
+        // matters is "use the build you already have", not "go and download one".
+        name: 'the requested build is missing, but a usable one is present',
+        ctx: ctxWith({
+            detection: {
+                selection: null,
+                error: null,
+                wouldDownload: true,
+                requested: 'chrome recommended (build 151.0.7922.71)',
+                requestedVersion: 'recommended',
+                versionForm: 'recommended',
+                resolvedBuildId: '151.0.7922.71',
+            },
+        }),
+        ids: ['BSI-BROWSER-017'],
+        severities: [SEVERITY.ERROR],
+    },
+    {
+        check: 'browser-selection',
+        name: 'detection stopped with an error',
+        ctx: ctxWith({
+            detection: {
+                selection: null,
+                error: { message: 'the browser cache directory could not be read' },
+                wouldDownload: false,
+                requested: 'chrome recommended',
+                requestedVersion: 'recommended',
+                versionForm: 'recommended',
+                resolvedBuildId: '138.0.7204.94',
+            },
+        }),
+        ids: ['BSI-BROWSER-012'],
+        severities: [SEVERITY.ERROR],
+        supersededBy: ['BSI-BROWSER-002'],
+    },
+    {
+        check: 'browser-selection',
+        name: 'a floating keyword cannot be checked without internet access',
+        ctx: ctxWith({
+            detection: {
+                selection: {
+                    source: 'cache',
+                    executablePath: HEALTHY_BUILD.executablePath,
+                    browser: 'chrome',
+                    buildId: HEALTHY_BUILD.buildId,
+                },
+                error: null,
+                wouldDownload: false,
+                requested: 'chrome stable',
+                requestedVersion: 'stable',
+                versionForm: 'floating',
+                resolvedBuildId: undefined,
+            },
+        }),
+        ids: ['BSI-BROWSER-010', 'BSI-BROWSER-013'],
+        severities: [SEVERITY.OK, SEVERITY.WARNING],
+    },
+    {
+        check: 'browser-selection',
+        // A milestone is an explicit pin that happens to need a lookup. Calling it a value that
+        // "names whichever build is newest" told an administrator their deliberate pin floated,
+        // and then advised them to name an exact build id - which is what they thought they had.
+        // A milestone or build prefix is NOT the same as a floating keyword, and sharing
+        // BSI-BROWSER-013's warning severity with one hid a false OK. `resolveRequestedBuildId`
+        // only degrades to a cached build when `isVersionKeyword` is true, and `isVersionKeyword`
+        // ('151') is false - so on an air-gapped host a real run throws before it ever reaches
+        // the cache, while the check said OK. Its own finding, and an error.
+        name: 'a milestone pin is an error, because a real run cannot resolve it offline',
+        ctx: ctxWith({
+            detection: {
+                selection: {
+                    source: 'cache',
+                    executablePath: HEALTHY_BUILD.executablePath,
+                    browser: 'chrome',
+                    buildId: HEALTHY_BUILD.buildId,
+                },
+                error: null,
+                wouldDownload: false,
+                requested: 'chrome 151',
+                requestedVersion: '151',
+                versionForm: 'partial',
+                resolvedBuildId: undefined,
+            },
+        }),
+        ids: ['BSI-BROWSER-010', 'BSI-BROWSER-022'],
+        severities: [SEVERITY.OK, SEVERITY.ERROR],
+    },
+    {
+        check: 'browser-selection',
+        // The browser is the unsupported thing, not the version. Overwriting the version form
+        // with INVALID here made the report say `--browser-version "recommended" is neither a
+        // keyword nor a build id`, sending the administrator to change the setting that was fine.
+        name: 'an unsupported browser is named as the problem',
+        ctx: ctxWith({
+            options: { browser: 'firefox', browserVersion: 'recommended', headless: true },
+            detection: {
+                selection: null,
+                error: null,
+                wouldDownload: true,
+                requested: 'firefox recommended',
+                requestedVersion: 'recommended',
+                versionForm: 'recommended',
+                browserError:
+                    'Unsupported browser "firefox". Butler Sheet Icons can install chrome.',
+                resolvedBuildId: undefined,
+            },
+        }),
+        ids: ['BSI-BROWSER-023'],
+        severities: [SEVERITY.ERROR],
+    },
+    {
+        check: 'browser-selection',
+        // The false-OK route: an unrecognised value used to be accepted as a floating keyword, so
+        // the check exited 0 while resolveBrowserVersion threw and the real run died.
+        name: 'a version a real run would reject is an error',
+        ctx: ctxWith({
+            detection: {
+                selection: {
+                    source: 'cache',
+                    executablePath: HEALTHY_BUILD.executablePath,
+                    browser: 'chrome',
+                    buildId: HEALTHY_BUILD.buildId,
+                },
+                error: null,
+                wouldDownload: false,
+                requested: 'chrome garbage',
+                requestedVersion: 'garbage',
+                versionForm: 'invalid',
+                resolvedBuildId: undefined,
+            },
+        }),
+        ids: ['BSI-BROWSER-010', 'BSI-BROWSER-018'],
+        severities: [SEVERITY.OK, SEVERITY.ERROR],
+    },
+    {
+        check: 'browser-launch',
+        name: 'the browser started and answered',
+        ctx: ctxWith(),
+        ids: ['BSI-BROWSER-014'],
+        severities: [SEVERITY.OK],
+    },
+    {
+        check: 'browser-launch',
+        name: 'the browser process could not be started',
+        ctx: ctxWith({
+            launch: {
+                attempted: true,
+                started: false,
+                ok: false,
+                version: null,
+                error: 'Failed to launch the browser process!',
+                skipped: false,
+                elapsedMs: 120,
+            },
+        }),
+        ids: ['BSI-BROWSER-015'],
+        severities: [SEVERITY.ERROR],
+    },
+    {
+        check: 'browser-launch',
+        // Issue #878: the browser starts perfectly well and dies on the first command sent to it.
+        // Reporting that as "could not be started" was false, and it led with antivirus advice
+        // while the actual fix - use a different build - sat at step 2 with the build id never
+        // named.
+        name: 'the browser started and then could not be driven',
+        ctx: ctxWith({
+            launch: {
+                attempted: true,
+                started: true,
+                ok: false,
+                version: null,
+                error: 'Protocol error (Browser.getVersion): Session closed.',
+                skipped: false,
+                elapsedMs: 900,
+            },
+        }),
+        ids: ['BSI-BROWSER-020'],
+        severities: [SEVERITY.ERROR],
+    },
+    {
+        check: 'browser-launch',
+        // The stall no timeout catches: process creation is synchronous inside libuv, so the
+        // launch budget never fires and the run is merely inexplicably slow. Reported as OK
+        // before, which let an administrator rule the browser out and chase the wrong thing.
+        name: 'a launch that succeeded slowly is reported as well as passing',
+        ctx: ctxWith({
+            launch: {
+                attempted: true,
+                started: true,
+                ok: true,
+                version: 'Chrome/138.0.7204.94',
+                error: null,
+                skipped: false,
+                elapsedMs: 92_000,
+            },
+        }),
+        ids: ['BSI-BROWSER-014', 'BSI-BROWSER-021'],
+        severities: [SEVERITY.OK, SEVERITY.WARNING],
+    },
+    {
+        check: 'browser-launch',
+        name: '--skip-launch says so rather than staying silent',
+        ctx: ctxWith({
+            launch: {
+                attempted: false,
+                started: false,
+                ok: false,
+                version: null,
+                error: null,
+                skipped: true,
+                elapsedMs: 0,
+            },
+        }),
+        ids: ['BSI-BROWSER-016'],
+        severities: [SEVERITY.INFO],
+    },
+];
+
+describe('every check is a pure function of its context', () => {
+    test.each(SCENARIOS.map((s) => [`${s.check}: ${s.name}`, s]))('%s', async (_name, scenario) => {
+        // `nothingSelected` clears the healthy default's selection. A cache fault only fails the
+        // run when the cache is what the run depended on, so a scenario asserting an error has to
+        // say that no browser was found in the end - otherwise it is asserting the old, wrong
+        // behaviour, where a leftover build directory failed a machine that had already launched.
+        const ctx = scenario.nothingSelected
+            ? {
+                  ...scenario.ctx,
+                  detection: { ...scenario.ctx.detection, selection: null, wouldDownload: true },
+              }
+            : scenario.ctx;
+        const findings = await findingsOf(scenario.check, ctx);
+
+        expect(findings.map((f) => f.id)).toEqual(scenario.ids);
+        expect(findings.map((f) => f.severity)).toEqual(scenario.severities);
+
+        // Where a scenario states the causes a finding defers to, hold it to them. A typo in a
+        // supersededBy id fails silently in the worst possible direction: the cause never matches,
+        // so nothing is ever demoted and the duplicate remediation quietly comes back.
+        if (scenario.supersededBy) {
+            expect(findings.at(-1).supersededBy).toEqual(scenario.supersededBy);
+        }
+    });
+
+    test('every finding states what was observed, with the values it observed', () => {
+        // §15.4: "No browser found" helps nobody. A detail that never names anything concrete is
+        // a finding that ends no investigation.
+        return Promise.all(
+            SCENARIOS.map(async (scenario) => {
+                const findings = await findingsOf(scenario.check, scenario.ctx);
+
+                for (const finding of findings) {
+                    expect({ id: finding.id, hasTitle: finding.title?.length > 10 }).toEqual({
+                        id: finding.id,
+                        hasTitle: true,
+                    });
+                    expect({ id: finding.id, hasDetail: finding.detail?.length > 10 }).toEqual({
+                        id: finding.id,
+                        hasDetail: true,
+                    });
+                }
+            })
+        );
+    });
+
+    test('every error finding carries at least one remediation step', () => {
+        // §15.9: wrong advice is worse than none - but an error with no advice at all is a dead
+        // end on a machine whose administrator cannot open the documentation site.
+        return Promise.all(
+            SCENARIOS.map(async (scenario) => {
+                const findings = await findingsOf(scenario.check, scenario.ctx);
+
+                for (const finding of findings.filter((f) => f.severity === SEVERITY.ERROR)) {
+                    expect({ id: finding.id, steps: finding.remediation.length > 0 }).toEqual({
+                        id: finding.id,
+                        steps: true,
+                    });
+                }
+            })
+        );
+    });
+});
+
+describe('a cache problem that did not stop the run does not fail the run', () => {
+    // Both of these were false FAILEDs on machines that demonstrably work - the opposite gate
+    // failure from the one the earlier fixes were about, and the more likely to reach a customer:
+    // a leftover build directory beside a working one is ordinary, not exotic.
+
+    /**
+     * A ctx where a browser really was selected, whatever else is wrong with the cache.
+     *
+     * @param {object} cache - The cache state to report alongside a successful selection.
+     *
+     * @returns {object} The context.
+     */
+    const withSelection = (cache) =>
+        ctxWith({
+            cache,
+            detection: {
+                selection: {
+                    source: 'cache',
+                    executablePath: HEALTHY_BUILD.executablePath,
+                    browser: 'chrome',
+                    buildId: HEALTHY_BUILD.buildId,
+                },
+                error: null,
+                wouldDownload: false,
+                requested: 'chrome recommended',
+                requestedVersion: 'recommended',
+                versionForm: 'recommended',
+                resolvedBuildId: HEALTHY_BUILD.buildId,
+            },
+        });
+
+    test('a stale build beside a working one is a warning, not a failure', async () => {
+        const [entry] = await findingsOf(
+            'browser-cache-executable',
+            withSelection({
+                dir: 'C:\\bsi\\browser-cache',
+                source: 'standalone',
+                sourceLabel: 'default location next to the Butler Sheet Icons executable',
+                exists: true,
+                inUse: true,
+                notConsultedReason: undefined,
+                builds: [
+                    HEALTHY_BUILD,
+                    {
+                        ...HEALTHY_BUILD,
+                        buildId: '137.0.7100.10',
+                        executableExists: false,
+                        usable: false,
+                        reason: 'executable not found on disk',
+                    },
+                ],
+            })
+        );
+
+        expect(entry.id).toBe('BSI-BROWSER-009');
+        expect(entry.severity).toBe(SEVERITY.WARNING);
+    });
+
+    test('an unreadable cache that nothing was going to read is a warning', async () => {
+        const [entry] = await findingsOf(
+            'browser-cache-platform',
+            withSelection({
+                ...EMPTY_CACHE,
+                exists: true,
+                inUse: false,
+                notConsultedReason:
+                    'an executable path is configured, so the cache is not consulted',
+                readError: "EACCES: permission denied, scandir 'D:\\bsi\\cache\\chrome'",
+            })
+        );
+
+        expect(entry.id).toBe('BSI-BROWSER-019');
+        expect(entry.severity).toBe(SEVERITY.WARNING);
+    });
+
+    test('but an unreadable cache that decided the run is still an error', async () => {
+        const [entry] = await findingsOf(
+            'browser-cache-platform',
+            ctxWith({
+                cache: {
+                    ...EMPTY_CACHE,
+                    exists: true,
+                    readError: "EACCES: permission denied, scandir 'D:\\bsi\\cache\\chrome'",
+                },
+                detection: {
+                    selection: null,
+                    error: null,
+                    wouldDownload: true,
+                    requested: 'chrome recommended',
+                    requestedVersion: 'recommended',
+                    versionForm: 'recommended',
+                    resolvedBuildId: '138.0.7204.94',
+                },
+            })
+        );
+
+        expect(entry.severity).toBe(SEVERITY.ERROR);
+    });
+});
+
+describe('one build, one diagnosis', () => {
+    test('a foreign build with no binary is reported as foreign, once', async () => {
+        // Both cache checks judged the same build against different criteria, so a build that was
+        // BOTH wrong-platform and binary-less produced two errors and a four-step Next steps whose
+        // last two entries ("copy again, preserving hidden files") cannot help a build compiled
+        // for another operating system. `unusableReason` already declares the precedence - platform
+        // first - and the executable check now honours it.
+        const ctx = ctxWith({
+            cache: {
+                dir: 'D:\\bsi\\cache',
+                source: 'option',
+                sourceLabel: 'from --browser-cache-dir / BSI_BROWSER_CACHE_DIR',
+                exists: true,
+                inUse: true,
+                notConsultedReason: undefined,
+                builds: [
+                    {
+                        ...HEALTHY_BUILD,
+                        platform: 'mac_arm',
+                        canRunHere: false,
+                        executableExists: false,
+                        usable: false,
+                        reason: 'built for another platform',
+                    },
+                ],
+            },
+            detection: {
+                selection: null,
+                error: null,
+                wouldDownload: true,
+                requested: 'chrome recommended',
+                requestedVersion: 'recommended',
+                versionForm: 'recommended',
+                resolvedBuildId: '138.0.7204.94',
+            },
+        });
+
+        const platform = await findingsOf('browser-cache-platform', ctx);
+        const executable = checkById('browser-cache-executable').appliesTo(ctx)
+            ? await findingsOf('browser-cache-executable', ctx)
+            : [];
+
+        expect(platform.map((f) => f.id)).toEqual(['BSI-BROWSER-006']);
+        // The executable check has nothing to add: the binary is not why this build is unusable.
+        expect(executable).toEqual([]);
+    });
+
+    test('a runnable build with no binary is still reported by the executable check', async () => {
+        const ctx = ctxWith({
+            cache: {
+                dir: 'D:\\bsi\\cache',
+                source: 'option',
+                sourceLabel: 'from --browser-cache-dir / BSI_BROWSER_CACHE_DIR',
+                exists: true,
+                inUse: true,
+                notConsultedReason: undefined,
+                builds: [
+                    {
+                        ...HEALTHY_BUILD,
+                        executableExists: false,
+                        usable: false,
+                        reason: 'executable not found on disk',
+                    },
+                ],
+            },
+            detection: {
+                selection: null,
+                error: null,
+                wouldDownload: true,
+                requested: 'chrome recommended',
+                requestedVersion: 'recommended',
+                versionForm: 'recommended',
+                resolvedBuildId: '138.0.7204.94',
+            },
+        });
+
+        const [entry] = await findingsOf('browser-cache-executable', ctx);
+
+        expect(entry.id).toBe('BSI-BROWSER-009');
+        expect(entry.severity).toBe(SEVERITY.ERROR);
+    });
+});
+
+describe('advice is aimed at the configuration actually in force', () => {
+    /**
+     * A ctx whose browser came from --browser-executable-path rather than the cache.
+     *
+     * @param {object} [overrides] - `detection` fields to replace, and `rest` to merge into the ctx.
+     *
+     * @returns {object} The context.
+     */
+    const namedExecutable = (overrides = {}) =>
+        ctxWith({
+            executableOverride: {
+                path: '/usr/bin/chromium',
+                configuredValue: '/usr/bin/chromium',
+                source: 'option',
+                sourceLabel: 'from --browser-executable-path / BSI_BROWSER_EXECUTABLE_PATH',
+                explicit: true,
+                exists: true,
+            },
+            cache: {
+                ...EMPTY_CACHE,
+                inUse: false,
+                notConsultedReason:
+                    'an executable path is configured, so the cache is not consulted',
+            },
+            detection: {
+                selection: {
+                    source: 'system',
+                    executablePath: '/usr/bin/chromium',
+                    browser: 'chrome',
+                    buildId: 'system-installed',
+                },
+                error: null,
+                wouldDownload: false,
+                requested: 'chrome recommended',
+                requestedVersion: 'recommended',
+                versionForm: 'recommended',
+                resolvedBuildId: '138.0.7204.94',
+                ...overrides.detection,
+            },
+            ...overrides.rest,
+        });
+
+    test('a failed launch of a named executable does not blame the browser cache', async () => {
+        // The cache is not consulted on this path, and `--browser-version recommended` changes
+        // nothing: detection returns the override before it ever looks at the version, so pasting
+        // that command reproduces the identical failure.
+        const ctx = namedExecutable();
+        ctx.launch = {
+            attempted: true,
+            started: false,
+            ok: false,
+            version: null,
+            error: 'spawn EACCES',
+            skipped: false,
+            elapsedMs: 40,
+        };
+
+        const [entry] = await findingsOf('browser-launch', ctx);
+        const advice = entry.remediation
+            .map((step) => `${step.text} ${step.command?.bash ?? ''}`)
+            .join('\n');
+
+        expect(entry.severity).toBe(SEVERITY.ERROR);
+        expect(advice).not.toContain('browser cache');
+        expect(advice).not.toContain('--browser-version');
+        // It should point at the thing that is actually in force.
+        expect(advice).toContain('/usr/bin/chromium');
+    });
+
+    test('no version finding fires when a named executable makes the version moot', async () => {
+        // resolveBrowserExecutablePath skips version resolution entirely when a named executable
+        // exists, so a real run neither validates nor uses --browser-version here. Warning about
+        // it sent customers chasing version drift that cannot occur on their configuration - and
+        // an invalid value must not fail the check either, because a real run would succeed.
+        for (const versionForm of ['floating', 'partial', 'invalid']) {
+            const ctx = namedExecutable({
+                detection: { versionForm, requestedVersion: 'stable' },
+            });
+
+            const ids = (await findingsOf('browser-selection', ctx)).map((f) => f.id);
+
+            expect({ versionForm, ids }).toEqual({ versionForm, ids: ['BSI-BROWSER-010'] });
+        }
+    });
+
+    test('version findings still fire when the cache is what decides', async () => {
+        // The other half: without a named executable the version really does select the build, so
+        // silence would hide a genuine mismatch.
+        const ctx = ctxWith({
+            detection: {
+                selection: {
+                    source: 'cache',
+                    executablePath: HEALTHY_BUILD.executablePath,
+                    browser: 'chrome',
+                    buildId: HEALTHY_BUILD.buildId,
+                },
+                error: null,
+                wouldDownload: false,
+                requested: 'chrome stable',
+                requestedVersion: 'stable',
+                versionForm: 'floating',
+                resolvedBuildId: undefined,
+            },
+        });
+
+        const ids = (await findingsOf('browser-selection', ctx)).map((f) => f.id);
+
+        expect(ids).toEqual(['BSI-BROWSER-010', 'BSI-BROWSER-013']);
+    });
+
+    test('remediation quotes the version as normalised, never as undefined', async () => {
+        // browserCheck({}) is a supported call shape, and reaching past the normalised value back
+        // to the raw options bag printed `--browser-version undefined` into a command an
+        // administrator is invited to paste.
+        const ctx = ctxWith({
+            options: { browser: 'chrome' },
+            detection: {
+                selection: null,
+                error: null,
+                wouldDownload: true,
+                requested: 'chrome recommended (build 151.0.7922.71)',
+                requestedVersion: 'recommended',
+                versionForm: 'recommended',
+                resolvedBuildId: '151.0.7922.71',
+            },
+        });
+
+        const findings = await findingsOf('browser-selection', ctx);
+        const printed = findings
+            .flatMap((entry) => entry.remediation)
+            .map(
+                (step) =>
+                    `${step.text} ${step.command?.powershell ?? ''} ${step.command?.bash ?? ''}`
+            )
+            .join('\n');
+
+        expect(printed).not.toContain('undefined');
+    });
+});
+
+describe('the registry', () => {
+    test('every finding id is unique across every registered check', () => {
+        // The one-line test that prevents the id collisions §15.4 warns about, at the moment they
+        // are introduced rather than after they have shipped in someone's logs.
+        const ids = CHECKS.flatMap((check) => check.findingIds);
+
+        expect(ids.length).toBe(new Set(ids).size);
+    });
+
+    test('every check id is unique', () => {
+        const ids = CHECKS.map((check) => check.id);
+
+        expect(ids.length).toBe(new Set(ids).size);
+    });
+
+    test('every finding id is shaped for a permanent, searchable identifier', () => {
+        for (const check of CHECKS) {
+            for (const id of check.findingIds) {
+                expect(`${check.id}: ${id}`).toMatch(/: BSI-[A-Z]+-\d{3}$/);
+            }
+        }
+    });
+
+    test('every check declares the whole contract', () => {
+        for (const check of CHECKS) {
+            expect({
+                id: check.id,
+                shape: {
+                    title: typeof check.title,
+                    section: typeof check.section,
+                    area: typeof check.area,
+                    needsNetwork: typeof check.needsNetwork,
+                    appliesTo: typeof check.appliesTo,
+                    run: typeof check.run,
+                    findingIds: Array.isArray(check.findingIds),
+                },
+            }).toEqual({
+                id: check.id,
+                shape: {
+                    title: 'string',
+                    section: 'string',
+                    area: 'string',
+                    needsNetwork: 'boolean',
+                    appliesTo: 'function',
+                    run: 'function',
+                    findingIds: true,
+                },
+            });
+        }
+    });
+
+    test('every check declares an area the contract recognises', async () => {
+        // `checksForAreas` filters on a free-form string, so a typo does not throw, warn, or
+        // produce a skipped result - the check simply is not there. Renaming browser-selection's
+        // area to `browserr` was measured to leave `browser check` reporting OK and exiting 0 on
+        // a machine with no browser at all, with the whole suite green: the per-check tests call
+        // `run()` directly and never go through the registry.
+        const { CHECK_AREAS } = await import('../run-checks.js');
+
+        for (const check of CHECKS) {
+            expect({ check: check.id, known: CHECK_AREAS.includes(check.area) }).toEqual({
+                check: check.id,
+                known: true,
+            });
+        }
+    });
+
+    test('browser check runs every check it is meant to, and asks for real areas', async () => {
+        // The other half: `AREAS` is a hand-written list in the worker, so a typo *there* drops a
+        // check just as silently. Both lists are read from the real modules rather than restated.
+        const { checksForAreas } = await import('../checks/index.js');
+        const { CHECK_AREAS } = await import('../run-checks.js');
+        const { BROWSER_CHECK_AREAS } = await import('../../browser/browser-check.js');
+
+        for (const area of BROWSER_CHECK_AREAS) {
+            expect({ area, known: CHECK_AREAS.includes(area) }).toEqual({ area, known: true });
+        }
+
+        // Every registered check belongs to one of the areas this command runs. When a check for
+        // another area is added - the qseow connectivity check the design anticipates - this
+        // assertion is the deliberate place to say so.
+        expect(checksForAreas(BROWSER_CHECK_AREAS).map((check) => check.id)).toEqual(
+            CHECKS.map((check) => check.id)
+        );
+    });
+
+    test('no check reaches the network, so the default is safe on an air-gapped server', () => {
+        // Every phase 1 check reads facts the gatherer already collected locally. The field
+        // exists for the checks that come later; this asserts none of today's has quietly
+        // acquired one.
+        expect(CHECKS.filter((check) => check.needsNetwork).map((check) => check.id)).toEqual([]);
+    });
+
+    test('the ids each check declares are exactly the ids the scenarios above produce', () => {
+        // What keeps `findingIds` honest as checks grow. A branch added without a scenario, or a
+        // declared id no branch can reach, both fail here.
+        return Promise.all(
+            CHECKS.map(async (check) => {
+                const emitted = new Set();
+
+                for (const scenario of SCENARIOS.filter((s) => s.check === check.id)) {
+                    const ctx = scenario.nothingSelected
+                        ? {
+                              ...scenario.ctx,
+                              detection: { ...scenario.ctx.detection, selection: null },
+                          }
+                        : scenario.ctx;
+
+                    for (const finding of await check.run(ctx)) {
+                        emitted.add(finding.id);
+                    }
+                }
+
+                expect({ check: check.id, ids: [...emitted].sort() }).toEqual({
+                    check: check.id,
+                    ids: [...check.findingIds].sort(),
+                });
+            })
+        );
+    });
+});
+
+describe('the runner isolates the report from one broken check', () => {
+    /**
+     * A minimal check for exercising the runner.
+     *
+     * @param {object} overrides - Fields to replace on the default shape.
+     *
+     * @returns {object} A check object.
+     */
+    const fakeCheck = (overrides) => ({
+        id: 'fake',
+        title: 'A fake check',
+        section: 'Fake',
+        area: 'browser',
+        needsNetwork: false,
+        findingIds: [],
+        appliesTo: () => true,
+        run: async () => [],
+        ...overrides,
+    });
+
+    test('a check that throws becomes an error finding naming it', async () => {
+        const results = await runChecks(
+            [
+                fakeCheck({
+                    id: 'explodes',
+                    run: async () => {
+                        throw new Error('the cache directory could not be read');
+                    },
+                }),
+                fakeCheck({
+                    id: 'survives',
+                    run: async () => [{ id: 'BSI-TEST-001', severity: SEVERITY.OK, title: 'fine' }],
+                }),
+            ],
+            ctxWith()
+        );
+
+        const [broken, survivor] = results;
+
+        expect(broken.findings).toHaveLength(1);
+        expect(broken.findings[0].severity).toBe(SEVERITY.ERROR);
+        expect(broken.findings[0].id).toBe(RUNNER_ERROR_ID);
+        // Naming the check is the point: without it the report says something failed and gives
+        // nobody a place to look.
+        expect(broken.findings[0].detail).toContain('explodes');
+        expect(broken.findings[0].detail).toContain('the cache directory could not be read');
+
+        // And the rest of the report still happened, which is the whole reason for the try/catch.
+        expect(survivor.findings[0].id).toBe('BSI-TEST-001');
+    });
+
+    test('a check returning a bare finding instead of a list cannot erase the report', async () => {
+        // The runner used to reassemble per-check findings by slicing a flattened array with a
+        // running cursor. A non-array return made `result.findings.length` undefined, the cursor
+        // NaN, and every subsequent slice empty - so ONE malformed check silently deleted every
+        // finding in the report and the command exited 0 on a broken machine.
+        const results = await runChecks(
+            [
+                fakeCheck({
+                    id: 'returns-bare-object',
+                    run: async () => ({
+                        id: 'BSI-TEST-100',
+                        severity: SEVERITY.OK,
+                        title: 'a bare finding',
+                        detail: 'not wrapped in an array',
+                    }),
+                }),
+                fakeCheck({
+                    id: 'reports-a-real-problem',
+                    run: async () => [
+                        {
+                            id: 'BSI-TEST-101',
+                            severity: SEVERITY.ERROR,
+                            title: 'the real problem',
+                            detail: 'd',
+                            facts: [],
+                            remediation: [{ text: 'Fix it.' }],
+                        },
+                    ],
+                }),
+            ],
+            ctxWith()
+        );
+
+        expect(results[0].findings.map((f) => f.id)).toEqual(['BSI-TEST-100']);
+        // The half that matters: the healthy check's error must survive, so the run still fails.
+        expect(results[1].findings.map((f) => f.id)).toEqual(['BSI-TEST-101']);
+        expect(results[1].findings[0].severity).toBe(SEVERITY.ERROR);
+    });
+
+    test('findings stay attributed to the check that produced them', async () => {
+        // The other half of the cursor bug: mis-slicing silently moved findings between sections,
+        // which reads as the wrong check having found something.
+        const results = await runChecks(
+            [
+                fakeCheck({ id: 'a', run: async () => [] }),
+                fakeCheck({
+                    id: 'b',
+                    run: async () => [
+                        { id: 'B1', severity: SEVERITY.OK, title: 't', detail: 'd', facts: [] },
+                        { id: 'B2', severity: SEVERITY.OK, title: 't', detail: 'd', facts: [] },
+                    ],
+                }),
+                fakeCheck({
+                    id: 'c',
+                    run: async () => [
+                        { id: 'C1', severity: SEVERITY.OK, title: 't', detail: 'd', facts: [] },
+                    ],
+                }),
+            ],
+            ctxWith()
+        );
+
+        expect(results.map((r) => [r.check.id, r.findings.map((f) => f.id)])).toEqual([
+            ['a', []],
+            ['b', ['B1', 'B2']],
+            ['c', ['C1']],
+        ]);
+    });
+
+    test('a finding repaired by the runner cannot demote a genuine error', async () => {
+        // Normalisation promotes an unrecognised severity to `error` so a malformed finding is
+        // never silently passing. That made it eligible as a *cause*: a check writing
+        // `severity: 'WARNING'` - the constant is lowercase - was repaired into an error, joined
+        // the cause set, and demoted a real finding that named its id, stripping the remediation
+        // an administrator needed. A repaired finding fails the run; it does not get to explain
+        // away someone else's.
+        const results = await runChecks(
+            [
+                fakeCheck({
+                    id: 'typo',
+                    run: async () => [
+                        {
+                            id: 'BSI-TEST-100',
+                            severity: 'WARNING',
+                            title: 'a severity typo',
+                            detail: 'd',
+                            facts: [],
+                            remediation: [],
+                        },
+                    ],
+                }),
+                fakeCheck({
+                    id: 'real',
+                    run: async () => [
+                        {
+                            id: 'BSI-TEST-101',
+                            severity: SEVERITY.ERROR,
+                            title: 'the real problem',
+                            detail: 'd',
+                            facts: [],
+                            remediation: [{ text: 'Fix the real problem.' }],
+                            supersededBy: ['BSI-TEST-100'],
+                        },
+                    ],
+                }),
+            ],
+            ctxWith()
+        );
+
+        const real = results[1].findings[0];
+
+        expect(real.severity).toBe(SEVERITY.ERROR);
+        expect(real.remediation).toHaveLength(1);
+        // The malformed one still fails the run, so nothing is swept under the carpet.
+        expect(results[0].findings[0].severity).toBe(SEVERITY.ERROR);
+    });
+
+    test('a check that throws a non-Error is still reported', async () => {
+        const [result] = await runChecks(
+            [
+                fakeCheck({
+                    run: async () => {
+                        throw 'a bare string';
+                    },
+                }),
+            ],
+            ctxWith()
+        );
+
+        expect(result.findings[0].severity).toBe(SEVERITY.ERROR);
+        expect(result.findings[0].detail).toContain('a bare string');
+    });
+
+    test('a needsNetwork check is skipped unless the network is allowed', async () => {
+        const run = jest.fn(async () => []);
+
+        const [result] = await runChecks([fakeCheck({ needsNetwork: true, run })], ctxWith());
+
+        expect(run).not.toHaveBeenCalled();
+        expect(result.skipped).toBe(SKIP_NETWORK);
+    });
+
+    test('a needsNetwork check runs when the network is allowed', async () => {
+        const run = jest.fn(async () => []);
+
+        const [result] = await runChecks([fakeCheck({ needsNetwork: true, run })], ctxWith(), {
+            allowNetwork: true,
+        });
+
+        expect(run).toHaveBeenCalledTimes(1);
+        expect(result.skipped).toBeUndefined();
+    });
+
+    test('a check that does not apply is skipped without being run', async () => {
+        const run = jest.fn(async () => []);
+
+        const [result] = await runChecks([fakeCheck({ appliesTo: () => false, run })], ctxWith());
+
+        expect(run).not.toHaveBeenCalled();
+        expect(result.skipped).toBe(SKIP_NOT_APPLICABLE);
+    });
+
+    test('an appliesTo that throws is reported rather than taking down the report', async () => {
+        const [result] = await runChecks(
+            [
+                fakeCheck({
+                    appliesTo: () => {
+                        throw new Error('predicate exploded');
+                    },
+                }),
+            ],
+            ctxWith()
+        );
+
+        expect(result.findings[0].severity).toBe(SEVERITY.ERROR);
+        expect(result.findings[0].detail).toContain('predicate exploded');
+    });
+
+    test('an error is demoted when the cause it names is present in the report', async () => {
+        // How a consequence stops repeating its cause's advice. Declarative: the consequence names
+        // the finding ids that explain it, and the runner demotes it only when one of them is
+        // actually there. The check does not predict what other checks will do.
+        const results = await runChecks(
+            [
+                fakeCheck({
+                    id: 'cause',
+                    run: async () => [
+                        {
+                            id: 'BSI-TEST-100',
+                            severity: SEVERITY.ERROR,
+                            title: 'the cause',
+                            detail: 'd',
+                            facts: [],
+                            remediation: [{ text: 'Fix the cause.' }],
+                        },
+                    ],
+                }),
+                fakeCheck({
+                    id: 'consequence',
+                    run: async () => [
+                        {
+                            id: 'BSI-TEST-101',
+                            severity: SEVERITY.ERROR,
+                            title: 'the consequence',
+                            detail: 'd',
+                            facts: [],
+                            remediation: [{ text: 'Fix the cause.' }],
+                            supersededBy: ['BSI-TEST-100'],
+                        },
+                    ],
+                }),
+            ],
+            ctxWith()
+        );
+
+        const consequence = results[1].findings[0];
+
+        expect(consequence.severity).toBe(SEVERITY.INFO);
+        // And its advice is dropped, so "Next steps" does not list the same fix twice.
+        expect(consequence.remediation).toEqual([]);
+    });
+
+    test('an error is NOT demoted when the cause it names is absent', async () => {
+        // The half that matters. Demotion driven by a prediction rather than by a present finding
+        // is how `browser check` exited 0 on a machine that could not take a screenshot: every
+        // other check reported OK, and the one real error demoted itself anyway.
+        const results = await runChecks(
+            [
+                fakeCheck({
+                    id: 'cause',
+                    run: async () => [
+                        {
+                            id: 'BSI-TEST-100',
+                            severity: SEVERITY.OK,
+                            title: 'the cause did not fire',
+                            detail: 'd',
+                            facts: [],
+                            remediation: [],
+                        },
+                    ],
+                }),
+                fakeCheck({
+                    id: 'consequence',
+                    run: async () => [
+                        {
+                            id: 'BSI-TEST-101',
+                            severity: SEVERITY.ERROR,
+                            title: 'the consequence',
+                            detail: 'd',
+                            facts: [],
+                            remediation: [{ text: 'Fix something.' }],
+                            supersededBy: ['BSI-TEST-100'],
+                        },
+                    ],
+                }),
+            ],
+            ctxWith()
+        );
+
+        expect(results[1].findings[0].severity).toBe(SEVERITY.ERROR);
+        expect(results[1].findings[0].remediation).toHaveLength(1);
+    });
+
+    test('a cause that is itself only a warning does not supersede', async () => {
+        // Only an error explains an error. A warning left the run passable, so a consequence
+        // demoted by one would leave the report with no error and the command exiting 0.
+        const results = await runChecks(
+            [
+                fakeCheck({
+                    id: 'cause',
+                    run: async () => [
+                        {
+                            id: 'BSI-TEST-100',
+                            severity: SEVERITY.WARNING,
+                            title: 'a warning',
+                            detail: 'd',
+                            facts: [],
+                            remediation: [],
+                        },
+                    ],
+                }),
+                fakeCheck({
+                    id: 'consequence',
+                    run: async () => [
+                        {
+                            id: 'BSI-TEST-101',
+                            severity: SEVERITY.ERROR,
+                            title: 'the consequence',
+                            detail: 'd',
+                            facts: [],
+                            remediation: [{ text: 'Fix something.' }],
+                            supersededBy: ['BSI-TEST-100'],
+                        },
+                    ],
+                }),
+            ],
+            ctxWith()
+        );
+
+        expect(results[1].findings[0].severity).toBe(SEVERITY.ERROR);
+    });
+
+    test('supersession works regardless of the order the causes ran in', async () => {
+        // The consequence may run before its cause. Resolving after every check has run is what
+        // makes registry order a reading order rather than a correctness dependency.
+        const results = await runChecks(
+            [
+                fakeCheck({
+                    id: 'consequence',
+                    run: async () => [
+                        {
+                            id: 'BSI-TEST-101',
+                            severity: SEVERITY.ERROR,
+                            title: 'the consequence',
+                            detail: 'd',
+                            facts: [],
+                            remediation: [{ text: 'Fix the cause.' }],
+                            supersededBy: ['BSI-TEST-100'],
+                        },
+                    ],
+                }),
+                fakeCheck({
+                    id: 'cause',
+                    run: async () => [
+                        {
+                            id: 'BSI-TEST-100',
+                            severity: SEVERITY.ERROR,
+                            title: 'the cause',
+                            detail: 'd',
+                            facts: [],
+                            remediation: [{ text: 'Fix the cause.' }],
+                        },
+                    ],
+                }),
+            ],
+            ctxWith()
+        );
+
+        expect(results[0].findings[0].severity).toBe(SEVERITY.INFO);
+    });
+
+    test('checks run in registry order, so the report reads top to bottom', async () => {
+        const results = await runChecks(
+            [fakeCheck({ id: 'first' }), fakeCheck({ id: 'second' }), fakeCheck({ id: 'third' })],
+            ctxWith()
+        );
+
+        expect(results.map((result) => result.check.id)).toEqual(['first', 'second', 'third']);
+    });
+});

--- a/src/lib/doctor/__tests__/render-report.test.js
+++ b/src/lib/doctor/__tests__/render-report.test.js
@@ -1,0 +1,595 @@
+import { jest, test, expect, describe, beforeEach } from '@jest/globals';
+
+const loggerMock = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    verbose: jest.fn(),
+    debug: jest.fn(),
+};
+
+jest.unstable_mockModule('../../../globals.js', () => ({
+    logger: loggerMock,
+}));
+
+const { renderReport, BEST_EFFORT_DISCLAIMER } = await import('../render-report.js');
+const { SEVERITY } = await import('../findings.js');
+
+/**
+ * The shared renderer.
+ *
+ * `browser check`'s output comes from here rather than being formatted inline, which is what makes
+ * the second diagnostic nearly free. The consequence tested throughout this file is that the
+ * renderer knows nothing about browsers: it renders sections, facts, findings and remediation,
+ * whatever produced them.
+ */
+
+/**
+ * A check result as the runner produces one.
+ *
+ * @param {string} section - Section heading the check belongs under.
+ * @param {object[]} findings - Findings the check produced.
+ * @param {object} [extra] - Extra fields on the result.
+ *
+ * @returns {object} A check result.
+ */
+const result = (section, findings, extra = {}) => ({
+    check: { id: `${section.toLowerCase()}-check`, title: `${section} check`, section },
+    findings,
+    ...extra,
+});
+
+/**
+ * Every line at every level, in the order they were logged.
+ *
+ * @returns {string[]} The lines, each prefixed with the level it went to.
+ */
+const lines = () =>
+    [
+        ...loggerMock.info.mock.calls.map(([line]) => ['info', String(line)]),
+        ...loggerMock.warn.mock.calls.map(([line]) => ['warn', String(line)]),
+        ...loggerMock.error.mock.calls.map(([line]) => ['error', String(line)]),
+    ].map(([level, line]) => `${level}: ${line}`);
+
+/**
+ * Only the lines the renderer sent at info, in order.
+ *
+ * @returns {string[]} The lines.
+ */
+const infoLines = () => loggerMock.info.mock.calls.map(([line]) => String(line));
+
+/**
+ * Only the lines the renderer sent at error, in order.
+ *
+ * @returns {string[]} The lines.
+ */
+const errorLines = () => loggerMock.error.mock.calls.map(([line]) => String(line));
+
+beforeEach(() => {
+    loggerMock.info.mockClear();
+    loggerMock.warn.mockClear();
+    loggerMock.error.mockClear();
+    loggerMock.verbose.mockClear();
+    loggerMock.debug.mockClear();
+});
+
+describe('sections and facts', () => {
+    test('prints one heading per section, in the order the checks ran', () => {
+        renderReport({
+            heading: 'Butler Sheet Icons browser check',
+            results: [
+                result('Environment', [
+                    {
+                        id: 'BSI-ENV-001',
+                        severity: SEVERITY.INFO,
+                        title: 'Environment',
+                        detail: 'x',
+                        facts: [{ label: 'Platform', value: 'win32 x64' }],
+                        remediation: [],
+                    },
+                ]),
+                result('Browser cache', [
+                    {
+                        id: 'BSI-BROWSER-005',
+                        severity: SEVERITY.OK,
+                        title: 'Cached browsers match this machine',
+                        detail: 'x',
+                        facts: [{ label: 'Directory', value: 'C:\\bsi\\cache' }],
+                        remediation: [],
+                    },
+                ]),
+            ],
+            okMessage: 'fine',
+        });
+
+        expect(infoLines()).toEqual([
+            'Butler Sheet Icons browser check',
+            'Environment',
+            '    Platform            : win32 x64',
+            'Browser cache',
+            '    Directory           : C:\\bsi\\cache',
+            ...BEST_EFFORT_DISCLAIMER,
+            expect.stringContaining('Result: OK'),
+        ]);
+    });
+
+    test('two checks sharing a section print one heading between them', () => {
+        // §7.3 has one "Browser cache" block, and §15.3 has two checks looking at the cache. The
+        // section is what reconciles them, and it is why a check declares one.
+        renderReport({
+            heading: 'h',
+            results: [
+                result('Browser cache', [
+                    {
+                        id: 'A',
+                        severity: SEVERITY.OK,
+                        title: 't',
+                        detail: 'd',
+                        facts: [{ label: 'Directory', value: '/cache' }],
+                        remediation: [],
+                    },
+                ]),
+                result('Browser cache', [
+                    {
+                        id: 'B',
+                        severity: SEVERITY.OK,
+                        title: 't',
+                        detail: 'd',
+                        facts: [{ label: 'Cached builds', value: '1' }],
+                        remediation: [],
+                    },
+                ]),
+            ],
+            okMessage: 'fine',
+        });
+
+        expect(infoLines().filter((line) => line === 'Browser cache')).toHaveLength(1);
+    });
+
+    test('renders sub-lines under the fact they belong to', () => {
+        renderReport({
+            heading: 'h',
+            results: [
+                result('Browser cache', [
+                    {
+                        id: 'A',
+                        severity: SEVERITY.OK,
+                        title: 't',
+                        detail: 'd',
+                        facts: [
+                            {
+                                label: 'Cached builds',
+                                value: '2',
+                                sublines: ['chrome 138 usable', 'chrome 131 not usable'],
+                            },
+                        ],
+                        remediation: [],
+                    },
+                ]),
+            ],
+            okMessage: 'fine',
+        });
+
+        expect(infoLines()).toContain('        chrome 138 usable');
+        expect(infoLines()).toContain('        chrome 131 not usable');
+    });
+
+    test('a section whose check was skipped is left out entirely', () => {
+        renderReport({
+            heading: 'h',
+            results: [result('Launch test', [], { skipped: 'not-applicable' })],
+            okMessage: 'fine',
+        });
+
+        expect(infoLines()).not.toContain('Launch test');
+    });
+});
+
+describe('findings', () => {
+    test('an error finding states what was observed, at error level', () => {
+        renderReport({
+            heading: 'h',
+            results: [
+                result('Selection', [
+                    {
+                        id: 'BSI-BROWSER-011',
+                        severity: SEVERITY.ERROR,
+                        title: 'no usable browser was found',
+                        detail: 'The cache at D:\\bsi holds no chrome build this machine can run.',
+                        facts: [],
+                        remediation: [{ text: 'Stage a browser.' }],
+                    },
+                ]),
+            ],
+            okMessage: 'fine',
+        });
+
+        expect(errorLines()).toContain(
+            '    The cache at D:\\bsi holds no chrome build this machine can run.'
+        );
+    });
+
+    test('an ok finding does not shout at info, but is visible at verbose', () => {
+        // §7.3's healthy output is facts, not a wall of "OK: ..." lines. The titles are still
+        // emitted, one level down, so a verbose run says what was actually examined.
+        renderReport({
+            heading: 'h',
+            results: [
+                result('Browser cache', [
+                    {
+                        id: 'BSI-BROWSER-005',
+                        severity: SEVERITY.OK,
+                        title: 'Cached browsers match this machine',
+                        detail: 'One chrome build, for win64.',
+                        facts: [],
+                        remediation: [],
+                    },
+                ]),
+            ],
+            okMessage: 'fine',
+        });
+
+        expect(infoLines().join('\n')).not.toContain('Cached browsers match this machine');
+        expect(loggerMock.verbose.mock.calls.map(([line]) => String(line)).join('\n')).toContain(
+            'Cached browsers match this machine'
+        );
+    });
+
+    test('a warning finding is rendered at warn, and does not fail the run', () => {
+        renderReport({
+            heading: 'h',
+            results: [
+                result('Browser executable', [
+                    {
+                        id: 'BSI-BROWSER-003',
+                        severity: SEVERITY.WARNING,
+                        title: 'PUPPETEER_EXECUTABLE_PATH names a file that does not exist',
+                        detail: 'Set to "/usr/bin/chromium-browser", which is not there.',
+                        facts: [],
+                        remediation: [],
+                    },
+                ]),
+            ],
+            okMessage: 'fine',
+        });
+
+        expect(loggerMock.warn.mock.calls.map(([line]) => String(line)).join('\n')).toContain(
+            'which is not there'
+        );
+        expect(infoLines().at(-1)).toContain('Result: OK');
+    });
+});
+
+describe('the result line', () => {
+    test("is OK when nothing failed, and carries the command's own headline", () => {
+        renderReport({
+            heading: 'h',
+            results: [result('Environment', [])],
+            okMessage: 'Butler Sheet Icons can take screenshots on this machine.',
+        });
+
+        expect(infoLines().at(-1)).toBe(
+            'Result: OK - Butler Sheet Icons can take screenshots on this machine.'
+        );
+    });
+
+    test('is FAILED when any finding is an error, and quotes the first one', () => {
+        renderReport({
+            heading: 'h',
+            results: [
+                result('Selection', [
+                    {
+                        id: 'BSI-BROWSER-011',
+                        severity: SEVERITY.ERROR,
+                        title: 'no usable browser was found, and taking screenshots would require downloading one over the internet',
+                        detail: 'd',
+                        facts: [],
+                        remediation: [{ text: 'Stage a browser.' }],
+                    },
+                ]),
+            ],
+            okMessage: 'fine',
+        });
+
+        expect(errorLines()).toContain(
+            'Result: FAILED - no usable browser was found, and taking screenshots would require downloading one over the internet'
+        );
+    });
+
+    test('reports the outcome it renders', () => {
+        const ok = renderReport({
+            heading: 'h',
+            results: [
+                result('Selection', [
+                    {
+                        id: 'X',
+                        severity: SEVERITY.ERROR,
+                        title: 't',
+                        detail: 'd',
+                        facts: [],
+                        remediation: [{ text: 'Do a thing.' }],
+                    },
+                ]),
+            ],
+            okMessage: 'fine',
+        });
+
+        expect(ok).toBe(false);
+    });
+});
+
+describe('remediation', () => {
+    test('is numbered once across every error finding, worst first', () => {
+        renderReport({
+            heading: 'h',
+            results: [
+                result('A', [
+                    {
+                        id: 'X',
+                        severity: SEVERITY.WARNING,
+                        title: 't',
+                        detail: 'd',
+                        facts: [],
+                        remediation: [{ text: 'A warning step.' }],
+                    },
+                ]),
+                result('B', [
+                    {
+                        id: 'Y',
+                        severity: SEVERITY.ERROR,
+                        title: 't',
+                        detail: 'd',
+                        facts: [],
+                        remediation: [{ text: 'First step.' }, { text: 'Second step.' }],
+                    },
+                ]),
+            ],
+            okMessage: 'fine',
+        });
+
+        expect(errorLines()).toContain('Next steps:');
+        expect(errorLines()).toContain('    1. First step.');
+        expect(errorLines()).toContain('    2. Second step.');
+        // A warning's advice does not belong in the "this run failed, do these things" list.
+        expect(errorLines().join('\n')).not.toContain('A warning step.');
+    });
+
+    test('prints the command for the host, not both', () => {
+        // BSI's primary platform is Windows Server, where a bash snippet is noise.
+        renderReport({
+            heading: 'h',
+            results: [
+                result('A', [
+                    {
+                        id: 'X',
+                        severity: SEVERITY.ERROR,
+                        title: 't',
+                        detail: 'd',
+                        facts: [],
+                        remediation: [
+                            {
+                                text: 'Install it.',
+                                command: {
+                                    powershell: 'butler-sheet-icons.exe browser install',
+                                    bash: './butler-sheet-icons browser install',
+                                },
+                            },
+                        ],
+                    },
+                ]),
+            ],
+            okMessage: 'fine',
+            platform: 'win32',
+        });
+
+        const text = errorLines().join('\n');
+
+        expect(text).toContain('butler-sheet-icons.exe browser install');
+        expect(text).not.toContain('./butler-sheet-icons browser install');
+    });
+
+    test('prints the bash command on a non-Windows host', () => {
+        renderReport({
+            heading: 'h',
+            results: [
+                result('A', [
+                    {
+                        id: 'X',
+                        severity: SEVERITY.ERROR,
+                        title: 't',
+                        detail: 'd',
+                        facts: [],
+                        remediation: [
+                            {
+                                text: 'Install it.',
+                                command: {
+                                    powershell: 'butler-sheet-icons.exe browser install',
+                                    bash: './butler-sheet-icons browser install',
+                                },
+                            },
+                        ],
+                    },
+                ]),
+            ],
+            okMessage: 'fine',
+            platform: 'linux',
+        });
+
+        expect(errorLines().join('\n')).toContain('./butler-sheet-icons browser install');
+    });
+});
+
+describe('a malformed finding cannot take down the report', () => {
+    // The runner isolates each check, but everything from the renderer onward was unguarded: a
+    // severity outside the four it knows made `logger[undefined]` a TypeError, thrown after the
+    // heading and facts had already printed, so the user got a half-written report with no
+    // disclaimer and no Result line.
+    const malformed = {
+        id: 'BSI-TEST-001',
+        severity: 'critical',
+        title: 'a severity nobody declared',
+        detail: 'something went wrong',
+        facts: [{ label: 'Thing', value: 'value' }],
+        remediation: [{ text: 'Do a thing.' }],
+    };
+
+    test.each([
+        ['no facts', { id: 'X', severity: SEVERITY.ERROR, title: 't', detail: 'd' }],
+        [
+            'no remediation',
+            { id: 'X', severity: SEVERITY.ERROR, title: 't', detail: 'd', facts: [] },
+        ],
+        ['nothing but a severity', { severity: SEVERITY.ERROR }],
+        ['a null finding', null],
+    ])('a finding with %s renders rather than throwing', (_name, entry) => {
+        // supersede()'s own contract says "a check is free to return plain objects", so the
+        // renderer has to survive them. Repairing only `severity` left `for (const fact of
+        // entry.facts)` throwing from inside the section loop - after the heading had printed and
+        // outside the runner's isolation, producing exactly the truncated report with no
+        // disclaimer and no Result line that the repair was written to prevent.
+        expect(() =>
+            renderReport({ heading: 'h', results: [result('A', [entry])], okMessage: 'fine' })
+        ).not.toThrow();
+
+        const text = lines().join('\n');
+
+        expect(text).toContain(BEST_EFFORT_DISCLAIMER[0]);
+        expect(text).toContain('Result:');
+    });
+
+    test('renders rather than throwing', () => {
+        expect(() =>
+            renderReport({
+                heading: 'h',
+                results: [result('A', [malformed])],
+                okMessage: 'fine',
+            })
+        ).not.toThrow();
+
+        // And the report is complete, not truncated at the point of the bad finding.
+        expect(lines().join('\n')).toContain(BEST_EFFORT_DISCLAIMER[0]);
+        expect(lines().join('\n')).toContain('Result:');
+    });
+
+    test('is treated as a failure rather than silently passing', () => {
+        // A finding whose severity cannot be interpreted is a bug in a check. On a command used
+        // as a deployment gate, the safe reading is "something is wrong here", not "fine".
+        const ok = renderReport({
+            heading: 'h',
+            results: [result('A', [malformed])],
+            okMessage: 'fine',
+        });
+
+        expect(ok).toBe(false);
+    });
+});
+
+describe('the FAILED headline names the machine problem, not the diagnostic', () => {
+    // BSI-DOCTOR-001 is emitted in place of whichever check threw, so registry position could put
+    // it first among errors and let it speak for the machine - burying the real diagnosis under
+    // "re-run with --loglevel debug and file an issue".
+    const runnerError = {
+        id: 'BSI-DOCTOR-001',
+        severity: SEVERITY.ERROR,
+        title: 'A diagnostic check could not be completed',
+        detail: 'the check "environment" stopped with an error',
+        facts: [],
+        remediation: [{ text: 'File a Butler Sheet Icons issue.' }],
+    };
+
+    const realProblem = {
+        id: 'BSI-BROWSER-011',
+        severity: SEVERITY.ERROR,
+        title: 'no usable browser was found',
+        detail: 'the cache is empty',
+        facts: [],
+        remediation: [{ text: 'Stage a browser.' }],
+    };
+
+    test('a runner error does not outrank a real finding it happens to precede', () => {
+        renderReport({
+            heading: 'h',
+            results: [result('A', [runnerError]), result('B', [realProblem])],
+            okMessage: 'fine',
+        });
+
+        expect(errorLines()).toContain('Result: FAILED - no usable browser was found');
+    });
+
+    test('but it is still the headline when it is the only error', () => {
+        // Suppressing it entirely would leave a failed run with no stated reason.
+        renderReport({
+            heading: 'h',
+            results: [result('A', [runnerError])],
+            okMessage: 'fine',
+        });
+
+        expect(errorLines()).toContain(
+            'Result: FAILED - A diagnostic check could not be completed'
+        );
+    });
+
+    test('its advice still appears in Next steps', () => {
+        renderReport({
+            heading: 'h',
+            results: [result('A', [runnerError]), result('B', [realProblem])],
+            okMessage: 'fine',
+        });
+
+        const text = errorLines().join('\n');
+
+        expect(text).toContain('Stage a browser.');
+        expect(text).toContain('File a Butler Sheet Icons issue.');
+    });
+});
+
+describe('the best-effort disclaimer', () => {
+    test('sits immediately before the Result line on a healthy run', () => {
+        renderReport({ heading: 'h', results: [result('A', [])], okMessage: 'fine' });
+
+        const printed = lines();
+        const resultIndex = printed.findIndex((line) => line.includes('Result:'));
+        const disclaimerEnd = printed.findIndex((line) =>
+            line.includes(BEST_EFFORT_DISCLAIMER.at(-1))
+        );
+
+        expect(disclaimerEnd).toBeGreaterThan(-1);
+        expect(resultIndex).toBe(disclaimerEnd + 1);
+    });
+
+    test('is printed on the failure path too', () => {
+        renderReport({
+            heading: 'h',
+            results: [
+                result('A', [
+                    {
+                        id: 'X',
+                        severity: SEVERITY.ERROR,
+                        title: 't',
+                        detail: 'd',
+                        facts: [],
+                        remediation: [{ text: 'Do a thing.' }],
+                    },
+                ]),
+            ],
+            okMessage: 'fine',
+        });
+
+        expect(lines().join('\n')).toContain(BEST_EFFORT_DISCLAIMER[0]);
+    });
+
+    test('has no flag that suppresses it', () => {
+        // Deliberately asserted as an absence: a switch to hide it would be used by exactly the
+        // automated contexts where a human later reads the output without knowing it was hidden.
+        renderReport({
+            heading: 'h',
+            results: [result('A', [])],
+            okMessage: 'fine',
+            disclaimer: false,
+            showDisclaimer: false,
+            quiet: true,
+        });
+
+        expect(lines().join('\n')).toContain(BEST_EFFORT_DISCLAIMER[0]);
+    });
+});

--- a/src/lib/doctor/checks/browser-cache-executable.js
+++ b/src/lib/doctor/checks/browser-cache-executable.js
@@ -1,0 +1,113 @@
+import { SEVERITY, finding } from '../findings.js';
+import { failedTheRun } from './cache-severity.js';
+
+/**
+ * Whether the cached builds have a browser behind them.
+ *
+ * `computeExecutablePath()` derives the binary's path from the cache layout without ever stat-ing
+ * it, so a cache copied without its binaries - or without the `.metadata` file, which is what a
+ * `tar` invocation that skips dotfiles produces - yields a perfectly plausible path to nothing.
+ * The directory listing looks right, `browser list-installed` looks right, and the run fails at
+ * launch.
+ *
+ * Renders under the same heading as {@link ./browser-cache-platform.js}, which carries the cache
+ * overview facts. This check adds only its verdict.
+ */
+export const check = {
+    id: 'browser-cache-executable',
+    title: 'Cached browsers have their executables',
+    section: 'Browser cache',
+    area: 'browser',
+    needsNetwork: false,
+    findingIds: ['BSI-BROWSER-008', 'BSI-BROWSER-009'],
+
+    // Applies only when there is a build whose binary is the *remaining* question: of the
+    // requested browser, and able to run here. Everything else is the platform check's subject.
+    //
+    // That precedence is `unusableReason`'s, and honouring it is what stops one build producing
+    // two diagnoses. A cache that is both foreign-platform and binary-less used to emit
+    // BSI-BROWSER-006 and BSI-BROWSER-009 together, giving a four-step "Next steps" whose last two
+    // entries told the administrator to re-copy the cache preserving hidden files - advice that
+    // cannot help a build compiled for another operating system.
+    //
+    // An empty or unreadable cache is excluded for the same reason: the platform check reports
+    // both, and "0 of 0 builds are missing their binaries" is noise.
+    appliesTo: (ctx) =>
+        !ctx.cache.readError &&
+        ctx.cache.builds.some(
+            (build) => build.browser === (ctx.options.browser ?? 'chrome') && build.canRunHere
+        ),
+
+    /**
+     * Reports which cached builds are missing their binary.
+     *
+     * @param {object} ctx - The check context.
+     *
+     * @returns {Promise<import('../findings.js').Finding[]>} One finding.
+     */
+    run: async (ctx) => {
+        const { cache } = ctx;
+        // Only builds a real run would actually reach for. A chrome-headless-shell build with no
+        // binary behind it is not this run's problem, and reporting it as an error would fail a
+        // machine over a browser Butler Sheet Icons never looks at.
+        const requestedBrowser = ctx.options.browser ?? 'chrome';
+        const ofType = cache.builds.filter(
+            (build) => build.browser === requestedBrowser && build.canRunHere
+        );
+        const incomplete = ofType.filter((build) => !build.executableExists);
+
+        if (incomplete.length === 0) {
+            return [
+                finding({
+                    id: 'BSI-BROWSER-008',
+                    severity: SEVERITY.OK,
+                    title: 'Every cached browser has its executable',
+                    detail: `All ${ofType.length} cached ${requestedBrowser} build(s) in ${cache.dir} have their browser binary on disk.`,
+                    evidence: { cacheDir: cache.dir, buildCount: ofType.length },
+                }),
+            ];
+        }
+
+        return [
+            finding({
+                id: 'BSI-BROWSER-009',
+                // Only a failure when it actually stopped the run. An incomplete build sitting
+                // beside a working one is cruft, not a fault: the real run selected the good build
+                // and took its screenshots. Judging every build in isolation made `browser check`
+                // print "Launched: yes / Reported version: Chrome/..." and then FAIL, blocking a
+                // Sense server that demonstrably works - and one leftover directory from an
+                // interrupted install is ordinary, which is what made this the likeliest way for
+                // the gate to reject a healthy machine.
+                //
+                // The real run's own policy, from browser-detect.js: "a healthy run with one stale
+                // directory beside a usable build stays quiet, because warnings that fire on
+                // success get ignored."
+                severity: failedTheRun(ctx) ? SEVERITY.ERROR : SEVERITY.WARNING,
+                title: 'cached browsers are missing their executable files',
+                detail: `${incomplete.length} of ${ofType.length} cached ${requestedBrowser} build(s) in ${cache.dir} have no browser binary where one should be: ${incomplete.map((build) => `${build.browser} ${build.buildId} (expected at ${build.executablePath})`).join('; ')}. The cache directory is incomplete - copied without the browser binary, or left behind by a failed install.`,
+                evidence: {
+                    cacheDir: cache.dir,
+                    incomplete: incomplete.map((build) => ({
+                        browser: build.browser,
+                        buildId: build.buildId,
+                        executablePath: build.executablePath,
+                    })),
+                },
+                remediation: [
+                    {
+                        text: 'Copy the browser cache directory again, preserving hidden files - a tar or robocopy invocation that skips dotfiles leaves the .metadata file behind and produces exactly this.',
+                    },
+                    {
+                        text: 'Or install the browser again on a machine with internet access, and copy the whole cache directory here.',
+                        command: {
+                            powershell:
+                                'butler-sheet-icons.exe browser install --browser chrome --browser-version recommended',
+                            bash: './butler-sheet-icons browser install --browser chrome --browser-version recommended',
+                        },
+                    },
+                ],
+                docs: 'guide/advanced/air-gapped-installation',
+            }),
+        ];
+    },
+};

--- a/src/lib/doctor/checks/browser-cache-platform.js
+++ b/src/lib/doctor/checks/browser-cache-platform.js
@@ -1,0 +1,214 @@
+import { SEVERITY, finding } from '../findings.js';
+import { failedTheRun } from './cache-severity.js';
+
+/**
+ * Whether the browser cache holds a build this machine can actually run.
+ *
+ * The most likely staging mistake, and the one whose old symptom named nothing useful: the
+ * connected machine an administrator downloads a browser on is usually their own Mac, and the
+ * target is a Windows server. A cache copied between the two contains perfectly real browser
+ * builds that this machine cannot execute.
+ *
+ * This check also carries the cache overview - where the cache is, whether it exists, whether it
+ * will be consulted at all, and what is in it. Those facts belong to the section rather than to
+ * one check, and this is the first check in it. The second cache check ({@link
+ * ./browser-cache-executable.js}) renders under the same heading.
+ */
+
+/** Column widths for the per-build lines, so the list reads as a table. */
+const NAME_WIDTH = 24;
+const PLATFORM_WIDTH = 18;
+
+/**
+ * One line describing a cached build.
+ *
+ * @param {object} build - A build from the context's cache inventory.
+ *
+ * @returns {string} The rendered line.
+ */
+const buildLine = (build) => {
+    const name = `${build.browser} ${build.buildId}`.padEnd(NAME_WIDTH);
+    const platform = `platform=${build.platform}`.padEnd(PLATFORM_WIDTH);
+    const executable = build.executableExists ? 'executable present' : 'executable MISSING';
+
+    return `${name} ${platform} ${executable.padEnd(20)} ${build.usable ? 'usable' : `not usable (${build.reason})`}`;
+};
+
+/**
+ * The cache facts every finding in this section is read against.
+ *
+ * @param {object} ctx - The check context.
+ *
+ * @returns {import('../findings.js').Fact[]} The facts.
+ */
+const cacheFacts = (ctx) => {
+    const { cache } = ctx;
+
+    return [
+        { label: 'Source', value: cache.sourceLabel },
+        { label: 'Directory', value: cache.dir },
+        { label: 'Directory exists', value: cache.exists ? 'yes' : 'no' },
+        {
+            // Not decoration. When both an executable path and a cache directory are configured,
+            // the cache is not consulted at all - and without this line administrators file bugs
+            // about a cache directory that "does nothing".
+            label: 'In use',
+            value: cache.inUse ? 'yes' : `no (${cache.notConsultedReason})`,
+        },
+        {
+            label: 'Cached builds',
+            value: String(cache.builds.length),
+            sublines: cache.builds.map(buildLine),
+        },
+    ];
+};
+
+export const check = {
+    id: 'browser-cache-platform',
+    title: 'Cached browsers match this machine',
+    section: 'Browser cache',
+    area: 'browser',
+    needsNetwork: false,
+    findingIds: ['BSI-BROWSER-005', 'BSI-BROWSER-006', 'BSI-BROWSER-007', 'BSI-BROWSER-019'],
+    appliesTo: () => true,
+
+    /**
+     * Reports which cached builds this machine can run.
+     *
+     * @param {object} ctx - The check context.
+     *
+     * @returns {Promise<import('../findings.js').Finding[]>} One finding.
+     */
+    run: async (ctx) => {
+        const { cache, host } = ctx;
+        const facts = cacheFacts(ctx);
+        // This check judges the browser type and the platform, and nothing else. Deliberately not
+        // `build.usable`: that also folds in whether the binary is on disk, which is the sibling
+        // check's question, and reading it here made a build whose binary is present but
+        // unusable for some third reason report as "built for a different operating system" -
+        // a headline naming a cause that was not the cause.
+        const requestedBrowser = ctx.options.browser ?? 'chrome';
+        const ofType = cache.builds.filter((build) => build.browser === requestedBrowser);
+        const runnable = ofType.filter((build) => build.canRunHere);
+
+        if (cache.readError) {
+            // The cache could not be read at all. An error, because on a machine with no browser
+            // executable configured this is the whole of what a real run would look at - and it
+            // is the LocalSystem symptom this command exists to surface: a directory staged by an
+            // administrator that the service account cannot open.
+            return [
+                finding({
+                    id: 'BSI-BROWSER-019',
+                    // Gated like its siblings. An unreadable cache that nothing was going to read
+                    // - because --browser-executable-path names a browser that works - is worth
+                    // saying and is not a failure. Unconditional ERROR here failed machines whose
+                    // report said, three lines earlier, that the browser had launched.
+                    severity: failedTheRun(ctx) ? SEVERITY.ERROR : SEVERITY.WARNING,
+                    title: 'the browser cache directory could not be read',
+                    // Same shape as the launch check's: the interpolated error is last, because a
+                    // message that ends in its own period would otherwise produce two.
+                    detail: `Butler Sheet Icons could not read ${cache.dir}. Whatever browsers are staged there, this account cannot see them, so a real run would behave as though the cache were empty. The error was: ${cache.readError}`,
+                    facts,
+                    evidence: { cacheDir: cache.dir, error: cache.readError },
+                    remediation: [
+                        {
+                            text: `Check that the account this runs as (${ctx.host.user}) can read ${cache.dir} and everything under it. A cache staged from an administrator's own profile is the usual cause - under a Windows scheduled task Butler Sheet Icons often runs as LocalSystem, not as the person who staged it.`,
+                        },
+                        {
+                            text: 'Or move the browser cache somewhere the service account can read, and point Butler Sheet Icons at it with --browser-cache-dir or BSI_BROWSER_CACHE_DIR.',
+                        },
+                    ],
+                    docs: 'guide/advanced/air-gapped-installation',
+                }),
+            ];
+        }
+
+        if (cache.builds.length === 0) {
+            return [
+                finding({
+                    id: 'BSI-BROWSER-007',
+                    severity: SEVERITY.INFO,
+                    title: 'The browser cache holds no browser builds',
+                    // Informational rather than an error on its own: a machine with a system
+                    // browser named by --browser-executable-path needs nothing in the cache. The
+                    // selection check is what decides whether the absence matters.
+                    detail: `No browser builds were found in ${cache.dir}${cache.exists ? '' : ', which does not exist'}.`,
+                    facts,
+                    evidence: { cacheDir: cache.dir, cacheDirExists: cache.exists },
+                }),
+            ];
+        }
+
+        // The cache holds browsers, but none of the type this run needs. Reported before the
+        // platform question because the remedy is different and the platform sentence would be
+        // simply false: `~/.cache/puppeteer` is shared with any other Puppeteer install on the
+        // host, so a cache full of perfectly good chrome-headless-shell builds for exactly this
+        // platform is a normal way to arrive here.
+        if (ofType.length === 0) {
+            const types = [...new Set(cache.builds.map((build) => build.browser))];
+
+            return [
+                finding({
+                    id: 'BSI-BROWSER-007',
+                    severity: SEVERITY.INFO,
+                    title: `The browser cache holds no ${requestedBrowser} builds`,
+                    detail: `The cache at ${cache.dir} holds ${cache.builds.length} build(s), but of ${types.join(', ')} rather than ${requestedBrowser}. Butler Sheet Icons only looks for ${requestedBrowser}, so none of them can be used.`,
+                    facts,
+                    evidence: { cacheDir: cache.dir, cachedTypes: types, requestedBrowser },
+                }),
+            ];
+        }
+
+        if (runnable.length > 0) {
+            return [
+                finding({
+                    id: 'BSI-BROWSER-005',
+                    severity: SEVERITY.OK,
+                    title: 'Cached browsers match this machine',
+                    detail: `${runnable.length} of ${ofType.length} cached ${requestedBrowser} build(s) in ${cache.dir} can run on this machine (platform "${host.hostPlatform ?? 'unknown'}").`,
+                    facts,
+                    evidence: {
+                        cacheDir: cache.dir,
+                        hostPlatform: host.hostPlatform,
+                        runnableBuildIds: runnable.map((build) => build.buildId),
+                    },
+                }),
+            ];
+        }
+
+        const platforms = [...new Set(ofType.map((build) => build.platform))];
+
+        return [
+            finding({
+                id: 'BSI-BROWSER-006',
+                // The same rule as its siblings: an observation about the cache is a failure only
+                // when the cache is what this run depended on and nothing was selected. §7.3's
+                // healthy sample is exactly the other case - a foreign build listed beside a
+                // working executable override.
+                severity: failedTheRun(ctx) ? SEVERITY.ERROR : SEVERITY.WARNING,
+                title: 'the cached browsers were built for a different operating system',
+                detail: `The cache at ${cache.dir} holds ${ofType.length} ${requestedBrowser} build(s), for ${platforms.join(', ')}. This machine is ${host.hostPlatform ?? 'a platform Butler Sheet Icons does not recognise'}. A browser cache copied from a machine with a different operating system cannot be used.`,
+                facts,
+                evidence: {
+                    cacheDir: cache.dir,
+                    hostPlatform: host.hostPlatform,
+                    cachedPlatforms: platforms,
+                },
+                remediation: [
+                    {
+                        text: "Stage the browser from a machine running the same operating system as this one, and copy that machine's browser cache directory here.",
+                        command: {
+                            powershell:
+                                'butler-sheet-icons.exe browser install --browser chrome --browser-version recommended',
+                            bash: './butler-sheet-icons browser install --browser chrome --browser-version recommended',
+                        },
+                    },
+                    {
+                        text: 'Or, if Chrome or Edge is already installed on this machine, point Butler Sheet Icons at it with --browser-executable-path or BSI_BROWSER_EXECUTABLE_PATH.',
+                    },
+                ],
+                docs: 'guide/advanced/air-gapped-installation',
+            }),
+        ];
+    },
+};

--- a/src/lib/doctor/checks/browser-executable-override.js
+++ b/src/lib/doctor/checks/browser-executable-override.js
@@ -1,0 +1,110 @@
+import { SEVERITY, finding } from '../findings.js';
+
+/**
+ * Whether a browser executable named by the administrator is actually there.
+ *
+ * The single most valuable thing this command can catch, because it means somebody's *explicit*
+ * configuration is wrong - and until issue #1061 the only symptom was a run that failed much later
+ * with an error naming none of this.
+ *
+ * The two tiers are treated differently on purpose, mirroring `detectAvailableBrowser`:
+ *
+ * - `--browser-executable-path` / `BSI_BROWSER_EXECUTABLE_PATH` is a stated intent. If the file is
+ *   not there, a real run stops rather than downloading some other browser, so this is an error.
+ * - `PUPPETEER_EXECUTABLE_PATH` is a much weaker signal - typically inherited from a container
+ *   image or a developer shell - and a real run falls through to the cache, so this is a warning.
+ *   Reporting it as an error would fail the check on every machine that has the variable set and
+ *   works perfectly.
+ */
+export const check = {
+    id: 'browser-executable-override',
+    title: 'A named browser executable resolves and exists',
+    section: 'Browser executable',
+    area: 'browser',
+    needsNetwork: false,
+    findingIds: ['BSI-BROWSER-001', 'BSI-BROWSER-002', 'BSI-BROWSER-003', 'BSI-BROWSER-004'],
+    appliesTo: () => true,
+
+    /**
+     * Reports on the configured browser executable, if there is one.
+     *
+     * @param {object} ctx - The check context.
+     *
+     * @returns {Promise<import('../findings.js').Finding[]>} One finding.
+     */
+    run: async (ctx) => {
+        const override = ctx.executableOverride;
+
+        if (!override) {
+            return [
+                finding({
+                    id: 'BSI-BROWSER-004',
+                    severity: SEVERITY.OK,
+                    title: 'No browser executable is configured',
+                    detail: `Neither --browser-executable-path nor PUPPETEER_EXECUTABLE_PATH is set, so Butler Sheet Icons will use a browser from its cache at ${ctx.cache.dir}.`,
+                    facts: [{ label: 'Configured', value: 'no' }],
+                }),
+            ];
+        }
+
+        const facts = [
+            { label: 'Source', value: override.sourceLabel },
+            { label: 'Path', value: override.path },
+            { label: 'Exists', value: override.exists ? 'yes' : 'no' },
+        ];
+
+        if (override.exists) {
+            return [
+                finding({
+                    id: 'BSI-BROWSER-001',
+                    severity: SEVERITY.OK,
+                    title: 'The configured browser executable exists',
+                    detail: `${override.sourceLabel}: ${override.path}, which is present on this machine.`,
+                    facts,
+                    evidence: { path: override.path, source: override.source },
+                }),
+            ];
+        }
+
+        if (override.explicit) {
+            return [
+                finding({
+                    id: 'BSI-BROWSER-002',
+                    severity: SEVERITY.ERROR,
+                    title: 'the configured browser executable does not exist',
+                    // The value as the operator wrote it, not as it resolved. A relative path
+                    // printed back absolute is one they cannot find in their unit file.
+                    detail: `--browser-executable-path / BSI_BROWSER_EXECUTABLE_PATH is set to "${override.configuredValue}", and no such file exists on this machine. Butler Sheet Icons will not fall back to downloading a browser when an executable path has been given explicitly, so every thumbnail run will stop here.`,
+                    facts,
+                    evidence: {
+                        configuredValue: override.configuredValue,
+                        path: override.path,
+                        source: override.source,
+                    },
+                    remediation: [
+                        {
+                            text: `Correct the path so it names a browser that exists on this machine, or remove the setting to let Butler Sheet Icons find a browser itself. On Windows, Google Chrome is usually at C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe and Microsoft Edge at C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe.`,
+                        },
+                    ],
+                    docs: 'guide/advanced/air-gapped-installation',
+                }),
+            ];
+        }
+
+        return [
+            finding({
+                id: 'BSI-BROWSER-003',
+                severity: SEVERITY.WARNING,
+                title: 'PUPPETEER_EXECUTABLE_PATH names a file that does not exist',
+                detail: `PUPPETEER_EXECUTABLE_PATH is set to "${override.configuredValue}", and no such file exists on this machine. Butler Sheet Icons will ignore it and look in the browser cache instead, so this is not fatal - but the variable is doing nothing, and on a Docker image it usually means the browser is not where the image put it.`,
+                facts,
+                evidence: { configuredValue: override.configuredValue, path: override.path },
+                remediation: [
+                    {
+                        text: 'Unset PUPPETEER_EXECUTABLE_PATH, or point it at a browser that exists.',
+                    },
+                ],
+            }),
+        ];
+    },
+};

--- a/src/lib/doctor/checks/browser-launch.js
+++ b/src/lib/doctor/checks/browser-launch.js
@@ -1,0 +1,216 @@
+import { SEVERITY, finding } from '../findings.js';
+import { BROWSER_LAUNCH_TIMEOUT_MS } from '../../browser/browser-launch.js';
+
+/**
+ * Whether the selected browser actually starts and answers.
+ *
+ * Resolving a path proves far less than starting the process. A browser build can be present,
+ * correct for the platform, complete on disk - and still fail to start, because endpoint
+ * protection holds it, because a shared library is missing on a minimal Linux image, or because
+ * the build is one Puppeteer cannot drive at all.
+ *
+ * Three outcomes, and they are deliberately not one:
+ *
+ * - **The process never started.** Usually the environment: permissions, missing libraries,
+ *   security software.
+ * - **It started and then could not be driven.** Issue #878: the browser launches perfectly well
+ *   and dies on the first command sent to it. The remedy is a different *build*, and nothing in
+ *   the protocol error says so. Reporting this as "could not be started" was false, and it put
+ *   antivirus advice in front of the fix.
+ * - **It started slowly and worked.** The stall no timeout catches, because process creation is
+ *   synchronous inside libuv and blocks the event loop. Reported as a clean pass before, which is
+ *   how an administrator rules the browser out and then spends a week on the wrong thing.
+ *
+ * The launch itself is performed by the worker, before any check runs, and this reports the
+ * result. That is not squeamishness about the rule that a check must not mutate anything: it is
+ * what keeps this check a pure function of its context, so every branch here is unit-testable
+ * without a browser.
+ *
+ * `needsNetwork: false` - starting a local process reaches nothing.
+ */
+
+/**
+ * Remediation for a browser that never started, aimed at where the browser actually came from.
+ *
+ * A browser named by `--browser-executable-path` is not in the cache and is not chosen by
+ * `--browser-version`: detection returns the override before it consults either. Offering the
+ * cached-browser advice there sent administrators to exclude a directory nothing reads and to
+ * paste a command that reproduces the identical failure.
+ *
+ * @param {object} ctx - The check context.
+ *
+ * @returns {import('../findings.js').Remediation[]} Steps that apply to this configuration.
+ */
+const startFailureRemediation = (ctx) => {
+    const { executablePath, source } = ctx.detection.selection;
+
+    if (source === 'system') {
+        return [
+            {
+                text: `Check that ${executablePath} is a browser this machine can run, and that the account Butler Sheet Icons runs as (${ctx.host.user}) is allowed to execute it.`,
+            },
+            {
+                text: 'On Windows, exclude that executable from real-time antivirus scanning. Endpoint protection holding a browser it has not seen before is the most common cause of this on a Sense server.',
+            },
+            {
+                text: 'Or remove --browser-executable-path / BSI_BROWSER_EXECUTABLE_PATH and let Butler Sheet Icons use a browser from its own cache instead.',
+            },
+        ];
+    }
+
+    return [
+        {
+            text: 'On Windows, exclude the Butler Sheet Icons browser cache directory from real-time antivirus scanning. Endpoint protection holding a browser executable it has not seen before is the most common cause of this on a Sense server.',
+        },
+        {
+            text: 'Try a different browser build - "recommended" selects the one Butler Sheet Icons is tested with.',
+            command: {
+                powershell: 'butler-sheet-icons.exe browser check --browser-version recommended',
+                bash: './butler-sheet-icons browser check --browser-version recommended',
+            },
+        },
+        {
+            text: "On Linux, check that the browser's shared library dependencies are installed. A minimal container image often lacks them, and the failure names none of them.",
+        },
+    ];
+};
+
+export const check = {
+    id: 'browser-launch',
+    title: 'The selected browser starts and responds',
+    section: 'Launch test',
+    area: 'browser',
+    needsNetwork: false,
+    findingIds: [
+        'BSI-BROWSER-014',
+        'BSI-BROWSER-015',
+        'BSI-BROWSER-016',
+        'BSI-BROWSER-020',
+        'BSI-BROWSER-021',
+    ],
+
+    // Nothing to launch, and nothing to say about it. The selection check has already reported
+    // why there is no browser, and a "not attempted" line under a heading of its own would put a
+    // second, emptier answer beneath the real one.
+    appliesTo: (ctx) => Boolean(ctx.detection.selection),
+
+    /**
+     * Reports the launch attempt.
+     *
+     * @param {object} ctx - The check context.
+     *
+     * @returns {Promise<import('../findings.js').Finding[]>} One finding, or two when a launch
+     * succeeded but took longer than the launch budget allows for.
+     */
+    run: async (ctx) => {
+        const { launch, detection } = ctx;
+        const { executablePath } = detection.selection;
+
+        if (launch.skipped) {
+            return [
+                finding({
+                    id: 'BSI-BROWSER-016',
+                    severity: SEVERITY.INFO,
+                    title: 'The launch test was skipped',
+                    detail: `--skip-launch was given, so the browser at ${executablePath} was found but never started. Whether it runs on this machine has not been established.`,
+                    facts: [{ label: 'Launched', value: 'no (--skip-launch)' }],
+                }),
+            ];
+        }
+
+        if (!launch.started) {
+            return [
+                finding({
+                    id: 'BSI-BROWSER-015',
+                    severity: SEVERITY.ERROR,
+                    title: 'the browser could not be started',
+                    detail: `The browser at ${executablePath} was found, but the process would not start: ${launch.error}`,
+                    facts: [{ label: 'Launched', value: 'no' }],
+                    evidence: { executablePath, error: launch.error },
+                    remediation: startFailureRemediation(ctx),
+                }),
+            ];
+        }
+
+        if (!launch.ok) {
+            // Issue #878. The build id is named because it is the thing to change, and because a
+            // protocol error mentions nothing that ties the failure to --browser-version.
+            const build = detection.selection.buildId;
+
+            return [
+                finding({
+                    id: 'BSI-BROWSER-020',
+                    severity: SEVERITY.ERROR,
+                    title: 'the browser starts but cannot be driven by Butler Sheet Icons',
+                    // The interpolated error goes last. Puppeteer's protocol errors end in a
+                    // period of their own, so embedding one mid-sentence produced "Session
+                    // closed.. The process is fine" - which reads as a typo in a line an
+                    // administrator is being asked to trust.
+                    detail: `The browser at ${executablePath} started and then stopped responding on the first command sent to it. The process is fine; this build cannot be driven. A real run fails the same way, part-way through a sheet. The error was: ${launch.error}`,
+                    facts: [
+                        { label: 'Launched', value: 'yes' },
+                        { label: 'Responded', value: 'no' },
+                        { label: 'Build', value: build },
+                    ],
+                    evidence: { executablePath, buildId: build, error: launch.error },
+                    remediation: [
+                        {
+                            text: `Use a different browser build. "recommended" selects the build Butler Sheet Icons is tested against${build && build !== 'system-installed' ? `, rather than ${build}` : ''}.`,
+                            command: {
+                                powershell:
+                                    'butler-sheet-icons.exe browser check --browser-version recommended',
+                                bash: './butler-sheet-icons browser check --browser-version recommended',
+                            },
+                        },
+                        {
+                            text: "The same value can be set for a real run through the command's BSI_*_BROWSER_VERSION environment variable.",
+                        },
+                    ],
+                }),
+            ];
+        }
+
+        const findings = [
+            finding({
+                id: 'BSI-BROWSER-014',
+                severity: SEVERITY.OK,
+                title: 'The browser started and responded',
+                detail: `The browser at ${executablePath} started and reported version ${launch.version}.`,
+                facts: [
+                    { label: 'Launched', value: 'yes' },
+                    { label: 'Reported version', value: launch.version },
+                ],
+                evidence: { version: launch.version, elapsedMs: launch.elapsedMs },
+            }),
+        ];
+
+        // A pass, with a caveat that matters more than it looks. `timeout` bounds the wait for the
+        // browser to announce its debugging endpoint - it does not bound getting the process off
+        // the ground, and on Windows process creation blocks the event loop, so no timer can fire
+        // while it happens. Anything over the launch budget is by definition time that budget did
+        // not account for, which makes it the natural threshold and means no second number to keep
+        // in sync.
+        if (launch.elapsedMs > BROWSER_LAUNCH_TIMEOUT_MS) {
+            findings.push(
+                finding({
+                    id: 'BSI-BROWSER-021',
+                    severity: SEVERITY.WARNING,
+                    title: 'the browser started, but took far longer than it should have',
+                    detail: `Starting the browser took ${Math.round(launch.elapsedMs / 1000)}s, longer than the ${BROWSER_LAUNCH_TIMEOUT_MS / 1000}s launch timeout allows for. It worked this time, so this check passes - but a real run can exceed the timeout on the same machine and fail with an error naming none of this.`,
+                    facts: [{ label: 'Launch took', value: `${Math.round(launch.elapsedMs)} ms` }],
+                    evidence: {
+                        elapsedMs: launch.elapsedMs,
+                        budgetMs: BROWSER_LAUNCH_TIMEOUT_MS,
+                    },
+                    remediation: [
+                        {
+                            text: 'On Windows this is typically antivirus or endpoint protection scanning a browser executable it has not seen before. Excluding the Butler Sheet Icons browser cache directory from real-time scanning avoids it.',
+                        },
+                    ],
+                })
+            );
+        }
+
+        return findings;
+    },
+};

--- a/src/lib/doctor/checks/browser-selection.js
+++ b/src/lib/doctor/checks/browser-selection.js
@@ -1,0 +1,314 @@
+import { SEVERITY, finding } from '../findings.js';
+import { VERSION_FORM } from '../../browser/browser-version.js';
+
+/**
+ * Which browser a real run would use, decided the same way a real run decides it.
+ *
+ * This is the check the whole command exists for. Detection has already run - without touching the
+ * network, see `browserCheck()` - and this reports what it chose, or why it chose nothing.
+ *
+ * "Would have to download one" is an error even on a machine with a working internet connection.
+ * The question `browser check` answers is whether this machine can take screenshots *by itself*;
+ * a run that depends on reaching the Chrome for Testing servers is a run that will fail the first
+ * time a proxy rule changes, and on the air-gapped hosts this work is about it fails today.
+ */
+export const check = {
+    id: 'browser-selection',
+    title: 'A browser can be selected without downloading one',
+    section: 'Selection',
+    area: 'browser',
+    needsNetwork: false,
+    findingIds: [
+        'BSI-BROWSER-010',
+        'BSI-BROWSER-011',
+        'BSI-BROWSER-012',
+        'BSI-BROWSER-013',
+        'BSI-BROWSER-017',
+        'BSI-BROWSER-018',
+        'BSI-BROWSER-022',
+        'BSI-BROWSER-023',
+    ],
+    appliesTo: () => true,
+
+    /**
+     * Reports the selected browser, or the reason there is none.
+     *
+     * @param {object} ctx - The check context.
+     *
+     * @returns {Promise<import('../findings.js').Finding[]>} One finding, or two when a version
+     * pin could not be checked.
+     */
+    run: async (ctx) => {
+        const { detection, cache } = ctx;
+        const findings = [];
+        const usable = cache.builds.filter((build) => build.usable);
+        const requestedBrowser = ctx.options.browser ?? 'chrome';
+
+        // Whether `--browser-version` has any bearing on this run at all. It does not when a named
+        // executable exists: `resolveBrowserExecutablePath` skips version resolution entirely in
+        // that case, so a real run neither validates the value nor uses it.
+        //
+        // Both directions of that matter. Warning about version drift sent customers chasing a
+        // problem their configuration cannot have - and, since an invalid version became an error,
+        // failing the check for it would be worse still: the doctor would report FAILED for a
+        // configuration on which a real run succeeds.
+        const versionDecidesTheBuild = !ctx.executableOverride?.exists;
+
+        // The browser itself is unsupported, so nothing about the version is worth saying: the
+        // version findings below would all be describing a setting that is not the problem.
+        if (detection.browserError) {
+            findings.push(
+                finding({
+                    id: 'BSI-BROWSER-023',
+                    severity: SEVERITY.ERROR,
+                    title: 'the requested browser is not one Butler Sheet Icons can drive',
+                    detail: `--browser is set to "${requestedBrowser}", which Butler Sheet Icons cannot use: ${detection.browserError} Chrome is the only supported browser - the screenshot path speaks the Chrome DevTools Protocol and passes a Chromium-only argument list, so no other browser could be driven.`,
+                    facts: [{ label: 'Requested browser', value: requestedBrowser }],
+                    evidence: { browser: requestedBrowser, error: detection.browserError },
+                    remediation: [
+                        {
+                            text: 'Set --browser to "chrome", or leave it unset - "chrome" is the default.',
+                        },
+                    ],
+                })
+            );
+
+            return findings;
+        }
+
+        if (detection.selection) {
+            const { source, executablePath, browser, buildId } = detection.selection;
+            const wouldUse =
+                source === 'system' ? 'system browser' : `cached browser (${browser} ${buildId})`;
+
+            findings.push(
+                finding({
+                    id: 'BSI-BROWSER-010',
+                    severity: SEVERITY.OK,
+                    title: 'A browser was selected without downloading one',
+                    detail: `A real run would use the ${wouldUse} at ${executablePath}.`,
+                    facts: [
+                        { label: 'Requested', value: detection.requested },
+                        { label: 'Would use', value: wouldUse },
+                        { label: 'Executable', value: executablePath },
+                    ],
+                    evidence: { source, executablePath, browser, buildId },
+                })
+            );
+        } else if (detection.error) {
+            // Detection refused to continue rather than finding nothing. Today the only way that
+            // happens is an explicitly named executable that is not there, which the
+            // executable-override check reports in full - so this names that finding as its cause
+            // and the runner demotes this one when it is present. Declaring the cause rather than
+            // predicting it is what keeps an unexplained detection failure a failure.
+            findings.push(
+                finding({
+                    id: 'BSI-BROWSER-012',
+                    severity: SEVERITY.ERROR,
+                    title: 'no browser could be selected',
+                    detail: `Browser detection stopped with an error, so no browser was selected: ${detection.error.message}`,
+                    facts: [
+                        { label: 'Requested', value: detection.requested },
+                        { label: 'Would use', value: 'nothing - detection could not complete' },
+                    ],
+                    evidence: { error: detection.error.message },
+                    supersededBy: ['BSI-BROWSER-002'],
+                    remediation: [
+                        {
+                            text: 'Correct the browser configuration named in the error above, then run this check again.',
+                        },
+                    ],
+                })
+            );
+        } else if (usable.length > 0) {
+            // The difference between a lookup table and an investigator, and it is a distinct
+            // condition rather than a variation on the one below: this machine has a browser it
+            // can run, and the only obstacle is that a *different* build was asked for. Telling
+            // this administrator to go and download something would send them to fix a problem
+            // they do not have - which is exactly the "wrong advice is worse than none" risk.
+            //
+            // Since issue #878 every version, keyword included, resolves to exactly one build
+            // before the cache is searched, so "use --browser-version latest instead" is not a
+            // way out: it would miss in precisely the same way. Naming the build ids is the only
+            // advice that works.
+            findings.push(
+                finding({
+                    id: 'BSI-BROWSER-017',
+                    severity: SEVERITY.ERROR,
+                    title: 'the requested browser build is not in the cache, although other builds are',
+                    detail: `${detection.requested} was requested, and ${cache.dir} holds no such build. It does hold ${usable.length} build(s) this machine can run: ${usable.map((build) => `${build.browser} ${build.buildId}`).join(', ')}. A real run would try to download the requested build, which needs internet access.`,
+                    facts: [
+                        { label: 'Requested', value: detection.requested },
+                        {
+                            label: 'Would use',
+                            value: 'nothing - the requested build would have to be downloaded',
+                        },
+                    ],
+                    evidence: {
+                        cacheDir: cache.dir,
+                        requested: detection.requested,
+                        usableBuildIds: usable.map((build) => build.buildId),
+                    },
+                    remediation: [
+                        {
+                            text: `Use one of the builds already on this machine: set --browser-version to ${usable.map((build) => build.buildId).join(' or ')}, or set the matching BSI_*_BROWSER_VERSION environment variable.`,
+                            command: {
+                                powershell: `butler-sheet-icons.exe browser check --browser-version ${usable[0].buildId}`,
+                                bash: `./butler-sheet-icons browser check --browser-version ${usable[0].buildId}`,
+                            },
+                        },
+                        {
+                            text: 'Or, on a machine with internet access and the same operating system as this one, install the requested build and copy the browser cache directory here.',
+                            // The normalised values from `detection`, never the raw options bag:
+                            // `browserCheck({})` is a supported call shape, and reading
+                            // `ctx.options.browserVersion` there printed
+                            // `--browser-version undefined` into a command an administrator is
+                            // being invited to paste.
+                            command: {
+                                powershell: `butler-sheet-icons.exe browser install --browser ${requestedBrowser} --browser-version ${detection.requestedVersion}`,
+                                bash: `./butler-sheet-icons browser install --browser ${requestedBrowser} --browser-version ${detection.requestedVersion}`,
+                            },
+                        },
+                    ],
+                    docs: 'guide/advanced/air-gapped-installation',
+                })
+            );
+        } else {
+            // Nothing usable at all. Always an error, with the full remediation - the runner
+            // demotes it if one of the cache checks named below is actually reporting the reason.
+            //
+            // It used to decide that for itself, from `cache.inUse && cache.builds.length > 0`.
+            // That was a prediction about two other checks, and it held only while `usable` meant
+            // exactly `canRunHere && executableExists`: the moment a build could be unusable for a
+            // third reason, both cache checks reported OK, this demoted itself anyway, and the
+            // command exited 0 on a machine that could not take a screenshot.
+            findings.push(
+                finding({
+                    id: 'BSI-BROWSER-011',
+                    severity: SEVERITY.ERROR,
+                    title: 'no usable browser was found, and taking screenshots would require downloading one over the internet',
+                    detail: `Neither a configured browser executable nor a usable build in ${cache.dir} could be used for ${detection.requested}. A real run would try to download a browser, which needs internet access.`,
+                    facts: [
+                        { label: 'Requested', value: detection.requested },
+                        {
+                            label: 'Would use',
+                            value: 'nothing - a browser would have to be downloaded',
+                        },
+                    ],
+                    evidence: { cacheDir: cache.dir, requested: detection.requested },
+                    supersededBy: ['BSI-BROWSER-006', 'BSI-BROWSER-009', 'BSI-BROWSER-019'],
+                    remediation: [
+                        {
+                            text: 'On a machine with internet access, and the same operating system as this one, run:',
+                            command: {
+                                powershell:
+                                    'butler-sheet-icons.exe browser install --browser chrome --browser-version recommended',
+                                bash: './butler-sheet-icons browser install --browser chrome --browser-version recommended',
+                            },
+                        },
+                        {
+                            text: `Copy that machine's browser cache directory to this machine, and point Butler Sheet Icons at it with --browser-cache-dir or BSI_BROWSER_CACHE_DIR.`,
+                        },
+                        {
+                            text: 'Or, if Chrome or Edge is already installed here, point at it with --browser-executable-path or BSI_BROWSER_EXECUTABLE_PATH.',
+                        },
+                    ],
+                    docs: 'guide/advanced/air-gapped-installation',
+                })
+            );
+        }
+
+        // A version a real run refuses outright. Reported as an error rather than a warning, and
+        // independently of whether a browser was found: `browser check` used to accept any
+        // unrecognised value as a floating keyword and exit 0, while `resolveBrowserVersion`
+        // threw for the same value and killed the real thumbnail run. A gate that passes on the
+        // misconfiguration it was run to catch is worse than no gate.
+        if (versionDecidesTheBuild && detection.versionForm === VERSION_FORM.INVALID) {
+            findings.push(
+                finding({
+                    id: 'BSI-BROWSER-018',
+                    severity: SEVERITY.ERROR,
+                    title: 'the requested browser version is not a value Butler Sheet Icons accepts',
+                    detail: `--browser-version "${detection.requestedVersion}" is neither a keyword nor a build id, so a real run would stop with "Invalid --browser-version" before it looked for a browser at all. Whatever this check reports about the browser on this machine, a run with this setting cannot start.`,
+                    facts: [{ label: 'Requested version', value: detection.requestedVersion }],
+                    evidence: { browserVersion: detection.requestedVersion },
+                    remediation: [
+                        {
+                            text: 'Use a keyword - "recommended" for the build Butler Sheet Icons is tested against, or "stable" for the newest stable release - or an exact version: a milestone such as "151", a build prefix such as "151.0.7922", or a full build id such as "151.0.7922.77".',
+                        },
+                        {
+                            text: 'To see which builds are already on this machine, run:',
+                            command: {
+                                powershell: 'butler-sheet-icons.exe browser list-installed',
+                                bash: './butler-sheet-icons browser list-installed',
+                            },
+                        },
+                    ],
+                })
+            );
+        }
+
+        // The pin is valid but could not be confirmed without the network. Worth saying whatever
+        // the outcome, because the doctor must not report OK under different pin semantics than
+        // the real run would use - and this command will not make that call, since a diagnostic
+        // that hangs on a DNS timeout on an air-gapped server is worse than no diagnostic.
+        //
+        // The two forms are described separately. A milestone or build prefix is an *explicit
+        // pin* that happens to need a lookup; calling it a value that "names whichever build is
+        // newest" told an administrator their deliberate pin was floating, and then advised them
+        // to name an exact build id - which is what they thought they had done.
+        // A milestone or build prefix. Its own finding, and an error - not a variation on the
+        // floating-keyword warning below, which is what it used to be.
+        //
+        // The difference is in `resolveRequestedBuildId` (browser-launch.js): a failed lookup
+        // degrades to the newest cached build **only** when `isVersionKeyword` is true, and
+        // `isVersionKeyword('151')` is false. So on an air-gapped host a real run does not quietly
+        // use a different build - it throws before it ever reaches the cache. Sharing a WARNING
+        // with `stable` reported OK for a configuration that cannot start, on exactly the machines
+        // this command exists for.
+        if (versionDecidesTheBuild && detection.versionForm === VERSION_FORM.PARTIAL) {
+            findings.push(
+                finding({
+                    id: 'BSI-BROWSER-022',
+                    severity: SEVERITY.ERROR,
+                    title: 'the requested browser version can only be resolved over the internet',
+                    detail: `--browser-version "${detection.requestedVersion}" names a milestone or a partial build id, and turning that into a single build is the browser vendor's lookup. Butler Sheet Icons does not fall back to a cached build for this form - only for keywords such as "recommended" and "stable" - so a real run on a machine without internet access stops with a lookup error before it looks at the cache at all. Whatever this check reports about the browser here, a run with this setting cannot start offline.`,
+                    facts: [{ label: 'Requested version', value: detection.requestedVersion }],
+                    evidence: { browserVersion: detection.requestedVersion, form: 'partial' },
+                    remediation: [
+                        {
+                            text: 'Name the full build id, such as "151.0.7922.77" - "butler-sheet-icons browser list-installed" shows the builds already on this machine.',
+                            command: {
+                                powershell: 'butler-sheet-icons.exe browser list-installed',
+                                bash: './butler-sheet-icons browser list-installed',
+                            },
+                        },
+                        {
+                            text: 'Or use "recommended", which resolves from a value compiled into Butler Sheet Icons and needs no lookup at all.',
+                        },
+                    ],
+                    docs: 'guide/advanced/air-gapped-installation',
+                })
+            );
+        }
+
+        if (versionDecidesTheBuild && detection.versionForm === VERSION_FORM.FLOATING) {
+            findings.push(
+                finding({
+                    id: 'BSI-BROWSER-013',
+                    severity: SEVERITY.WARNING,
+                    title: 'the requested browser version could not be checked without internet access',
+                    detail: `--browser-version "${detection.requestedVersion}" names whichever build is newest at the time it runs, which can only be resolved over the internet. This check did not make that call, so it accepted the newest suitable build already present instead. A real run on a machine with internet access may therefore choose a different build than the one reported here.`,
+                    evidence: { browserVersion: detection.requestedVersion, form: 'floating' },
+                    remediation: [
+                        {
+                            text: 'Use --browser-version recommended, which resolves from a value compiled into Butler Sheet Icons and needs no lookup, or name an exact build id.',
+                        },
+                    ],
+                })
+            );
+        }
+
+        return findings;
+    },
+};

--- a/src/lib/doctor/checks/cache-severity.js
+++ b/src/lib/doctor/checks/cache-severity.js
@@ -1,0 +1,26 @@
+/**
+ * Whether a problem with the browser cache actually stopped this run.
+ *
+ * Shared by every cache check, because getting it wrong in either direction breaks the command's
+ * one job. `browser check` is documented as a deployment gate, so:
+ *
+ * - reporting a cache fault as an **error** when a browser was found and launched anyway fails a
+ *   Sense server that works. A leftover build directory from an interrupted install, or an
+ *   unreadable cache that a configured `--browser-executable-path` means nothing will ever read,
+ *   both produced exactly that - a report saying `Launched: yes` and then `Result: FAILED`;
+ * - reporting it as a **warning** when it is the reason nothing could be selected lets a broken
+ *   machine pass.
+ *
+ * Two conditions, and both must hold for it to be a failure: the cache had to be the thing being
+ * consulted, and nothing can have been selected in the end. The second is what the checks were
+ * missing - they judged the cache's contents in isolation, never asking whether a browser was
+ * found regardless.
+ *
+ * Note this deliberately does not ask *which* build was selected. A run that selected a browser is
+ * a run that works, whatever else is lying about in the directory.
+ *
+ * @param {object} ctx - The check context.
+ *
+ * @returns {boolean} `true` when the cache problem is why this machine has no browser.
+ */
+export const failedTheRun = (ctx) => Boolean(ctx.cache.inUse) && !ctx.detection.selection;

--- a/src/lib/doctor/checks/environment.js
+++ b/src/lib/doctor/checks/environment.js
@@ -1,0 +1,58 @@
+import { SEVERITY, finding } from '../findings.js';
+
+/**
+ * What this machine is, and who Butler Sheet Icons is running as.
+ *
+ * No verdict: this reports facts and leaves the reading to the administrator. It is nonetheless
+ * the most valuable block in the report on Windows Server, because it turns the LocalSystem trap
+ * into something visible. A scheduled task running as LocalSystem has its home directory under
+ * `C:\Windows\system32\config\systemprofile` and its working directory at `C:\Windows\system32`,
+ * so the browser cache an administrator staged into their own profile is not there, and the `.env`
+ * file beside the executable is never loaded. Every one of those symptoms is baffling until these
+ * five lines are in front of you.
+ */
+export const check = {
+    id: 'environment',
+    title: 'This machine, and the account Butler Sheet Icons is running as',
+    section: 'Environment',
+    area: 'environment',
+    needsNetwork: false,
+    findingIds: ['BSI-ENV-001'],
+    appliesTo: () => true,
+
+    /**
+     * Reports the machine facts.
+     *
+     * @param {object} ctx - The check context.
+     *
+     * @returns {Promise<import('../findings.js').Finding[]>} One informational finding.
+     */
+    run: async (ctx) => {
+        const { hostPlatform, nodePlatform, arch, user, homeDir, cwd, isSea } = ctx.host;
+
+        // Naming the Puppeteer platform matters: it is the name cached browser builds are filed
+        // under, so it is the value a "built for another platform" message has to be compared
+        // against. An unrecognised host is stated rather than left blank - it changes how
+        // detection behaves, because an undetectable platform makes every cached build eligible.
+        const platformValue = hostPlatform
+            ? `${nodePlatform} ${arch} (Puppeteer platform "${hostPlatform}")`
+            : `${nodePlatform} ${arch} (Puppeteer platform not recognised)`;
+
+        return [
+            finding({
+                id: 'BSI-ENV-001',
+                severity: SEVERITY.INFO,
+                title: 'Machine and account details',
+                detail: `Running on ${platformValue} as user "${user}", from working directory ${cwd}.`,
+                facts: [
+                    { label: 'Platform', value: platformValue },
+                    { label: 'Running as user', value: user },
+                    { label: 'Home directory', value: homeDir },
+                    { label: 'Working directory', value: cwd },
+                    { label: 'Standalone binary', value: String(isSea) },
+                ],
+                evidence: { hostPlatform, nodePlatform, arch, user, homeDir, cwd, isSea },
+            }),
+        ];
+    },
+};

--- a/src/lib/doctor/checks/index.js
+++ b/src/lib/doctor/checks/index.js
@@ -1,0 +1,41 @@
+import { check as environment } from './environment.js';
+import { check as browserExecutableOverride } from './browser-executable-override.js';
+import { check as browserCachePlatform } from './browser-cache-platform.js';
+import { check as browserCacheExecutable } from './browser-cache-executable.js';
+import { check as browserSelection } from './browser-selection.js';
+import { check as browserLaunch } from './browser-launch.js';
+
+/**
+ * The check registry.
+ *
+ * A flat array, in the order the report reads. **Adding a diagnostic is one new file and one entry
+ * here** - no change to the runner, the renderer or any command. That property is the whole point
+ * of the contract, and it is the acceptance test for it (§14). Anything that erodes it - a check
+ * needing a special case in the runner, a finding needing bespoke formatting - means the contract
+ * is wrong, not that the check is special.
+ *
+ * Order is deliberate and is what the reader sees: the machine first, then how a browser would be
+ * found, then whether it runs. A check that would read oddly out of that sequence probably belongs
+ * in a different section rather than at a different position.
+ *
+ * Each import is a literal specifier for the same reason the interactive registry's are: a
+ * templated import is not statically analysable, so esbuild would not bundle the target and the
+ * failure would appear only inside the packaged binary, on a user's machine.
+ */
+export const CHECKS = Object.freeze([
+    environment,
+    browserExecutableOverride,
+    browserCachePlatform,
+    browserCacheExecutable,
+    browserSelection,
+    browserLaunch,
+]);
+
+/**
+ * The registered checks for a set of areas.
+ *
+ * @param {string[]} areas - Areas to include, e.g. `['environment', 'browser']`.
+ *
+ * @returns {import('../run-checks.js').Check[]} The matching checks, in registry order.
+ */
+export const checksForAreas = (areas) => CHECKS.filter((check) => areas.includes(check.area));

--- a/src/lib/doctor/context.js
+++ b/src/lib/doctor/context.js
@@ -1,0 +1,72 @@
+import os from 'node:os';
+
+import { logger, isSea } from '../../globals.js';
+
+/**
+ * The facts every diagnostic check starts from.
+ *
+ * `ctx` is assembled once per run and handed to every check. Passing facts in, rather than letting
+ * a check read the world for itself, is what makes checks unit-testable without mocking the
+ * filesystem - and it is what lets the runner promise that a check never reaches the network.
+ *
+ * This module holds the part that is true of any subject. Area-specific facts are added by
+ * whichever worker is running the checks: `browserCheck()` extends this with the browser cache,
+ * the executable override, the cached builds and the launch result.
+ */
+
+/**
+ * The account this process is running as.
+ *
+ * `os.userInfo()` throws when the effective uid has no passwd entry, which happens in slim
+ * containers. The account is diagnostic information, not a reason to fail a diagnosis.
+ *
+ * @returns {string} The username, or a plain statement that it could not be determined.
+ */
+const currentUser = () => {
+    try {
+        return os.userInfo().username;
+    } catch {
+        return 'unknown';
+    }
+};
+
+/**
+ * Builds the context every check receives.
+ *
+ * `user`, `homeDir` and `cwd` are here deliberately, and they earn their place on Windows Server:
+ * a scheduled task running as LocalSystem has a home directory under
+ * `C:\Windows\system32\config\systemprofile` and a working directory of `C:\Windows\system32`.
+ * That turns "the browser cache is empty" into a one-glance diagnosis. The working directory
+ * matters for a second reason: `globals.js` loads `dotenv/config`, so a `.env` file beside the
+ * executable may never be found under a scheduled task.
+ *
+ * @param {object} options - Resolved CLI options for the command being run.
+ * @param {object} [extra] - Extra fields to merge in.
+ * @param {string} [extra.hostPlatform] - Puppeteer's name for this machine's platform, when it
+ * could be detected.
+ *
+ * @returns {object} The base context.
+ */
+export const buildBaseContext = (options, { hostPlatform } = {}) => ({
+    options,
+    // A snapshot rather than `process.env` itself, so a check cannot read a variable that was set
+    // after the run began, and so the environment a report describes is the one it was made from.
+    env: {
+        PUPPETEER_CACHE_DIR: process.env.PUPPETEER_CACHE_DIR,
+        PUPPETEER_EXECUTABLE_PATH: process.env.PUPPETEER_EXECUTABLE_PATH,
+        BSI_BROWSER_CACHE_DIR: process.env.BSI_BROWSER_CACHE_DIR,
+        BSI_BROWSER_EXECUTABLE_PATH: process.env.BSI_BROWSER_EXECUTABLE_PATH,
+    },
+    host: {
+        hostPlatform,
+        nodePlatform: process.platform,
+        arch: process.arch,
+        user: currentUser(),
+        homeDir: os.homedir(),
+        cwd: process.cwd(),
+        isSea,
+    },
+    // For `debug` only. A check that logs anything a user is meant to read has taken over the
+    // renderer's job, and the finding it should have returned is then invisible to JSON output.
+    logger,
+});

--- a/src/lib/doctor/findings.js
+++ b/src/lib/doctor/findings.js
@@ -1,0 +1,309 @@
+/**
+ * Findings: what a diagnostic check produces.
+ *
+ * A finding is plain data. It never logs, never formats and never touches process state - the
+ * renderer decides how it appears and the command decides what its severity means for the exit
+ * code. That separation is what lets one renderer serve `browser check` today and `doctor check`
+ * tomorrow without either of them growing a special case.
+ *
+ * See §15.4 of `docs/todo/airgap-browser-phase-1.md` for the design rules. The two that cost the
+ * most to get wrong:
+ *
+ * - **Finding ids are permanent and append-only.** They appear in logs, in GitHub issues and, in
+ *   time, in `doctor explain`. Never reuse one, never renumber, and retire one by marking it
+ *   obsolete rather than deleting it. Each area has its own block (`BSI-BROWSER-*`, `BSI-ENV-*`)
+ *   so areas can grow independently.
+ * - **`ok` findings are emitted, not omitted.** "I checked this and it is fine" is what lets an
+ *   administrator rule a cause out, and it is what makes the output usable as a bug report.
+ */
+
+/**
+ * How serious a finding is.
+ *
+ * `ok` and `info` are deliberately distinct. `ok` means a question was asked and answered
+ * favourably, and is what rules a cause out; `info` is a fact with no verdict attached, such as
+ * the machine's platform. Only `error` fails a run.
+ */
+export const SEVERITY = Object.freeze({
+    ERROR: 'error',
+    WARNING: 'warning',
+    INFO: 'info',
+    OK: 'ok',
+});
+
+/**
+ * Ordering for "worst first". Lower sorts earlier.
+ */
+export const SEVERITY_RANK = Object.freeze({
+    [SEVERITY.ERROR]: 0,
+    [SEVERITY.WARNING]: 1,
+    [SEVERITY.INFO]: 2,
+    [SEVERITY.OK]: 3,
+});
+
+/** The severities anything downstream of a check is allowed to see. */
+const KNOWN_SEVERITIES = new Set(Object.values(SEVERITY));
+
+/**
+ * Forces a finding into the shape everything downstream assumes.
+ *
+ * Applied by the runner and again at the renderer's entry, so that nothing further along has to
+ * test for the absurd. This exists because a check is allowed to return plain objects - the
+ * contract is "one new file and one registry entry", and the next contributor will hand-write a
+ * finding literal rather than call {@link finding}.
+ *
+ * It repairs the whole shape, not just the severity, and that scope was bought the hard way. An
+ * earlier version fixed only `severity`, which left three faults live: a finding with no `facts`
+ * threw `entry.facts is not iterable` *from inside the renderer's section loop* - after the
+ * heading had printed, and outside the runner's per-check isolation, so the user got a
+ * half-written report with no disclaimer and no `Result:` line; a finding with no `remediation`
+ * got as far as printing a "Next steps:" header and then threw; and `{...null}` yielded an object
+ * with a severity and nothing else.
+ *
+ * An unrecognised severity becomes `error`, never `info`. A finding whose severity cannot be
+ * interpreted is a bug in a check, and on a command used as a deployment gate the safe reading of
+ * "I do not understand this" is "something is wrong here".
+ *
+ * Idempotent, and returns the original object untouched when it is already well formed, so
+ * applying it at more than one boundary costs nothing.
+ *
+ * @param {import('./findings.js').Finding} entry - The finding to normalise.
+ *
+ * @returns {import('./findings.js').Finding} A finding with every field the renderer reads.
+ */
+export const normalizeFinding = (entry) => {
+    const wellFormed =
+        entry !== null &&
+        typeof entry === 'object' &&
+        KNOWN_SEVERITIES.has(entry.severity) &&
+        Array.isArray(entry.facts) &&
+        Array.isArray(entry.remediation) &&
+        Array.isArray(entry.supersededBy);
+
+    if (wellFormed) {
+        return entry;
+    }
+
+    const source = entry !== null && typeof entry === 'object' ? entry : {};
+
+    return {
+        ...source,
+        // Marked only when the *severity* could not be read, which is what `errorIdsOf` acts on.
+        // Filling in an omitted `facts` or `supersededBy` is ordinary defaulting and says nothing
+        // about the finding's meaning; an uninterpretable severity does. Such a finding is
+        // promoted to `error` so it still fails the run - but it must not become a *cause* that
+        // explains another finding away: a check writing `severity: 'WARNING'` was repaired into
+        // an error, joined the cause set, and demoted a genuine error that named its id, taking
+        // the remediation an administrator needed with it.
+        malformed: !KNOWN_SEVERITIES.has(source.severity),
+        id: source.id ?? 'BSI-DOCTOR-002',
+        severity: KNOWN_SEVERITIES.has(source.severity) ? source.severity : SEVERITY.ERROR,
+        title:
+            source.title ?? 'a diagnostic check returned a finding Butler Sheet Icons cannot read',
+        detail:
+            source.detail ??
+            'The check that produced this did not describe what it found. This is a fault in the diagnostic, not in the machine it was run on.',
+        facts: Array.isArray(source.facts) ? source.facts : [],
+        remediation: Array.isArray(source.remediation) ? source.remediation : [],
+        supersededBy: Array.isArray(source.supersededBy) ? source.supersededBy : [],
+    };
+};
+
+/**
+ * @typedef {object} RemediationCommand
+ * @property {string} [powershell] - Command to run on Windows.
+ * @property {string} [bash] - Command to run on macOS and Linux.
+ */
+
+/**
+ * @typedef {object} Remediation
+ * @property {string} text - What to do, in one sentence.
+ * @property {RemediationCommand} [command] - The command that does it, keyed by host shell. The
+ * renderer prints only the one matching this machine: Butler Sheet Icons' primary platform is
+ * Windows Server, where a bash snippet is noise.
+ */
+
+/**
+ * @typedef {object} Fact
+ * @property {string} label - Left-hand label, e.g. `Home directory`.
+ * @property {string} value - The observed value.
+ * @property {string[]} [sublines] - Lines rendered one level deeper, for list-shaped facts such
+ * as the contents of the browser cache.
+ */
+
+/**
+ * @typedef {object} Finding
+ * @property {string} id - Stable, permanent identifier, e.g. `BSI-BROWSER-003`.
+ * @property {string} severity - One of {@link SEVERITY}.
+ * @property {string} title - What was found, as a statement.
+ * @property {string} detail - What was observed, **with the actual values**. "No browser found"
+ * helps nobody; naming the directory, the builds in it and this machine's platform ends the
+ * investigation.
+ * @property {Fact[]} facts - Key/value rows for the human renderer.
+ * @property {object} [evidence] - Structured data behind the finding, for JSON output.
+ * @property {Remediation[]} remediation - Ordered, concrete steps.
+ * @property {string[]} supersededBy - Finding ids that, if present as errors in the same report,
+ * explain this one. See {@link supersede}.
+ * @property {string} [docs] - Relative doc-site path, resolved to a URL by the renderer and
+ * printed as a bare path offline.
+ */
+
+/**
+ * Builds a finding, filling in the fields a check did not need.
+ *
+ * Every field has a default so a check can state only what it knows, and so the renderer never
+ * has to test for absence. `facts` and `remediation` are always arrays for that reason.
+ *
+ * @param {object} spec - The finding's fields.
+ * @param {string} spec.id - Stable identifier.
+ * @param {string} spec.severity - One of {@link SEVERITY}.
+ * @param {string} spec.title - What was found.
+ * @param {string} spec.detail - What was observed, with values.
+ * @param {Fact[]} [spec.facts] - Key/value rows.
+ * @param {object} [spec.evidence] - Structured evidence.
+ * @param {Remediation[]} [spec.remediation] - Ordered remediation steps.
+ * @param {string[]} [spec.supersededBy] - Finding ids that explain this one.
+ * @param {string} [spec.docs] - Relative doc-site path.
+ *
+ * @returns {Finding} The finding.
+ */
+export const finding = ({
+    id,
+    severity,
+    title,
+    detail,
+    facts = [],
+    evidence,
+    remediation = [],
+    supersededBy = [],
+    docs,
+}) => ({
+    id,
+    severity,
+    title,
+    detail,
+    facts,
+    evidence,
+    remediation,
+    supersededBy,
+    docs,
+});
+
+/**
+ * Ids of every finding currently reported as an error.
+ *
+ * Computed once from the whole report and handed to {@link demoteIfSuperseded}, so supersession is
+ * decided against a single snapshot rather than re-derived per check.
+ *
+ * @param {Finding[]} findings - Every finding in the report.
+ *
+ * @returns {Set<string>} The error ids.
+ */
+export const errorIdsOf = (findings) =>
+    new Set(
+        findings
+            // A finding the runner had to repair is not evidence of anything. It still fails the
+            // run, which is right, but only a finding a check actually meant may explain another
+            // one away - see the `malformed` marker in {@link normalizeFinding}.
+            .filter((entry) => entry.severity === SEVERITY.ERROR && !entry.malformed)
+            .map((entry) => entry.id)
+    );
+
+/**
+ * Demotes one error whose cause is present among `errorIds`.
+ *
+ * Separated from {@link supersede} so the runner can resolve supersession without flattening the
+ * per-check structure and slicing it back apart - reassembly by cursor arithmetic was how a single
+ * malformed check erased every finding in the report.
+ *
+ * @param {Finding} entry - The finding to consider.
+ * @param {Set<string>} errorIds - Ids of every finding reported as an error in this run.
+ *
+ * @returns {Finding} The finding, demoted if one of its declared causes is present.
+ */
+export const demoteIfSuperseded = (entry, errorIds) => {
+    // Defensive about the field's absence rather than trusting `finding()` to have filled it in:
+    // a check is free to return plain objects, and the runner's promise that one bad check cannot
+    // take down the report has to survive that.
+    const causes = entry.supersededBy ?? [];
+
+    if (entry.severity !== SEVERITY.ERROR || causes.length === 0) {
+        return entry;
+    }
+
+    // Never itself: a self-referential declaration would demote an error on the strength of its
+    // own presence, which is the one input that makes "fails safe" false.
+    const cause = causes.find((id) => id !== entry.id && errorIds.has(id));
+
+    if (!cause) {
+        return entry;
+    }
+
+    return {
+        ...entry,
+        severity: SEVERITY.INFO,
+        // The cause carries the advice. Keeping a copy here is what put the same fix in the list
+        // twice.
+        remediation: [],
+        supersededByFinding: cause,
+    };
+};
+
+/**
+ * Demotes error findings whose cause is already reported, once every check has run.
+ *
+ * A consequence and its cause are often both true - "the cached browsers are for another operating
+ * system" *and* "no browser could be selected" - and reporting both as errors produced a "Next
+ * steps" list whose second half repeated its first. So a consequence names the ids that would
+ * explain it, and is demoted to `info` when one of them is actually present.
+ *
+ * Three properties make this safe, and each was bought by a real defect:
+ *
+ * - **It is declarative, not predictive.** Checks used to infer "a cache check will have raised an
+ *   error" from the shape of the cache. That inference held only while `usable` meant exactly
+ *   `canRunHere && executableExists`; the moment a build could be unusable for a third reason,
+ *   every check reported OK, the one real error demoted itself, and `browser check` exited **0** on
+ *   a machine that could not take a screenshot.
+ * - **It fails safe.** With no matching cause present the error stands, so an unexplained failure
+ *   is still a failure. Only an `error` supersedes: a warning left the run passable, and demoting
+ *   an error on the strength of one would leave the report with nothing to fail on.
+ * - **A finding cannot supersede itself.** Without that, a self-referential declaration demoted an
+ *   error on the strength of its own presence - and a pair naming each other demoted both, leaving
+ *   a report with two real problems, no errors, and exit code 0.
+ *
+ * Resolved after every check has run, so a consequence may be registered before its cause.
+ *
+ * @param {Finding[]} findings - Every finding in the report.
+ *
+ * @returns {Finding[]} The same findings, with superseded errors demoted and their now-duplicated
+ * remediation dropped.
+ */
+export const supersede = (findings) => {
+    const errorIds = errorIdsOf(findings);
+
+    return findings.map((entry) => demoteIfSuperseded(entry, errorIds));
+};
+
+/**
+ * Whether a set of findings should fail the run.
+ *
+ * One rule, in one place, so `browser check`'s exit code and the renderer's `Result:` line cannot
+ * disagree about what "failed" means. Only `error` counts: a warning is something worth knowing
+ * that did not stop this machine from working, and failing on those would make the command
+ * useless as a deployment gate.
+ *
+ * @param {Finding[]} findings - Findings to judge.
+ *
+ * @returns {boolean} `true` when nothing failed.
+ */
+export const isHealthy = (findings) => findings.every((entry) => entry.severity !== SEVERITY.ERROR);
+
+/**
+ * Findings sorted worst first, preserving the order checks ran in within a severity.
+ *
+ * @param {Finding[]} findings - Findings to sort.
+ *
+ * @returns {Finding[]} A new, sorted array.
+ */
+export const worstFirst = (findings) =>
+    [...findings].sort((a, b) => SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity]);

--- a/src/lib/doctor/render-report.js
+++ b/src/lib/doctor/render-report.js
@@ -1,0 +1,227 @@
+import { logger } from '../../globals.js';
+import { SEVERITY, isHealthy, normalizeFinding, worstFirst } from './findings.js';
+import { allFindings, RUNNER_ERROR_ID } from './run-checks.js';
+
+/**
+ * The shared renderer for every diagnostic command.
+ *
+ * `browser check`'s output comes from here rather than being formatted inline. That is the whole
+ * point of the check contract: the second diagnostic is nearly free because it inherits this, and
+ * a command users already depend on never has to be rewritten to get it. Consequently this file
+ * knows nothing about browsers - it renders sections, facts, findings and remediation, whatever
+ * produced them.
+ *
+ * The layout is §7.3 of `docs/todo/airgap-browser-phase-1.md`, which follows the repo's existing
+ * 4-space `Key : value` style (`cloud-test-connection.js`, `browser-installed.js:41`).
+ */
+
+/**
+ * The best-effort disclaimer, verbatim (§15.7).
+ *
+ * **Not suppressible.** There is no flag to hide it, and adding one would be a mistake: it would
+ * be used by exactly the automated contexts where a human later reads the output without knowing
+ * it was hidden.
+ *
+ * It appears once, immediately before the `Result:` line, so it is read next to the advice rather
+ * than scrolled away above it. The wording is shared with every command in this family, so an
+ * administrator who has read it once recognises it and skips it rather than re-reading a variant.
+ */
+export const BEST_EFFORT_DISCLAIMER = Object.freeze([
+    'Note: these findings are best-effort. Butler Sheet Icons reports what it can observe on this',
+    'machine, and cannot see everything about your environment - group policy, antivirus, proxy rules',
+    'and Qlik Sense itself are all invisible to it. Review suggested commands before running them on a',
+    'production server.',
+]);
+
+/** Width the fact labels are padded to, matching §7.3. */
+const LABEL_WIDTH = 20;
+
+/**
+ * The logger method a finding's verdict is printed at.
+ *
+ * `ok` and `info` go to `verbose`, and that is the deliberate part. §7.3's healthy output is facts,
+ * not a wall of "OK: ..." lines - so on a working machine the report is the observations and
+ * nothing else. The findings are still emitted in the returned data, and still printed one level
+ * down, so `--loglevel verbose` says exactly what was examined and a future JSON consumer sees
+ * every one of them.
+ */
+const LOG_AT = Object.freeze({
+    [SEVERITY.ERROR]: 'error',
+    [SEVERITY.WARNING]: 'warn',
+    [SEVERITY.INFO]: 'verbose',
+    [SEVERITY.OK]: 'verbose',
+});
+
+/**
+ * What a finding's verdict line says.
+ *
+ * A verdict that carries weight states what was observed; one that does not simply names the
+ * question that was answered.
+ *
+ * @param {import('./findings.js').Finding} entry - The finding.
+ *
+ * @returns {string} The line to print.
+ */
+const verdictLine = (entry) =>
+    entry.severity === SEVERITY.ERROR || entry.severity === SEVERITY.WARNING
+        ? `    ${entry.detail}`
+        : `    ${entry.title}`;
+
+/**
+ * One `    Label               : value` row.
+ *
+ * @param {import('./findings.js').Fact} fact - The fact to render.
+ *
+ * @returns {string} The rendered row.
+ */
+const factLine = (fact) => `    ${fact.label.padEnd(LABEL_WIDTH)}: ${fact.value}`;
+
+/**
+ * The remediation command for this host, if the step carries one.
+ *
+ * Only one is printed. Butler Sheet Icons' primary platform is Windows Server, where a bash
+ * snippet beneath every step is noise an administrator has to read past.
+ *
+ * @param {import('./findings.js').Remediation} step - The remediation step.
+ * @param {string} platform - Node platform identifier.
+ *
+ * @returns {string|undefined} The command, or `undefined` when the step carries none.
+ */
+const commandFor = (step, platform) =>
+    platform === 'win32' ? step.command?.powershell : step.command?.bash;
+
+/**
+ * Renders the facts of every finding a check produced, under the check's section heading.
+ *
+ * The heading is emitted when the section changes rather than once per check, so two checks
+ * looking at the same subject - the two cache checks of §15.3 - produce §7.3's single
+ * "Browser cache" block rather than two.
+ *
+ * @param {import('./run-checks.js').CheckResult[]} results - Results to render.
+ *
+ * @returns {void}
+ */
+const renderSections = (results) => {
+    let currentSection;
+
+    for (const result of results) {
+        // A skipped check has nothing to say. Saying "skipped" for each one would put the
+        // machinery in front of the diagnosis.
+        if (result.skipped || result.findings.length === 0) {
+            continue;
+        }
+
+        if (result.check.section !== currentSection) {
+            currentSection = result.check.section;
+            logger.info(currentSection);
+        }
+
+        for (const entry of result.findings) {
+            for (const fact of entry.facts) {
+                logger.info(factLine(fact));
+
+                for (const subline of fact.sublines ?? []) {
+                    logger.info(`        ${subline}`);
+                }
+            }
+
+            // The verdict, at the level its severity earns.
+            logger[LOG_AT[entry.severity]](verdictLine(entry));
+        }
+    }
+};
+
+/**
+ * Renders the numbered "Next steps" block from every failing finding's remediation.
+ *
+ * Only `error` findings contribute. A warning's advice is worth having, and is printed with the
+ * warning itself, but it does not belong in the list headed "this run failed, do these things".
+ *
+ * @param {import('./findings.js').Finding[]} findings - Every finding in the report.
+ * @param {string} platform - Node platform identifier.
+ *
+ * @returns {void}
+ */
+const renderNextSteps = (findings, platform) => {
+    const steps = worstFirst(findings)
+        .filter((entry) => entry.severity === SEVERITY.ERROR)
+        .flatMap((entry) => entry.remediation);
+
+    if (steps.length === 0) {
+        return;
+    }
+
+    logger.error('Next steps:');
+
+    steps.forEach((step, index) => {
+        logger.error(`    ${index + 1}. ${step.text}`);
+
+        const command = commandFor(step, platform);
+
+        if (command) {
+            logger.error(`       ${command}`);
+        }
+    });
+};
+
+/**
+ * Prints a diagnostic report.
+ *
+ * @param {object} args - What to render.
+ * @param {string} args.heading - First line, e.g. `Butler Sheet Icons browser check`.
+ * @param {import('./run-checks.js').CheckResult[]} args.results - Results from `runChecks`.
+ * @param {string} args.okMessage - The sentence after `Result: OK - `. The command's own headline;
+ * the failure sentence comes from the first failing finding, because only it knows what failed.
+ * @param {string} [args.platform] - Node platform identifier. Defaults to this machine's, and is
+ * a parameter only so both branches can be tested on either host.
+ *
+ * @returns {boolean} `true` when nothing failed - the same judgement the `Result:` line printed,
+ * returned so a caller cannot reach a different one.
+ */
+export const renderReport = ({ heading, results, okMessage, platform = process.platform }) => {
+    // Normalised here as well as in the runner, because this function is callable on its own and
+    // a severity it does not recognise used to throw from inside the section loop - after the
+    // heading and some facts had already printed, and outside the runner's isolation. Idempotent,
+    // so runner-produced input passes straight through.
+    const safeResults = results.map((result) => ({
+        ...result,
+        findings: result.findings.map(normalizeFinding),
+    }));
+    const findings = allFindings(safeResults);
+    const ok = isHealthy(findings);
+
+    logger.info(heading);
+
+    renderSections(safeResults);
+
+    // Immediately before the Result line, so it sits next to the advice. Unconditional: see
+    // BEST_EFFORT_DISCLAIMER.
+    for (const line of BEST_EFFORT_DISCLAIMER) {
+        logger.info(line);
+    }
+
+    if (ok) {
+        logger.info(`Result: OK - ${okMessage}`);
+
+        return true;
+    }
+
+    // The failing finding's own title, not a generic sentence. "no usable browser was found" and
+    // "the configured browser executable does not exist" send an administrator to completely
+    // different places, and a shared summary line would send them to neither.
+    //
+    // A fault in the diagnostic itself is passed over for the headline when anything else failed.
+    // BSI-DOCTOR-001 is emitted in place of whichever check threw, so registry position alone
+    // could put it first and let it speak for the machine - handing the administrator "re-run
+    // with --loglevel debug and file an issue" as the summary of a server that simply has no
+    // browser staged. It still headlines when it is the only error, because a failed run with no
+    // stated reason is worse, and its advice appears in Next steps either way.
+    const errors = worstFirst(findings).filter((entry) => entry.severity === SEVERITY.ERROR);
+    const worst = errors.find((entry) => entry.id !== RUNNER_ERROR_ID) ?? errors[0];
+
+    logger.error(`Result: FAILED - ${worst.title}`);
+
+    renderNextSteps(findings, platform);
+
+    return false;
+};

--- a/src/lib/doctor/run-checks.js
+++ b/src/lib/doctor/run-checks.js
@@ -1,0 +1,225 @@
+import { SEVERITY, demoteIfSuperseded, errorIdsOf, finding, normalizeFinding } from './findings.js';
+
+/**
+ * The check runner.
+ *
+ * Runs registered checks against one context and collects their findings. It knows nothing about
+ * browsers, Qlik Sense or any other subject - **adding a check must be one new file plus one
+ * registry entry, with no change to this file**. Anything that erodes that (a check needing a
+ * special case here, a finding needing bespoke handling) is a signal that the contract is wrong,
+ * not that the check is special. See §15.3 of `docs/todo/airgap-browser-phase-1.md`.
+ *
+ * Two rules are enforced here rather than trusted to each check:
+ *
+ * - **A check may not reach the network unless it says so and the caller allowed it.** The default
+ *   has to be safe to run on a production Sense server at any time, and must never hang on a DNS
+ *   timeout on an air-gapped host.
+ * - **One broken check may not take down the report.** Every check is isolated, and a throw
+ *   becomes an error finding naming the check that threw.
+ */
+
+/**
+ * @typedef {object} Check
+ * @property {string} id - Stable, kebab-case, unique across the registry.
+ * @property {string} title - What the check asserts, as a statement.
+ * @property {string} section - Heading the findings render under. Checks sharing a section render
+ * under one heading, in registry order, which is how two cache checks produce §7.3's single
+ * "Browser cache" block.
+ * @property {string} area - One of {@link CHECK_AREAS}.
+ * @property {boolean} needsNetwork - `true` checks are skipped unless the caller allows network.
+ * @property {string[]} findingIds - Every finding id this check can emit. Declared rather than
+ * discovered so the registry can be checked for collisions without running anything - see
+ * `checks.test.js`.
+ * @property {(ctx: object) => boolean} appliesTo - Cheap predicate; skips irrelevant checks.
+ * @property {(ctx: object) => Promise<import('./findings.js').Finding[]>} run - The check itself.
+ * Pure with respect to the world: it reads `ctx` and returns findings. It does not log, format,
+ * install, write files or set `process.exitCode`.
+ */
+
+/**
+ * @typedef {object} CheckResult
+ * @property {Check} check - The check that produced this.
+ * @property {import('./findings.js').Finding[]} findings - What it found, empty when skipped.
+ * @property {string} [skipped] - Why it did not run, when it did not.
+ */
+
+/**
+ * The areas a check may declare.
+ *
+ * A closed list rather than free-form text, because `checksForAreas` filters on this string and a
+ * value nobody selects is indistinguishable from a check that does not exist. There is no throw,
+ * no warning and no skipped result - the check is simply absent from the report. Measured: a
+ * one-letter typo in `browser-selection`'s area left `browser check` reporting `Result: OK` and
+ * exiting 0 on a machine with no browser at all, with the whole suite green, because the per-check
+ * tests call `run()` directly and never go through the registry.
+ *
+ * `checks.test.js` holds every registered check to this list, so adding an area is a deliberate
+ * line here rather than a silent consequence of a spelling.
+ */
+export const CHECK_AREAS = Object.freeze(['browser', 'environment', 'config', 'qseow', 'qscloud']);
+
+/** Reported when a check was skipped because it needs network access that was not allowed. */
+export const SKIP_NETWORK = 'network';
+
+/** Reported when a check's own `appliesTo` predicate said it was irrelevant here. */
+export const SKIP_NOT_APPLICABLE = 'not-applicable';
+
+/**
+ * The finding a check's own failure is reported as.
+ *
+ * Its own id rather than one borrowed from the area being checked: this says something about
+ * Butler Sheet Icons, not about the machine, and an administrator seeing it should be able to
+ * tell those apart at a glance.
+ */
+export const RUNNER_ERROR_ID = 'BSI-DOCTOR-001';
+
+/**
+ * Renders a thrown value as text.
+ *
+ * Not everything thrown is an `Error` - a rejected promise carrying a string reaches here too,
+ * and `err.message` on it is `undefined`, which would produce a finding that says nothing.
+ *
+ * @param {unknown} err - The thrown value.
+ *
+ * @returns {string} Something worth printing.
+ */
+const describeError = (err) => {
+    if (err instanceof Error) {
+        return err.message;
+    }
+
+    return String(err);
+};
+
+/**
+ * The finding a check's failure becomes.
+ *
+ * @param {Check} check - The check that threw.
+ * @param {unknown} err - What it threw.
+ *
+ * @returns {import('./findings.js').Finding} An error finding naming the check.
+ */
+const checkFailedFinding = (check, err) =>
+    finding({
+        id: RUNNER_ERROR_ID,
+        severity: SEVERITY.ERROR,
+        title: 'A diagnostic check could not be completed',
+        // The check id is the whole point. Without it the report says something failed and gives
+        // nobody a place to look.
+        detail: `The check "${check.id}" (${check.title}) stopped with an error: ${describeError(err)}. Everything else in this report still ran.`,
+        evidence: { check: check.id },
+        remediation: [
+            {
+                text: 'Re-run with --loglevel debug and include the output in a Butler Sheet Icons issue. This is a fault in the diagnostic itself, not in the machine it was run on.',
+            },
+        ],
+    });
+
+/**
+ * Runs a set of checks and collects their findings.
+ *
+ * Sequential rather than concurrent, and deliberately so: the findings appear in registry order,
+ * which is what makes the rendered report read top to bottom, and no check is expensive enough
+ * for the parallelism to buy anything.
+ *
+ * @param {Check[]} checks - Checks to run, in the order their findings should appear.
+ * @param {object} ctx - The context every check is handed.
+ * @param {object} [runOptions] - How to run them.
+ * @param {boolean} [runOptions.allowNetwork] - Whether `needsNetwork` checks may run.
+ *
+ * @returns {Promise<CheckResult[]>} One result per check, in the order given.
+ */
+export const runChecks = async (checks, ctx, { allowNetwork = false } = {}) => {
+    const results = [];
+
+    for (const check of checks) {
+        if (check.needsNetwork && !allowNetwork) {
+            ctx.logger?.debug?.(
+                `Doctor: skipping check "${check.id}" because it needs network access`
+            );
+            results.push({ check, findings: [], skipped: SKIP_NETWORK });
+            continue;
+        }
+
+        try {
+            // Inside the try with `run`, because a predicate is code too. An `appliesTo` that
+            // throws would otherwise escape the isolation the runner exists to provide.
+            if (!check.appliesTo(ctx)) {
+                ctx.logger?.debug?.(`Doctor: check "${check.id}" does not apply here`);
+                results.push({ check, findings: [], skipped: SKIP_NOT_APPLICABLE });
+                continue;
+            }
+
+            results.push({ check, findings: asFindingList(await check.run(ctx)) });
+        } catch (err) {
+            results.push({ check, findings: [checkFailedFinding(check, err)] });
+        }
+    }
+
+    // After every check, never during: a consequence may be registered before the cause that
+    // explains it, so registry order stays a reading order rather than a correctness dependency.
+    return applySupersession(results);
+};
+
+/**
+ * Whatever a check returned, as a list of findings.
+ *
+ * A check is meant to return an array. When one returns a bare finding instead - an easy mistake,
+ * and the contract invites hand-written checks - the runner used to reassemble the per-check
+ * structure by slicing a flattened array with a running cursor, so a missing `.length` made the
+ * cursor `NaN` and **every** finding after that point silently vanished. One malformed check
+ * emptied the whole report and the command exited 0 on a broken machine.
+ *
+ * Coercing here means the structure is never flattened and re-cut in the first place.
+ *
+ * @param {unknown} produced - Whatever `check.run()` resolved to.
+ *
+ * @returns {object[]} The findings, always an array.
+ */
+const asFindingList = (produced) => {
+    if (Array.isArray(produced)) {
+        return produced;
+    }
+
+    // `null`/`undefined` is a check that found nothing worth saying. Anything else is a single
+    // finding the author forgot to wrap.
+    return produced == null ? [] : [produced];
+};
+
+/**
+ * Normalises every finding and resolves supersession, preserving the per-check structure.
+ *
+ * Maps in place rather than flattening and re-cutting: a finding must stay attributed to the check
+ * that produced it, because the renderer groups by check section and a mis-attributed finding
+ * reads as the wrong subsystem having found something.
+ *
+ * @param {CheckResult[]} results - Results to resolve.
+ *
+ * @returns {CheckResult[]} The results, normalised and with superseded errors demoted.
+ */
+const applySupersession = (results) => {
+    // Normalised before anything reasons about severity, so the renderer, the sort and the exit
+    // code all see a shape they understand.
+    const normalised = results.map((result) => ({
+        ...result,
+        findings: result.findings.map(normalizeFinding),
+    }));
+
+    // One snapshot of what failed, taken across the whole report, so a consequence may be
+    // registered before its cause.
+    const errorIds = errorIdsOf(normalised.flatMap((result) => result.findings));
+
+    return normalised.map((result) => ({
+        ...result,
+        findings: result.findings.map((entry) => demoteIfSuperseded(entry, errorIds)),
+    }));
+};
+
+/**
+ * Every finding from a set of results, flattened in the order they were produced.
+ *
+ * @param {CheckResult[]} results - Results from {@link runChecks}.
+ *
+ * @returns {import('./findings.js').Finding[]} The findings.
+ */
+export const allFindings = (results) => results.flatMap((result) => result.findings);

--- a/src/lib/interactive/__tests__/option-introspect.test.js
+++ b/src/lib/interactive/__tests__/option-introspect.test.js
@@ -56,6 +56,7 @@ describe('true/false options, in both the forms Commander accepts', () => {
 describe('command-tree', () => {
     test('finds every leaf command, across all three namespaces', () => {
         expect(LEAVES.map((leaf) => leaf.path).sort()).toEqual([
+            'browser check',
             'browser install',
             'browser list-available',
             'browser list-installed',

--- a/src/lib/interactive/__tests__/option-introspect.test.js
+++ b/src/lib/interactive/__tests__/option-introspect.test.js
@@ -1,6 +1,12 @@
 import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { Option } from 'commander';
 import { everyLeafCommand, leafCommandAt } from '../command-tree.js';
-import { specsFromCommand, specFromOption, splitDescription } from '../option-introspect.js';
+import {
+    specsFromCommand,
+    specFromOption,
+    splitDescription,
+    isTrueFalseOption,
+} from '../option-introspect.js';
 import { isInteractiveOption, INTERACTIVE_OPTION_ATTRIBUTE } from '../interactive-option.js';
 
 const ENV_SNAPSHOT = { ...process.env };
@@ -21,6 +27,31 @@ afterEach(() => {
 const LEAVES = everyLeafCommand();
 const EVERY_COMMAND = LEAVES.map(({ path, command }) => [path, command]);
 const optionOn = (path, long) => leafCommandAt(path).options.find((option) => option.long === long);
+
+describe('true/false options, in both the forms Commander accepts', () => {
+    // The optional-argument form is not cosmetic. An option declared as a bare flag takes its
+    // value from the mere *presence* of its environment variable, so `BSI_..._SKIP_LAUNCH=false`
+    // switches the flag on; declaring the argument optional is what makes Commander pass the
+    // variable's value to the parser instead. Recognising only the angle-bracket form classified
+    // such an option as free text, so the wizard would have asked for a boolean with an input
+    // prompt and fed it whatever was typed.
+    test.each([
+        ['<true|false>', true],
+        ['[true|false]', true],
+        ['<value>', false],
+        ['[value]', false],
+    ])('--flag %s -> isTrueFalseOption %s', (arg, expected) => {
+        expect(isTrueFalseOption(new Option(`--flag ${arg}`, 'description'))).toBe(expected);
+    });
+
+    test('both forms are asked as a confirm, not as free text', () => {
+        for (const arg of ['<true|false>', '[true|false]']) {
+            const spec = specFromOption(new Option(`--flag ${arg}`, 'description').default(false));
+
+            expect({ arg, type: spec.type }).toEqual({ arg, type: 'confirm' });
+        }
+    });
+});
 
 describe('command-tree', () => {
     test('finds every leaf command, across all three namespaces', () => {

--- a/src/lib/interactive/__tests__/round-trip.test.js
+++ b/src/lib/interactive/__tests__/round-trip.test.js
@@ -141,11 +141,11 @@ const CASES = everyLeafCommand().flatMap(({ path, command }) =>
 );
 
 describe('the wizard produces what the command line it prints produces', () => {
-    test('there are nine commands to check, across three answer sets', () => {
+    test('there are ten commands to check, across three answer sets', () => {
         // Guards against the walk silently finding nothing, which would make
         // every assertion below pass vacuously.
-        expect(everyLeafCommand()).toHaveLength(9);
-        expect(CASES).toHaveLength(27);
+        expect(everyLeafCommand()).toHaveLength(10);
+        expect(CASES).toHaveLength(30);
     });
 
     test.each(CASES)('%s', (_label, command, strategy) => {

--- a/src/lib/interactive/option-introspect.js
+++ b/src/lib/interactive/option-introspect.js
@@ -32,7 +32,7 @@ const SECRET_KEYS = new Set(BSI_SECRET_KEYS.map((key) => key.toLowerCase()));
  */
 
 /**
- * Whether an option is declared as `--flag <true|false>`.
+ * Whether an option is declared as `--flag <true|false>` or `--flag [true|false]`.
  *
  * These are the trap in this codebase: they are *string* options carrying
  * boolean* defaults, so `--secure` is `true` when defaulted and `'true'` when
@@ -40,11 +40,20 @@ const SECRET_KEYS = new Set(BSI_SECRET_KEYS.map((key) => key.toLowerCase()));
  * the answer back to the string form is what keeps the wizard's options bag
  * identical to the CLI's.
  *
+ * The optional-argument form matters as much as the required one. `browser
+ * check` declares `--skip-launch [true|false]` so that Commander passes an
+ * environment variable's *value* to the parser rather than setting the flag on
+ * the variable's mere presence - which is what made
+ * `BSI_BROWSER_C_SKIP_LAUNCH=false` turn skip-launch on. Matching only the
+ * angle-bracket form classified that option as free text, so the wizard would
+ * have asked for a boolean with an input prompt.
+ *
  * @param {import('commander').Option} option - The option to test.
  *
- * @returns {boolean} True for a `<true|false>` option.
+ * @returns {boolean} True for a `<true|false>` or `[true|false]` option.
  */
-export const isTrueFalseOption = (option) => option.flags.includes('<true|false>');
+export const isTrueFalseOption = (option) =>
+    option.flags.includes('<true|false>') || option.flags.includes('[true|false]');
 
 /**
  * Split a description into the question and its supporting detail.

--- a/src/lib/interactive/registry.js
+++ b/src/lib/interactive/registry.js
@@ -28,6 +28,8 @@ export const NOT_INTERACTIVE = Object.freeze({
     'browser list-installed': 'Takes nothing but a log level; there is nothing to ask.',
     'browser list-available': 'Takes nothing but a browser and a channel, both with defaults.',
     'browser uninstall-all': 'Takes nothing but a log level, and asks for confirmation itself.',
+    'browser check':
+        'A diagnostic: every option describes the machine it is run on, and each already defaults to what a real run would use. Asking would only invite an answer that makes the check less honest.',
     'qscloud list-collections': 'Phase 2 - needs tenant credentials.',
     'qscloud remove-sheet-icons': 'Phase 2 - needs tenant credentials.',
 });

--- a/src/lib/util/boolean-option.js
+++ b/src/lib/util/boolean-option.js
@@ -1,0 +1,68 @@
+import { InvalidArgumentError } from 'commander';
+
+/**
+ * Words administrators actually write for "off" in a unit file or a `.env`.
+ */
+const FALSE_WORDS = new Set(['false', '0', 'no', 'off']);
+
+/** The matching set for "on", so an unrecognised value can be told from a deliberate one. */
+const TRUE_WORDS = new Set(['true', '1', 'yes', 'on']);
+
+/**
+ * Parses the value of a flag that can also be set through an environment variable.
+ *
+ * This exists because of a trap in how Commander reads environment variables. For an option
+ * declared with **no argument** - a bare `--skip-launch` - Commander sets the flag on the mere
+ * presence of its variable and never looks at the value, so `BSI_BROWSER_C_SKIP_LAUNCH=false`
+ * turned skip-launch **on**. On a diagnostic used as a deployment gate that inverted the result:
+ * the gate passed having never started a browser.
+ *
+ * Declaring the argument optional (`--skip-launch [true|false]`) makes Commander pass the
+ * variable's value through `argParser`, which is what this builds. Commander runs `argParser` on
+ * command-line and environment values alike, so both spellings are judged the same way.
+ *
+ * A bare `--skip-launch` on the command line never reaches the parser: Commander stores boolean
+ * `true` for an optional-argument option given without a value, which is why that keeps working.
+ *
+ * **An unrecognised value is refused, not guessed at.** Silently treating `--skip-launch oops` as
+ * "off" cost the arity check that a no-argument flag used to provide: the flag *and* the stray
+ * word both disappeared with no diagnostic, and the check ran as though neither had been typed.
+ * Refusing is also what the repo already does for a malformed value - see `parsePositiveInteger`.
+ *
+ * `whenEmpty` is separate from that, because empty is not malformed. A bare `BSI_..._HEADLESS=`
+ * line in a unit file means "unset" throughout this codebase - the same idiom as
+ * `PUPPETEER_EXECUTABLE_PATH=""` - so each option says what its own unset value is, which is
+ * normally its declared default.
+ *
+ * @param {object} [config] - Parser configuration.
+ * @param {boolean} [config.whenEmpty] - What a set-but-empty value means for this option.
+ *
+ * @returns {(value: string|boolean) => boolean} A Commander `argParser`.
+ */
+export const booleanOptionParser =
+    ({ whenEmpty = false } = {}) =>
+    (value) => {
+        if (typeof value === 'boolean') {
+            return value;
+        }
+
+        const normalized = String(value ?? '')
+            .trim()
+            .toLowerCase();
+
+        if (normalized === '') {
+            return whenEmpty;
+        }
+
+        if (TRUE_WORDS.has(normalized)) {
+            return true;
+        }
+
+        if (FALSE_WORDS.has(normalized)) {
+            return false;
+        }
+
+        throw new InvalidArgumentError(
+            `"${value}" is not a true/false value. Use one of: ${[...TRUE_WORDS].join(', ')} - or ${[...FALSE_WORDS].join(', ')}.`
+        );
+    };


### PR DESCRIPTION
Closes #1062. The last unfinished item of the phase 1 air-gapped plan.

## What this adds

`butler-sheet-icons browser check` answers *"will a real thumbnail run work on this machine?"* without contacting Qlik Sense, without changing anything, and without making a network request. Exit code 0 or 1, so it can gate a deployment script.

Until now the only way to find out whether an air-gapped install could drive a browser was to run a full job against production, where a browser problem surfaced late and with an error that named nothing about browsers.

## Built on a check contract, not as a one-off

This is the part worth reviewing. A check is a module exposing `{id, title, section, area, needsNetwork, findingIds, appliesTo, run}`, pure with respect to the world; the runner isolates each one so a throw becomes a finding naming it; a shared renderer turns findings into the report.

The acceptance test from the design (§14) is that a new diagnostic costs **one file and one registry entry**, with no change to the runner, the renderer or any command. Verified by adding a throwaway seventh check, watching it render its own section from context facts nobody wrote for it, and removing it again. `doctor` (#1063) is the consumer that will exercise this properly.

## Two constraints on the worker

- **No network request.** Detection is called directly rather than through `resolveBrowserExecutablePath`, which falls through to an install; a version is resolved locally or not at all. A doctor that hangs on a DNS timeout on an air-gapped server is worse than no doctor.
- **It does launch the browser**, with the production arguments and timeouts, because resolving a path proves far less than starting the process.

## Reviewing the three commits

Split by topic, and the two shared-code changes stand on their own:

| | |
| --- | --- |
| `refactor: read the browser version grammar from one place` | Extracts `classifyBrowserVersion`, which the real run's validator now also uses. Behaviour-preserving for every string form, verified by a differential run over both implementations. |
| `fix: recognise an optional true/false option in the wizard` | `[true|false]` was classified as free text, so the wizard would ask for a boolean with an input prompt. |
| `feat: add a browser check command` | The command, the contract, and the doc draft. |

`detectAvailableBrowser` gains an optional pre-read inventory. Without it the cache was read twice per run and the report described one snapshot while the verdict came from another — a build removed between them produced a report listing it as usable and, four lines later, saying it was missing. One reading also takes the filesystem work from 37 calls to 16 on a three-build cache.

## Risk

GitNexus reports high risk: `assertBrowserIsSupported` and `detectAvailableBrowser` both sit on the thumbnail path. Backing that up — the version grammar was verified identical for every string input, and the new detection parameter defaults so every existing caller takes the original path with `browser_detect.test.js` untouched.

## Verification

`npm run lint` and `npm run test:unit` both pass (2868 tests). Beyond the suite, the command was run against a real machine for every documented scenario — healthy, empty cache, wrong-platform cache, cache without binaries, cache holding another browser, unreadable cache, bad executable path, invalid version, milestone pin, floating keyword — and the doc draft's sample output is reproduced from those runs rather than written from intent.

Three review passes found fifteen defects, seven of them introduced while fixing earlier ones. All are closed, and the tests covering them were written from the reproductions.

## Follow-ups, not in this PR

- `docs/to-doc-site/browser-check-command.md` is staged for publication and not yet on the doc site.
- `docs/todo/airgap-browser-phase-1.md` is referenced from shipped source in ~18 places, and `docs/todo/README.md` says to delete a design doc once the work ships. That needs a decision before the doc is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)