### PR TITLE
Archive the browser check draft now that it is published

### DIFF
--- a/docs/to-doc-site/done/done_browser-check-command.md
+++ b/docs/to-doc-site/done/done_browser-check-command.md
@@ -1,5 +1,39 @@
 # `browser check`: find out whether a server can take screenshots
 
+<!--
+PUBLISHED 2026-08-14, doc site PR #99, merged to `next` as be8f742.
+
+Published to four pages:
+  /reference/browser                    new "### check" section, first under Commands
+                                        Reference; `check` row in Available Commands;
+                                        now troubleshooting step 1
+  /guide/troubleshooting                quick diagnostic step 4 replaced; pointers added
+                                        to five symptom sections it diagnoses
+  /reference/commands                   `browser check` row in Quick Reference
+  /guide/concepts/browser-detection-and-environment-variables
+                                        confirmation step in the Strategy 3 staging
+                                        procedure, plus a run-as-the-service-account tip
+
+Corrections to this draft, recorded so they do not resurface:
+
+- "Suggested target pages" names an "air-gapped installation guide". No such page
+  exists on the doc site — docs/guide/advanced/ holds browser-cache-directory, ci-cd,
+  crash-dumps, docker and proxy. The staging cross-link went to the browser detection
+  concept page instead, which is where Strategy 3 lives. Note that seven findings in
+  src/lib/doctor/checks/ carry `docs: 'guide/advanced/air-gapped-installation'`, which
+  points at the same non-existent page; it is not rendered today, so no user sees a
+  dead link, but it will be one as soon as anything resolves that field to a URL.
+
+- "Status: new command, not yet on the doc site" was true when written; the version
+  gate published is 5.0.0, taken from the open release-please PR title rather than from
+  this draft. A `feat!` in the same window makes the next release major, not 4.2.0.
+
+Everything else verified as correct against the merged implementation (44209d8): the
+option table is byte-identical to what `docs:cli-tables` generates, and every message
+string, report label, `Result:` sentence and exit code was reproduced by running the
+command rather than read from this file.
+-->
+
 **Status:** new command, not yet on the doc site.
 **Suggested target pages:** a new section under `/reference/browser`, plus a link from the air-gapped installation guide and from the troubleshooting pages.
 


### PR DESCRIPTION
## What & why

`docs/to-doc-site/browser-check-command.md` has been published to the doc site, so it moves to `docs/to-doc-site/done/` with the `done_` prefix. Staging-folder housekeeping only — no code, no user-visible change.

Published as [butler-sheet-icons-docs#99](https://github.com/ptarmiganlabs/butler-sheet-icons-docs/pull/99), merged to `next` as `be8f742`, across four pages:

| Page | What changed |
| --- | --- |
| `/reference/browser` | New `### check` section, first under Commands Reference; `check` row in Available Commands; now troubleshooting step 1 |
| `/guide/troubleshooting` | Quick diagnostic step 4 replaced; pointers added to five symptom sections it diagnoses |
| `/reference/commands` | `browser check` row in Quick Reference |
| `/guide/concepts/browser-detection-and-environment-variables` | Confirmation step in the Strategy 3 staging procedure, plus a run-as-the-service-account tip |

This empties the staging folder — `README.md` and `done/` are all that remain.

## How it was verified

The draft was checked against `upstream/main` immediately before the move (`git diff 44209d8..upstream/main` on that path was empty), so this archives the version that was actually published rather than one rewritten mid-pass.

The published content itself was verified against the merged implementation, not the draft: the option table is byte-identical to what `docs:cli-tables` generates and `--check` reports all six tables on the page as current; every message string, report label, `Result:` sentence and exit code was reproduced by running `browser check` across six scenarios (default, `--skip-launch`, an invalid `--headless` value, `--browser-version` as milestone / `stable` / exact build, and the three `BSI_BROWSER_C_SKIP_LAUNCH` forms). `npm run docs:build` passed and all 20 anchors were confirmed against the generated HTML.

`gitnexus detect_changes` reports 0 changed symbols and 0 affected processes, as expected for a file move under `docs/`.

## Docs

`docs/to-doc-site/done/done_browser-check-command.md` — the archived file itself, which now records two corrections to the draft:

- It suggested linking from an "air-gapped installation guide". No such page exists (`docs/guide/advanced/` holds browser-cache-directory, ci-cd, crash-dumps, docker and proxy), so the staging cross-link went to the browser detection concept page instead.
- The published version gate is 5.0.0, taken from the open release-please PR title rather than from the draft — a `feat!` in this window makes the next release major.

**Worth a follow-up, not fixed here:** seven findings under `src/lib/doctor/checks/` carry `docs: 'guide/advanced/air-gapped-installation'`, the same page that does not exist. `render-report.js` never resolves that field, so no user can reach a dead link today — but the JSDoc describes it as "resolved to a URL by the renderer", so it becomes one as soon as anything does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)