### PR TITLE
Let administrators turn off the timestamp prefix on log output

### DIFF
--- a/docs/to-doc-site/log-timestamps-switch.md
+++ b/docs/to-doc-site/log-timestamps-switch.md
@@ -1,0 +1,82 @@
+# Turning off the timestamp prefix on log output
+
+> **Publisher note:** this is an **edit to an existing page**, not a new page —
+> `docs/guide/concepts/environment-variables.md` in the doc site repo. Two changes there:
+> add `BSI_LOG_TIMESTAMPS` to the **"Output and interaction"** table, and add the section
+> below alongside **"Colour codes in captured logs"**, which this mirrors in shape.
+> No sidebar change needed. Establish the version for the gate from the open
+> release-please PR title at publication time, per this folder's README.
+
+## Table row for "Output and interaction"
+
+| Variable                  | Effect                                             |
+| ------------------------- | -------------------------------------------------- |
+| `BSI_LOG_TIMESTAMPS=false` | Remove the timestamp prefix from every log line   |
+
+## New section: "Timestamps in log output"
+
+---
+
+::: warning Requires BSI X.Y.Z or later
+In earlier versions the timestamp prefix cannot be turned off.
+:::
+
+Every log line Butler Sheet Icons writes starts with a timestamp and a log level:
+
+```
+2026-08-17T09:14:22.105Z info: Starting creation of thumbnails for Qlik Sense Enterprise on Windows (QSEoW)
+```
+
+That prefix is about 31 characters before any content. It is useful when the console is the
+only record of when something happened — and pure duplication when something else already
+records the time, which is the case in most scheduled setups:
+
+- **Docker / Kubernetes** — the container runtime stamps every line (`docker logs -t`,
+  `kubectl logs --timestamps`)
+- **systemd / journald** — the journal stamps every line
+- **Most log shippers** — the collector adds its own receive time
+
+In those environments each line effectively carries two timestamps, and the one Butler Sheet
+Icons adds is the less trustworthy of the two.
+
+Set the environment variable `BSI_LOG_TIMESTAMPS` to `false`, `0`, `no`, or `off` (any
+capitalisation; surrounding whitespace is ignored) and the prefix is dropped:
+
+```
+info: Starting creation of thumbnails for Qlik Sense Enterprise on Windows (QSEoW)
+```
+
+The log level and the message are unchanged — only the timestamp goes away. Any other value,
+and an unset variable, leave timestamps on.
+
+Set it anywhere Butler Sheet Icons reads its environment:
+
+::: code-group
+
+```powershell [PowerShell]
+$env:BSI_LOG_TIMESTAMPS = 'false'
+.\butler-sheet-icons.exe qseow create-sheet-thumbnails ...
+```
+
+```bash [Bash]
+BSI_LOG_TIMESTAMPS=false ./butler-sheet-icons qseow create-sheet-thumbnails ...
+```
+
+:::
+
+In Docker, pass it with `-e BSI_LOG_TIMESTAMPS=false`. It also works from a `.env` file next
+to where you run Butler Sheet Icons, together with your other `BSI_` settings.
+
+If you are unsure whether the variable is reaching Butler Sheet Icons — or whether the value
+you set was understood — run `butler-sheet-icons interactive --self-test`: the **Logging**
+rows show the raw value received and whether timestamps are on or off as a result.
+
+**What it does not affect.** This switch applies to log lines only. Output that never carried
+a timestamp is unchanged: the JSON document from `doctor check --outputformat json`, the
+interactive wizard's prompts and tables, and `--help`/`--version` text. `--log-level`
+filtering and the messages themselves are also unchanged.
+
+**If you parse Butler Sheet Icons log output:** nothing changes unless you set the variable.
+With it set, anything matching on the leading timestamp (log filters, monitoring rules,
+scripts using the timestamp column) will need adjusting — log lines then start directly with
+the level, e.g. `info:` or `error:`.

--- a/src/__tests__/butler-sheet-icons.test.js
+++ b/src/__tests__/butler-sheet-icons.test.js
@@ -103,6 +103,41 @@ describe('butler-sheet-icons CLI', () => {
         expect(result.stdout).toContain('Commands:');
     });
 
+    describe('BSI_LOG_TIMESTAMPS (issue #1002)', () => {
+        // One pattern, composed everywhere it is asserted, so the three copies
+        // cannot drift: the prefix winston emits is an ISO-8601 timestamp.
+        const STAMP = String.raw`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z`;
+
+        // Ambient colour settings rewrite `info.level` in the child and break
+        // any regex anchored on a bare `info:` - jest-worker itself injects
+        // FORCE_COLOR=1 into worker children, so this bites anyone running
+        // this file outside the --runInBand npm scripts. Same scrub as
+        // NON_TTY_ENV below.
+        const scrubbedEnv = { ...process.env };
+        delete scrubbedEnv.NO_COLOR;
+        delete scrubbedEnv.FORCE_COLOR;
+
+        // The default (stamped) case is asserted in-process against the real
+        // transport in globals.test.js - spawning a child for it would cost
+        // ~3.5 s on the Windows runner. Only the disabled branch needs a real
+        // process, because `consoleTimestamps` is fixed at module load.
+        //
+        // `browser list-installed` is the cheapest command that routes a real
+        // line through the logger: no network, no config, read-only. No
+        // assertion on exit status - a corrupt entry in the host's browser
+        // cache fails the command for reasons unrelated to timestamps, and
+        // the App version line is emitted before any cache work happens.
+        test('BSI_LOG_TIMESTAMPS=false drops the prefix but keeps level and message', () => {
+            const result = execCLI(['browser', 'list-installed'], {
+                env: { ...scrubbedEnv, BSI_LOG_TIMESTAMPS: 'false' },
+                timeout: 20000,
+            });
+            expect(result.stdout).toMatch(/^info: App version:/m);
+            // No line anywhere in the output may still carry the stamp.
+            expect(result.stdout).not.toMatch(new RegExp(`^${STAMP}`, 'm'));
+        });
+    });
+
     test('should handle qseow create-sheet-thumbnails command', () => {
         // Since we don't want to actually run the command and we've mocked all the dependencies,
         // we'll test that the command is registered correctly

--- a/src/__tests__/globals.test.js
+++ b/src/__tests__/globals.test.js
@@ -53,6 +53,34 @@ describe('logger redaction', () => {
     });
 });
 
+describe('console line format (BSI_LOG_TIMESTAMPS default)', () => {
+    // The default (stamped) shape is asserted in-process against the real transport rather
+    // than by spawning the CLI - a child process costs ~3.5 s on the Windows runner. The
+    // disabled branch cannot be tested this way (`consoleTimestamps` is fixed at module
+    // load), so that one lives as a spawn test in butler-sheet-icons.test.js.
+    test('console lines carry the ISO timestamp prefix by default', async () => {
+        const { logger: realLogger } = await import('../globals.js');
+        const transport = realLogger.transports.find((t) => t.name === 'console');
+
+        // Mirror winston's real pipeline: the logger-level format runs first
+        // (Logger._transform), then the transport's own format over the result
+        // (winston-transport modern.js). The transport chain deliberately has no
+        // timestamp() of its own - it relies on the logger-level stamp, which is
+        // exactly what this test pins.
+        const afterLogger = realLogger.format.transform(
+            { level: 'info', message: 'App version: 0.0.0-test' },
+            realLogger.format.options
+        );
+        const line = transport.format.transform({ ...afterLogger }, transport.format.options)[
+            Symbol.for('message')
+        ];
+
+        expect(line).toMatch(
+            /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z info: App version: 0\.0\.0-test$/
+        );
+    });
+});
+
 describe('sendConsoleLogToStderr', () => {
     // Winston's Console transport writes *every* level to stdout unless given `stderrLevels`,
     // `error` included. That is easy to assume otherwise - the assumption is why a winston error

--- a/src/globals.js
+++ b/src/globals.js
@@ -12,6 +12,7 @@ import path from 'node:path';
 // The CLI entry point loads it instead; integration tests load it themselves.
 import { redactSensitivePatterns, redactValue } from './lib/util/redact-secrets.js';
 import { isColourEnabled } from './lib/util/colour.js';
+import { isTimestampEnabled } from './lib/util/log-timestamps.js';
 
 const require = createRequire(import.meta.url);
 const LEVEL = Symbol.for('level');
@@ -134,6 +135,18 @@ const sanitizeFormat = winston.format((info) => {
 // process - the stream cannot become a terminal later.
 const colourConsole = isColourEnabled();
 
+// Timestamps on console lines, decided once at load time for the same reason as
+// colour above. Console only, deliberately: the logger-level format below keeps
+// its own timestamp, so a future file transport inheriting it stays stamped.
+//
+// This chain deliberately has no `timestamp()` or `simple()` of its own. The
+// logger-level format runs first and has already set `info.timestamp`, and a
+// plain transport-level `timestamp()` is a no-op on an already-stamped record
+// (logform sets the field only when absent - though `timestamp({ format })`
+// WOULD override, so don't add one casually). `simple()` only wrote
+// Symbol(message), which the printf below overwrites unconditionally.
+const consoleTimestamps = isTimestampEnabled();
+
 logTransports.push(
     new winston.transports.Console({
         name: 'console',
@@ -141,10 +154,12 @@ logTransports.push(
         format: winston.format.combine(
             winston.format.errors({ stack: true }),
             sanitizeFormat(),
-            winston.format.timestamp(),
             ...(colourConsole ? [winston.format.colorize()] : []),
-            winston.format.simple(),
-            winston.format.printf((info) => `${info.timestamp} ${info.level}: ${info.message}`)
+            winston.format.printf((info) =>
+                consoleTimestamps
+                    ? `${info.timestamp} ${info.level}: ${info.message}`
+                    : `${info.level}: ${info.message}`
+            )
         ),
     })
 );

--- a/src/lib/interactive/__tests__/self-test.test.js
+++ b/src/lib/interactive/__tests__/self-test.test.js
@@ -85,7 +85,27 @@ describe('collectCapabilities', () => {
             'Colour',
             'Unicode',
             'Interactive mode',
+            'Logging',
         ]);
+    });
+
+    test('reports the timestamp switch: raw value and verdict', () => {
+        const withoutVar = Object.fromEntries(
+            selfTest.collectCapabilities(capableDeps()).map((r) => [r.label, r.value])
+        );
+        expect(withoutVar['timestamps on log lines']).toBe('yes');
+        expect(withoutVar.BSI_LOG_TIMESTAMPS).toBe('(not set)');
+
+        // The raw value is JSON-quoted so an operator can see a trailing \r
+        // arriving from a CRLF .env - the verdict row shows it still disables,
+        // and the quoted value makes the invisible byte visible.
+        const withVar = Object.fromEntries(
+            selfTest
+                .collectCapabilities(pipedDeps({ BSI_LOG_TIMESTAMPS: 'false\r' }))
+                .map((r) => [r.label, r.value])
+        );
+        expect(withVar['timestamps on log lines']).toBe('no');
+        expect(withVar.BSI_LOG_TIMESTAMPS).toBe('"false\\r"');
     });
 
     test('records that hasColors is absent on a piped stream, not merely false', () => {

--- a/src/lib/interactive/self-test.js
+++ b/src/lib/interactive/self-test.js
@@ -2,6 +2,7 @@ import { execFileSync } from 'node:child_process';
 import { getBorderCharacters } from 'table';
 import { isSea } from '../../globals.js';
 import { isColourEnabled, createPalette } from '../util/colour.js';
+import { isTimestampEnabled, LOG_TIMESTAMPS_ENV } from '../util/log-timestamps.js';
 import {
     ASCII_ONLY_ENV,
     ASCII_SYMBOLS,
@@ -123,6 +124,12 @@ export const collectCapabilities = ({
         ['Interactive mode', 'available', yesNo(blocker === null)],
         ['Interactive mode', 'blocked by', blocker ? blocker.reason : '(nothing)'],
         ['Interactive mode', INTERACTIVE_OPT_OUT_ENV, orUnset(env[INTERACTIVE_OPT_OUT_ENV])],
+
+        // Raw value and verdict, like colour and Unicode above: the raw value is
+        // what shows an operator that their `False\r` or `off ` was received -
+        // orUnset JSON-quotes it, so invisible whitespace becomes visible.
+        ['Logging', 'timestamps on log lines', yesNo(isTimestampEnabled(env))],
+        ['Logging', LOG_TIMESTAMPS_ENV, orUnset(env[LOG_TIMESTAMPS_ENV])],
     ];
 
     return rows.map(([section, label, value]) => ({ section, label, value: String(value) }));

--- a/src/lib/util/__tests__/log-timestamps.test.js
+++ b/src/lib/util/__tests__/log-timestamps.test.js
@@ -1,0 +1,58 @@
+import { describe, test, expect, afterEach } from '@jest/globals';
+import { isTimestampEnabled, LOG_TIMESTAMPS_ENV } from '../log-timestamps.js';
+
+describe('isTimestampEnabled', () => {
+    test('enabled when the variable is unset', () => {
+        expect(isTimestampEnabled({})).toBe(true);
+    });
+
+    test('enabled when the variable is empty', () => {
+        expect(isTimestampEnabled({ [LOG_TIMESTAMPS_ENV]: '' })).toBe(true);
+    });
+
+    // The same FALSE_WORDS vocabulary as booleanOptionParser, case-folded.
+    test.each(['false', '0', 'no', 'off', 'FALSE', 'False', 'Off'])('disabled by "%s"', (value) => {
+        expect(isTimestampEnabled({ [LOG_TIMESTAMPS_ENV]: value })).toBe(false);
+    });
+
+    // Values arrive dirty from real deployment routes: `docker run --env-file`
+    // keeps the trailing \r of a CRLF .env, and cmd.exe keeps trailing spaces
+    // from `set NAME=value `. Both must still disable.
+    test.each(['false\r', ' false', 'false ', '\toff\t'])(
+        'whitespace-wrapped %j still disables',
+        (value) => {
+            expect(isTimestampEnabled({ [LOG_TIMESTAMPS_ENV]: value })).toBe(false);
+        }
+    );
+
+    // An unrecognised value keeps timestamps on: this runs during logger
+    // construction, where refusing (as booleanOptionParser does) has nowhere
+    // to report to, and silently losing timestamps would be worse.
+    test.each(['true', '1', 'yes', 'on', 'anything'])(
+        'unrecognised or affirmative value ("%s") leaves timestamps enabled',
+        (value) => {
+            expect(isTimestampEnabled({ [LOG_TIMESTAMPS_ENV]: value })).toBe(true);
+        }
+    );
+
+    describe('default environment', () => {
+        const hadValue = Object.prototype.hasOwnProperty.call(process.env, LOG_TIMESTAMPS_ENV);
+        const savedValue = process.env[LOG_TIMESTAMPS_ENV];
+
+        afterEach(() => {
+            if (hadValue) {
+                process.env[LOG_TIMESTAMPS_ENV] = savedValue;
+            } else {
+                delete process.env[LOG_TIMESTAMPS_ENV];
+            }
+        });
+
+        test('reads process.env when no env is passed', () => {
+            process.env[LOG_TIMESTAMPS_ENV] = 'false';
+            expect(isTimestampEnabled()).toBe(false);
+
+            delete process.env[LOG_TIMESTAMPS_ENV];
+            expect(isTimestampEnabled()).toBe(true);
+        });
+    });
+});

--- a/src/lib/util/boolean-option.js
+++ b/src/lib/util/boolean-option.js
@@ -2,8 +2,13 @@ import { InvalidArgumentError } from 'commander';
 
 /**
  * Words administrators actually write for "off" in a unit file or a `.env`.
+ *
+ * Exported because it is the vocabulary, not just this parser's detail:
+ * `isTimestampEnabled` in `log-timestamps.js` judges its environment variable
+ * against the same word set, so an administrator who writes `off` is understood
+ * the same way everywhere.
  */
-const FALSE_WORDS = new Set(['false', '0', 'no', 'off']);
+export const FALSE_WORDS = new Set(['false', '0', 'no', 'off']);
 
 /** The matching set for "on", so an unrecognised value can be told from a deliberate one. */
 const TRUE_WORDS = new Set(['true', '1', 'yes', 'on']);

--- a/src/lib/util/log-timestamps.js
+++ b/src/lib/util/log-timestamps.js
@@ -1,0 +1,50 @@
+import { FALSE_WORDS } from './boolean-option.js';
+
+/**
+ * Environment variable that removes the timestamp prefix from console log lines.
+ *
+ * Console lines are prefixed with an ISO-8601 timestamp and the level - around
+ * 31 columns before any content. Under Docker, systemd/journald, and most log
+ * shippers the runtime adds its own timestamp, so the prefix is duplicated
+ * noise there; it also dominates terminal recordings.
+ *
+ * An environment variable rather than a CLI flag for the same reason as
+ * `BSI_ASCII_ONLY` and `BSI_NO_INTERACTIVE`: this is an ambient presentation
+ * choice, not a per-invocation one, and a flag would have to be declared on
+ * every leaf command.
+ */
+export const LOG_TIMESTAMPS_ENV = 'BSI_LOG_TIMESTAMPS';
+
+/**
+ * Whether console log lines should carry the timestamp prefix.
+ *
+ * Off exactly when the value is one of the {@link FALSE_WORDS} administrators
+ * actually write - `false`, `0`, `no`, `off` - shared with the boolean CLI
+ * options so the two never disagree on vocabulary. The value is trimmed and
+ * case-folded first: a `.env` authored on Windows arrives with a trailing
+ * `\r` through `docker run --env-file`, and `cmd.exe` keeps trailing spaces
+ * from `set NAME=value `, and both used to be silent no-ops.
+ *
+ * Unlike `booleanOptionParser`, an unrecognised value is *not* refused - it
+ * leaves timestamps on. This runs while the logger is being constructed, so
+ * there is nowhere to report a refusal yet, and losing timestamps to a typo
+ * would be worse than the reverse. The raw value is surfaced in
+ * `interactive --self-test` so an ignored value is at least visible.
+ *
+ * This governs the console transport only. A log *file* without timestamps is
+ * far less useful than a terminal without them, so any future file transport
+ * is expected to keep its own prefix regardless of this switch.
+ *
+ * @param {object} [env] - Environment to read. Defaults to `process.env`. Injectable for tests.
+ *
+ * @returns {boolean} True when the timestamp prefix should be emitted.
+ */
+export const isTimestampEnabled = (env = process.env) => {
+    const value = env[LOG_TIMESTAMPS_ENV];
+
+    if (typeof value !== 'string') {
+        return true;
+    }
+
+    return !FALSE_WORDS.has(value.trim().toLowerCase());
+};


### PR DESCRIPTION
Closes #1002.

## What

Every console log line starts with a ~31-column ISO-8601 timestamp and level prefix. Under Docker, systemd/journald and most log shippers the runtime stamps every line itself, so the prefix is duplicated noise — and there was no way to turn it off.

`BSI_LOG_TIMESTAMPS` set to `false`, `0`, `no` or `off` (case-insensitive, whitespace-trimmed) now drops the prefix. The word set is `FALSE_WORDS` from `boolean-option.js`, now exported, so the switch and the boolean CLI options share one vocabulary. An unrecognised value leaves timestamps on — this is evaluated during logger construction, where refusing (as `booleanOptionParser` does) has nowhere to report to.

Scope is the console transport only: the logger-level format keeps its own timestamp, so a future file transport stays stamped. The value and its verdict are reported in a new **Logging** section of `interactive --self-test`, JSON-quoted so a `"false\r"` from a CRLF `.env` is visible rather than a silent no-op.

Also removes the console transport chain's dead `timestamp()` and `simple()` components (the logger-level format always stamps the record first; `printf` overwrites `Symbol(message)` unconditionally), with a comment noting the one real trap (`timestamp({ format })` *would* override).

## Environment variable, not a flag

Same reasoning as `BSI_ASCII_ONLY` and `BSI_NO_INTERACTIVE`: an ambient presentation choice, and a flag would need declaring on every leaf command. This resolves #1002's open question 1 as the issue leaned; question 2 (file transport keeps timestamps) is resolved in the code structure.

## Verification

- Full unit suite passes (exit code checked directly, not through a pipe).
- Live matrix: default stamped; `false`/`0`/`off`/`False `/`false\r` all drop the prefix; `maybe` stays stamped; error-path lines keep their `error:` prefix.
- `doctor check --outputformat json` with the switch set still emits parseable JSON on stdout (the payload never goes through the console transport).
- A max-effort review (10 finder angles + verification + sweep) ran against this diff; all 14 applicable findings are fixed in this PR — including test hardening against ambient `FORCE_COLOR` (which jest-worker injects into worker children), a Windows-specific empty-string env pitfall, and `spawnSync` timeouts. The one deferred finding (a single line-shape seam for the run-output ladder) is left for #1072 where it naturally lands.

## Docs

`docs/to-doc-site/log-timestamps-switch.md` stages an **edit to the doc site's existing** `environment-variables.md` page ("Output and interaction" table + a section mirroring the colour-codes precedent), per the staging README — version gate left for the publisher to fill from the open release-please PR.

## Breaking change for log parsers

None by default. With the variable set, anything matching on the leading timestamp needs adjusting; the doc draft says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)