### PR TITLE
Archive the doctor and redaction doc drafts as published

### DIFF
--- a/docs/to-doc-site/done/done_doctor-command.md
+++ b/docs/to-doc-site/done/done_doctor-command.md
@@ -1,3 +1,12 @@
+> **Archived 2026-08-17.** Published to the doc site as `/reference/doctor` (butler-sheet-icons-docs
+> PR #101, `next` branch), with the cross-link applied to the browser check section of
+> `/reference/browser`. Not published from below: the sample transcripts' `info: App version: 4.1.0`
+> lines (this folder's rule against version numbers in pasted output), the JSON sample's literal
+> `"toolVersion": "4.1.0"` (replaced with a placeholder), and the draft's relative `.md` cross-link
+> (replaced with the absolute extensionless form the site build requires). The proposed target path
+> `guide/troubleshooting/doctor.md` did not match the site - troubleshooting is a single page - so
+> the page lives under Reference beside the other command pages.
+
 # `doctor`: ask Butler Sheet Icons what is wrong with this server
 
 **Target page:** a new page under the same part of the site as `browser check`, for example

--- a/docs/to-doc-site/done/done_log-redaction-quoted-values.md
+++ b/docs/to-doc-site/done/done_log-redaction-quoted-values.md
@@ -1,3 +1,8 @@
+> **Archived 2026-08-17.** Published into `/reference/log-redaction` (butler-sheet-icons-docs
+> PR #101, `next` branch): the quoted-value pattern joined the recognised-patterns list, the
+> "one shape is not redacted" subsection follows it, and the `doctor check` JSON report was added
+> to the list of places redaction runs. Published essentially as drafted.
+
 # Log redaction now covers quoted passwords
 
 **Target page:** the existing `Log redaction` reference page, which lists the patterns Butler Sheet


### PR DESCRIPTION
Both drafts published via [butler-sheet-icons-docs PR #101](https://github.com/ptarmiganlabs/butler-sheet-icons-docs/pull/101) to the `next` branch. Per the `docs/to-doc-site/README.md` workflow, the drafts move to `done/` with a `done_` prefix; each archived copy opens with a note recording what the publishing pass changed (trimmed `App version:` lines, link form, target path) so draft and page cannot be mistaken for each other later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)