### PR TITLE
Dry runs: see exactly what a thumbnail run would change before it changes anything

### DIFF
--- a/docs/to-doc-site/dry-run.md
+++ b/docs/to-doc-site/dry-run.md
@@ -1,0 +1,153 @@
+# See what a run would change before it changes anything: --dry-run
+
+> **Publisher note:** new page — it needs a sidebar entry in `docs/.vitepress/config.js`,
+> suggested next to the reference pages for the three commands it covers. Adding
+> `--dry-run` also made three generated CLI option tables stale; regenerate them with
+> `scripts/docs-cli-tables.js` for `qseow create-sheet-thumbnails`,
+> `qscloud create-sheet-thumbnails` and `qscloud remove-sheet-icons` before publishing.
+> Establish the version for the gate below from the open release-please PR title at
+> publication time, per this folder's README. The sample report below is generated from
+> the real renderer — do not re-align it by hand.
+
+::: warning Requires BSI X.Y.Z or later
+Earlier versions do not have the `--dry-run` option.
+:::
+
+Three Butler Sheet Icons commands change Qlik Sense apps in place, with no undo:
+
+- `qseow create-sheet-thumbnails` (see [/reference/qseow](/reference/qseow))
+- `qscloud create-sheet-thumbnails` (see [/reference/qscloud](/reference/qscloud))
+- `qscloud remove-sheet-icons` (see [/reference/qscloud](/reference/qscloud))
+
+All three now accept `--dry-run`. With the flag set, Butler Sheet Icons **does every read
+the real run would do — connects, signs in to the APIs, resolves the app list, lists every
+sheet, applies every exclude and blur rule — and then stops.** Nothing is captured, uploaded,
+overwritten or deleted. Instead it prints the plan: what would happen to every sheet in every
+selected app, and which of your options is responsible for each decision.
+
+A dry run announces itself immediately — the log opens with a
+`DRY RUN of <command>: planning only - NOTHING WILL BE CHANGED` banner before anything
+connects, and each app line reads `About to plan app …` rather than `About to process app …`.
+
+## Why you would use it
+
+The dangerous part of a thumbnail run is not the connection settings — a wrong host or a bad
+API key fails loudly on the first request. The dangerous part is **sheet selection, which
+fails silently** (see [/guide/concepts/sheet-exclusion](/guide/concepts/sheet-exclusion) and
+[/guide/concepts/sheet-blurring](/guide/concepts/sheet-blurring)):
+
+- A misspelled `--exclude-sheet-tag` or `--blur-sheet-tag` behaves exactly as if the option
+  was never given. For the blur rule that means publishing readable thumbnails you believed
+  were blurred.
+- `--appid` and the tag/collection selectors are additive: a tag that matches more apps than
+  you expected updates more apps than you expected.
+- `--exclude-sheet-number` counts sheet positions in Butler Sheet Icons' processing order,
+  which is not something you can see in the QMC. An off-by-one is invisible until afterwards.
+
+A dry run makes all three visible before anything is touched.
+
+## Running it
+
+Add `--dry-run` to the exact command line you intend to run — same options, same
+environment variables:
+
+::: code-group
+
+```powershell [PowerShell]
+.\butler-sheet-icons.exe qseow create-sheet-thumbnails `
+    --host sense.company.com `
+    --appid a1b2c3d4-0000-4a1b-9c8d-000000000001 `
+    --qliksensetag "sheet-thumbnails" `
+    --exclude-sheet-status private `
+    --exclude-sheet-title "Internal notes" `
+    --blur-sheet-tag "confidential" `
+    --apiuserdir INTERNAL --apiuserid sa_api `
+    --logonuserdir COMPANY --logonuserid svc_bsi --logonpwd password-here `
+    --dry-run
+```
+
+```bash [Bash]
+./butler-sheet-icons qseow create-sheet-thumbnails \
+    --host sense.company.com \
+    --appid a1b2c3d4-0000-4a1b-9c8d-000000000001 \
+    --qliksensetag "sheet-thumbnails" \
+    --exclude-sheet-status private \
+    --exclude-sheet-title "Internal notes" \
+    --blur-sheet-tag "confidential" \
+    --apiuserdir INTERNAL --apiuserid sa_api \
+    --logonuserdir COMPANY --logonuserid svc_bsi --logonpwd password-here \
+    --dry-run
+```
+
+:::
+
+`--dry-run` is deliberately **not** available as an environment variable. A `BSI_DRY_RUN`
+inherited by a scheduler would silently turn every scheduled run into a no-op — the inverse
+of the surprise the flag exists to prevent.
+
+The report always prints, even at `--log-level warn` or `error`: the report is the entire
+product of a dry run, so its visibility does not depend on the log level.
+
+## Reading the report
+
+The report lists every app, every sheet, and the decision with the option responsible. This
+is the exact output the command above produces (timestamps trimmed):
+
+```
+DRY RUN of qseow create-sheet-thumbnails - nothing will be changed
+
+App selection: 1 app(s) - 1 named by --appid, 1 matched by --qliksensetag "sheet-thumbnails", 1 selected twice
+
+App 1/1: "Finance operations" (a1b2c3d4-0000-4a1b-9c8d-000000000001)
+  7 sheets
+
+   #  Sheet                 Would do
+   1  Overview              update
+   2  Sales detail          update, blurred  (--blur-sheet-tag)
+   3  Scratch               skip  (--exclude-sheet-status private)
+   4  Internal notes        skip  (--exclude-sheet-title)
+   5  KPI summary           skip  (hidden by show condition)
+   6  Regional              update
+   7  Notes                 update
+
+Summary: 1 app(s), 7 sheets. 4 would be updated (1 blurred), 3 skipped.
+Nothing was changed. Re-run without --dry-run to apply.
+```
+
+Things to check before running for real:
+
+- **The `Would do` column.** If you passed a blur option and no row says `blurred`, the rule
+  matched nothing — check the tag or title spelling. This situation is exactly what the dry
+  run exists to catch.
+- **The `App selection` line.** If the tag or collection matched more apps than you expected,
+  the real run would update more apps than you expected. `selected twice` counts apps that
+  were both named and matched — they are processed once.
+- **`PLAN INCOMPLETE` or `could not be planned` lines.** If an app or sheet could not be
+  read, the report says so explicitly rather than presenting a partial plan as complete.
+  The exit code is 1 in that case.
+
+For `qscloud remove-sheet-icons` the column reads `clear icon` instead, sheets that
+currently have no icon are marked `(no icon currently set)`, and each app's section also
+shows how many thumbnail files would be deleted from the app's media library, as
+`N thumbnail media file(s) would also be deleted from the app media library`.
+
+## What a dry run does not prove
+
+- **It does not verify the web UI login.** No browser is started, so the
+  `--logonuserdir`/`--logonuserid`/`--logonpwd` credentials (and the Cloud login) are never
+  exercised. On client-managed Qlik Sense the certificate and repository API path *is*
+  exercised — those are different credentials.
+- **It does not check that `--imagedir` is writable.** Creating the image directory is a
+  write, so a dry run never attempts it. A real run in Docker can still fail on a
+  read-only or root-owned image directory that the dry run reported nothing about.
+- **It does not prove a sheet will render.** Page timeouts and rendering problems are
+  runtime outcomes of a real run.
+- **It is a snapshot.** Apps and sheets can change between the dry run and the real run,
+  especially when a tag or collection selects them.
+
+## Exit code
+
+A dry run that cannot be planned at all — missing certificate, no apps matched, an app that
+does not exist or cannot be read — exits 1, exactly as the real run would. A plan that
+completes exits 0, even when every sheet was excluded; check the report rather than the exit
+code for that.

--- a/src/lib/cloud/__tests__/cloud_create_thumbnails_app_loop.test.js
+++ b/src/lib/cloud/__tests__/cloud_create_thumbnails_app_loop.test.js
@@ -13,6 +13,7 @@ jest.unstable_mockModule('../../../globals.js', () => ({
         warn: jest.fn(),
     },
     setLoggingLevel: jest.fn(),
+    getLoggingLevel: jest.fn(() => 'info'),
     bsiExecutablePath: '/test/path',
     isSea: false,
 }));
@@ -31,6 +32,10 @@ jest.unstable_mockModule('../process-cloud-app.js', () => ({
     processCloudApp: jest.fn().mockResolvedValue(true),
 }));
 
+jest.unstable_mockModule('../cloud-plan-app.js', () => ({
+    cloudPlanApp: jest.fn().mockResolvedValue(undefined),
+}));
+
 jest.unstable_mockModule('../../util/redact-secrets.js', () => ({
     redactOptions: jest.fn((o) => o),
 }));
@@ -40,6 +45,8 @@ jest.unstable_mockModule('../../util/run-over-apps.js', () => ({ runOverApps }))
 
 const { logger } = await import('../../../globals.js');
 const { qscloudCreateThumbnails } = await import('../cloud-create-thumbnails.js');
+const { processCloudApp } = await import('../process-cloud-app.js');
+const { cloudPlanApp } = await import('../cloud-plan-app.js');
 
 const OPTIONS = {
     tenanturl: 'tenant.eu.qlikcloud.com',
@@ -239,6 +246,52 @@ describe('qscloudCreateThumbnails app loop', () => {
             ).resolves.toBe(true);
 
             expect(runOverApps.mock.calls[0][0]).toEqual(['test-app-id']);
+        });
+    });
+
+    describe('--dry-run routing (#993) - Cloud twin of the QSEoW block', () => {
+        test('a dry run hands runOverApps the planner, never the processor', async () => {
+            runOverApps.mockResolvedValue(true);
+
+            await qscloudCreateThumbnails({ ...OPTIONS, dryRun: true });
+
+            const processor = runOverApps.mock.calls[0][2];
+            await processor('app-under-test');
+
+            expect(cloudPlanApp).toHaveBeenCalledWith(
+                'app-under-test',
+                expect.any(Object),
+                expect.objectContaining({ dryRun: true }),
+                expect.objectContaining({ dryRun: true, apps: expect.any(Array) })
+            );
+            // The write path must be unreachable in a dry run.
+            expect(processCloudApp).not.toHaveBeenCalled();
+        });
+
+        test('a dry run renders the report after the app loop', async () => {
+            runOverApps.mockResolvedValue(true);
+
+            await qscloudCreateThumbnails({ ...OPTIONS, dryRun: true });
+
+            const infoLog = logger.info.mock.calls.map((call) => String(call[0])).join('\n');
+            expect(infoLog).toContain('DRY RUN of qscloud create-sheet-thumbnails');
+            expect(infoLog).toContain('Re-run without --dry-run to apply.');
+        });
+
+        test('a real run hands runOverApps the processor, never the planner', async () => {
+            runOverApps.mockResolvedValue(true);
+
+            await qscloudCreateThumbnails({ ...OPTIONS });
+
+            const processor = runOverApps.mock.calls[0][2];
+            await processor('app-under-test');
+
+            expect(processCloudApp).toHaveBeenCalledWith(
+                'app-under-test',
+                expect.any(Object),
+                expect.any(Object)
+            );
+            expect(cloudPlanApp).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/lib/cloud/__tests__/cloud_create_thumbnails_empty_selection.test.js
+++ b/src/lib/cloud/__tests__/cloud_create_thumbnails_empty_selection.test.js
@@ -9,6 +9,7 @@ jest.unstable_mockModule('../../../globals.js', () => ({
         warn: jest.fn(),
     },
     setLoggingLevel: jest.fn(),
+    getLoggingLevel: jest.fn(() => 'info'),
     bsiExecutablePath: '/test/path',
     isSea: false,
 }));

--- a/src/lib/cloud/__tests__/cloud_create_thumbnails_validation.test.js
+++ b/src/lib/cloud/__tests__/cloud_create_thumbnails_validation.test.js
@@ -12,6 +12,7 @@ jest.unstable_mockModule('../../../globals.js', () => ({
         warn: jest.fn(),
     },
     setLoggingLevel: jest.fn(),
+    getLoggingLevel: jest.fn(() => 'info'),
     bsiExecutablePath: '/test/path',
     isSea: false,
 }));

--- a/src/lib/cloud/__tests__/cloud_plan_app.test.js
+++ b/src/lib/cloud/__tests__/cloud_plan_app.test.js
@@ -1,0 +1,145 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+// Executes the REAL cloudPlanApp - no planner mock. The review found that the
+// routing tests mock both sides, so no planner line ran under any test and a
+// crash in the plan path shipped green. QSEoW twin: qseow_plan_app.test.js.
+
+jest.unstable_mockModule('../../../globals.js', () => ({
+    logger: {
+        info: jest.fn(),
+        error: jest.fn(),
+        verbose: jest.fn(),
+        debug: jest.fn(),
+        warn: jest.fn(),
+    },
+    setLoggingLevel: jest.fn(),
+    getLoggingLevel: jest.fn(() => 'info'),
+    isSea: false,
+}));
+
+jest.unstable_mockModule('../cloud-enigma.js', () => ({
+    setupEnigmaConnection: jest.fn().mockReturnValue({ url: 'wss://tenant' }),
+}));
+
+// The session helper is mocked at its seam: hand the callback a fake global.
+let fakeGlobal;
+jest.unstable_mockModule('../../util/engine-session.js', () => ({
+    withEngineSession: jest.fn(async (config, ctx, cb) => cb(fakeGlobal)),
+}));
+
+const { cloudPlanApp } = await import('../cloud-plan-app.js');
+const { createRunReport } = await import('../../util/run-report.js');
+
+const sheetItem = (qId, rank, { title = `Sheet ${qId}`, qMeta, showCondition = null } = {}) => ({
+    qInfo: { qId },
+    ...(qMeta === null ? {} : { qMeta: qMeta ?? { title, description: '' } }),
+    qData: { rank, showCondition },
+});
+
+const wireApp = (items, { evaluateEx } = {}) => {
+    const app = {
+        createSessionObject: jest.fn().mockResolvedValue({
+            getLayout: jest.fn().mockResolvedValue({
+                qAppObjectList: { qItems: items },
+            }),
+        }),
+        evaluateEx: evaluateEx ?? jest.fn().mockResolvedValue({ qIsNumeric: false }),
+    };
+
+    fakeGlobal = { openDoc: jest.fn().mockResolvedValue(app) };
+
+    return app;
+};
+
+const saasWithName = (name) => ({
+    Get: jest.fn(async () => ({ attributes: { name, publishTime: '' } })),
+});
+
+const OPTIONS = { tenanturl: 'tenant', loglevel: 'info' };
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('cloudPlanApp', () => {
+    test('records one decision per sheet, in rank order', async () => {
+        wireApp([sheetItem('b', 2), sheetItem('a', 1)]);
+        const report = createRunReport({
+            command: 'qscloud create-sheet-thumbnails',
+            dryRun: true,
+        });
+
+        await cloudPlanApp('app-1', saasWithName('Finance'), OPTIONS, report);
+
+        expect(report.apps).toHaveLength(1);
+        expect(report.apps[0].name).toBe('Finance');
+        expect(report.apps[0].sheets.map((sheet) => [sheet.n, sheet.title, sheet.action])).toEqual([
+            [1, 'Sheet a', 'update'],
+            [2, 'Sheet b', 'update'],
+        ]);
+    });
+
+    test('applies exclude and blur rules with reasons', async () => {
+        wireApp([sheetItem('a', 1, { title: 'Keep' }), sheetItem('b', 2, { title: 'Blur me' })]);
+        const report = createRunReport({
+            command: 'qscloud create-sheet-thumbnails',
+            dryRun: true,
+        });
+
+        await cloudPlanApp(
+            'app-1',
+            saasWithName('Finance'),
+            { ...OPTIONS, excludeSheetTitle: ['Keep'], blurSheetTitle: ['Blur me'] },
+            report
+        );
+
+        expect(report.apps[0].sheets).toEqual([
+            { n: 1, title: 'Keep', action: 'skip', reason: '--exclude-sheet-title' },
+            { n: 2, title: 'Blur me', action: 'blur', reason: '--blur-sheet-title' },
+        ]);
+    });
+
+    test('a sheet the engine returned without qMeta is planned, not thrown on', async () => {
+        wireApp([sheetItem('bare', 1, { qMeta: null })]);
+        const report = createRunReport({
+            command: 'qscloud create-sheet-thumbnails',
+            dryRun: true,
+        });
+
+        await cloudPlanApp('app-1', saasWithName('Finance'), OPTIONS, report);
+
+        expect(report.apps[0].sheets).toEqual([
+            { n: 1, title: undefined, action: 'update', reason: null },
+        ]);
+    });
+
+    test('one failing sheet does not abort the remaining rows', async () => {
+        // Sheet 2 has a show condition whose evaluation the engine rejects. The
+        // real run isolates it through runOverSheets - the planner must too.
+        const evaluateEx = jest
+            .fn()
+            .mockRejectedValueOnce(new Error('bad expression'))
+            .mockResolvedValue({ qIsNumeric: false });
+        wireApp(
+            [
+                sheetItem('a', 1, { showCondition: '=broken(' }),
+                sheetItem('b', 2),
+                sheetItem('c', 3),
+            ],
+            { evaluateEx }
+        );
+        const report = createRunReport({
+            command: 'qscloud create-sheet-thumbnails',
+            dryRun: true,
+        });
+
+        // The app still fails overall - same semantics as the real run - but
+        // every other sheet's decision was recorded first.
+        await expect(
+            cloudPlanApp('app-1', saasWithName('Finance'), OPTIONS, report)
+        ).rejects.toThrow();
+
+        expect(report.apps[0].sheets.map((sheet) => sheet.title)).toEqual(['Sheet b', 'Sheet c']);
+        expect(report.apps[0].sheetCount).toBe(3);
+    });
+});

--- a/src/lib/cloud/__tests__/cloud_remove_sheet_icons.test.js
+++ b/src/lib/cloud/__tests__/cloud_remove_sheet_icons.test.js
@@ -36,6 +36,7 @@ jest.unstable_mockModule('../../../globals.js', () => ({
         warn: jest.fn(),
     },
     setLoggingLevel: jest.fn(),
+    getLoggingLevel: jest.fn(() => 'info'),
     bsiExecutablePath: '/opt/bsi',
     isSea: false,
 }));
@@ -721,6 +722,107 @@ describe('qscloudRemoveSheetIcons', () => {
             });
 
             await expect(qscloudRemoveSheetIcons({ ...BASE_OPTIONS })).resolves.toBe(false);
+        });
+    });
+
+    describe('--dry-run (#993): the writes-nothing proof', () => {
+        // These are the assertions that actually guard the feature: the real
+        // worker with dryRun set must reach the planner and never touch a
+        // write. Everything below drives the REAL qscloudRemoveSheetIcons -
+        // no planner mock, no runOverApps mock - so a routing regression that
+        // swapped the ternary would fail here with icons "cleared".
+        const withAppAndThumbnails = () => {
+            Get.mockImplementation(async (path) => {
+                if (path === 'apps/test-app-id') {
+                    return { attributes: { name: 'Finance operations' } };
+                }
+                if (path.endsWith('/media/list')) {
+                    return [{ type: 'directory', name: 'thumbnails' }];
+                }
+                if (path.endsWith('/media/list/thumbnails')) {
+                    return [
+                        { type: 'image', name: 'thumb-1.png' },
+                        { type: 'image', name: 'thumb-2.png' },
+                        { type: 'directory', name: 'nested' },
+                    ];
+                }
+                return [];
+            });
+        };
+
+        test('a dry run performs every read and no write', async () => {
+            withAppAndThumbnails();
+            const sheets = [makeSheet('s1', 1), makeSheet('s2', 2)];
+            const { app } = wireEnigma(sheets);
+
+            await expect(qscloudRemoveSheetIcons({ ...BASE_OPTIONS, dryRun: true })).resolves.toBe(
+                true
+            );
+
+            // Reads happened: the engine session was opened and properties read.
+            expect(enigmaCreate).toHaveBeenCalled();
+
+            // Writes did not - this is the feature's core promise.
+            for (const sheet of sheets) {
+                expect(sheet.obj.setProperties).not.toHaveBeenCalled();
+            }
+            expect(app.doSave).not.toHaveBeenCalled();
+            expect(Delete).not.toHaveBeenCalled();
+        });
+
+        test('the report names the app, the icons, and the media files', async () => {
+            withAppAndThumbnails();
+            wireEnigma([makeSheet('s1', 1), makeSheet('s2', 2)]);
+
+            await qscloudRemoveSheetIcons({ ...BASE_OPTIONS, dryRun: true });
+
+            const info = logger.info.mock.calls.map((call) => String(call[0])).join('\n');
+            expect(info).toContain('DRY RUN of qscloud remove-sheet-icons');
+            expect(info).toContain('"Finance operations"');
+            expect(info).toContain('clear icon');
+            expect(info).toContain(
+                '2 thumbnail media file(s) would also be deleted from the app media library'
+            );
+            expect(info).toContain('2 icon(s) would be cleared, 0 skipped.');
+            expect(info).toContain('Nothing was changed. Re-run without --dry-run to apply.');
+        });
+
+        test('a sheet without an icon is reported, not skipped', async () => {
+            withAppAndThumbnails();
+            const bare = makeSheet('s1', 1);
+            bare.props.thumbnail.qStaticContentUrlDef.qUrl = '';
+            wireEnigma([bare]);
+
+            await qscloudRemoveSheetIcons({ ...BASE_OPTIONS, dryRun: true });
+
+            const info = logger.info.mock.calls.map((call) => String(call[0])).join('\n');
+            expect(info).toContain('(no icon currently set)');
+        });
+
+        test('the real run still writes when dryRun is absent - the control case', async () => {
+            withAppAndThumbnails();
+            const sheets = [makeSheet('s1', 1)];
+            wireEnigma(sheets);
+
+            await qscloudRemoveSheetIcons({ ...BASE_OPTIONS });
+
+            expect(sheets[0].obj.setProperties).toHaveBeenCalled();
+        });
+
+        test('the real run skips, not fails, a sheet without a thumbnail structure', async () => {
+            // The guard added with the dry-run work: clearing a sheet that has
+            // no thumbnail object used to throw and fail the whole app.
+            withAppAndThumbnails();
+            const broken = makeSheet('s1', 1);
+            broken.obj.getProperties.mockResolvedValue({});
+            const fine = makeSheet('s2', 2);
+            const { app } = wireEnigma([broken, fine]);
+
+            await expect(qscloudRemoveSheetIcons({ ...BASE_OPTIONS })).resolves.toBe(true);
+
+            expect(broken.obj.setProperties).not.toHaveBeenCalled();
+            expect(fine.obj.setProperties).toHaveBeenCalled();
+            expect(app.doSave).toHaveBeenCalled();
         });
     });
 });

--- a/src/lib/cloud/__tests__/determine_sheet_blur_status.test.js
+++ b/src/lib/cloud/__tests__/determine_sheet_blur_status.test.js
@@ -1,0 +1,87 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { determineSheetBlurStatus } from '../determine-sheet-blur-status.js';
+import { BLUR_REASON } from '../../util/sheet-decision-reasons.js';
+
+// QSEoW twin: src/lib/qseow/__tests__/determine_sheet_blur_status.test.js.
+// The platforms differ where the code does: no tag rule here, and the
+// approved/published flags are read through undefined-safe normalisation.
+
+const log = { verbose: jest.fn() };
+
+const createSheet = ({ approved, published, title = 'Sheet', qId = 's1' } = {}) => ({
+    qMeta: { approved, published, title, description: '' },
+    qInfo: { qId },
+});
+
+const run = ({ sheet = createSheet(), options = {}, n = 1 } = {}) =>
+    determineSheetBlurStatus(sheet, options, n, log);
+
+describe('determineSheetBlurStatus (Cloud)', () => {
+    test('no blur options: no blur, no reason', () => {
+        expect(run()).toEqual({ blurSheet: false, blurReason: null });
+    });
+
+    test('public sheet blurred when "public" is listed', () => {
+        expect(
+            run({
+                sheet: createSheet({ approved: true, published: true }),
+                options: { blurSheetStatus: ['public'] },
+            })
+        ).toEqual({ blurSheet: true, blurReason: BLUR_REASON.STATUS_PUBLIC });
+    });
+
+    test('published sheet blurred when "published" is listed', () => {
+        expect(
+            run({
+                sheet: createSheet({ approved: false, published: true }),
+                options: { blurSheetStatus: ['published'] },
+            })
+        ).toEqual({ blurSheet: true, blurReason: BLUR_REASON.STATUS_PUBLISHED });
+    });
+
+    test('undefined approved/published flags read as false rather than throwing', () => {
+        // The Cloud engine omits both flags on some sheets; a sheet with
+        // neither is not "published", so the published rule must not fire.
+        expect(
+            run({
+                sheet: createSheet({}),
+                options: { blurSheetStatus: ['published', 'public'] },
+            })
+        ).toEqual({ blurSheet: false, blurReason: null });
+    });
+
+    test('sheet number rule matches on the 1-based position as a string', () => {
+        expect(run({ options: { blurSheetNumber: ['2'] }, n: 2 })).toEqual({
+            blurSheet: true,
+            blurReason: BLUR_REASON.NUMBER,
+        });
+    });
+
+    test('title rule matches exactly', () => {
+        expect(
+            run({
+                sheet: createSheet({ title: 'Board pack' }),
+                options: { blurSheetTitle: ['Board pack'] },
+            })
+        ).toEqual({ blurSheet: true, blurReason: BLUR_REASON.TITLE });
+    });
+
+    test('the first matching rule names the reason', () => {
+        expect(
+            run({
+                sheet: createSheet({ approved: true, published: true }),
+                options: { blurSheetStatus: ['public'], blurSheetNumber: ['1'] },
+                n: 1,
+            })
+        ).toEqual({ blurSheet: true, blurReason: BLUR_REASON.STATUS_PUBLIC });
+    });
+    test('does not throw for a sheet the engine returned without qMeta', () => {
+        // The extraction regression the review caught: the log label used to be
+        // built eagerly from sheet.qMeta.title, so a qMeta-less sheet threw even
+        // with no blur options passed - in the planner AND the real write path.
+        expect(run({ sheet: { qInfo: { qId: 'bare' } } })).toEqual({
+            blurSheet: false,
+            blurReason: null,
+        });
+    });
+});

--- a/src/lib/cloud/__tests__/determine_sheet_exclude_status.test.js
+++ b/src/lib/cloud/__tests__/determine_sheet_exclude_status.test.js
@@ -1,4 +1,5 @@
 import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+import { EXCLUDE_REASON } from '../../util/sheet-decision-reasons.js';
 
 import { determineSheetExcludeStatus } from '../determine-sheet-exclude-status.js';
 
@@ -71,7 +72,11 @@ beforeEach(() => {
 
 describe('determineSheetExcludeStatus (Cloud)', () => {
     test('processes a sheet when no exclusion options are set', async () => {
-        await expect(run()).resolves.toEqual({ excludeSheet: false, sheetIsHidden: false });
+        await expect(run()).resolves.toEqual({
+            excludeSheet: false,
+            sheetIsHidden: false,
+            excludeReason: null,
+        });
     });
 
     describe('sheets with missing metadata', () => {
@@ -81,6 +86,7 @@ describe('determineSheetExcludeStatus (Cloud)', () => {
             await expect(run({ sheet: {} })).resolves.toEqual({
                 excludeSheet: false,
                 sheetIsHidden: false,
+                excludeReason: null,
             });
         });
 
@@ -112,7 +118,11 @@ describe('determineSheetExcludeStatus (Cloud)', () => {
         test('treats a literal "false" showCondition as hidden', async () => {
             const result = await run({ sheet: createSheet({ showCondition: 'false' }) });
 
-            expect(result).toEqual({ excludeSheet: true, sheetIsHidden: true });
+            expect(result).toEqual({
+                excludeSheet: true,
+                sheetIsHidden: true,
+                excludeReason: EXCLUDE_REASON.HIDDEN,
+            });
         });
 
         test('matches the "false" literal case-insensitively', async () => {
@@ -129,14 +139,22 @@ describe('determineSheetExcludeStatus (Cloud)', () => {
             const result = await run({ sheet: createSheet({ showCondition: '=1=2' }), app });
 
             expect(app.evaluateEx).toHaveBeenCalledWith({ qExpression: '=1=2' });
-            expect(result).toEqual({ excludeSheet: true, sheetIsHidden: true });
+            expect(result).toEqual({
+                excludeSheet: true,
+                sheetIsHidden: true,
+                excludeReason: EXCLUDE_REASON.HIDDEN,
+            });
         });
 
         test('keeps a sheet whose show condition evaluates to numeric 1', async () => {
             const app = createApp({ qIsNumeric: true, qNumber: 1 });
             const result = await run({ sheet: createSheet({ showCondition: '=1=1' }), app });
 
-            expect(result).toEqual({ excludeSheet: false, sheetIsHidden: false });
+            expect(result).toEqual({
+                excludeSheet: false,
+                sheetIsHidden: false,
+                excludeReason: null,
+            });
         });
     });
 
@@ -239,6 +257,11 @@ describe('determineSheetExcludeStatus (Cloud)', () => {
             options: { excludeSheetStatus: ['private'] },
         });
 
-        expect(result).toEqual({ excludeSheet: true, sheetIsHidden: true });
+        expect(result).toEqual({
+            excludeSheet: true,
+            sheetIsHidden: true,
+            // Status ran first, so the reason names it - hidden did not overwrite it.
+            excludeReason: EXCLUDE_REASON.STATUS_PRIVATE,
+        });
     });
 });

--- a/src/lib/cloud/cloud-app-selection.js
+++ b/src/lib/cloud/cloud-app-selection.js
@@ -1,0 +1,42 @@
+import { logger } from '../../globals.js';
+import { listAppsByCollection } from './cloud-apps.js';
+import { toAppIdList } from '../util/app-ids.js';
+
+/**
+ * Resolves which Cloud apps a command should run over, with the provenance the
+ * run report records.
+ *
+ * `--appid` and `--collectionid` are additive, not alternatives: apps named
+ * either way are all processed, and `runOverApps()` dedupes, so an app that is
+ * both named and in the collection is still processed once. Shared by
+ * create-sheet-thumbnails and remove-sheet-icons, which carried identical
+ * copies of this block.
+ *
+ * @param {object} saasInstance - QlikSaas object.
+ * @param {object} options - The command's options bag.
+ * @param {string[]} [options.appid] - Apps named directly.
+ * @param {string} [options.collectionid] - Collection whose apps are added.
+ *
+ * @returns {Promise<{appIds: string[], namedAppIds: string[], selectorAppIds: string[], selector: {option: string, value: string}|null}>}
+ *     The selection, shaped for `runOverAppsWithReport`.
+ */
+export const resolveCloudAppSelection = async (saasInstance, options) => {
+    const namedAppIds = toAppIdList(options.appid);
+    const appIds = [...namedAppIds];
+
+    let selectorAppIds = [];
+    const useCollection = Boolean(options.collectionid && options.collectionid.length > 0);
+    if (useCollection) {
+        const apps = await listAppsByCollection(saasInstance, options.collectionid);
+        logger.verbose(`Collection '${options.collectionid}' exists`);
+        selectorAppIds = apps.map((app) => app.id);
+        appIds.push(...selectorAppIds);
+    }
+
+    return {
+        appIds,
+        namedAppIds,
+        selectorAppIds,
+        selector: useCollection ? { option: 'collectionid', value: options.collectionid } : null,
+    };
+};

--- a/src/lib/cloud/cloud-create-thumbnails.js
+++ b/src/lib/cloud/cloud-create-thumbnails.js
@@ -3,9 +3,16 @@ import { redactOptions } from '../util/redact-secrets.js';
 import QlikSaas from './cloud-repo.js';
 import { qscloudTestConnection } from './cloud-test-connection.js';
 import { processCloudApp } from './process-cloud-app.js';
+import { cloudPlanApp } from './cloud-plan-app.js';
 import { runOverApps } from '../util/run-over-apps.js';
 import { listAppsByCollection } from './cloud-apps.js';
 import { toAppIdList } from '../util/app-ids.js';
+import {
+    createRunReport,
+    recordSelection,
+    renderDryRunReport,
+    announceDryRun,
+} from '../util/run-report.js';
 import { CLOUD_SHEET_PARTS } from './sheet-parts.js';
 import { logError } from '../util/log-error.js';
 
@@ -37,6 +44,12 @@ import { logError } from '../util/log-error.js';
 export const qscloudCreateThumbnails = async (options) => {
     try {
         setLoggingLevel(options.loglevel);
+
+        const dryRun = Boolean(options.dryRun);
+        if (dryRun) {
+            // Before anything connects - mirrors the QSEoW twin.
+            announceDryRun('qscloud create-sheet-thumbnails');
+        }
 
         logger.info('Starting creation of thumbnails for Qlik Sense Cloud');
         logger.verbose(`Running as standalone app: ${isSea}`);
@@ -104,25 +117,53 @@ export const qscloudCreateThumbnails = async (options) => {
         }
 
         // Apps named directly. --appid is variadic, so this is a list.
-        appIdsToProcess.push(...toAppIdList(options.appid));
+        const namedAppIds = toAppIdList(options.appid);
+        appIdsToProcess.push(...namedAppIds);
 
         // --appid and --collectionid are additive, not alternatives: apps named either
         // way are all processed. runOverApps() dedupes, so an app that is both named by
         // --appid and in the collection is still processed once.
-        if (options.collectionid && options.collectionid.length > 0) {
+        let collectionAppIds = [];
+        const useCollection = Boolean(options.collectionid && options.collectionid.length > 0);
+        if (useCollection) {
             const apps = await listAppsByCollection(saasInstance, options.collectionid);
             logger.verbose(`Collection '${options.collectionid}' exists`);
-            appIdsToProcess.push(...apps.map((app) => app.id));
+            collectionAppIds = apps.map((app) => app.id);
+            appIdsToProcess.push(...collectionAppIds);
         }
 
-        return await runOverApps(
+        // The report is built for both modes; only a dry run renders it today.
+        // Selection provenance is recorded up front because "the collection
+        // matched 40 apps, not 4" is a silent surprise the report exists to
+        // catch (#993). Mirrors the QSEoW twin in qseow-create-thumbnails.js.
+        const report = createRunReport({ command: 'qscloud create-sheet-thumbnails', dryRun });
+        recordSelection(report, {
+            namedAppIds,
+            selectorAppIds: collectionAppIds,
+            selector: useCollection
+                ? { option: 'collectionid', value: options.collectionid }
+                : null,
+        });
+
+        const result = await runOverApps(
             appIdsToProcess,
             {
-                logPrefix: 'CLOUD PROCESS APP',
+                logPrefix: dryRun ? 'CLOUD PLAN APP' : 'CLOUD PROCESS APP',
+                action: dryRun ? 'plan' : 'process',
                 emptySelectionHint: 'Check the --appid and --collectionid options.',
             },
-            (appId) => processCloudApp(appId, saasInstance, options)
+            dryRun
+                ? (appId) => cloudPlanApp(appId, saasInstance, options, report)
+                : (appId) => processCloudApp(appId, saasInstance, options)
         );
+
+        // Rendered even when some apps failed to plan: the decisions that were
+        // reached belong next to the per-app error lines already logged.
+        if (dryRun) {
+            renderDryRunReport(report);
+        }
+
+        return result;
     } catch (err) {
         logError('CLOUD CREATE THUMBNAILS 2', err);
 

--- a/src/lib/cloud/cloud-create-thumbnails.js
+++ b/src/lib/cloud/cloud-create-thumbnails.js
@@ -4,15 +4,9 @@ import QlikSaas from './cloud-repo.js';
 import { qscloudTestConnection } from './cloud-test-connection.js';
 import { processCloudApp } from './process-cloud-app.js';
 import { cloudPlanApp } from './cloud-plan-app.js';
-import { runOverApps } from '../util/run-over-apps.js';
 import { listAppsByCollection } from './cloud-apps.js';
 import { toAppIdList } from '../util/app-ids.js';
-import {
-    createRunReport,
-    recordSelection,
-    renderDryRunReport,
-    announceDryRun,
-} from '../util/run-report.js';
+import { runOverAppsWithReport, announceDryRun } from '../util/run-report.js';
 import { CLOUD_SHEET_PARTS } from './sheet-parts.js';
 import { logError } from '../util/log-error.js';
 
@@ -132,38 +126,20 @@ export const qscloudCreateThumbnails = async (options) => {
             appIdsToProcess.push(...collectionAppIds);
         }
 
-        // The report is built for both modes; only a dry run renders it today.
-        // Selection provenance is recorded up front because "the collection
-        // matched 40 apps, not 4" is a silent surprise the report exists to
-        // catch (#993). Mirrors the QSEoW twin in qseow-create-thumbnails.js.
-        const report = createRunReport({ command: 'qscloud create-sheet-thumbnails', dryRun });
-        recordSelection(report, {
+        return await runOverAppsWithReport({
+            command: 'qscloud create-sheet-thumbnails',
+            dryRun,
+            appIds: appIdsToProcess,
             namedAppIds,
             selectorAppIds: collectionAppIds,
             selector: useCollection
                 ? { option: 'collectionid', value: options.collectionid }
                 : null,
+            logPrefix: { plan: 'CLOUD PLAN APP', process: 'CLOUD PROCESS APP' },
+            emptySelectionHint: 'Check the --appid and --collectionid options.',
+            planApp: (appId, report) => cloudPlanApp(appId, saasInstance, options, report),
+            processApp: (appId) => processCloudApp(appId, saasInstance, options),
         });
-
-        const result = await runOverApps(
-            appIdsToProcess,
-            {
-                logPrefix: dryRun ? 'CLOUD PLAN APP' : 'CLOUD PROCESS APP',
-                action: dryRun ? 'plan' : 'process',
-                emptySelectionHint: 'Check the --appid and --collectionid options.',
-            },
-            dryRun
-                ? (appId) => cloudPlanApp(appId, saasInstance, options, report)
-                : (appId) => processCloudApp(appId, saasInstance, options)
-        );
-
-        // Rendered even when some apps failed to plan: the decisions that were
-        // reached belong next to the per-app error lines already logged.
-        if (dryRun) {
-            renderDryRunReport(report);
-        }
-
-        return result;
     } catch (err) {
         logError('CLOUD CREATE THUMBNAILS 2', err);
 

--- a/src/lib/cloud/cloud-create-thumbnails.js
+++ b/src/lib/cloud/cloud-create-thumbnails.js
@@ -4,8 +4,7 @@ import QlikSaas from './cloud-repo.js';
 import { qscloudTestConnection } from './cloud-test-connection.js';
 import { processCloudApp } from './process-cloud-app.js';
 import { cloudPlanApp } from './cloud-plan-app.js';
-import { listAppsByCollection } from './cloud-apps.js';
-import { toAppIdList } from '../util/app-ids.js';
+import { resolveCloudAppSelection } from './cloud-app-selection.js';
 import { runOverAppsWithReport, announceDryRun } from '../util/run-report.js';
 import { CLOUD_SHEET_PARTS } from './sheet-parts.js';
 import { logError } from '../util/log-error.js';
@@ -69,8 +68,6 @@ export const qscloudCreateThumbnails = async (options) => {
             }
         }
 
-        const appIdsToProcess = [];
-
         // Commander always yields a string here (.default('1'), .env() and the .choices()
         // wrapper all produce strings), but programmatic and test callers may pass a number.
         // Normalise once so the check below - and the string-only sheet-part comparisons
@@ -110,31 +107,14 @@ export const qscloudCreateThumbnails = async (options) => {
             return false;
         }
 
-        // Apps named directly. --appid is variadic, so this is a list.
-        const namedAppIds = toAppIdList(options.appid);
-        appIdsToProcess.push(...namedAppIds);
-
-        // --appid and --collectionid are additive, not alternatives: apps named either
-        // way are all processed. runOverApps() dedupes, so an app that is both named by
-        // --appid and in the collection is still processed once.
-        let collectionAppIds = [];
-        const useCollection = Boolean(options.collectionid && options.collectionid.length > 0);
-        if (useCollection) {
-            const apps = await listAppsByCollection(saasInstance, options.collectionid);
-            logger.verbose(`Collection '${options.collectionid}' exists`);
-            collectionAppIds = apps.map((app) => app.id);
-            appIdsToProcess.push(...collectionAppIds);
-        }
+        // Selection resolution is shared with the other Cloud command; the
+        // provenance it returns feeds the run report directly.
+        const selection = await resolveCloudAppSelection(saasInstance, options);
 
         return await runOverAppsWithReport({
             command: 'qscloud create-sheet-thumbnails',
             dryRun,
-            appIds: appIdsToProcess,
-            namedAppIds,
-            selectorAppIds: collectionAppIds,
-            selector: useCollection
-                ? { option: 'collectionid', value: options.collectionid }
-                : null,
+            ...selection,
             logPrefix: { plan: 'CLOUD PLAN APP', process: 'CLOUD PROCESS APP' },
             emptySelectionHint: 'Check the --appid and --collectionid options.',
             planApp: (appId, report) => cloudPlanApp(appId, saasInstance, options, report),

--- a/src/lib/cloud/cloud-plan-app.js
+++ b/src/lib/cloud/cloud-plan-app.js
@@ -1,0 +1,129 @@
+import { logger } from '../../globals.js';
+import { setupEnigmaConnection } from './cloud-enigma.js';
+import { determineSheetExcludeStatus } from './determine-sheet-exclude-status.js';
+import { determineSheetBlurStatus } from './determine-sheet-blur-status.js';
+import { withEngineSession } from '../util/engine-session.js';
+import {
+    getSheetList,
+    sortSheetsByRank,
+    runOverSheets,
+    SHEET_LIST_FIELDS_WITH_SHOW_CONDITION,
+} from '../util/sheet-list.js';
+import { CloudError } from '../util/errors.js';
+import { addAppToReport, recordSheetDecision } from '../util/run-report.js';
+
+/**
+ * Plans one Qlik Sense Cloud app without changing anything: the dry-run twin
+ * of `processCloudApp`, and the Cloud twin of `qseowPlanApp`.
+ *
+ * Performs the same reads, in the same order, through the same functions - the
+ * app metadata lookup, the published check, the engine session, the sheet
+ * list, the rank sort, and the exclude and blur rules - and records a decision
+ * per sheet instead of acting on it.
+ *
+ * What it deliberately does not do is longer here than on QSEoW, because
+ * `processCloudApp` performs a write surprisingly early: it deletes the app's
+ * existing thumbnail media files before opening the engine session. A dry run
+ * must not - so this function never touches `apps/{id}/media` beyond the
+ * metadata read, never creates the image directory, and never launches a
+ * browser, captures, uploads, or updates sheets.
+ *
+ * @param {string} appId - The Cloud app to plan.
+ * @param {import('./cloud-test-connection.js').QlikSaasInstance} saasInstance - QlikSaas object.
+ * @param {object} options - The same options bag the real run receives.
+ * @param {object} report - Run report from `createRunReport`; one app section
+ *     and one decision per sheet are recorded onto it.
+ *
+ * @returns {Promise<void>} Resolves when the app's plan is recorded.
+ */
+export const cloudPlanApp = async (appId, saasInstance, options, report) => {
+    // Get app name - same read, same endpoint as the real run.
+    const appMetadata = await saasInstance.Get(`apps/${appId}`);
+
+    // If empty the app is not published
+    const appIsPublished = !!appMetadata.attributes.publishTime;
+
+    const configEnigma = setupEnigmaConnection(appId, options);
+
+    await withEngineSession(
+        configEnigma,
+        {
+            logPrefix: 'CLOUD PLAN APP',
+            loglevel: options.loglevel,
+            connectionLabel: `Qlik Sense Cloud tenant ${options.tenanturl}`,
+            sessionLogLevel: 'info',
+        },
+        async (global) => {
+            const app = await global.openDoc(appId, '', '', '', false);
+            logger.info(`Opened app ${appId}`);
+            logger.info(`App name: "${appMetadata.attributes.name}"`);
+            logger.info(`App is published: ${appIsPublished}`);
+
+            const sheets = await getSheetList(app, SHEET_LIST_FIELDS_WITH_SHOW_CONDITION);
+            logger.info(`Number of sheets in app: ${sheets.length}`);
+
+            const appEntry = addAppToReport(report, {
+                id: appId,
+                name: appMetadata.attributes.name,
+                sheetCount: sheets.length,
+            });
+
+            // Same order the real run processes in - the number rules count
+            // positions in this order, not the engine's.
+            sortSheetsByRank(sheets);
+
+            // Through runOverSheets, exactly like the real run: one sheet whose
+            // show condition the engine rejects must fail alone, not abort the
+            // remaining sheets' plan. The report marks the app "plan incomplete"
+            // when rows are missing.
+            const sheetRun = await runOverSheets(
+                sheets,
+                {
+                    logPrefix: 'CLOUD PLAN APP',
+                    appId,
+                    action: 'plan',
+                    ErrorClass: CloudError,
+                },
+                async (sheet, iSheetNum) => {
+                    const { excludeSheet, excludeReason } = await determineSheetExcludeStatus(
+                        app,
+                        sheet,
+                        options,
+                        appIsPublished,
+                        iSheetNum,
+                        logger
+                    );
+
+                    if (excludeSheet === true) {
+                        recordSheetDecision(appEntry, {
+                            n: iSheetNum,
+                            title: sheet?.qMeta?.title,
+                            action: 'skip',
+                            reason: excludeReason,
+                        });
+                    } else {
+                        const { blurSheet, blurReason } = determineSheetBlurStatus(
+                            sheet,
+                            options,
+                            iSheetNum,
+                            logger
+                        );
+
+                        recordSheetDecision(appEntry, {
+                            n: iSheetNum,
+                            title: sheet?.qMeta?.title,
+                            action: blurSheet ? 'blur' : 'update',
+                            reason: blurReason,
+                        });
+                    }
+                }
+            );
+
+            // Same failure semantics as the real run: a sheet that could not be
+            // planned fails the app after every other sheet was still planned.
+            sheetRun.assertAllProcessed();
+        }
+    );
+
+    logger.verbose(`Planned Qlik Sense Cloud app ${appId} - no changes made`);
+};

--- a/src/lib/cloud/cloud-plan-app.js
+++ b/src/lib/cloud/cloud-plan-app.js
@@ -10,7 +10,7 @@ import {
     SHEET_LIST_FIELDS_WITH_SHOW_CONDITION,
 } from '../util/sheet-list.js';
 import { CloudError } from '../util/errors.js';
-import { addAppToReport, recordSheetDecision } from '../util/run-report.js';
+import { addAppToReport, recordPlannedSheet } from '../util/run-report.js';
 
 /**
  * Plans one Qlik Sense Cloud app without changing anything: the dry-run twin
@@ -94,28 +94,18 @@ export const cloudPlanApp = async (appId, saasInstance, options, report) => {
                         logger
                     );
 
-                    if (excludeSheet === true) {
-                        recordSheetDecision(appEntry, {
-                            n: iSheetNum,
-                            title: sheet?.qMeta?.title,
-                            action: 'skip',
-                            reason: excludeReason,
-                        });
-                    } else {
-                        const { blurSheet, blurReason } = determineSheetBlurStatus(
-                            sheet,
-                            options,
-                            iSheetNum,
-                            logger
-                        );
+                    const { blurSheet, blurReason } = excludeSheet
+                        ? { blurSheet: false, blurReason: null }
+                        : determineSheetBlurStatus(sheet, options, iSheetNum, logger);
 
-                        recordSheetDecision(appEntry, {
-                            n: iSheetNum,
-                            title: sheet?.qMeta?.title,
-                            action: blurSheet ? 'blur' : 'update',
-                            reason: blurReason,
-                        });
-                    }
+                    recordPlannedSheet(appEntry, {
+                        n: iSheetNum,
+                        title: sheet?.qMeta?.title,
+                        excludeSheet,
+                        excludeReason,
+                        blurSheet,
+                        blurReason,
+                    });
                 }
             );
 

--- a/src/lib/cloud/cloud-remove-sheet-icons.js
+++ b/src/lib/cloud/cloud-remove-sheet-icons.js
@@ -13,8 +13,7 @@ import {
     SHEET_SKIPPED,
 } from '../util/sheet-list.js';
 import { withEngineSession } from '../util/engine-session.js';
-import { listAppsByCollection } from './cloud-apps.js';
-import { toAppIdList } from '../util/app-ids.js';
+import { resolveCloudAppSelection } from './cloud-app-selection.js';
 import { CLEAR_REASON } from '../util/sheet-decision-reasons.js';
 import {
     runOverAppsWithReport,
@@ -300,8 +299,6 @@ export const qscloudRemoveSheetIcons = async (options) => {
         logger.debug(`BSI executable path: ${bsiExecutablePath}`);
         logger.debug(`Options: ${JSON.stringify(redactOptions(options), null, 2)}`);
 
-        const appIdsToProcess = [];
-
         // Get array of all available collections
         const cloudConfig = {
             url: options.tenanturl,
@@ -330,31 +327,14 @@ export const qscloudRemoveSheetIcons = async (options) => {
             return false;
         }
 
-        // Apps named directly. --appid is variadic, so this is a list.
-        const namedAppIds = toAppIdList(options.appid);
-        appIdsToProcess.push(...namedAppIds);
-
-        // --appid and --collectionid are additive, not alternatives: apps named either
-        // way are all processed. runOverApps() dedupes, so an app that is both named by
-        // --appid and in the collection is still processed once.
-        let collectionAppIds = [];
-        const useCollection = Boolean(options.collectionid && options.collectionid.length > 0);
-        if (useCollection) {
-            const apps = await listAppsByCollection(saasInstance, options.collectionid);
-            logger.verbose(`Collection '${options.collectionid}' exists`);
-            collectionAppIds = apps.map((app) => app.id);
-            appIdsToProcess.push(...collectionAppIds);
-        }
+        // Selection resolution is shared with the other Cloud command; the
+        // provenance it returns feeds the run report directly.
+        const selection = await resolveCloudAppSelection(saasInstance, options);
 
         return await runOverAppsWithReport({
             command: 'qscloud remove-sheet-icons',
             dryRun,
-            appIds: appIdsToProcess,
-            namedAppIds,
-            selectorAppIds: collectionAppIds,
-            selector: useCollection
-                ? { option: 'collectionid', value: options.collectionid }
-                : null,
+            ...selection,
             logPrefix: { plan: 'CLOUD PLAN REMOVE ICONS', process: 'CLOUD REMOVE SHEET ICONS' },
             emptySelectionHint: 'Check the --appid and --collectionid options.',
             planApp: (appId, report) =>

--- a/src/lib/cloud/cloud-remove-sheet-icons.js
+++ b/src/lib/cloud/cloud-remove-sheet-icons.js
@@ -11,10 +11,20 @@ import {
     saveIfChanged,
     getSheetList,
     SHEET_LIST_FIELDS_EXTENDED,
+    SHEET_SKIPPED,
 } from '../util/sheet-list.js';
 import { withEngineSession } from '../util/engine-session.js';
 import { listAppsByCollection } from './cloud-apps.js';
 import { toAppIdList } from '../util/app-ids.js';
+import { CLEAR_REASON } from '../util/sheet-decision-reasons.js';
+import {
+    createRunReport,
+    recordSelection,
+    renderDryRunReport,
+    announceDryRun,
+    addAppToReport,
+    recordSheetDecision,
+} from '../util/run-report.js';
 import { logError } from '../util/log-error.js';
 
 /**
@@ -81,6 +91,18 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
                             // Get properties of current sheet
                             const sheetObj = await app.getObject(sheet.qInfo.qId);
                             const sheetProperties = await sheetObj.getProperties();
+
+                            // A sheet without the thumbnail structure has no icon
+                            // to clear - failing the whole app over it turned a
+                            // no-op into an error, and made the dry run predict
+                            // success for exactly the input that broke the run.
+                            if (!sheetProperties?.thumbnail?.qStaticContentUrlDef) {
+                                logger.verbose(
+                                    `Sheet ${iSheetNum} has no thumbnail structure - nothing to clear`
+                                );
+
+                                return SHEET_SKIPPED;
+                            }
 
                             // Clear sheet icon
                             sheetProperties.thumbnail.qStaticContentUrlDef.qUrl = '';
@@ -152,6 +174,107 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
 };
 
 /**
+ * Plans icon removal for one Cloud app without changing anything: the dry-run
+ * twin of `removeSheetIconsCloudApp`.
+ *
+ * Reads the same sheet list in the same order, plus each sheet's current
+ * thumbnail property so the report can say which sheets actually carry an icon
+ * - a read the real run skips because it clears unconditionally. Also counts
+ * the thumbnail media files the real run would delete afterwards. Writes
+ * nothing: no `setProperties`, no save, no media `Delete`.
+ *
+ * @param {string} appId - The Cloud app to plan.
+ * @param {import('./cloud-test-connection.js').QlikSaasInstance} saasInstance - QlikSaas object.
+ * @param {object} options - The same options bag the real run receives.
+ * @param {object} report - Run report; one app section is recorded onto it.
+ *
+ * @returns {Promise<void>} Resolves when the app's plan is recorded.
+ */
+const planRemoveSheetIconsCloudApp = async (appId, saasInstance, options, report) => {
+    // Get app name - the report is the product here, and a plan listing bare
+    // GUIDs cannot be recognised by the operator it exists for. This is one
+    // read the real remover does not make; that is the right trade.
+    const appMetadata = await saasInstance.Get(`apps/${appId}`);
+
+    const configEnigma = setupEnigmaConnection(appId, options);
+
+    await withEngineSession(
+        configEnigma,
+        {
+            logPrefix: 'CLOUD PLAN REMOVE ICONS',
+            sessionLogLevel: 'info',
+            loglevel: options.loglevel,
+            connectionLabel: `Qlik Sense Cloud tenant ${options.tenanturl}`,
+        },
+        async (global) => {
+            const app = await global.openDoc(appId, '', '', '', false);
+            logger.info(`Opened app ${appId}`);
+
+            const sheets = await getSheetList(app, SHEET_LIST_FIELDS_EXTENDED);
+            logger.info(`Number of sheets in app: ${sheets.length}`);
+
+            const appEntry = addAppToReport(report, {
+                id: appId,
+                name: appMetadata?.attributes?.name,
+                sheetCount: sheets.length,
+            });
+
+            sortSheetsByRank(sheets);
+
+            // Through runOverSheets, like the real run: one unreadable sheet
+            // fails alone rather than aborting the remaining rows.
+            const sheetRun = await runOverSheets(
+                sheets,
+                {
+                    logPrefix: 'CLOUD PLAN REMOVE ICONS',
+                    appId,
+                    action: 'plan icon removal for',
+                    ErrorClass: CloudError,
+                },
+                async (sheet, iSheetNum) => {
+                    // The real run clears every sheet unconditionally, so the
+                    // action is always `clear`; the reason column reports the
+                    // sheets where that clear is already a no-op. The sheet
+                    // list projection already carries /thumbnail, so prefer it
+                    // and only fall back to a per-sheet engine read when the
+                    // engine omitted the field from the projection.
+                    let iconUrl = sheet?.qData?.thumbnail?.qStaticContentUrlDef?.qUrl;
+                    if (sheet?.qData?.thumbnail === undefined) {
+                        const sheetObj = await app.getObject(sheet.qInfo.qId);
+                        const sheetProperties = await sheetObj.getProperties();
+                        iconUrl = sheetProperties?.thumbnail?.qStaticContentUrlDef?.qUrl;
+                    }
+
+                    recordSheetDecision(appEntry, {
+                        n: iSheetNum,
+                        title: sheet?.qMeta?.title,
+                        action: 'clear',
+                        reason: iconUrl ? null : CLEAR_REASON.NO_ICON,
+                    });
+                }
+            );
+
+            sheetRun.assertAllProcessed();
+
+            // The read half of the media cleanup, recorded on the report so the
+            // deletion count renders inside the app's section rather than as a
+            // log line scrolled far above it.
+            const mediaList = await saasInstance.Get(`apps/${appId}/media/list`);
+            if (mediaList.find((item) => item.type === 'directory' && item.name === 'thumbnails')) {
+                const existingThumbnails = await saasInstance.Get(
+                    `apps/${appId}/media/list/thumbnails`
+                );
+                appEntry.mediaFilesToDelete = existingThumbnails.filter(
+                    (item) => item.type === 'image'
+                ).length;
+            }
+        }
+    );
+
+    logger.verbose(`Planned icon removal for Qlik Sense Cloud app ${appId} - no changes made`);
+};
+
+/**
  * Removes all sheet icons from one or more Qlik Sense Cloud applications.
  *
  * @param {object} options - Configuration options for the command.
@@ -167,6 +290,13 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
 export const qscloudRemoveSheetIcons = async (options) => {
     try {
         setLoggingLevel(options.loglevel);
+
+        const dryRun = Boolean(options.dryRun);
+        if (dryRun) {
+            // Before anything connects - this command's real mode is the most
+            // destructive in the CLI, so the log must not open like it.
+            announceDryRun('qscloud remove-sheet-icons');
+        }
 
         logger.info('Starting removal of sheet icons for Qlik Sense Cloud');
         logger.verbose(`Running as standalone app: ${isSea}`);
@@ -204,25 +334,47 @@ export const qscloudRemoveSheetIcons = async (options) => {
         }
 
         // Apps named directly. --appid is variadic, so this is a list.
-        appIdsToProcess.push(...toAppIdList(options.appid));
+        const namedAppIds = toAppIdList(options.appid);
+        appIdsToProcess.push(...namedAppIds);
 
         // --appid and --collectionid are additive, not alternatives: apps named either
         // way are all processed. runOverApps() dedupes, so an app that is both named by
         // --appid and in the collection is still processed once.
-        if (options.collectionid && options.collectionid.length > 0) {
+        let collectionAppIds = [];
+        const useCollection = Boolean(options.collectionid && options.collectionid.length > 0);
+        if (useCollection) {
             const apps = await listAppsByCollection(saasInstance, options.collectionid);
             logger.verbose(`Collection '${options.collectionid}' exists`);
-            appIdsToProcess.push(...apps.map((app) => app.id));
+            collectionAppIds = apps.map((app) => app.id);
+            appIdsToProcess.push(...collectionAppIds);
         }
 
-        return await runOverApps(
+        const report = createRunReport({ command: 'qscloud remove-sheet-icons', dryRun });
+        recordSelection(report, {
+            namedAppIds,
+            selectorAppIds: collectionAppIds,
+            selector: useCollection
+                ? { option: 'collectionid', value: options.collectionid }
+                : null,
+        });
+
+        const result = await runOverApps(
             appIdsToProcess,
             {
-                logPrefix: 'CLOUD REMOVE SHEET ICONS',
+                logPrefix: dryRun ? 'CLOUD PLAN REMOVE ICONS' : 'CLOUD REMOVE SHEET ICONS',
+                action: dryRun ? 'plan' : 'process',
                 emptySelectionHint: 'Check the --appid and --collectionid options.',
             },
-            (appId) => removeSheetIconsCloudApp(appId, saasInstance, options)
+            dryRun
+                ? (appId) => planRemoveSheetIconsCloudApp(appId, saasInstance, options, report)
+                : (appId) => removeSheetIconsCloudApp(appId, saasInstance, options)
         );
+
+        if (dryRun) {
+            renderDryRunReport(report);
+        }
+
+        return result;
     } catch (err) {
         logError('CLOUD REMOVE THUMBNAILS 3', err);
 

--- a/src/lib/cloud/cloud-remove-sheet-icons.js
+++ b/src/lib/cloud/cloud-remove-sheet-icons.js
@@ -3,7 +3,6 @@ import { logger, setLoggingLevel, bsiExecutablePath, isSea } from '../../globals
 import { redactOptions } from '../util/redact-secrets.js';
 import QlikSaas from './cloud-repo.js';
 import { qscloudTestConnection } from './cloud-test-connection.js';
-import { runOverApps } from '../util/run-over-apps.js';
 import { CloudError } from '../util/errors.js';
 import {
     runOverSheets,
@@ -18,9 +17,7 @@ import { listAppsByCollection } from './cloud-apps.js';
 import { toAppIdList } from '../util/app-ids.js';
 import { CLEAR_REASON } from '../util/sheet-decision-reasons.js';
 import {
-    createRunReport,
-    recordSelection,
-    renderDryRunReport,
+    runOverAppsWithReport,
     announceDryRun,
     addAppToReport,
     recordSheetDecision,
@@ -349,32 +346,21 @@ export const qscloudRemoveSheetIcons = async (options) => {
             appIdsToProcess.push(...collectionAppIds);
         }
 
-        const report = createRunReport({ command: 'qscloud remove-sheet-icons', dryRun });
-        recordSelection(report, {
+        return await runOverAppsWithReport({
+            command: 'qscloud remove-sheet-icons',
+            dryRun,
+            appIds: appIdsToProcess,
             namedAppIds,
             selectorAppIds: collectionAppIds,
             selector: useCollection
                 ? { option: 'collectionid', value: options.collectionid }
                 : null,
+            logPrefix: { plan: 'CLOUD PLAN REMOVE ICONS', process: 'CLOUD REMOVE SHEET ICONS' },
+            emptySelectionHint: 'Check the --appid and --collectionid options.',
+            planApp: (appId, report) =>
+                planRemoveSheetIconsCloudApp(appId, saasInstance, options, report),
+            processApp: (appId) => removeSheetIconsCloudApp(appId, saasInstance, options),
         });
-
-        const result = await runOverApps(
-            appIdsToProcess,
-            {
-                logPrefix: dryRun ? 'CLOUD PLAN REMOVE ICONS' : 'CLOUD REMOVE SHEET ICONS',
-                action: dryRun ? 'plan' : 'process',
-                emptySelectionHint: 'Check the --appid and --collectionid options.',
-            },
-            dryRun
-                ? (appId) => planRemoveSheetIconsCloudApp(appId, saasInstance, options, report)
-                : (appId) => removeSheetIconsCloudApp(appId, saasInstance, options)
-        );
-
-        if (dryRun) {
-            renderDryRunReport(report);
-        }
-
-        return result;
     } catch (err) {
         logError('CLOUD REMOVE THUMBNAILS 3', err);
 

--- a/src/lib/cloud/cloud-updatesheets.js
+++ b/src/lib/cloud/cloud-updatesheets.js
@@ -10,6 +10,7 @@ import {
     saveIfChanged,
     getSheetList,
 } from '../util/sheet-list.js';
+import { determineSheetBlurStatus } from './determine-sheet-blur-status.js';
 
 /**
  * Updates sheet thumbnails in a Qlik Sense Cloud app.
@@ -88,85 +89,15 @@ export const qscloudUpdateSheetThumbnails = async (createdFiles, appId, options)
 
                                 return SHEET_SKIPPED;
                             } else {
-                                // Should blurred sheet thumbnail be used?
-                                // Options are
-                                // --blur-sheet-number <number...>
-                                // --blur-sheet-title <title...>
-                                // --blur-sheet-status <status...>
-
-                                let blurSheet = false;
-
-                                // Get published status of sheet
-                                let sheetPublished;
-                                if (
-                                    sheet.qMeta?.published === undefined ||
-                                    sheet.qMeta.published === false
-                                ) {
-                                    sheetPublished = false;
-                                } else {
-                                    sheetPublished = true;
-                                }
-
-                                // Get approved status of sheet
-                                let sheetApproved;
-                                if (
-                                    sheet.qMeta?.approved === undefined ||
-                                    sheet.qMeta.approved === false
-                                ) {
-                                    sheetApproved = false;
-                                } else {
-                                    sheetApproved = true;
-                                }
-
-                                // Should this sheet be blurred based on its published status?
-                                // Public sheets
-                                if (
-                                    sheetApproved === true &&
-                                    sheetPublished === true &&
-                                    options.blurSheetStatus &&
-                                    options.blurSheetStatus.includes('public')
-                                ) {
-                                    blurSheet = true;
-                                    logger.verbose(
-                                        `Blurred sheet thumbnail (status public): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
-                                    );
-                                }
-
-                                // Published sheets
-                                if (
-                                    sheetApproved === false &&
-                                    sheetPublished === true &&
-                                    options.blurSheetStatus &&
-                                    options.blurSheetStatus.includes('published')
-                                ) {
-                                    blurSheet = true;
-                                    logger.verbose(
-                                        `Blurred sheet thumbnail (status published): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
-                                    );
-                                }
-
-                                // Should this sheet be blurred based on its position/sheet number?
-                                if (options.blurSheetNumber && blurSheet === false) {
-                                    // Does the sheet number match any of the numbers in options.blurSheetNumber array?
-                                    // Take into account that iSheetNum is an integer, so we need to convert it to a string
-                                    if (options.blurSheetNumber.includes(iSheetNum.toString())) {
-                                        blurSheet = true;
-                                        logger.verbose(
-                                            `Blurred sheet thumbnail (via sheet number): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
-                                        );
-                                    }
-                                }
-
-                                // Should this sheet be blurred based on its title?
-                                if (options.blurSheetTitle && blurSheet === false) {
-                                    // Does the sheet title match any of the titles options.blurSheetTitle array?
-                                    if (options.blurSheetTitle.includes(sheet.qMeta.title)) {
-                                        blurSheet = true;
-                                        logger.verbose(
-                                            `Blurred sheet thumbnail (via sheet title): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
-                                        );
-                                    }
-                                }
+                                // The blur decision lives in determine-sheet-blur-status.js so
+                                // the dry-run planner shares it (#993); only the write below
+                                // stays here.
+                                const { blurSheet } = determineSheetBlurStatus(
+                                    sheet,
+                                    options,
+                                    iSheetNum,
+                                    logger
+                                );
 
                                 // Get properties of current sheet
                                 const sheetObj = await app.getObject(sheet.qInfo.qId);

--- a/src/lib/cloud/determine-sheet-blur-status.js
+++ b/src/lib/cloud/determine-sheet-blur-status.js
@@ -1,0 +1,87 @@
+import { BLUR_REASON } from '../util/sheet-decision-reasons.js';
+
+/**
+ * Determines whether a Qlik Sense Cloud sheet's thumbnail should be blurred.
+ *
+ * Extracted verbatim from `qscloudUpdateSheetThumbnails`, where the rules lived
+ * inside the write step - which meant a dry run could not report the blur plan
+ * without performing the writes (issue #993). The QSEoW twin lives in
+ * `src/lib/qseow/determine-sheet-blur-status.js` with the same name and return
+ * shape. The twins differ where the platforms do: Cloud has no blur-by-tag on
+ * this path, and reads the approved/published flags through undefined-safe
+ * normalisation because the Cloud engine omits them on some sheets.
+ *
+ * Rule order matches the original: both status rules evaluated, then number
+ * and title, each only consulted while no earlier rule matched. `blurReason`
+ * names the FIRST rule that matched - it is what the dry-run report prints.
+ *
+ * @param {object} sheet - Sheet from `qAppObjectList.qItems`.
+ * @param {object} options - Blur options.
+ * @param {string[]} [options.blurSheetStatus] - Statuses to blur: `published`, `public`.
+ * @param {string[]} [options.blurSheetNumber] - Sheet numbers to blur, as strings.
+ * @param {string[]} [options.blurSheetTitle] - Sheet titles to blur.
+ * @param {number} iSheetNum - 1-based position of the sheet within the app.
+ * @param {object} log - Logger; verbose output explains which rule matched.
+ *
+ * @returns {{blurSheet: boolean, blurReason: string|null}} Whether to blur, and
+ *     the responsible option when so.
+ */
+export const determineSheetBlurStatus = (sheet, options, iSheetNum, log) => {
+    let blurSheet = false;
+    let blurReason = null;
+
+    // Get published status of sheet
+    const sheetPublished = !(
+        sheet.qMeta?.published === undefined || sheet.qMeta.published === false
+    );
+
+    // Get approved status of sheet
+    const sheetApproved = !(sheet.qMeta?.approved === undefined || sheet.qMeta.approved === false);
+
+    const sheetLabel = `${iSheetNum}: '${sheet?.qMeta?.title}', ID ${sheet?.qInfo?.qId}, description '${sheet?.qMeta?.description}', approved '${sheet?.qMeta?.approved}', published '${sheet?.qMeta?.published}'`;
+
+    // Should this sheet be blurred based on its published status?
+    // Public sheets
+    if (
+        sheetApproved === true &&
+        sheetPublished === true &&
+        options.blurSheetStatus &&
+        options.blurSheetStatus.includes('public')
+    ) {
+        blurSheet = true;
+        blurReason ??= BLUR_REASON.STATUS_PUBLIC;
+        log.verbose(`Blurred sheet thumbnail (status public): ${sheetLabel}`);
+    }
+
+    // Published sheets
+    if (
+        sheetApproved === false &&
+        sheetPublished === true &&
+        options.blurSheetStatus &&
+        options.blurSheetStatus.includes('published')
+    ) {
+        blurSheet = true;
+        blurReason ??= BLUR_REASON.STATUS_PUBLISHED;
+        log.verbose(`Blurred sheet thumbnail (status published): ${sheetLabel}`);
+    }
+
+    // Should this sheet be blurred based on its position/sheet number?
+    if (options.blurSheetNumber && blurSheet === false) {
+        if (options.blurSheetNumber.includes(iSheetNum.toString())) {
+            blurSheet = true;
+            blurReason = BLUR_REASON.NUMBER;
+            log.verbose(`Blurred sheet thumbnail (via sheet number): ${sheetLabel}`);
+        }
+    }
+
+    // Should this sheet be blurred based on its title?
+    if (options.blurSheetTitle && blurSheet === false) {
+        if (options.blurSheetTitle.includes(sheet?.qMeta?.title)) {
+            blurSheet = true;
+            blurReason = BLUR_REASON.TITLE;
+            log.verbose(`Blurred sheet thumbnail (via sheet title): ${sheetLabel}`);
+        }
+    }
+
+    return { blurSheet, blurReason };
+};

--- a/src/lib/cloud/determine-sheet-exclude-status.js
+++ b/src/lib/cloud/determine-sheet-exclude-status.js
@@ -1,3 +1,5 @@
+import { EXCLUDE_REASON } from '../util/sheet-decision-reasons.js';
+
 /**
  * Determines whether a Qlik Sense Cloud sheet should be excluded from thumbnail updates.
  *
@@ -22,8 +24,9 @@
  * @param {number} iSheetNum - 1-based position of the sheet within the app.
  * @param {object} logger - Logger; verbose output explains which rule excluded the sheet.
  *
- * @returns {Promise<{excludeSheet: boolean, sheetIsHidden: boolean}>} Whether to skip the
- *     sheet, and whether it was hidden - the caller logs the hidden flag either way.
+ * @returns {Promise<{excludeSheet: boolean, sheetIsHidden: boolean, excludeReason: string|null}>} Whether to skip the
+ *     sheet, whether it was hidden - the caller logs the hidden flag either way - and
+ *     `excludeReason` naming the first rule that matched (from `sheet-decision-reasons.js`), or null.
  */
 export const determineSheetExcludeStatus = async (
     app,
@@ -34,6 +37,8 @@ export const determineSheetExcludeStatus = async (
     logger
 ) => {
     let excludeSheet = false;
+    // First rule to exclude the sheet names the reason; ??= keeps the first writer.
+    let excludeReason = null;
 
     // Get published status of sheet
     let sheetPublished;
@@ -61,6 +66,7 @@ export const determineSheetExcludeStatus = async (
             options.excludeSheetStatus?.includes('public')
         ) {
             excludeSheet = true;
+            excludeReason ??= EXCLUDE_REASON.STATUS_PUBLIC;
             logger.verbose(
                 `Excluded sheet (status public): ${iSheetNum}: '${sheet?.qMeta?.title}', ID ${sheet?.qInfo?.qId}, description '${sheet?.qMeta?.description}', approved '${sheetApproved}', published '${sheetPublished}'`
             );
@@ -73,6 +79,7 @@ export const determineSheetExcludeStatus = async (
     ) {
         // App is not published. Public sheets in this case have approved===false and published===true
         excludeSheet = true;
+        excludeReason ??= EXCLUDE_REASON.STATUS_PUBLIC;
         logger.verbose(
             `Excluded sheet (status public): ${iSheetNum}: '${sheet?.qMeta?.title}', ID ${sheet?.qInfo?.qId}, description '${sheet?.qMeta?.description}', approved '${sheetApproved}', published '${sheetPublished}'`
         );
@@ -88,6 +95,7 @@ export const determineSheetExcludeStatus = async (
             options.excludeSheetStatus.includes('published')
         ) {
             excludeSheet = true;
+            excludeReason ??= EXCLUDE_REASON.STATUS_PUBLISHED;
             logger.verbose(
                 `Excluded sheet (status published): ${iSheetNum}: '${sheet?.qMeta?.title}', ID ${sheet?.qInfo?.qId}, description '${sheet?.qMeta?.description}', approved '${sheetApproved}', published '${sheetPublished}'`
             );
@@ -103,6 +111,7 @@ export const determineSheetExcludeStatus = async (
         options.excludeSheetStatus.includes('private')
     ) {
         excludeSheet = true;
+        excludeReason ??= EXCLUDE_REASON.STATUS_PRIVATE;
         logger.verbose(
             `Excluded sheet (status private): ${iSheetNum}: '${sheet?.qMeta?.title}', ID ${sheet?.qInfo?.qId}, description '${sheet?.qMeta?.description}', approved '${sheetApproved}', published '${sheetPublished}'`
         );
@@ -111,19 +120,25 @@ export const determineSheetExcludeStatus = async (
     // Is this sheet hidden?
     // Never process hidden sheets
     // Evaluate showCondition
-    const showConditionCall = {
-        qExpression: sheet?.qData?.showCondition,
-    };
-    const showConditionEval = await app.evaluateEx(showConditionCall);
-    const sheetIsHidden =
-        sheet?.qData?.showCondition &&
-        (sheet.qData.showCondition.toLowerCase() === 'false' ||
-            (showConditionEval?.qIsNumeric === true && showConditionEval?.qNumber === 0))
-            ? true
-            : false;
+    // The engine round trip only happens when there is a condition to evaluate
+    // and the literal-'false' shortcut has not already answered it. In a dry
+    // run this call is the entire per-sheet cost, and most sheets have no show
+    // condition at all - the result is byte-identical either way.
+    const showCondition = sheet?.qData?.showCondition;
+    let sheetIsHidden = false;
+    if (showCondition) {
+        if (showCondition.toLowerCase() === 'false') {
+            sheetIsHidden = true;
+        } else {
+            const showConditionEval = await app.evaluateEx({ qExpression: showCondition });
+            sheetIsHidden =
+                showConditionEval?.qIsNumeric === true && showConditionEval?.qNumber === 0;
+        }
+    }
 
     if (sheetIsHidden === true && excludeSheet === false) {
         excludeSheet = true;
+        excludeReason = EXCLUDE_REASON.HIDDEN;
         logger.verbose(
             `Excluded sheet (hidden): ${iSheetNum}: '${sheet?.qMeta?.title}', ID ${sheet?.qInfo?.qId}, description '${sheet?.qMeta?.description}', approved '${sheetApproved}', published '${sheetPublished}', hidden '${sheetIsHidden}'`
         );
@@ -135,6 +150,7 @@ export const determineSheetExcludeStatus = async (
         // Take into account that iSheetNum is an integer, so we need to convert it to a string
         if (options.excludeSheetNumber.includes(iSheetNum.toString())) {
             excludeSheet = true;
+            excludeReason = EXCLUDE_REASON.NUMBER;
             logger.verbose(
                 `Excluded sheet (via sheet number): ${iSheetNum}: '${sheet?.qMeta?.title}', ID ${sheet?.qInfo?.qId}, description '${sheet?.qMeta?.description}', approved '${sheet?.qMeta?.approved}', published '${sheet?.qMeta?.published}', hidden '${sheetIsHidden}'`
             );
@@ -146,11 +162,12 @@ export const determineSheetExcludeStatus = async (
         // Does the sheet title match any of the titles options.excludeSheetTitle array?
         if (options.excludeSheetTitle.includes(sheet?.qMeta?.title)) {
             excludeSheet = true;
+            excludeReason = EXCLUDE_REASON.TITLE;
             logger.verbose(
                 `Excluded sheet (via sheet title): ${iSheetNum}: '${sheet?.qMeta?.title}', ID ${sheet?.qInfo?.qId}, description '${sheet?.qMeta?.description}', approved '${sheet?.qMeta?.approved}', published '${sheet?.qMeta?.published}', hidden '${sheetIsHidden}'`
             );
         }
     }
 
-    return { excludeSheet, sheetIsHidden };
+    return { excludeSheet, sheetIsHidden, excludeReason };
 };

--- a/src/lib/commands/__tests__/commands.test.js
+++ b/src/lib/commands/__tests__/commands.test.js
@@ -17,6 +17,8 @@ const loggerMock = {
 };
 
 const mockGlobalsPromise = jest.unstable_mockModule('../../../globals.js', () => ({
+    getLoggingLevel: jest.fn(() => 'info'),
+    setLoggingLevel: jest.fn(),
     logger: loggerMock,
     appVersion: 'test-version',
     sendConsoleLogToStderr: jest.fn(),

--- a/src/lib/commands/__tests__/dry-run-guard.test.js
+++ b/src/lib/commands/__tests__/dry-run-guard.test.js
@@ -1,0 +1,72 @@
+import { describe, test, expect } from '@jest/globals';
+import { everyLeafCommand } from '../../interactive/command-tree.js';
+import { isDryRunOption, DRY_RUN_OPTION_ATTRIBUTE } from '../dry-run-option.js';
+
+// The guard behind issue #993's rule: a command that changes something gets
+// --dry-run. Every leaf command must appear in exactly one of the two lists
+// below, so a new mutating command cannot ship without someone consciously
+// deciding which side it is on - the same net registry.test.js provides for
+// the interactive flag.
+
+/** Commands that change something and therefore declare --dry-run. */
+const DRY_RUN_COMMANDS = [
+    'qseow create-sheet-thumbnails',
+    'qscloud create-sheet-thumbnails',
+    'qscloud remove-sheet-icons',
+];
+
+/**
+ * Commands that do not declare --dry-run, each with the reason on record.
+ * An entry here is a decision, not an omission.
+ */
+const NO_DRY_RUN = [
+    // Read-only: a dry-run flag that is always a no-op teaches people it
+    // might be a no-op elsewhere too (#993).
+    'qscloud list-collections',
+    'browser list-installed',
+    'browser list-available',
+    'browser check',
+    'doctor check',
+    // Mutating, deferred: the useful dry-run output for browser install is
+    // "which build would 'latest' resolve to, and is it cached" - #993 open
+    // question 5 says to settle that shape together with the air-gapped work
+    // in #929-#933 rather than design it twice. The uninstall pair follows
+    // install so the browser command family lands as one piece.
+    'browser install',
+    'browser uninstall',
+    'browser uninstall-all',
+];
+
+describe('every leaf command has decided about --dry-run', () => {
+    const leaves = everyLeafCommand();
+
+    test('the two lists cover every leaf command exactly once', () => {
+        const classified = [...DRY_RUN_COMMANDS, ...NO_DRY_RUN].sort();
+        const actual = leaves.map((leaf) => leaf.path).sort();
+
+        // A new command failing here is the guard working: add it to one of
+        // the two lists above, consciously.
+        expect(actual).toEqual(classified);
+    });
+
+    test.each(DRY_RUN_COMMANDS)('%s declares --dry-run', (path) => {
+        const leaf = leaves.find((entry) => entry.path === path);
+
+        expect(leaf.command.options.some((option) => isDryRunOption(option))).toBe(true);
+    });
+
+    test.each(NO_DRY_RUN)('%s does not declare --dry-run', (path) => {
+        const leaf = leaves.find((entry) => entry.path === path);
+
+        expect(leaf.command.options.some((option) => isDryRunOption(option))).toBe(false);
+    });
+
+    test('Commander stores the flag under the attribute the handlers read', () => {
+        // The #890 regression net: a hyphenated long flag camel-cases, and a
+        // handler reading options.dryrun would silently never see it.
+        const leaf = leaves.find((entry) => entry.path === DRY_RUN_COMMANDS[0]);
+        const option = leaf.command.options.find((entry) => isDryRunOption(entry));
+
+        expect(option.attributeName()).toBe(DRY_RUN_OPTION_ATTRIBUTE);
+    });
+});

--- a/src/lib/commands/dry-run-option.js
+++ b/src/lib/commands/dry-run-option.js
@@ -1,0 +1,59 @@
+import { Option } from 'commander';
+
+/**
+ * The flags the dry-run option is declared with. No short flag: `-d` is not
+ * obviously "dry run" and short slots are scarce across the CLI's eleven leaf
+ * commands.
+ */
+export const DRY_RUN_OPTION_FLAGS = '--dry-run';
+
+/**
+ * The long flag. Aliased rather than spelled again: unlike `-i, --interactive`
+ * there is no short form here, so a second literal could only ever drift.
+ */
+export const DRY_RUN_OPTION_LONG = DRY_RUN_OPTION_FLAGS;
+
+/**
+ * The key Commander stores the option under. Exported because a hyphenated
+ * long flag camel-cases, and this repo has shipped that bug before:
+ * `--skip-login` read as `options.skiplogin` - a key Commander never sets -
+ * did nothing at all (#890). Handlers must read `options[DRY_RUN_OPTION_ATTRIBUTE]`
+ * or literal `options.dryRun`, never a lowercased variant, and the guard test
+ * in `dry-run-guard.test.js` pins the attribute name.
+ */
+export const DRY_RUN_OPTION_ATTRIBUTE = 'dryRun';
+
+/**
+ * Whether an option is the dry-run flag. Matched on the long flag, like
+ * `isInteractiveOption`, because command builders re-create their options on
+ * every call.
+ *
+ * @param {import('commander').Option} option - The option to test.
+ *
+ * @returns {boolean} True for the dry-run flag.
+ */
+export const isDryRunOption = (option) => option?.long === DRY_RUN_OPTION_LONG;
+
+/**
+ * Add `--dry-run` to a command.
+ *
+ * A shared helper, like `addInteractiveOption`, so the flag, description and
+ * storage key cannot drift across the commands that offer it. Hand-written
+ * copies of the same option are that many chances for the description to disagree.
+ *
+ * Deliberately not an `.env()`-bound option: a dry run is a per-invocation
+ * decision made by a person at a keyboard. An ambient BSI_DRY_RUN that a
+ * scheduler inherits would turn every scheduled run into a silent no-op - the
+ * inverse of the silent surprise this flag exists to prevent.
+ *
+ * @param {import('commander').Command} command - The command to extend.
+ *
+ * @returns {import('commander').Command} The same command, for chaining.
+ */
+export const addDryRunOption = (command) =>
+    command.addOption(
+        new Option(
+            DRY_RUN_OPTION_FLAGS,
+            'Perform every read and decision the real run would - connect, resolve apps, list sheets, apply every exclude and blur rule - but change nothing. Prints the per-sheet plan and exits.'
+        )
+    );

--- a/src/lib/commands/qscloud/create-sheet-thumbnails.js
+++ b/src/lib/commands/qscloud/create-sheet-thumbnails.js
@@ -16,6 +16,7 @@ import {
 } from '../helpers.js';
 import { toAppIdList } from '../../util/app-ids.js';
 import { addInteractiveOption } from '../../interactive/interactive-option.js';
+import { addDryRunOption } from '../dry-run-option.js';
 import { runCommand } from '../run-command.js';
 
 /**
@@ -282,6 +283,7 @@ const buildCloudCreateSheetThumbnailsCommand = () => {
         .addOption(buildBrowserExecutablePathOption());
 
     addInteractiveOption(command);
+    addDryRunOption(command);
 
     return command;
 };

--- a/src/lib/commands/qscloud/remove-sheet-icons.js
+++ b/src/lib/commands/qscloud/remove-sheet-icons.js
@@ -1,4 +1,5 @@
 import { Command, Option } from 'commander';
+import { addDryRunOption } from '../dry-run-option.js';
 import { logger, appVersion } from '../../../globals.js';
 import { qscloudRemoveSheetIcons } from '../../cloud/cloud-remove-sheet-icons.js';
 import { runCommand } from '../run-command.js';
@@ -80,6 +81,8 @@ const buildCloudRemoveSheetIconsCommand = () => {
                 .default('')
                 .env('BSI_QSCLOUD_RSI_COLLECTIONID')
         );
+
+    addDryRunOption(command);
 
     return command;
 };

--- a/src/lib/commands/qseow/__tests__/qseow_wizard.test.js
+++ b/src/lib/commands/qseow/__tests__/qseow_wizard.test.js
@@ -988,3 +988,35 @@ describe('both platforms label an app the same way', () => {
         );
     });
 });
+
+describe('--dry-run combined with -i (#993)', () => {
+    // The regression this pins: --dry-run has no wizard question, and the
+    // final options bag is rebuilt from the question specs - which is how the
+    // flag used to evaporate between the CLI parse and wizard.run, turning
+    // the safety flag into a real, writing run.
+    test('the dry-run flag survives the wizard into the run options', async () => {
+        const runtime = scriptedRuntime(baseAnswers({ _review: 'run' }));
+
+        await runInteractive({
+            path: PATH,
+            runtime,
+            presetOptions: { dryRun: true },
+        });
+
+        expect(qseowCreateThumbnails).toHaveBeenCalledTimes(1);
+        expect(qseowCreateThumbnails).toHaveBeenCalledWith(
+            expect.objectContaining({ dryRun: true })
+        );
+        expect(runtime.output()).toContain('DRY RUN: --dry-run is in effect');
+    });
+
+    test('without the flag, the run options carry no dryRun key', async () => {
+        const runtime = scriptedRuntime(baseAnswers({ _review: 'run' }));
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(qseowCreateThumbnails).toHaveBeenCalledTimes(1);
+        expect(qseowCreateThumbnails.mock.calls[0][0].dryRun).toBeUndefined();
+        expect(runtime.output()).not.toContain('DRY RUN');
+    });
+});

--- a/src/lib/commands/qseow/index.js
+++ b/src/lib/commands/qseow/index.js
@@ -17,6 +17,7 @@ import {
 } from '../helpers.js';
 import { toAppIdList } from '../../util/app-ids.js';
 import { addInteractiveOption } from '../../interactive/interactive-option.js';
+import { addDryRunOption } from '../dry-run-option.js';
 import { runCommand } from '../run-command.js';
 
 /**
@@ -377,6 +378,7 @@ const buildQseowCommand = () => {
         .addOption(buildBrowserExecutablePathOption());
 
     addInteractiveOption(qseow.commands[0]);
+    addDryRunOption(qseow.commands[0]);
 
     return qseow;
 };

--- a/src/lib/interactive/__tests__/option-introspect.test.js
+++ b/src/lib/interactive/__tests__/option-introspect.test.js
@@ -8,6 +8,7 @@ import {
     isTrueFalseOption,
 } from '../option-introspect.js';
 import { isInteractiveOption, INTERACTIVE_OPTION_ATTRIBUTE } from '../interactive-option.js';
+import { isDryRunOption } from '../../commands/dry-run-option.js';
 
 const ENV_SNAPSHOT = { ...process.env };
 
@@ -86,9 +87,10 @@ describe('command-tree', () => {
 });
 
 describe('every option yields exactly one question', () => {
-    // Every option except the flag that opens the wizard, which is not one of
-    // the wizard's own questions.
-    const askableOptions = (command) => command.options.filter((o) => !isInteractiveOption(o));
+    // Every option except the flag that opens the wizard and the dry-run flag,
+    // which the wizard neither asks about nor emits (#993 q3, deferred to #897).
+    const askableOptions = (command) =>
+        command.options.filter((o) => !isInteractiveOption(o) && !isDryRunOption(o));
 
     test.each(EVERY_COMMAND)('%s', (_path, command) => {
         const specs = specsFromCommand(command);

--- a/src/lib/interactive/index.js
+++ b/src/lib/interactive/index.js
@@ -1,4 +1,5 @@
 import { logger } from '../../globals.js';
+import { DRY_RUN_OPTION_ATTRIBUTE } from '../commands/dry-run-option.js';
 import { leafCommandAt } from './command-tree.js';
 import { specsFromCommand } from './option-introspect.js';
 import { askQuestions } from './ask-questions.js';
@@ -366,6 +367,18 @@ export const runInteractive = async ({
         }
 
         const options = answersToOptions(specs, answers);
+
+        // --dry-run is deliberately not a wizard question (#993), so it has no
+        // spec - and answersToOptions builds the bag from specs, which is how
+        // the flag used to evaporate here: typing the safety flag alongside -i
+        // produced a real, writing run. Carry it through explicitly, and say so
+        // out loud, because the review screen cannot show it either.
+        if (answers[DRY_RUN_OPTION_ATTRIBUTE] === true) {
+            options[DRY_RUN_OPTION_ATTRIBUTE] = true;
+            runtime.write(
+                '\nDRY RUN: --dry-run is in effect - the run below plans only, nothing will be changed.\n'
+            );
+        }
 
         runtime.write('\n');
 

--- a/src/lib/interactive/option-introspect.js
+++ b/src/lib/interactive/option-introspect.js
@@ -1,6 +1,7 @@
 import { BSI_SECRET_KEYS } from '../util/redact-secrets.js';
 import { fromOption, validateEntries } from './validators.js';
 import { isInteractiveOption } from './interactive-option.js';
+import { isDryRunOption } from '../commands/dry-run-option.js';
 
 const SECRET_KEYS = new Set(BSI_SECRET_KEYS.map((key) => key.toLowerCase()));
 
@@ -229,6 +230,10 @@ export const specsFromCommand = (command, { env = process.env } = {}) => {
         // into the echoed command line, so the line the wizard tells you to
         // reuse would re-enter the wizard rather than run the command.
         .filter((option) => !isInteractiveOption(option))
+        // Nor is --dry-run: whether the wizard's review screen offers a dry run
+        // is an open design question (#993 q3, deferred to #897). Until then the
+        // wizard neither asks about it nor emits it.
+        .filter((option) => !isDryRunOption(option))
         .map((option) => specFromOption(option, { env }));
     const seen = new Set();
 

--- a/src/lib/qseow/__tests__/determine_sheet_blur_status.test.js
+++ b/src/lib/qseow/__tests__/determine_sheet_blur_status.test.js
@@ -1,0 +1,104 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { determineSheetBlurStatus } from '../determine-sheet-blur-status.js';
+import { BLUR_REASON } from '../../util/sheet-decision-reasons.js';
+
+// Cloud twin: src/lib/cloud/__tests__/determine_sheet_blur_status.test.js.
+// First direct coverage of the blur rules on either platform (#909) - the
+// rules previously lived inside the write step, unreachable by a unit test.
+
+const log = { verbose: jest.fn() };
+
+const createSheet = ({
+    approved = false,
+    published = false,
+    title = 'Sheet',
+    qId = 's1',
+} = {}) => ({
+    qMeta: { approved, published, title, description: '' },
+    qInfo: { qId },
+});
+
+const run = ({ sheet = createSheet(), options = {}, tagMetadata = [], n = 1 } = {}) =>
+    determineSheetBlurStatus(sheet, options, tagMetadata, n, log);
+
+describe('determineSheetBlurStatus (QSEoW)', () => {
+    test('no blur options: no blur, no reason', () => {
+        expect(run()).toEqual({ blurSheet: false, blurReason: null });
+    });
+
+    test('public sheet blurred when "public" is listed', () => {
+        expect(
+            run({
+                sheet: createSheet({ approved: true, published: true }),
+                options: { blurSheetStatus: ['public'] },
+            })
+        ).toEqual({ blurSheet: true, blurReason: BLUR_REASON.STATUS_PUBLIC });
+    });
+
+    test('published sheet blurred when "published" is listed', () => {
+        expect(
+            run({
+                sheet: createSheet({ approved: false, published: true }),
+                options: { blurSheetStatus: ['published'] },
+            })
+        ).toEqual({ blurSheet: true, blurReason: BLUR_REASON.STATUS_PUBLISHED });
+    });
+
+    test('tag match blurs, and names the tag rule', () => {
+        expect(
+            run({
+                sheet: createSheet({ qId: 'engine-7' }),
+                options: { blurSheetTag: 'confidential' },
+                tagMetadata: [{ engineObjectId: 'engine-7' }],
+            })
+        ).toEqual({ blurSheet: true, blurReason: BLUR_REASON.TAG });
+    });
+
+    test('tag option set but no match: no blur', () => {
+        expect(
+            run({
+                sheet: createSheet({ qId: 'engine-7' }),
+                options: { blurSheetTag: 'confidential' },
+                tagMetadata: [{ engineObjectId: 'other' }],
+            })
+        ).toEqual({ blurSheet: false, blurReason: null });
+    });
+
+    test('sheet number rule matches on the 1-based position as a string', () => {
+        expect(run({ options: { blurSheetNumber: ['3'] }, n: 3 })).toEqual({
+            blurSheet: true,
+            blurReason: BLUR_REASON.NUMBER,
+        });
+        expect(run({ options: { blurSheetNumber: ['3'] }, n: 2 })).toEqual({
+            blurSheet: false,
+            blurReason: null,
+        });
+    });
+
+    test('title rule matches exactly', () => {
+        expect(
+            run({
+                sheet: createSheet({ title: 'Board pack' }),
+                options: { blurSheetTitle: ['Board pack'] },
+            })
+        ).toEqual({ blurSheet: true, blurReason: BLUR_REASON.TITLE });
+    });
+
+    test('the first matching rule names the reason', () => {
+        // Status matches first; the number rule would also match but is never
+        // consulted once the flag is set.
+        expect(
+            run({
+                sheet: createSheet({ approved: true, published: true }),
+                options: { blurSheetStatus: ['public'], blurSheetNumber: ['1'] },
+                n: 1,
+            })
+        ).toEqual({ blurSheet: true, blurReason: BLUR_REASON.STATUS_PUBLIC });
+    });
+    test('does not throw for a sheet the engine returned without qMeta', () => {
+        expect(run({ sheet: { qInfo: { qId: 'bare' } } })).toEqual({
+            blurSheet: false,
+            blurReason: null,
+        });
+    });
+});

--- a/src/lib/qseow/__tests__/determine_sheet_exclude_status.test.js
+++ b/src/lib/qseow/__tests__/determine_sheet_exclude_status.test.js
@@ -1,6 +1,7 @@
 import { jest, describe, test, expect, beforeEach } from '@jest/globals';
 
 import { determineSheetExcludeStatus } from '../determine-sheet-exclude-status.js';
+import { EXCLUDE_REASON } from '../../util/sheet-decision-reasons.js';
 
 const mockLogger = {
     info: jest.fn(),
@@ -83,7 +84,11 @@ beforeEach(() => {
 describe('determineSheetExcludeStatus', () => {
     describe('no exclusion options set', () => {
         test('keeps a plain private sheet', async () => {
-            await expect(run()).resolves.toEqual({ excludeSheet: false, sheetIsHidden: false });
+            await expect(run()).resolves.toEqual({
+                excludeSheet: false,
+                sheetIsHidden: false,
+                excludeReason: null,
+            });
         });
 
         test('keeps a published sheet', async () => {
@@ -92,6 +97,7 @@ describe('determineSheetExcludeStatus', () => {
             await expect(run({ sheet })).resolves.toEqual({
                 excludeSheet: false,
                 sheetIsHidden: false,
+                excludeReason: null,
             });
         });
 
@@ -101,6 +107,7 @@ describe('determineSheetExcludeStatus', () => {
             await expect(run({ sheet })).resolves.toEqual({
                 excludeSheet: false,
                 sheetIsHidden: false,
+                excludeReason: null,
             });
         });
     });
@@ -177,6 +184,7 @@ describe('determineSheetExcludeStatus', () => {
             await expect(run({ sheet })).resolves.toEqual({
                 excludeSheet: false,
                 sheetIsHidden: false,
+                excludeReason: null,
             });
         });
 
@@ -186,6 +194,7 @@ describe('determineSheetExcludeStatus', () => {
             await expect(run({ sheet })).resolves.toEqual({
                 excludeSheet: true,
                 sheetIsHidden: true,
+                excludeReason: EXCLUDE_REASON.HIDDEN,
             });
         });
 
@@ -204,6 +213,7 @@ describe('determineSheetExcludeStatus', () => {
             await expect(run({ sheet, app })).resolves.toEqual({
                 excludeSheet: true,
                 sheetIsHidden: true,
+                excludeReason: EXCLUDE_REASON.HIDDEN,
             });
         });
 
@@ -214,6 +224,7 @@ describe('determineSheetExcludeStatus', () => {
             await expect(run({ sheet, app })).resolves.toEqual({
                 excludeSheet: false,
                 sheetIsHidden: false,
+                excludeReason: null,
             });
         });
 
@@ -256,6 +267,8 @@ describe('determineSheetExcludeStatus', () => {
             await expect(run({ sheet, options })).resolves.toEqual({
                 excludeSheet: true,
                 sheetIsHidden: true,
+                // Status ran first, so the reason names it - hidden did not overwrite it.
+                excludeReason: EXCLUDE_REASON.STATUS_PRIVATE,
             });
         });
     });

--- a/src/lib/qseow/__tests__/qseow_create_thumbnails_app_loop.test.js
+++ b/src/lib/qseow/__tests__/qseow_create_thumbnails_app_loop.test.js
@@ -14,6 +14,7 @@ jest.unstable_mockModule('../../../globals.js', () => ({
         warn: jest.fn(),
     },
     setLoggingLevel: jest.fn(),
+    getLoggingLevel: jest.fn(() => 'info'),
     bsiExecutablePath: '/test/path',
     isSea: false,
     sleep: jest.fn().mockResolvedValue(undefined),
@@ -37,6 +38,10 @@ jest.unstable_mockModule('../qseow-process-app.js', () => ({
     qseowProcessApp: jest.fn().mockResolvedValue(true),
 }));
 
+jest.unstable_mockModule('../qseow-plan-app.js', () => ({
+    qseowPlanApp: jest.fn().mockResolvedValue(undefined),
+}));
+
 jest.unstable_mockModule('../../util/redact-secrets.js', () => ({
     redactOptions: jest.fn((o) => o),
 }));
@@ -47,6 +52,8 @@ jest.unstable_mockModule('../../util/run-over-apps.js', () => ({ runOverApps }))
 const { logger } = await import('../../../globals.js');
 const qrsInteract = (await import('qrs-interact')).default;
 const { qseowCreateThumbnails } = await import('../qseow-create-thumbnails.js');
+const { qseowProcessApp } = await import('../qseow-process-app.js');
+const { qseowPlanApp } = await import('../qseow-plan-app.js');
 
 const OPTIONS = {
     host: 'sense.example.com',
@@ -211,5 +218,49 @@ describe('qseowCreateThumbnails app loop', () => {
         await expect(qseowCreateThumbnails({ ...OPTIONS })).resolves.toBe(false);
 
         expect(errorLog()).toContain('QSEOW CREATE THUMBNAILS 2');
+    });
+
+    describe('--dry-run routing (#993)', () => {
+        test('a dry run hands runOverApps the planner, never the processor', async () => {
+            runOverApps.mockResolvedValue(true);
+
+            await qseowCreateThumbnails({ ...OPTIONS, dryRun: true });
+
+            expect(runOverApps).toHaveBeenCalledTimes(1);
+            const processor = runOverApps.mock.calls[0][2];
+
+            await processor('app-under-test');
+
+            expect(qseowPlanApp).toHaveBeenCalledWith(
+                'app-under-test',
+                expect.objectContaining({ dryRun: true }),
+                expect.objectContaining({ dryRun: true, apps: expect.any(Array) })
+            );
+            // The write path must be unreachable in a dry run - this is the
+            // assertion that actually guards the feature.
+            expect(qseowProcessApp).not.toHaveBeenCalled();
+        });
+
+        test('a dry run renders the report after the app loop', async () => {
+            runOverApps.mockResolvedValue(true);
+
+            await qseowCreateThumbnails({ ...OPTIONS, dryRun: true });
+
+            const infoLog = logger.info.mock.calls.map((call) => String(call[0])).join('\n');
+            expect(infoLog).toContain('DRY RUN of qseow create-sheet-thumbnails');
+            expect(infoLog).toContain('Re-run without --dry-run to apply.');
+        });
+
+        test('a real run hands runOverApps the processor, never the planner', async () => {
+            runOverApps.mockResolvedValue(true);
+
+            await qseowCreateThumbnails({ ...OPTIONS });
+
+            const processor = runOverApps.mock.calls[0][2];
+            await processor('app-under-test');
+
+            expect(qseowProcessApp).toHaveBeenCalledWith('app-under-test', expect.any(Object));
+            expect(qseowPlanApp).not.toHaveBeenCalled();
+        });
     });
 });

--- a/src/lib/qseow/__tests__/qseow_create_thumbnails_empty_selection.test.js
+++ b/src/lib/qseow/__tests__/qseow_create_thumbnails_empty_selection.test.js
@@ -9,6 +9,7 @@ jest.unstable_mockModule('../../../globals.js', () => ({
         warn: jest.fn(),
     },
     setLoggingLevel: jest.fn(),
+    getLoggingLevel: jest.fn(() => 'info'),
     bsiExecutablePath: '/test/path',
     isSea: false,
     sleep: jest.fn().mockResolvedValue(undefined),

--- a/src/lib/qseow/__tests__/qseow_create_thumbnails_validation.test.js
+++ b/src/lib/qseow/__tests__/qseow_create_thumbnails_validation.test.js
@@ -12,6 +12,7 @@ jest.unstable_mockModule('../../../globals.js', () => ({
         warn: jest.fn(),
     },
     setLoggingLevel: jest.fn(),
+    getLoggingLevel: jest.fn(() => 'info'),
     bsiExecutablePath: '/test/path',
     isSea: false,
     sleep: jest.fn().mockResolvedValue(undefined),

--- a/src/lib/qseow/__tests__/qseow_plan_app.test.js
+++ b/src/lib/qseow/__tests__/qseow_plan_app.test.js
@@ -1,0 +1,116 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+// Executes the REAL qseowPlanApp - no planner mock. Cloud twin:
+// cloud_plan_app.test.js.
+
+jest.unstable_mockModule('../../../globals.js', () => ({
+    logger: {
+        info: jest.fn(),
+        error: jest.fn(),
+        verbose: jest.fn(),
+        debug: jest.fn(),
+        warn: jest.fn(),
+    },
+    setLoggingLevel: jest.fn(),
+    getLoggingLevel: jest.fn(() => 'info'),
+    isSea: false,
+}));
+
+jest.unstable_mockModule('../qseow-enigma.js', () => ({
+    setupEnigmaConnection: jest.fn().mockReturnValue({ url: 'wss://sense' }),
+}));
+
+const readQseowAppContext = jest.fn();
+jest.unstable_mockModule('../qseow-tagged-sheets.js', () => ({ readQseowAppContext }));
+
+let fakeGlobal;
+jest.unstable_mockModule('../../util/engine-session.js', () => ({
+    withEngineSession: jest.fn(async (config, ctx, cb) => cb(fakeGlobal)),
+}));
+
+const { qseowPlanApp } = await import('../qseow-plan-app.js');
+const { createRunReport } = await import('../../util/run-report.js');
+
+const sheetItem = (qId, rank, { title = `Sheet ${qId}` } = {}) => ({
+    qInfo: { qId },
+    qMeta: { title, description: '', approved: false, published: false },
+    qData: { rank, showCondition: null },
+});
+
+const wireApp = (items) => {
+    const app = {
+        createSessionObject: jest.fn().mockResolvedValue({
+            getLayout: jest.fn().mockResolvedValue({
+                qAppObjectList: { qItems: items },
+            }),
+        }),
+        evaluateEx: jest.fn().mockResolvedValue({ qIsNumeric: false }),
+    };
+
+    fakeGlobal = { openDoc: jest.fn().mockResolvedValue(app) };
+
+    return app;
+};
+
+const contextWith = ({ excludeTagged = [], blurTagged = [] } = {}) => ({
+    appMetadata: [{ name: 'Sales Discovery', published: true }],
+    tagSheetAppMetadata: excludeTagged,
+    blurTagSheetAppMetadata: blurTagged,
+    mapRepoEngineSheetId: new Map(),
+});
+
+const OPTIONS = { host: 'sense', loglevel: 'info' };
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    readQseowAppContext.mockResolvedValue(contextWith());
+});
+
+describe('qseowPlanApp', () => {
+    test('records name, sheet count and one decision per sheet', async () => {
+        wireApp([sheetItem('a', 1), sheetItem('b', 2)]);
+        const report = createRunReport({ command: 'qseow create-sheet-thumbnails', dryRun: true });
+
+        await qseowPlanApp('app-1', OPTIONS, report);
+
+        expect(report.apps[0].name).toBe('Sales Discovery');
+        expect(report.apps[0].sheetCount).toBe(2);
+        expect(report.apps[0].sheets.map((sheet) => sheet.action)).toEqual(['update', 'update']);
+    });
+
+    test('the blur tag set reaches the blur rule, not the exclude rule', async () => {
+        // The #840 trap: conflating the two tag sets blurs the sheets the
+        // operator asked to skip. The planner must keep them apart exactly as
+        // the real run does.
+        readQseowAppContext.mockResolvedValue(
+            contextWith({ blurTagged: [{ engineObjectId: 'b' }] })
+        );
+        wireApp([sheetItem('a', 1), sheetItem('b', 2)]);
+        const report = createRunReport({ command: 'qseow create-sheet-thumbnails', dryRun: true });
+
+        await qseowPlanApp('app-1', { ...OPTIONS, blurSheetTag: 'confidential' }, report);
+
+        expect(report.apps[0].sheets).toEqual([
+            { n: 1, title: 'Sheet a', action: 'update', reason: null },
+            { n: 2, title: 'Sheet b', action: 'blur', reason: '--blur-sheet-tag' },
+        ]);
+    });
+
+    test('exclude wins over blur, with the responsible option named', async () => {
+        readQseowAppContext.mockResolvedValue(
+            contextWith({ excludeTagged: [{ engineObjectId: 'a' }] })
+        );
+        wireApp([sheetItem('a', 1)]);
+        const report = createRunReport({ command: 'qseow create-sheet-thumbnails', dryRun: true });
+
+        await qseowPlanApp(
+            'app-1',
+            { ...OPTIONS, excludeSheetTag: 'no-thumbnail', blurSheetTitle: ['Sheet a'] },
+            report
+        );
+
+        expect(report.apps[0].sheets).toEqual([
+            { n: 1, title: 'Sheet a', action: 'skip', reason: '--exclude-sheet-tag' },
+        ]);
+    });
+});

--- a/src/lib/qseow/determine-sheet-blur-status.js
+++ b/src/lib/qseow/determine-sheet-blur-status.js
@@ -1,0 +1,95 @@
+import { isSheetTagged } from '../util/sheet-list.js';
+import { BLUR_REASON } from '../util/sheet-decision-reasons.js';
+
+/**
+ * Determines whether a QSEoW sheet's thumbnail should be blurred.
+ *
+ * Extracted verbatim from `qseowUpdateSheetThumbnails`, where the rules lived
+ * inside the write step - which meant a dry run could not report the blur plan
+ * without performing the writes (issue #993), and the function carried the
+ * bulk of its cognitive-complexity flag (issue #842). The Cloud twin lives in
+ * `src/lib/cloud/determine-sheet-blur-status.js` with the same name and return
+ * shape; the platforms differ in how tag data is resolved, so the twins stay
+ * separate the same way the exclude twins do.
+ *
+ * Rule order matches the original: the two status rules first (mutually
+ * exclusive on the approved flag, so at most one fires), then tag, number and
+ * title, each only consulted while no earlier rule matched. `blurReason`
+ * names the rule that matched - it is what the dry-run report prints.
+ *
+ * @param {object} sheet - Sheet from `qAppObjectList.qItems`.
+ * @param {object} options - Blur options.
+ * @param {string[]} [options.blurSheetStatus] - Statuses to blur: `published`, `public`.
+ * @param {string} [options.blurSheetTag] - Tag naming sheets to blur.
+ * @param {string[]} [options.blurSheetNumber] - Sheet numbers to blur, as strings.
+ * @param {string[]} [options.blurSheetTitle] - Sheet titles to blur.
+ * @param {Array<object>} tagSheetAppMetadata - QRS metadata for sheets carrying the
+ *     blur tag. The blur-tag set, never the exclude-tag one (issue #840).
+ * @param {number} iSheetNum - 1-based position of the sheet within the app.
+ * @param {object} log - Logger; verbose output explains which rule matched.
+ *
+ * @returns {{blurSheet: boolean, blurReason: string|null}} Whether to blur, and
+ *     the responsible option when so.
+ */
+export const determineSheetBlurStatus = (sheet, options, tagSheetAppMetadata, iSheetNum, log) => {
+    let blurSheet = false;
+    let blurReason = null;
+
+    const sheetLabel = `${iSheetNum}: '${sheet?.qMeta?.title}', ID ${sheet?.qInfo?.qId}, description '${sheet?.qMeta?.description}'`;
+
+    // Should this sheet be blurred based on its published status?
+    // Public sheets
+    if (
+        sheet?.qMeta?.approved === true &&
+        sheet?.qMeta?.published === true &&
+        options.blurSheetStatus &&
+        options.blurSheetStatus.includes('public')
+    ) {
+        blurSheet = true;
+        blurReason ??= BLUR_REASON.STATUS_PUBLIC;
+        log.verbose(`Blurred sheet thumbnail (status public): ${sheetLabel}`);
+    }
+
+    // Published sheets
+    if (
+        sheet?.qMeta?.approved === false &&
+        sheet?.qMeta?.published === true &&
+        options.blurSheetStatus &&
+        options.blurSheetStatus.includes('published')
+    ) {
+        blurSheet = true;
+        blurReason ??= BLUR_REASON.STATUS_PUBLISHED;
+        log.verbose(`Blurred sheet thumbnail (status published): ${sheetLabel}`);
+    }
+
+    // Should this sheet be blurred based on tags?
+    // tagSheetAppMetadata is looked up by the caller against --blur-sheet-tag; it
+    // arrives empty when no tag was given, so the rule matches nothing.
+    if (options.blurSheetTag && blurSheet === false) {
+        blurSheet = isSheetTagged(tagSheetAppMetadata, sheet);
+        if (blurSheet) {
+            blurReason = BLUR_REASON.TAG;
+            log.verbose(`Blurred sheet thumbnail (via tags): ${sheetLabel}`);
+        }
+    }
+
+    // Should this sheet be blurred based on its position/sheet number?
+    if (options.blurSheetNumber && blurSheet === false) {
+        if (options.blurSheetNumber.includes(iSheetNum.toString())) {
+            blurSheet = true;
+            blurReason = BLUR_REASON.NUMBER;
+            log.verbose(`Blurred sheet thumbnail (via sheet number): ${sheetLabel}`);
+        }
+    }
+
+    // Should this sheet be blurred based on its title?
+    if (options.blurSheetTitle && blurSheet === false) {
+        if (options.blurSheetTitle.includes(sheet?.qMeta?.title)) {
+            blurSheet = true;
+            blurReason = BLUR_REASON.TITLE;
+            log.verbose(`Blurred sheet thumbnail (via sheet title): ${sheetLabel}`);
+        }
+    }
+
+    return { blurSheet, blurReason };
+};

--- a/src/lib/qseow/determine-sheet-exclude-status.js
+++ b/src/lib/qseow/determine-sheet-exclude-status.js
@@ -1,4 +1,5 @@
 import { isSheetTagged } from '../util/sheet-list.js';
+import { EXCLUDE_REASON } from '../util/sheet-decision-reasons.js';
 
 /**
  * Determines whether a sheet should be excluded from updates based on various criteria.
@@ -12,7 +13,7 @@ import { isSheetTagged } from '../util/sheet-list.js';
  * @param {string} engineSheetId - The sheet ID in the engine.
  * @param {object} logger - Logger object used for logging verbose messages.
  *
- * @returns {Promise<{ excludeSheet: boolean, sheetIsHidden: boolean }>} Resolves with `excludeSheet` (true if the sheet should be excluded) and `sheetIsHidden` (true if the sheet is hidden via showCondition).
+ * @returns {Promise<{ excludeSheet: boolean, sheetIsHidden: boolean, excludeReason: string|null }>} Resolves with `excludeSheet` (true if the sheet should be excluded), `sheetIsHidden` (true if the sheet is hidden via showCondition), and `excludeReason` naming the first rule that matched (from `sheet-decision-reasons.js`), or null.
  */
 export const determineSheetExcludeStatus = async (
     app,
@@ -25,6 +26,9 @@ export const determineSheetExcludeStatus = async (
     logger
 ) => {
     let excludeSheet = false;
+    // First rule to exclude the sheet names the reason; later rules are skipped or,
+    // for the status trio, keep the first reason via ??=.
+    let excludeReason = null;
 
     // Should this sheet be excluded based on its published status?
     // Deal with public sheets first
@@ -35,6 +39,7 @@ export const determineSheetExcludeStatus = async (
         options.excludeSheetStatus.includes('public')
     ) {
         excludeSheet = true;
+        excludeReason ??= EXCLUDE_REASON.STATUS_PUBLIC;
         logger.verbose(
             `Excluded sheet (status public): ${iSheetNum}: '${sheet.qMeta.title}', sheet id '${repoDbSheetId}', engine sheet id '${engineSheetId}', description '${sheet.qMeta.description}', approved ${sheet.qMeta.approved}, published ${sheet.qMeta.published}`
         );
@@ -48,6 +53,7 @@ export const determineSheetExcludeStatus = async (
         options.excludeSheetStatus.includes('published')
     ) {
         excludeSheet = true;
+        excludeReason ??= EXCLUDE_REASON.STATUS_PUBLISHED;
         logger.verbose(
             `Excluded sheet (status published): ${iSheetNum}: '${sheet.qMeta.title}', sheet id '${repoDbSheetId}', engine sheet id '${engineSheetId}', description '${sheet.qMeta.description}', approved ${sheet.qMeta.approved}, published ${sheet.qMeta.published}`
         );
@@ -61,6 +67,7 @@ export const determineSheetExcludeStatus = async (
         options.excludeSheetStatus.includes('private')
     ) {
         excludeSheet = true;
+        excludeReason ??= EXCLUDE_REASON.STATUS_PRIVATE;
         logger.verbose(
             `Excluded sheet (status private): ${iSheetNum}: '${sheet.qMeta.title}', sheet id '${repoDbSheetId}', engine sheet id '${engineSheetId}', description '${sheet.qMeta.description}', approved ${sheet.qMeta.approved}, published ${sheet.qMeta.published}`
         );
@@ -69,20 +76,25 @@ export const determineSheetExcludeStatus = async (
     // Is this sheet hidden?
     // Never process hidden sheets
     // Evaluate showCondition
-    const showConditionCall = {
-        qExpression: sheet?.qData?.showCondition,
-    };
-
-    const showConditionEval = await app.evaluateEx(showConditionCall);
-    const sheetIsHidden =
-        sheet?.qData?.showCondition &&
-        (sheet.qData.showCondition.toLowerCase() === 'false' ||
-            (showConditionEval?.qIsNumeric === true && showConditionEval?.qNumber === 0))
-            ? true
-            : false;
+    // The engine round trip only happens when there is a condition to evaluate
+    // and the literal-'false' shortcut has not already answered it. In a dry
+    // run this call is the entire per-sheet cost, and most sheets have no show
+    // condition at all - the result is byte-identical either way.
+    const showCondition = sheet?.qData?.showCondition;
+    let sheetIsHidden = false;
+    if (showCondition) {
+        if (showCondition.toLowerCase() === 'false') {
+            sheetIsHidden = true;
+        } else {
+            const showConditionEval = await app.evaluateEx({ qExpression: showCondition });
+            sheetIsHidden =
+                showConditionEval?.qIsNumeric === true && showConditionEval?.qNumber === 0;
+        }
+    }
 
     if (sheetIsHidden === true && excludeSheet === false) {
         excludeSheet = true;
+        excludeReason = EXCLUDE_REASON.HIDDEN;
         logger.verbose(
             `Excluded sheet (hidden): ${iSheetNum}: '${sheet.qMeta.title}', sheet id '${repoDbSheetId}', engine sheet id '${engineSheetId}', description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}', hidden '${sheetIsHidden}'`
         );
@@ -98,6 +110,7 @@ export const determineSheetExcludeStatus = async (
         // Only claim an exclusion that actually happened: this line used to be logged
         // whether or not the tag matched.
         if (excludeSheet === true) {
+            excludeReason = EXCLUDE_REASON.TAG;
             logger.verbose(
                 `Excluded sheet (via tags): ${iSheetNum}: '${sheet.qMeta.title}', sheet id '${repoDbSheetId}', engine sheet id '${engineSheetId}', description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}', hidden '${sheetIsHidden}'`
             );
@@ -110,6 +123,7 @@ export const determineSheetExcludeStatus = async (
         // Take into account that iSheetNum is an integer, so we need to convert it to a string
         if (options.excludeSheetNumber.includes(iSheetNum.toString())) {
             excludeSheet = true;
+            excludeReason = EXCLUDE_REASON.NUMBER;
             logger.verbose(
                 `Excluded sheet (via sheet number): ${iSheetNum}: '${sheet.qMeta.title}', sheet id '${repoDbSheetId}', engine sheet id '${engineSheetId}', description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}', hidden '${sheetIsHidden}'`
             );
@@ -121,11 +135,12 @@ export const determineSheetExcludeStatus = async (
         // Does the sheet title match any of the titles options.excludeSheetTitle array?
         if (options.excludeSheetTitle.includes(sheet.qMeta.title)) {
             excludeSheet = true;
+            excludeReason = EXCLUDE_REASON.TITLE;
             logger.verbose(
                 `Excluded sheet (via sheet title): ${iSheetNum}: '${sheet.qMeta.title}', sheet id '${repoDbSheetId}', engine sheet id '${engineSheetId}', description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}', hidden '${sheetIsHidden}'`
             );
         }
     }
 
-    return { excludeSheet, sheetIsHidden };
+    return { excludeSheet, sheetIsHidden, excludeReason };
 };

--- a/src/lib/qseow/qseow-create-thumbnails.js
+++ b/src/lib/qseow/qseow-create-thumbnails.js
@@ -4,17 +4,11 @@ import { qseowVerifyContentLibraryExists } from './qseow-contentlibrary.js';
 import { qseowVerifyCertificatesExist } from './qseow-certificates.js';
 import { qseowProcessApp } from './qseow-process-app.js';
 import { qseowPlanApp } from './qseow-plan-app.js';
-import { runOverApps } from '../util/run-over-apps.js';
 import { listAppsByTag } from './qseow-app-lookup.js';
 import { toAppIdList } from '../util/app-ids.js';
 import { QSEOW_SHEET_PARTS } from './sheet-parts.js';
 import { logError } from '../util/log-error.js';
-import {
-    createRunReport,
-    recordSelection,
-    renderDryRunReport,
-    announceDryRun,
-} from '../util/run-report.js';
+import { runOverAppsWithReport, announceDryRun } from '../util/run-report.js';
 
 /**
  * Create thumbnails for Qlik Sense Enterprise on Windows (QSEoW).
@@ -105,36 +99,18 @@ export const qseowCreateThumbnails = async (options) => {
             appIdsToProcess.push(...taggedAppIds);
         }
 
-        // The report is built for both modes; only a dry run renders it today.
-        // Selection provenance is recorded up front because "the tag matched 40
-        // apps, not 4" is a silent surprise the report exists to catch (#993).
-        const report = createRunReport({ command: 'qseow create-sheet-thumbnails', dryRun });
-        recordSelection(report, {
+        return await runOverAppsWithReport({
+            command: 'qseow create-sheet-thumbnails',
+            dryRun,
+            appIds: appIdsToProcess,
             namedAppIds,
             selectorAppIds: taggedAppIds,
             selector: useTag ? { option: 'qliksensetag', value: options.qliksensetag } : null,
+            logPrefix: { plan: 'QSEOW PLAN APP', process: 'QSEOW PROCESS APP' },
+            emptySelectionHint: 'Check the --appid and --qliksensetag options.',
+            planApp: (appId, report) => qseowPlanApp(appId, options, report),
+            processApp: (appId) => qseowProcessApp(appId, options),
         });
-
-        const result = await runOverApps(
-            appIdsToProcess,
-            {
-                logPrefix: dryRun ? 'QSEOW PLAN APP' : 'QSEOW PROCESS APP',
-                action: dryRun ? 'plan' : 'process',
-                emptySelectionHint: 'Check the --appid and --qliksensetag options.',
-            },
-            dryRun
-                ? (appId) => qseowPlanApp(appId, options, report)
-                : (appId) => qseowProcessApp(appId, options)
-        );
-
-        // Rendered even when some apps failed to plan: the decisions that were
-        // reached are exactly what the operator needs to see alongside the
-        // per-app error lines runOverApps already logged.
-        if (dryRun) {
-            renderDryRunReport(report);
-        }
-
-        return result;
     } catch (err) {
         logError('QSEOW CREATE THUMBNAILS 2', err);
 

--- a/src/lib/qseow/qseow-create-thumbnails.js
+++ b/src/lib/qseow/qseow-create-thumbnails.js
@@ -3,11 +3,18 @@ import { redactOptions } from '../util/redact-secrets.js';
 import { qseowVerifyContentLibraryExists } from './qseow-contentlibrary.js';
 import { qseowVerifyCertificatesExist } from './qseow-certificates.js';
 import { qseowProcessApp } from './qseow-process-app.js';
+import { qseowPlanApp } from './qseow-plan-app.js';
 import { runOverApps } from '../util/run-over-apps.js';
 import { listAppsByTag } from './qseow-app-lookup.js';
 import { toAppIdList } from '../util/app-ids.js';
 import { QSEOW_SHEET_PARTS } from './sheet-parts.js';
 import { logError } from '../util/log-error.js';
+import {
+    createRunReport,
+    recordSelection,
+    renderDryRunReport,
+    announceDryRun,
+} from '../util/run-report.js';
 
 /**
  * Create thumbnails for Qlik Sense Enterprise on Windows (QSEoW).
@@ -32,6 +39,13 @@ import { logError } from '../util/log-error.js';
 export const qseowCreateThumbnails = async (options) => {
     try {
         setLoggingLevel(options.loglevel);
+
+        const dryRun = Boolean(options.dryRun);
+        if (dryRun) {
+            // Before anything connects: without this the log opens exactly like
+            // a real run and the first dry-run marker arrives after the last app.
+            announceDryRun('qseow create-sheet-thumbnails');
+        }
 
         logger.info('Starting creation of thumbnails for Qlik Sense Enterprise on Windows (QSEoW)');
         logger.verbose(`Running as standalone app: ${isSea}`);
@@ -75,26 +89,52 @@ export const qseowCreateThumbnails = async (options) => {
         }
 
         // Apps named directly. --appid is variadic, so this is a list.
-        appIdsToProcess.push(...toAppIdList(options.appid));
+        const namedAppIds = toAppIdList(options.appid);
+        appIdsToProcess.push(...namedAppIds);
 
         // --appid and --qliksensetag are additive, not alternatives: apps named either
         // way are all processed. runOverApps() dedupes, so an app that is both named by
         // --appid and carries the tag is still processed once.
-        if (options.qliksensetag && options.qliksensetag.length > 0) {
+        let taggedAppIds = [];
+        const useTag = Boolean(options.qliksensetag && options.qliksensetag.length > 0);
+        if (useTag) {
             // Get all apps matching the tag in --qliksensetag. listAppsByTag returns
             // { id, name } so a picker can label them; only the ids matter here.
             const taggedApps = await listAppsByTag(options);
-            appIdsToProcess.push(...taggedApps.map((app) => app.id));
+            taggedAppIds = taggedApps.map((app) => app.id);
+            appIdsToProcess.push(...taggedAppIds);
         }
 
-        return await runOverApps(
+        // The report is built for both modes; only a dry run renders it today.
+        // Selection provenance is recorded up front because "the tag matched 40
+        // apps, not 4" is a silent surprise the report exists to catch (#993).
+        const report = createRunReport({ command: 'qseow create-sheet-thumbnails', dryRun });
+        recordSelection(report, {
+            namedAppIds,
+            selectorAppIds: taggedAppIds,
+            selector: useTag ? { option: 'qliksensetag', value: options.qliksensetag } : null,
+        });
+
+        const result = await runOverApps(
             appIdsToProcess,
             {
-                logPrefix: 'QSEOW PROCESS APP',
+                logPrefix: dryRun ? 'QSEOW PLAN APP' : 'QSEOW PROCESS APP',
+                action: dryRun ? 'plan' : 'process',
                 emptySelectionHint: 'Check the --appid and --qliksensetag options.',
             },
-            (appId) => qseowProcessApp(appId, options)
+            dryRun
+                ? (appId) => qseowPlanApp(appId, options, report)
+                : (appId) => qseowProcessApp(appId, options)
         );
+
+        // Rendered even when some apps failed to plan: the decisions that were
+        // reached are exactly what the operator needs to see alongside the
+        // per-app error lines runOverApps already logged.
+        if (dryRun) {
+            renderDryRunReport(report);
+        }
+
+        return result;
     } catch (err) {
         logError('QSEOW CREATE THUMBNAILS 2', err);
 

--- a/src/lib/qseow/qseow-plan-app.js
+++ b/src/lib/qseow/qseow-plan-app.js
@@ -1,0 +1,127 @@
+import { logger } from '../../globals.js';
+import { setupEnigmaConnection } from './qseow-enigma.js';
+import { determineSheetExcludeStatus } from './determine-sheet-exclude-status.js';
+import { determineSheetBlurStatus } from './determine-sheet-blur-status.js';
+import { readQseowAppContext } from './qseow-tagged-sheets.js';
+import { withEngineSession } from '../util/engine-session.js';
+import {
+    getSheetList,
+    sortSheetsByRank,
+    SHEET_LIST_FIELDS_WITH_SHOW_CONDITION,
+} from '../util/sheet-list.js';
+import { addAppToReport, recordSheetDecision } from '../util/run-report.js';
+
+/**
+ * Plans one QSEoW app without changing anything: the dry-run twin of
+ * `qseowProcessApp`.
+ *
+ * Performs the same reads, in the same order, through the same functions - the
+ * QRS metadata lookup, both tagged-sheet lookups, the engine session, the sheet
+ * list, the rank sort, and the exclude and blur rules - and records a decision
+ * per sheet instead of acting on it. What it deliberately does not do: create
+ * the image directory, launch a browser, capture, upload, or update sheets.
+ *
+ * Kept as its own function rather than `if (dryRun)` guards inside
+ * `qseowProcessApp` (issue #993): the real processor is ~500 lines in which a
+ * missed guard is a write during a dry run - the one failure this feature can
+ * never have. The shared decision logic lives in the `determineSheet*Status`
+ * modules, so the two paths cannot disagree about a decision; what this
+ * duplicates is only the read scaffolding around them.
+ *
+ * The sort matters: `--exclude-sheet-number` and `--blur-sheet-number` count
+ * positions after `sortSheetsByRank`, so planning over the unsorted list would
+ * report decisions the real run does not make.
+ *
+ * @param {string} appId - The QSEoW app to plan.
+ * @param {object} options - The same options bag the real run receives.
+ * @param {object} report - Run report from `createRunReport`; one app section
+ *     and one decision per sheet are recorded onto it.
+ *
+ * @returns {Promise<void>} Resolves when the app's plan is recorded.
+ *
+ * @throws {Error} When the app does not exist in the repository (a `QseowError`
+ *     from `readQseowAppContext`) - planning an app that cannot be read is a
+ *     failure, exactly as running it would be.
+ */
+export const qseowPlanApp = async (appId, options, report) => {
+    // The same QRS reads the real run makes, from the same function - the
+    // planner cannot drift from the processor here by construction.
+    const { appMetadata, tagSheetAppMetadata, blurTagSheetAppMetadata, mapRepoEngineSheetId } =
+        await readQseowAppContext(appId, options);
+
+    const configEnigma = setupEnigmaConnection(appId, options);
+
+    await withEngineSession(
+        configEnigma,
+        {
+            logPrefix: 'QSEOW PLAN APP',
+            loglevel: options.loglevel,
+            connectionLabel: `server ${options.host}`,
+            sessionLogLevel: 'info',
+        },
+        async (global) => {
+            const app = await global.openDoc(appId, '', '', '', false);
+            logger.info(`Opened app ${appId}`);
+            logger.info(`App name: "${appMetadata[0].name}"`);
+            logger.info(`App is published: ${appMetadata[0].published}`);
+
+            const sheets = await getSheetList(app, SHEET_LIST_FIELDS_WITH_SHOW_CONDITION);
+            logger.info(`Number of sheets in app: ${sheets.length}`);
+
+            const appEntry = addAppToReport(report, {
+                id: appId,
+                name: appMetadata[0].name,
+                sheetCount: sheets.length,
+            });
+
+            // Same order the real run processes in - the number rules count
+            // positions in this order, not the engine's.
+            sortSheetsByRank(sheets);
+
+            let iSheetNum = 1;
+            for (const sheet of sheets) {
+                const engineSheetId = sheet.qInfo.qId;
+                const repoDbSheetId = mapRepoEngineSheetId.get(engineSheetId);
+
+                const { excludeSheet, excludeReason } = await determineSheetExcludeStatus(
+                    app,
+                    sheet,
+                    options,
+                    tagSheetAppMetadata,
+                    iSheetNum,
+                    repoDbSheetId,
+                    engineSheetId,
+                    logger
+                );
+
+                if (excludeSheet === true) {
+                    recordSheetDecision(appEntry, {
+                        n: iSheetNum,
+                        title: sheet.qMeta.title,
+                        action: 'skip',
+                        reason: excludeReason,
+                    });
+                } else {
+                    const { blurSheet, blurReason } = determineSheetBlurStatus(
+                        sheet,
+                        options,
+                        blurTagSheetAppMetadata,
+                        iSheetNum,
+                        logger
+                    );
+
+                    recordSheetDecision(appEntry, {
+                        n: iSheetNum,
+                        title: sheet.qMeta.title,
+                        action: blurSheet ? 'blur' : 'update',
+                        reason: blurReason,
+                    });
+                }
+
+                iSheetNum += 1;
+            }
+        }
+    );
+
+    logger.verbose(`Planned QSEoW app ${appId} - no changes made`);
+};

--- a/src/lib/qseow/qseow-plan-app.js
+++ b/src/lib/qseow/qseow-plan-app.js
@@ -9,7 +9,7 @@ import {
     sortSheetsByRank,
     SHEET_LIST_FIELDS_WITH_SHOW_CONDITION,
 } from '../util/sheet-list.js';
-import { addAppToReport, recordSheetDecision } from '../util/run-report.js';
+import { addAppToReport, recordPlannedSheet } from '../util/run-report.js';
 
 /**
  * Plans one QSEoW app without changing anything: the dry-run twin of
@@ -94,29 +94,24 @@ export const qseowPlanApp = async (appId, options, report) => {
                     logger
                 );
 
-                if (excludeSheet === true) {
-                    recordSheetDecision(appEntry, {
-                        n: iSheetNum,
-                        title: sheet.qMeta.title,
-                        action: 'skip',
-                        reason: excludeReason,
-                    });
-                } else {
-                    const { blurSheet, blurReason } = determineSheetBlurStatus(
-                        sheet,
-                        options,
-                        blurTagSheetAppMetadata,
-                        iSheetNum,
-                        logger
-                    );
+                const { blurSheet, blurReason } = excludeSheet
+                    ? { blurSheet: false, blurReason: null }
+                    : determineSheetBlurStatus(
+                          sheet,
+                          options,
+                          blurTagSheetAppMetadata,
+                          iSheetNum,
+                          logger
+                      );
 
-                    recordSheetDecision(appEntry, {
-                        n: iSheetNum,
-                        title: sheet.qMeta.title,
-                        action: blurSheet ? 'blur' : 'update',
-                        reason: blurReason,
-                    });
-                }
+                recordPlannedSheet(appEntry, {
+                    n: iSheetNum,
+                    title: sheet.qMeta.title,
+                    excludeSheet,
+                    excludeReason,
+                    blurSheet,
+                    blurReason,
+                });
 
                 iSheetNum += 1;
             }

--- a/src/lib/qseow/qseow-process-app.js
+++ b/src/lib/qseow/qseow-process-app.js
@@ -1,12 +1,11 @@
-import qrsInteract from 'qrs-interact';
 import { Jimp } from 'jimp';
 
 import { setupEnigmaConnection } from './qseow-enigma.js';
 import { logger, sleep } from '../../globals.js';
 import { qseowUploadToContentLibrary } from './qseow-upload.js';
 import { qseowUpdateSheetThumbnails } from './qseow-updatesheets.js';
-import { setupQseowQrsConnection } from './qseow-qrs.js';
 import { determineSheetExcludeStatus } from './determine-sheet-exclude-status.js';
+import { readQseowAppContext } from './qseow-tagged-sheets.js';
 import { QseowError } from '../util/errors.js';
 import { launchBrowserForApp, closeBrowserQuietly } from '../browser/browser-launch.js';
 import {
@@ -16,72 +15,11 @@ import {
 } from '../util/sheet-list.js';
 import { withEngineSession } from '../util/engine-session.js';
 import { createAppImageDir } from '../util/image-dir.js';
-import { qrsFilterAnyOf, qrsPathWithFilter, toFilterValueList } from './qrs-filter.js';
-import { qrsGetList } from './qrs-response.js';
 import { QSEOW_SHEET_PART_SELECTORS } from './sheet-parts.js';
 import { qseowLogout } from './qseow-logout.js';
 import { getQseowHubSelectors } from './qseow-selectors.js';
 import { logError } from '../util/log-error.js';
 import { normalizeVirtualProxyPrefix } from './qseow-prefix.js';
-
-/**
- * Looks up the sheets in an app that carry any of the supplied tags.
- *
- * Both `--exclude-sheet-tag` and `--blur-sheet-tag` need exactly this, against the same endpoint,
- * differing only in which option supplies the tags. They are kept as two separate queries rather
- * than one combined lookup because the two rules have to stay distinguishable: a sheet carrying
- * the exclude tag must not become a blurred sheet, and vice versa.
- *
- * Only worth asking when tags were actually supplied. Querying with none used to ask for a tag
- * literally named `undefined`, which costs a round trip per app and, on a site that happens to
- * have a tag by that name, would act on sheets nobody nominated.
- *
- * @param {object} qrsInteractInstance - Configured `qrs-interact` instance.
- * @param {string} appSheetsFilter - Filter term restricting results to sheets in one app.
- * @param {string|string[]|undefined} tagOption - Raw CLI option value naming the tags.
- * @param {string} optionName - The option's CLI spelling, used only in log messages.
- *
- * @returns {Promise<Array<object>>} Sheet metadata objects exposing `engineObjectId`, empty when
- *     no tags were supplied.
- *
- * @throws {QseowError} When QRS answers with something that is not a list.
- */
-const getSheetsTaggedWith = async (qrsInteractInstance, appSheetsFilter, tagOption, optionName) => {
-    // Variadic options arrive as arrays, so the tag term has to be an `or` group over every tag
-    // given: interpolating the array produced `tags.name eq 'A,B'`, one literal matching no tag.
-    const tags = toFilterValueList(tagOption);
-
-    if (tags.length === 0) {
-        logger.debug(`No ${optionName} supplied, skipping the QRS lookup for tagged sheets`);
-        return [];
-    }
-
-    const tagFilter = `${appSheetsFilter} and ${qrsFilterAnyOf('tags.name', tags)}`;
-    logger.debug(`GET sheets tagged for ${optionName}: app/object/full?filter=${tagFilter}`);
-
-    // Through qrsGetList: the count logged below is taken with `.length`, and a reply that is not
-    // a list answers that with a plausible number rather than failing - a quoted JSON string would
-    // report its character count as though that many sheets carried the tag.
-    const taggedSheets = await qrsGetList(
-        qrsInteractInstance,
-        qrsPathWithFilter('app/object/full', tagFilter)
-    );
-
-    // Report the count at the default log level whenever the option was used. A misspelled tag
-    // otherwise produces a run byte-identical to one where the option was never passed - the
-    // silent-no-op that made issue #840 hard to notice - and for the blur rule that means
-    // publishing readable thumbnails the operator believed were hidden.
-    //
-    // Deliberately info rather than warn: a run spanning many apps will legitimately find no
-    // tagged sheets in most of them, and a per-app warning for a normal outcome is the kind of
-    // noise that teaches operators to ignore warnings. A mistyped tag shows up as a trail of
-    // zeroes across every app instead.
-    logger.info(
-        `Sheets carrying a tag named by ${optionName}: ${taggedSheets.length} (tags: ${tags.join(', ')})`
-    );
-
-    return taggedSheets;
-};
 
 const selectorLoginPageUserName = '#username-input';
 const selectorLoginPageUserPwd = '#password-input';
@@ -145,61 +83,10 @@ export const qseowProcessApp = async (appId, options) => {
     });
 
     try {
-        // Get metadata about the app
-        const qseowConfigQrs = setupQseowQrsConnection(options);
-
-        const qrsInteractInstance = new qrsInteract(qseowConfigQrs);
-        logger.debug(`QSEoW QRS config: ${JSON.stringify(qseowConfigQrs, null, 2)}`);
-
-        // Get app top level metadata
-        const appMetadataPath = qrsPathWithFilter('app', `id eq ${appId}`);
-        logger.debug(`GET app top level metadata: ${appMetadataPath}`);
-        const appMetadata = await qrsGetList(qrsInteractInstance, appMetadataPath);
-
-        // An empty list is a real answer - the filter matched no app - but the two reads of
-        // appMetadata[0] further down sit inside the engine session, so leaving it unchecked
-        // spends a session and an openDoc before failing with `Cannot read properties of
-        // undefined`. In practice the engine refuses first, since the QRS lookup and the session
-        // use the same service identity; this is here so the invariant holds for the next reader.
-        if (appMetadata.length === 0) {
-            throw new QseowError(
-                `QSEoW app ${appId} was not found in the Qlik Sense repository. Check --appid, and that the account named by --apiuserdir/--apiuserid may read the app.`
-            );
-        }
-
-        const appSheetsFilter = `objectType eq 'sheet' and app.id eq ${appId}`;
-
-        // Get metadata for the app sheets that should be excluded based on sheet tags, and
-        // separately for those that should be blurred. Two lookups, deliberately: the exclude tag
-        // and the blur tag name different sets of sheets, and conflating them would blur every
-        // sheet the operator asked to leave alone.
-        const tagSheetAppMetadata = await getSheetsTaggedWith(
-            qrsInteractInstance,
-            appSheetsFilter,
-            options.excludeSheetTag,
-            '--exclude-sheet-tag'
-        );
-
-        const blurTagSheetAppMetadata = await getSheetsTaggedWith(
-            qrsInteractInstance,
-            appSheetsFilter,
-            options.blurSheetTag,
-            '--blur-sheet-tag'
-        );
-
-        // Create mapping between repo db sheet id and engine sheet id
-        const repoSheets = await qrsGetList(
-            qrsInteractInstance,
-            qrsPathWithFilter('app/object/full', appSheetsFilter)
-        );
-
-        // repoSheets is an array of sheet objects, each object has properties called 'id' and 'engineObjectId'
-        // Create a new bidirectional map between repo db sheet id and engine sheet id
-        const mapRepoEngineSheetId = new Map();
-        repoSheets.forEach((element) => {
-            mapRepoEngineSheetId.set(element.id, element.engineObjectId);
-            mapRepoEngineSheetId.set(element.engineObjectId, element.id);
-        });
+        // Every QRS read shared with the dry-run planner lives in
+        // readQseowAppContext, so the two modes cannot drift apart.
+        const { appMetadata, tagSheetAppMetadata, blurTagSheetAppMetadata, mapRepoEngineSheetId } =
+            await readQseowAppContext(appId, options);
 
         // Configure Enigma.js
         const configEnigma = setupEnigmaConnection(appId, options);

--- a/src/lib/qseow/qseow-tagged-sheets.js
+++ b/src/lib/qseow/qseow-tagged-sheets.js
@@ -1,0 +1,146 @@
+import qrsInteract from 'qrs-interact';
+import { logger } from '../../globals.js';
+import { setupQseowQrsConnection } from './qseow-qrs.js';
+import { QseowError } from '../util/errors.js';
+import { qrsFilterAnyOf, qrsPathWithFilter, toFilterValueList } from './qrs-filter.js';
+import { qrsGetList } from './qrs-response.js';
+
+/**
+ * Looks up the sheets in an app that carry any of the supplied tags.
+ *
+ * Both `--exclude-sheet-tag` and `--blur-sheet-tag` need exactly this, against the same endpoint,
+ * differing only in which option supplies the tags. They are kept as two separate queries rather
+ * than one combined lookup because the two rules have to stay distinguishable: a sheet carrying
+ * the exclude tag must not become a blurred sheet, and vice versa.
+ *
+ * Only worth asking when tags were actually supplied. Querying with none used to ask for a tag
+ * literally named `undefined`, which costs a round trip per app and, on a site that happens to
+ * have a tag by that name, would act on sheets nobody nominated.
+ *
+ * @param {object} qrsInteractInstance - Configured `qrs-interact` instance.
+ * @param {string} appSheetsFilter - Filter term restricting results to sheets in one app.
+ * @param {string|string[]|undefined} tagOption - Raw CLI option value naming the tags.
+ * @param {string} optionName - The option's CLI spelling, used only in log messages.
+ *
+ * @returns {Promise<Array<object>>} Sheet metadata objects exposing `engineObjectId`, empty when
+ *     no tags were supplied.
+ *
+ * @throws {Error} When QRS answers with something that is not a list (a `QseowError` from `qrsGetList`).
+ */
+export const getSheetsTaggedWith = async (
+    qrsInteractInstance,
+    appSheetsFilter,
+    tagOption,
+    optionName
+) => {
+    // Variadic options arrive as arrays, so the tag term has to be an `or` group over every tag
+    // given: interpolating the array produced `tags.name eq 'A,B'`, one literal matching no tag.
+    const tags = toFilterValueList(tagOption);
+
+    if (tags.length === 0) {
+        logger.debug(`No ${optionName} supplied, skipping the QRS lookup for tagged sheets`);
+        return [];
+    }
+
+    const tagFilter = `${appSheetsFilter} and ${qrsFilterAnyOf('tags.name', tags)}`;
+    logger.debug(`GET sheets tagged for ${optionName}: app/object/full?filter=${tagFilter}`);
+
+    // Through qrsGetList: the count logged below is taken with `.length`, and a reply that is not
+    // a list answers that with a plausible number rather than failing - a quoted JSON string would
+    // report its character count as though that many sheets carried the tag.
+    const taggedSheets = await qrsGetList(
+        qrsInteractInstance,
+        qrsPathWithFilter('app/object/full', tagFilter)
+    );
+
+    // Report the count at the default log level whenever the option was used. A misspelled tag
+    // otherwise produces a run byte-identical to one where the option was never passed - the
+    // silent-no-op that made issue #840 hard to notice - and for the blur rule that means
+    // publishing readable thumbnails the operator believed were hidden.
+    //
+    // Deliberately info rather than warn: a run spanning many apps will legitimately find no
+    // tagged sheets in most of them, and a per-app warning for a normal outcome is the kind of
+    // noise that teaches operators to ignore warnings. A mistyped tag shows up as a trail of
+    // zeroes across every app instead.
+    logger.info(
+        `Sheets carrying a tag named by ${optionName}: ${taggedSheets.length} (tags: ${tags.join(', ')})`
+    );
+
+    return taggedSheets;
+};
+
+/**
+ * The QRS reads both the real per-app processor and the dry-run planner make
+ * before opening an engine session: app metadata, the two tagged-sheet sets,
+ * and the repo-db/engine sheet-id map.
+ *
+ * One function rather than two copies, because the dry run's whole promise is
+ * "the same reads, in the same order" - a promise that was enforced only by
+ * eyeballing two files until the copies diverged within a single PR. Anything
+ * added here is automatically exercised by both modes.
+ *
+ * @param {string} appId - The QSEoW app to read.
+ * @param {object} options - The run's options bag.
+ *
+ * @returns {Promise<{appMetadata: Array<object>, tagSheetAppMetadata: Array<object>, blurTagSheetAppMetadata: Array<object>, mapRepoEngineSheetId: Map<string, string>}>} The app context.
+ *
+ * @throws {QseowError} When the app does not exist in the repository.
+ */
+export const readQseowAppContext = async (appId, options) => {
+    const qseowConfigQrs = setupQseowQrsConnection(options);
+
+    const qrsInteractInstance = new qrsInteract(qseowConfigQrs);
+    logger.debug(`QSEoW QRS config: ${JSON.stringify(qseowConfigQrs, null, 2)}`);
+
+    // Get app top level metadata
+    const appMetadataPath = qrsPathWithFilter('app', `id eq ${appId}`);
+    logger.debug(`GET app top level metadata: ${appMetadataPath}`);
+    const appMetadata = await qrsGetList(qrsInteractInstance, appMetadataPath);
+
+    // An empty list is a real answer - the filter matched no app - but the reads of
+    // appMetadata[0] further down sit inside the engine session, so leaving it unchecked
+    // spends a session and an openDoc before failing with `Cannot read properties of
+    // undefined`. In practice the engine refuses first, since the QRS lookup and the session
+    // use the same service identity; this is here so the invariant holds for the next reader.
+    if (appMetadata.length === 0) {
+        throw new QseowError(
+            `QSEoW app ${appId} was not found in the Qlik Sense repository. Check --appid, and that the account named by --apiuserdir/--apiuserid may read the app.`
+        );
+    }
+
+    const appSheetsFilter = `objectType eq 'sheet' and app.id eq ${appId}`;
+
+    // Get metadata for the app sheets that should be excluded based on sheet tags, and
+    // separately for those that should be blurred. Two lookups, deliberately: the exclude tag
+    // and the blur tag name different sets of sheets, and conflating them would blur every
+    // sheet the operator asked to leave alone.
+    const tagSheetAppMetadata = await getSheetsTaggedWith(
+        qrsInteractInstance,
+        appSheetsFilter,
+        options.excludeSheetTag,
+        '--exclude-sheet-tag'
+    );
+
+    const blurTagSheetAppMetadata = await getSheetsTaggedWith(
+        qrsInteractInstance,
+        appSheetsFilter,
+        options.blurSheetTag,
+        '--blur-sheet-tag'
+    );
+
+    // Create mapping between repo db sheet id and engine sheet id
+    const repoSheets = await qrsGetList(
+        qrsInteractInstance,
+        qrsPathWithFilter('app/object/full', appSheetsFilter)
+    );
+
+    // repoSheets is an array of sheet objects, each object has properties called 'id' and
+    // 'engineObjectId'. Bidirectional, so callers can resolve either direction.
+    const mapRepoEngineSheetId = new Map();
+    repoSheets.forEach((element) => {
+        mapRepoEngineSheetId.set(element.id, element.engineObjectId);
+        mapRepoEngineSheetId.set(element.engineObjectId, element.id);
+    });
+
+    return { appMetadata, tagSheetAppMetadata, blurTagSheetAppMetadata, mapRepoEngineSheetId };
+};

--- a/src/lib/qseow/qseow-updatesheets.js
+++ b/src/lib/qseow/qseow-updatesheets.js
@@ -4,13 +4,13 @@ import { QseowError } from '../util/errors.js';
 import { withEngineSession } from '../util/engine-session.js';
 import { logError } from '../util/log-error.js';
 import {
-    isSheetTagged,
     runOverSheets,
     SHEET_SKIPPED,
     sortSheetsByRank,
     saveIfChanged,
     getSheetList,
 } from '../util/sheet-list.js';
+import { determineSheetBlurStatus } from './determine-sheet-blur-status.js';
 
 /**
  * Updates sheet thumbnails in a Qlik Sense Enterprise on Windows (QSEoW) app.
@@ -92,77 +92,16 @@ export const qseowUpdateSheetThumbnails = async (
 
                                 return SHEET_SKIPPED;
                             } else {
-                                // Should blurred sheet thumbnail be used?
-                                // Options are
-                                // --blur-sheet-tag <value>
-                                // --blur-sheet-number <number...>
-                                // --blur-sheet-title <title...>
-                                // --blur-sheet-status <status...>
-
-                                let blurSheet = false;
-
-                                // Should this sheet be blurred based on its published status?
-                                // Public sheets
-                                if (
-                                    sheet.qMeta.approved === true &&
-                                    sheet.qMeta.published === true &&
-                                    options.blurSheetStatus &&
-                                    options.blurSheetStatus.includes('public')
-                                ) {
-                                    blurSheet = true;
-                                    logger.verbose(
-                                        `Blurred sheet thumbnail (status public): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
-                                    );
-                                }
-
-                                // Published sheets
-                                if (
-                                    sheet.qMeta.approved === false &&
-                                    sheet.qMeta.published === true &&
-                                    options.blurSheetStatus &&
-                                    options.blurSheetStatus.includes('published')
-                                ) {
-                                    blurSheet = true;
-                                    logger.verbose(
-                                        `Blurred sheet thumbnail (status published): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
-                                    );
-                                }
-
-                                // Should this sheet be blurred based on tags?
-                                // tagSheetAppMetadata is an array of sheet objects, each exposing
-                                // engineObjectId, looked up by the caller against --blur-sheet-tag.
-                                // It arrives empty when no tag was given, so the rule matches nothing.
-                                if (options.blurSheetTag && blurSheet === false) {
-                                    blurSheet = isSheetTagged(tagSheetAppMetadata, sheet);
-                                    if (blurSheet) {
-                                        logger.verbose(
-                                            `Blurred sheet thumbnail (via tags): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
-                                        );
-                                    }
-                                }
-
-                                // Should this sheet be blurred based on its position/sheet number?
-                                if (options.blurSheetNumber && blurSheet === false) {
-                                    // Does the sheet number match any of the numbers in options.blurSheetNumber array?
-                                    // Take into account that iSheetNum is an integer, so we need to convert it to a string
-                                    if (options.blurSheetNumber.includes(iSheetNum.toString())) {
-                                        blurSheet = true;
-                                        logger.verbose(
-                                            `Blurred sheet thumbnail (via sheet number): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
-                                        );
-                                    }
-                                }
-
-                                // Should this sheet be blurred based on its title?
-                                if (options.blurSheetTitle && blurSheet === false) {
-                                    // Does the sheet title match any of the titles options.blurSheetTitle array?
-                                    if (options.blurSheetTitle.includes(sheet.qMeta.title)) {
-                                        blurSheet = true;
-                                        logger.verbose(
-                                            `Blurred sheet thumbnail (via sheet title): ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
-                                        );
-                                    }
-                                }
+                                // The blur decision lives in determine-sheet-blur-status.js so
+                                // the dry-run planner shares it (#993); only the write below
+                                // stays here.
+                                const { blurSheet } = determineSheetBlurStatus(
+                                    sheet,
+                                    options,
+                                    tagSheetAppMetadata,
+                                    iSheetNum,
+                                    logger
+                                );
 
                                 // Get properties of current sheet
                                 const sheetObj = await app.getObject(sheet.qInfo.qId);

--- a/src/lib/util/__tests__/run-report.test.js
+++ b/src/lib/util/__tests__/run-report.test.js
@@ -1,0 +1,145 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import {
+    createRunReport,
+    recordSelection,
+    addAppToReport,
+    recordSheetDecision,
+    reportTotals,
+    renderDryRunReport,
+} from '../run-report.js';
+import { EXCLUDE_REASON, BLUR_REASON } from '../sheet-decision-reasons.js';
+
+const fakeLogger = () => {
+    const lines = [];
+
+    return {
+        lines,
+        info: jest.fn((line) => lines.push(String(line))),
+        text: () => lines.join('\n'),
+    };
+};
+
+/**
+ * A report with one app and one of every decision kind.
+ *
+ * @returns {object} The report.
+ */
+const sampleReport = () => {
+    const report = createRunReport({ command: 'qseow create-sheet-thumbnails', dryRun: true });
+    recordSelection(report, {
+        namedAppIds: ['app-1', 'app-7'],
+        selectorAppIds: ['app-1', 'app-2', 'app-3', 'app-4', 'app-5', 'app-6'],
+        selector: { option: 'qliksensetag', value: 'sheet-thumbnails' },
+    });
+
+    const app = addAppToReport(report, { id: 'app-1', name: 'Finance operations', sheetCount: 4 });
+    recordSheetDecision(app, { n: 1, title: 'Overview', action: 'update' });
+    recordSheetDecision(app, {
+        n: 2,
+        title: 'Sales detail',
+        action: 'blur',
+        reason: BLUR_REASON.STATUS_PUBLISHED,
+    });
+    recordSheetDecision(app, {
+        n: 3,
+        title: 'Scratch',
+        action: 'skip',
+        reason: EXCLUDE_REASON.STATUS_PRIVATE,
+    });
+    recordSheetDecision(app, {
+        n: 4,
+        title: 'KPI summary',
+        action: 'skip',
+        reason: EXCLUDE_REASON.HIDDEN,
+    });
+
+    return report;
+};
+
+describe('reportTotals', () => {
+    test('totals are derived from the rows, one per action kind', () => {
+        expect(reportTotals(sampleReport())).toEqual({
+            apps: 1,
+            sheets: 4,
+            update: 1,
+            blur: 1,
+            skip: 2,
+            clear: 0,
+        });
+    });
+
+    test('an empty report totals to zeroes', () => {
+        expect(reportTotals(createRunReport({ command: 'x', dryRun: true }))).toEqual({
+            apps: 0,
+            sheets: 0,
+            update: 0,
+            blur: 0,
+            skip: 0,
+            clear: 0,
+        });
+    });
+});
+
+describe('renderDryRunReport', () => {
+    test('names the responsible option next to every non-default decision', () => {
+        const log = fakeLogger();
+        renderDryRunReport(sampleReport(), log);
+
+        const text = log.text();
+        expect(text).toContain(
+            'DRY RUN of qseow create-sheet-thumbnails - nothing will be changed'
+        );
+        expect(text).toContain('(--blur-sheet-status published)');
+        expect(text).toContain('(--exclude-sheet-status private)');
+        expect(text).toContain('(hidden by show condition)');
+        // The default action carries no parenthetical - a reason on every row
+        // would bury the ones that matter.
+        expect(text).toMatch(/Overview\s+update\n/);
+    });
+
+    test('reports the app selection provenance', () => {
+        const log = fakeLogger();
+        renderDryRunReport(sampleReport(), log);
+
+        expect(log.text()).toContain(
+            'App selection: 7 app(s) - 2 named by --appid, 6 matched by --qliksensetag "sheet-thumbnails", 1 selected twice'
+        );
+    });
+
+    test('summarises and says how to apply', () => {
+        const log = fakeLogger();
+        renderDryRunReport(sampleReport(), log);
+
+        const text = log.text();
+        expect(text).toContain(
+            'Summary: 1 app(s), 4 sheets. 2 would be updated (1 blurred), 2 skipped.'
+        );
+        expect(text).toContain('Nothing was changed. Re-run without --dry-run to apply.');
+    });
+
+    test('clear-mode reports cleared icons instead of updates', () => {
+        const report = createRunReport({ command: 'qscloud remove-sheet-icons', dryRun: true });
+        const app = addAppToReport(report, { id: 'app-2', sheetCount: 2 });
+        recordSheetDecision(app, { n: 1, title: 'Main', action: 'clear' });
+        recordSheetDecision(app, {
+            n: 2,
+            title: 'Notes',
+            action: 'clear',
+            reason: 'no icon currently set',
+        });
+
+        const log = fakeLogger();
+        renderDryRunReport(report, log);
+
+        const text = log.text();
+        expect(text).toContain('2 icon(s) would be cleared');
+        expect(text).toContain('(no icon currently set)');
+    });
+
+    test('output is plain ASCII so it survives any console', () => {
+        const log = fakeLogger();
+        renderDryRunReport(sampleReport(), log);
+
+        expect(/^[\x20-\x7e\n]*$/.test(log.text())).toBe(true);
+    });
+});

--- a/src/lib/util/run-over-apps.js
+++ b/src/lib/util/run-over-apps.js
@@ -26,6 +26,8 @@ import { logger } from '../../globals.js';
  *     by both `--appid` and a collection is processed once.
  * @param {object} ctx - Logging context.
  * @param {string} ctx.logPrefix - Prefix for the per-app failure lines, e.g. `'CLOUD PROCESS APP'`.
+ * @param {string} [ctx.action] - Verb for the per-app banner line, e.g. `plan` for a dry
+ *     run. Defaults to `process`, so a dry run's log never claims to be processing.
  * @param {string} [ctx.emptySelectionHint] - Extra guidance logged when the list is empty,
  *     e.g. which options to check. An empty list is reported as an error, because it means
  *     the operator asked for work that did not happen.
@@ -34,7 +36,11 @@ import { logger } from '../../globals.js';
  * @returns {Promise<boolean>} `true` only when at least one app was selected and every one
  *     of them was processed without error. An empty selection is a failure, not a no-op.
  */
-export const runOverApps = async (appIds, { logPrefix, emptySelectionHint }, processApp) => {
+export const runOverApps = async (
+    appIds,
+    { logPrefix, emptySelectionHint, action = 'process' },
+    processApp
+) => {
     // An app named by both --appid and a collection must still be processed once.
     const uniqueAppIds = [...new Set(appIds)];
 
@@ -55,7 +61,7 @@ export const runOverApps = async (appIds, { logPrefix, emptySelectionHint }, pro
     for (const appId of uniqueAppIds) {
         try {
             logger.info(`--------------------------------------------------`);
-            logger.info(`About to process app ${appId}`);
+            logger.info(`About to ${action} app ${appId}`);
 
             await processApp(appId);
 

--- a/src/lib/util/run-report.js
+++ b/src/lib/util/run-report.js
@@ -1,4 +1,5 @@
 import { logger, getLoggingLevel, setLoggingLevel } from '../../globals.js';
+import { runOverApps } from './run-over-apps.js';
 
 /**
  * The run report: one object holding what a run resolved and decided, read by
@@ -329,4 +330,96 @@ export const renderDryRunReport = (report, log = logger) => {
     } else {
         emit();
     }
+};
+
+/**
+ * Record one planned sheet from the pair of decisions the shared modules made.
+ *
+ * The if/else mapping from (exclude, blur) to a report row is identical in
+ * every planner - this is that mapping, written once.
+ *
+ * @param {object} appEntry - From {@link addAppToReport}.
+ * @param {object} planned - The sheet and its decisions.
+ * @param {number} planned.n - 1-based sheet position.
+ * @param {string} planned.title - Sheet title.
+ * @param {boolean} planned.excludeSheet - Whether an exclude rule matched.
+ * @param {string|null} planned.excludeReason - The responsible exclude rule.
+ * @param {boolean} planned.blurSheet - Whether a blur rule matched.
+ * @param {string|null} planned.blurReason - The responsible blur rule.
+ *
+ * @returns {void}
+ */
+export const recordPlannedSheet = (
+    appEntry,
+    { n, title, excludeSheet, excludeReason, blurSheet, blurReason }
+) => {
+    if (excludeSheet === true) {
+        recordSheetDecision(appEntry, { n, title, action: 'skip', reason: excludeReason });
+    } else {
+        recordSheetDecision(appEntry, {
+            n,
+            title,
+            action: blurSheet ? 'blur' : 'update',
+            reason: blurReason,
+        });
+    }
+};
+
+/**
+ * The report-carrying app loop every dry-run-capable worker shares: build the
+ * report, record the selection, run the loop against the planner or the
+ * processor, and render the report when planning.
+ *
+ * One function rather than a block pasted into each worker - the three copies
+ * had already been flagged by review and by the duplication gate, and a
+ * report field added in one worker but not the others is exactly the drift
+ * the report exists to prevent.
+ *
+ * @param {object} run - The run.
+ * @param {string} run.command - The command, e.g. `qseow create-sheet-thumbnails`.
+ * @param {boolean} run.dryRun - Whether this is a dry run.
+ * @param {string[]} run.appIds - All selected app ids, in selection order.
+ * @param {string[]} run.namedAppIds - The `--appid` subset.
+ * @param {string[]} run.selectorAppIds - The tag/collection subset.
+ * @param {{option: string, value: string}|null} run.selector - The selector used, if any.
+ * @param {{plan: string, process: string}} run.logPrefix - Per-mode log prefixes.
+ * @param {string} run.emptySelectionHint - Guidance when nothing was selected.
+ * @param {(appId: string, report: object) => Promise<void>} run.planApp - The per-app planner.
+ * @param {(appId: string) => Promise<unknown>} run.processApp - The per-app processor.
+ *
+ * @returns {Promise<boolean>} The verdict from the app loop.
+ */
+export const runOverAppsWithReport = async ({
+    command,
+    dryRun,
+    appIds,
+    namedAppIds,
+    selectorAppIds,
+    selector,
+    logPrefix,
+    emptySelectionHint,
+    planApp,
+    processApp,
+}) => {
+    const report = createRunReport({ command, dryRun });
+    recordSelection(report, { namedAppIds, selectorAppIds, selector });
+
+    const result = await runOverApps(
+        appIds,
+        {
+            logPrefix: dryRun ? logPrefix.plan : logPrefix.process,
+            action: dryRun ? 'plan' : 'process',
+            emptySelectionHint,
+        },
+        dryRun ? (appId) => planApp(appId, report) : processApp
+    );
+
+    // Rendered even when some apps failed to plan: the decisions that were
+    // reached belong next to the per-app error lines already logged, and the
+    // renderer itself marks incomplete and unplanned apps.
+    if (dryRun) {
+        renderDryRunReport(report);
+    }
+
+    return result;
 };

--- a/src/lib/util/run-report.js
+++ b/src/lib/util/run-report.js
@@ -1,0 +1,332 @@
+import { logger, getLoggingLevel, setLoggingLevel } from '../../globals.js';
+
+/**
+ * The run report: one object holding what a run resolved and decided, read by
+ * every renderer.
+ *
+ * This exists to keep the dry-run report and the real run from drifting apart
+ * (issue #1072). The dry run is "do every read, perform no writes, report the
+ * decisions" (issue #993) - so the decisions must come from one place, filled
+ * in by the same code path both modes execute. A dry run that gathered its own
+ * facts could report a selection the real run does not make, which is worse
+ * than no dry run: confidently wrong about the one thing it exists to check.
+ *
+ * The report is created by the command worker and passed explicitly down
+ * through the per-app processors - never held in module state. A singleton
+ * would leak decisions across commands in a process that runs several (the
+ * test suite does; a future API consumer might).
+ *
+ * Today the object carries the selection and the per-sheet decisions; the
+ * fuller plan sections issue #1072 sketches (target, rules, browser, output)
+ * arrive with the run-output work in #1073 and are additive to this shape.
+ */
+
+/**
+ * Ensure a block of output is visible even when the console level is quieter
+ * than `info`.
+ *
+ * The dry-run report and its banner are the entire product of a `--dry-run`
+ * invocation, and the docs tell operators to reuse their real command line -
+ * which in schedulers routinely carries `--log-level warn`. Without this, such
+ * a dry run connects, plans everything, prints nothing and exits 0. Verbose
+ * and debug levels already show `info`, so only `warn`/`error` are raised.
+ *
+ * @param {Function} emit - Function that writes the block through the logger.
+ *
+ * @returns {void}
+ */
+const withReportVisible = (emit) => {
+    const level = getLoggingLevel();
+    const quiet = level === 'warn' || level === 'error';
+
+    if (quiet) {
+        setLoggingLevel('info');
+    }
+    try {
+        emit();
+    } finally {
+        if (quiet) {
+            setLoggingLevel(level);
+        }
+    }
+};
+
+/**
+ * Announce, before any connection is made, that this run is a dry run.
+ *
+ * Without this line the log of a dry run opens exactly like a real run -
+ * "Starting removal of sheet icons", "About to process app ..." - and the one
+ * line saying nothing was changed arrives only after the last app. An operator
+ * watching a destructive-looking scroll for two minutes has no reason to wait
+ * for it.
+ *
+ * @param {string} command - The command being planned, e.g. `qseow create-sheet-thumbnails`.
+ *
+ * @returns {void}
+ */
+export const announceDryRun = (command) => {
+    withReportVisible(() => {
+        logger.info('==================================================');
+        logger.info(`DRY RUN of ${command}: planning only - NOTHING WILL BE CHANGED`);
+        logger.info('==================================================');
+    });
+};
+
+/**
+ * Create a run report.
+ *
+ * @param {object} plan - What the run intends to do, resolved before the first write.
+ * @param {string} plan.command - The command, e.g. `qseow create-sheet-thumbnails`.
+ * @param {boolean} plan.dryRun - Whether this run will stop before the writes.
+ *
+ * @returns {object} The report, to be threaded through the run.
+ */
+export const createRunReport = ({ command, dryRun }) => ({
+    command,
+    dryRun,
+    selection: null,
+    apps: [],
+});
+
+/**
+ * Record how the app selection resolved.
+ *
+ * The provenance counts are the cheap line #993 asks for: "the tag matched 40
+ * apps, not 4" is the other silent surprise besides the sheet rules. Counts
+ * are derived here from the id arrays - callers hand over what they resolved,
+ * not numbers they computed by their own rules - and each list is deduplicated
+ * first, so a repeated `--appid` is not misreported as selector overlap.
+ *
+ * The selector is stored structurally (`option` + `value`), not as rendered
+ * text: a future renderer on the #1071 ladder - a JSON report especially -
+ * must not have to un-bake CLI quoting from a display string.
+ *
+ * @param {object} report - The report.
+ * @param {object} selection - Selection facts.
+ * @param {string[]} selection.namedAppIds - Apps named directly by `--appid`, raw.
+ * @param {string[]} selection.selectorAppIds - Apps contributed by the tag/collection selector, raw.
+ * @param {{option: string, value: string}|null} selection.selector - The selector
+ *     option (long-flag name without dashes) and its value, or null when not used.
+ *
+ * @returns {void}
+ */
+export const recordSelection = (report, { namedAppIds, selectorAppIds, selector }) => {
+    const named = new Set(namedAppIds);
+    const fromSelector = new Set(selectorAppIds);
+
+    report.selection = {
+        named: named.size,
+        fromSelector: fromSelector.size,
+        selector,
+        total: new Set([...named, ...fromSelector]).size,
+    };
+};
+
+/**
+ * Open a per-app section in the report.
+ *
+ * @param {object} report - The report.
+ * @param {object} app - App facts.
+ * @param {string} app.id - App id.
+ * @param {string} [app.name] - App name, when known.
+ * @param {number} [app.sheetCount] - Number of sheets found.
+ *
+ * @returns {object} The app entry; pass it to {@link recordSheetDecision}.
+ */
+export const addAppToReport = (report, { id, name, sheetCount }) => {
+    const entry = {
+        id,
+        name: name ?? null,
+        sheetCount: sheetCount ?? null,
+        sheets: [],
+        mediaFilesToDelete: null,
+    };
+    report.apps.push(entry);
+
+    return entry;
+};
+
+/**
+ * Record one sheet's decision.
+ *
+ * @param {object} appEntry - From {@link addAppToReport}.
+ * @param {object} decision - The decision.
+ * @param {number} decision.n - 1-based sheet position (after rank sort).
+ * @param {string} decision.title - Sheet title.
+ * @param {'update'|'blur'|'skip'|'clear'} decision.action - What the run would do:
+ *     `update` a regular thumbnail, `blur` it, `skip` the sheet, or `clear` an
+ *     existing icon (remove-sheet-icons).
+ * @param {string|null} [decision.reason] - The responsible option, from
+ *     `sheet-decision-reasons.js`, or null for the default action.
+ *
+ * @returns {void}
+ */
+export const recordSheetDecision = (appEntry, { n, title, action, reason = null }) => {
+    appEntry.sheets.push({ n, title, action, reason });
+};
+
+/**
+ * Totals over every recorded decision.
+ *
+ * Derived at render time rather than kept as counters, so the totals cannot
+ * disagree with the rows they summarise.
+ *
+ * @param {object} report - The report.
+ *
+ * @returns {{apps: number, sheets: number, update: number, blur: number, skip: number, clear: number}} Totals.
+ */
+export const reportTotals = (report) => {
+    const totals = { apps: report.apps.length, sheets: 0, update: 0, blur: 0, skip: 0, clear: 0 };
+
+    for (const app of report.apps) {
+        for (const sheet of app.sheets) {
+            totals.sheets += 1;
+            if (Object.hasOwn(totals, sheet.action)) {
+                totals[sheet.action] += 1;
+            }
+        }
+    }
+
+    return totals;
+};
+
+const ACTION_LABEL = Object.freeze({
+    update: 'update',
+    blur: 'update, blurred',
+    skip: 'skip',
+    clear: 'clear icon',
+});
+
+/**
+ * Whether the report describes an icon-removal command.
+ *
+ * Decided from `report.command`, never sniffed from the recorded rows: a
+ * remove run over zero sheets must still summarise in remove vocabulary.
+ *
+ * @param {object} report - The report.
+ *
+ * @returns {boolean} True for remove-sheet-icons reports.
+ */
+const isRemovalReport = (report) => (report.command ?? '').includes('remove-sheet-icons');
+
+/**
+ * Render the dry-run report through the logger.
+ *
+ * Through winston at `info` rather than straight to stdout (issue #993 open
+ * question 1): the report belongs in the same captured log as the run a
+ * scheduler would perform. Plain aligned text, no box drawing - this must
+ * survive any console. `withReportVisible` guarantees the block appears even
+ * under `--log-level warn`.
+ *
+ * @param {object} report - The report to render.
+ * @param {object} [log] - Logger. Defaults to the shared winston logger.
+ *
+ * @returns {void}
+ */
+export const renderDryRunReport = (report, log = logger) => {
+    const emit = () => {
+        // A selection that matched nothing is a failure the operator must not
+        // read past: the run exits 1, and a success-shaped report ending in
+        // "re-run without --dry-run" would invite re-running a command that
+        // just selected nothing.
+        if (report.apps.length === 0 && (report.selection?.total ?? 0) === 0) {
+            log.info('');
+            log.info(
+                `DRY RUN of ${report.command}: no apps were selected - there is nothing to plan.`
+            );
+            log.info('Check the app selection options named in the error above.');
+
+            return;
+        }
+
+        log.info('');
+        log.info(`DRY RUN of ${report.command} - nothing will be changed`);
+        log.info('');
+
+        if (report.selection) {
+            const s = report.selection;
+            const parts = [`${s.named} named by --appid`];
+            if (s.selector) {
+                parts.push(
+                    `${s.fromSelector} matched by --${s.selector.option} "${s.selector.value}"`
+                );
+            }
+            const overlap = s.named + s.fromSelector - s.total;
+            if (overlap > 0) {
+                parts.push(`${overlap} selected twice`);
+            }
+            log.info(`App selection: ${s.total} app(s) - ${parts.join(', ')}`);
+            log.info('');
+        }
+
+        const width = report.apps.reduce(
+            (max, app) =>
+                app.sheets.reduce((m, sheet) => Math.max(m, sheet.title?.length ?? 0), max),
+            20
+        );
+
+        report.apps.forEach((app, i) => {
+            log.info(`App ${i + 1}/${report.apps.length}: "${app.name ?? app.id}" (${app.id})`);
+            if (app.sheetCount !== null) {
+                log.info(`  ${app.sheetCount} sheets`);
+            }
+            log.info('');
+            log.info(`   #  ${'Sheet'.padEnd(width)}  Would do`);
+
+            for (const sheet of app.sheets) {
+                const action = ACTION_LABEL[sheet.action] ?? sheet.action;
+                const reason = sheet.reason ? `  (${sheet.reason})` : '';
+                log.info(
+                    `  ${String(sheet.n).padStart(2)}  ${(sheet.title ?? '').padEnd(width)}  ${action}${reason}`
+                );
+            }
+
+            // A truncated plan must say so: the app section opened claiming
+            // sheetCount sheets, and fewer rows means the planner failed
+            // mid-app. Silence here reads as "the remaining sheets are fine".
+            if (app.sheetCount !== null && app.sheets.length < app.sheetCount) {
+                log.info(
+                    `  PLAN INCOMPLETE: only ${app.sheets.length} of ${app.sheetCount} sheets were planned - see the error above.`
+                );
+            }
+
+            if (app.mediaFilesToDelete !== null && app.mediaFilesToDelete > 0) {
+                log.info(
+                    `  ${app.mediaFilesToDelete} thumbnail media file(s) would also be deleted from the app media library`
+                );
+            }
+            log.info('');
+        });
+
+        const t = reportTotals(report);
+
+        // Apps that failed before their section opened are invisible in the
+        // rows, so the count mismatch with the selection is stated explicitly.
+        const unplanned = (report.selection?.total ?? report.apps.length) - report.apps.length;
+        if (unplanned > 0) {
+            log.info(
+                `${unplanned} app(s) could not be planned at all - see the errors above. They are not included in the summary.`
+            );
+        }
+
+        if (isRemovalReport(report)) {
+            log.info(
+                `Summary: ${t.apps} app(s), ${t.sheets} sheets. ${t.clear} icon(s) would be cleared, ${t.skip} skipped.`
+            );
+        } else {
+            const blurNote = t.blur > 0 ? ` (${t.blur} blurred)` : '';
+            log.info(
+                `Summary: ${t.apps} app(s), ${t.sheets} sheets. ${t.update + t.blur} would be updated${blurNote}, ${t.skip} skipped.`
+            );
+        }
+        log.info('Nothing was changed. Re-run without --dry-run to apply.');
+    };
+
+    // Only force visibility on the real logger; an injected test logger has no
+    // winston level to manage.
+    if (log === logger) {
+        withReportVisible(emit);
+    } else {
+        emit();
+    }
+};

--- a/src/lib/util/sheet-decision-reasons.js
+++ b/src/lib/util/sheet-decision-reasons.js
@@ -1,0 +1,40 @@
+/**
+ * The reasons a sheet can be excluded from processing or given a blurred
+ * thumbnail, shared by both platform twins.
+ *
+ * One vocabulary rather than per-twin strings, because the dry-run report
+ * prints these verbatim and the two platforms must describe the same decision
+ * with the same words. Each value names the CLI option responsible - the whole
+ * point of the report is that a decision nobody asked for (or the absence of
+ * one somebody did ask for) is traceable to the option that caused it. See
+ * issue #993: a misspelled `--blur-sheet-tag` used to produce a run
+ * byte-identical to one where the option was never passed.
+ *
+ * `HIDDEN` is the one reason with no option behind it: sheets hidden by a show
+ * condition are always skipped, so it names the mechanism instead.
+ */
+export const EXCLUDE_REASON = Object.freeze({
+    STATUS_PUBLIC: '--exclude-sheet-status public',
+    STATUS_PUBLISHED: '--exclude-sheet-status published',
+    STATUS_PRIVATE: '--exclude-sheet-status private',
+    HIDDEN: 'hidden by show condition',
+    TAG: '--exclude-sheet-tag',
+    NUMBER: '--exclude-sheet-number',
+    TITLE: '--exclude-sheet-title',
+});
+
+export const BLUR_REASON = Object.freeze({
+    STATUS_PUBLIC: '--blur-sheet-status public',
+    STATUS_PUBLISHED: '--blur-sheet-status published',
+    TAG: '--blur-sheet-tag',
+    NUMBER: '--blur-sheet-number',
+    TITLE: '--blur-sheet-title',
+});
+
+/**
+ * Reasons specific to icon removal. `NO_ICON` marks a clear that is already a
+ * no-op - informational, not an option's doing.
+ */
+export const CLEAR_REASON = Object.freeze({
+    NO_ICON: 'no icon currently set',
+});


### PR DESCRIPTION
Closes #993. Delivers the core of #1072 (the shared RunReport object); the fuller plan sections specified there arrive with #1073 and are additive, so #1072 stays open.

## What

`qseow create-sheet-thumbnails`, `qscloud create-sheet-thumbnails` and `qscloud remove-sheet-icons` accept `--dry-run`: **every read the real run performs — connect, authenticate, resolve apps, list sheets, apply every exclude and blur rule — and none of the writes.** The output is a per-sheet decision report naming the option responsible for each decision:

```
DRY RUN of qseow create-sheet-thumbnails - nothing will be changed

App selection: 1 app(s) - 1 named by --appid, 1 matched by --qliksensetag "sheet-thumbnails", 1 selected twice

App 1/1: "Finance operations" (a1b2c3d4-...)
   #  Sheet                 Would do
   1  Overview              update
   2  Sales detail          update, blurred  (--blur-sheet-tag)
   3  Scratch               skip  (--exclude-sheet-status private)
   ...
Summary: 1 app(s), 7 sheets. 4 would be updated (1 blurred), 3 skipped.
Nothing was changed. Re-run without --dry-run to apply.
```

A misspelled `--blur-sheet-tag` — the silent no-op from #840 — is now a table where no row says `blurred`.

## Design (per #993's own spec)

- **One RunReport object** (#1072): plan and decisions filled by the same `determineSheet*Status` modules both modes execute; threaded explicitly, no module state. Selection stored structurally (`{option, value}` + id sets), ready for the #1071 renderers.
- **Prerequisite refactors named in #993**: the exclude twins now *return* their reason; the blur rules are extracted from both updatesheets write steps into `determineSheetBlurStatus` twins (first direct unit coverage either platform's blur rules have had — #909, and a dent in #842).
- **Planner = read half at the per-app processor**, not scattered `if (dryRun)` guards. The QSEoW pre-session QRS reads are shared via `readQseowAppContext`, so the two modes cannot drift. Sheet loops run through `runOverSheets`, so one unreadable sheet fails alone — exactly as in a real run.
- **Guard test**: every leaf command is classified dry-run-capable or excused with the reason on record (browser commands deferred to the air-gapped work, #929–#933, per #993 Q5).
- `--dry-run` is deliberately **not** env-bound: an inherited `BSI_DRY_RUN` would silently turn scheduled runs into no-ops.

## Review provenance

A max-effort review (10 finder angles, verification, gap sweep) ran against this diff before commit; **all 15 findings are fixed in these commits**, including three serious ones the first implementation had:

- `--dry-run -i` silently performed a **real run** (the flag evaporated when the wizard rebuilt its options bag) — now threaded through, announced, and pinned by tests.
- A dry run **looked identical to a real run** until the very end, and printed nothing at all at `--log-level warn` — now opens with a banner, per-app lines say `plan`, and the report renders at any level.
- The Cloud blur extraction **regressed a crash** on `qMeta`-less sheets — fixed with regression tests on both twins.

Plus: zero planner lines were executed by any test — there is now a writes-nothing suite driving the real `qscloud remove-sheet-icons` end to end (asserting `setProperties`/`doSave`/`Delete` are never called under `--dry-run`) and execution tests for both create planners.

## Also fixed while here

The real `qscloud remove-sheet-icons` no longer fails an entire app over a sheet with no thumbnail structure — it skips it as having nothing to clear.

## Verification

- Full unit suite: ~3050 tests, exit code checked directly.
- Live: banner precedes any connection; failed dry run exits 1; report visible at `--log-level warn`; `doctor check --outputformat json` unaffected.
- Doc page staged in `docs/to-doc-site/` with the sample generated from the real renderer; publisher note lists the three generated CLI tables needing regeneration.
- Not yet verified against a live QSEoW server — the decision fidelity is unit-tested, but a real `--dry-run` against the lab server before merge would be the honest final check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)