### PR TITLE
Every thumbnail run now prints a plan, countable progress and a verdict

### DIFF
--- a/docs/to-doc-site/dry-run.md
+++ b/docs/to-doc-site/dry-run.md
@@ -27,7 +27,8 @@ selected app, and which of your options is responsible for each decision.
 
 A dry run announces itself immediately — the log opens with a
 `DRY RUN of <command>: planning only - NOTHING WILL BE CHANGED` banner before anything
-connects, and each app line reads `About to plan app …` rather than `About to process app …`.
+connects, the run-card `PLAN` block reads `WOULD OVERWRITE …` rather than
+`WILL OVERWRITE …`, and each app line reads `plan app 1/2 …` rather than `app 1/2 …`.
 
 ## Why you would use it
 
@@ -90,13 +91,31 @@ product of a dry run, so its visibility does not depend on the log level.
 
 ## Reading the report
 
-The report lists every app, every sheet, and the decision with the option responsible. This
-is the exact output the command above produces (timestamps trimmed):
+Once the app selection is resolved — and before anything could be written — the dry run
+prints the run card's `PLAN` block, with the resolved selection, every rule and its match
+count, and the overwrite warning in the conditional:
+
+```
+PLAN
+  server        sense.company.com   https, no virtual proxy
+                engine 4747, qrs 4242, schema 12.612.0
+  api user      INTERNAL\sa_api via ./cert/client.pem
+  logon user    COMPANY\svc_bsi
+  apps          1   1 named by --appid, 1 matched by --qliksensetag "sheet-thumbnails", 1 selected twice
+  sheet part    1 of 4 -- sheet objects only
+  exclude       title "Internal notes", status private
+  blur          tag "confidential" (1 sheets)
+  browser       chrome (version: recommended), headless, 5s per sheet
+  images        ./img/qseow/<app-id>
+  uploads to    content library "Butler sheet thumbnails"
+  WOULD OVERWRITE existing sheet thumbnails in 1 app(s), 1 of them published
+```
+
+The report then lists every app, every sheet, and the decision with the option responsible.
+This is the exact output the command above produces (timestamps trimmed):
 
 ```
 DRY RUN of qseow create-sheet-thumbnails - nothing will be changed
-
-App selection: 1 app(s) - 1 named by --appid, 1 matched by --qliksensetag "sheet-thumbnails", 1 selected twice
 
 App 1/1: "Finance operations" (a1b2c3d4-0000-4a1b-9c8d-000000000001)
   7 sheets
@@ -119,9 +138,9 @@ Things to check before running for real:
 - **The `Would do` column.** If you passed a blur option and no row says `blurred`, the rule
   matched nothing — check the tag or title spelling. This situation is exactly what the dry
   run exists to catch.
-- **The `App selection` line.** If the tag or collection matched more apps than you expected,
-  the real run would update more apps than you expected. `selected twice` counts apps that
-  were both named and matched — they are processed once.
+- **The `apps` line in the `PLAN` block.** If the tag or collection matched more apps than
+  you expected, the real run would update more apps than you expected. `selected twice`
+  counts apps that were both named and matched — they are processed once.
 - **`PLAN INCOMPLETE` or `could not be planned` lines.** If an app or sheet could not be
   read, the report says so explicitly rather than presenting a partial plan as complete.
   The exit code is 1 in that case.

--- a/docs/to-doc-site/thumbnail-run-card.md
+++ b/docs/to-doc-site/thumbnail-run-card.md
@@ -1,0 +1,132 @@
+# The run card: plan, progress and verdict on every thumbnail run
+
+**Status:** pending publication
+**Suggested target pages:** `/guide/concepts/` (new page or section on run output), `/reference/qseow`, `/reference/qscloud`, `/guide/troubleshooting`
+**Version gate:** not released yet — read the open release-please PR title for the version before publishing. Do not copy a version number from this draft.
+
+---
+
+## What changed, in one paragraph
+
+Every `qseow create-sheet-thumbnails`, `qscloud create-sheet-thumbnails` and `qscloud remove-sheet-icons` run now prints a *run card*. Both dry and real runs open with a framed header and a **PLAN** block before anything is changed. A **real** run then adds countable **progress** lines while it works (`app 2/3`, `sheet 4/11`) and closes with a **RESULT** verdict; a **dry** run instead ends with the per-sheet decision report the dry-run feature already prints (no RESULT block — nothing was attempted, so there is no outcome to judge). The output is plain text through the normal log stream, so it lands unchanged in a file redirected from Windows Task Scheduler, in `docker logs`, and in CI transcripts. No new options are needed; there is nothing to configure.
+
+## Why administrators should care
+
+Butler Sheet Icons overwrites sheet thumbnails in place, with no undo. Until now a run announced a version number and started writing: which apps were selected and why, what the exclude and blur rules actually matched, and where the images would go were all discoverable only by watching them happen. A run in which 20 thumbnails were written and a run in which a mistyped tag matched nothing ended identically — silently, both with exit code 0.
+
+The run card answers the three questions a run raises, in order:
+
+| Moment | Question it answers |
+| --- | --- |
+| PLAN | What is about to be changed, where, and why those apps? |
+| Progress | Is it alive, how far in, and on what? |
+| RESULT | What actually changed, and did it work? |
+
+## What a run looks like now
+
+Sample generated from the real renderer (QSEoW, three apps selected by a tag plus one named directly). Shown with log timestamps disabled — see [Log timestamps](#interaction-with-bsi_log_timestamps) below.
+
+```text
+============================================================
+ BUTLER SHEET ICONS x.y.z -- QSEoW sheet thumbnails
+============================================================
+
+PLAN
+  server        sense.company.com   https, no virtual proxy
+                engine 4747, qrs 4242, schema 12.612.0
+  api user      INTERNAL\sa_api via ./cert/client.pem
+  logon user    COMPANY\bsi_svc
+  apps          3   1 named by --appid, 3 matched by --qliksensetag "sheet-thumbnails", 1 selected twice
+  sheet part    2 of 4 -- objects + sheet title
+  exclude       tag "no-thumbnail" (0 sheets), number 1
+  blur          tag "confidential" (2 sheets)
+  browser       chrome (version: recommended), headless, 5s per sheet
+  images        ./img/qseow/<app-id>
+  uploads to    content library "Butler sheet thumbnails"
+  WILL OVERWRITE existing sheet thumbnails in 3 app(s), 2 of them published
+
+app 1/3  c840670c-7178-4a5e-8c5d-2d3e5b0f9a12
+  "Sales Discovery" -- 11 sheet(s), published
+  sheet  1/11  excluded  'Scratch pad'  (--exclude-sheet-number)
+  sheet  2/11  captured  'Overview'
+  sheet  3/11  blurred   'Board pack'  (--blur-sheet-tag)
+  sheet  4/11  captured  'Revenue by region'
+  ...
+  uploaded 20 image file(s) to content library "Butler sheet thumbnails"
+  updated 10 of 11 sheet(s) with new thumbnails
+
+  ...two more apps...
+
+RESULT  ok
+  apps          3 ok, 0 failed
+  sheets        25 seen, 22 captured (2 blurred), 3 excluded
+  thumbnails    22 sheet(s) given new thumbnails in content library "Butler sheet thumbnails"
+  images kept   ./img/qseow   44 file(s), 2.6 MB
+  elapsed       4m 41s
+============================================================
+```
+
+Points worth calling out on the published page:
+
+- **The match counts in the PLAN block include zeroes.** `tag "no-thumbnail" (0 sheets)` printed before the first write is the cheapest possible "check your spelling" — a mistyped tag used to produce a run byte-identical to one where the option was never passed. (Match counts are shown for tag rules on QSEoW; number, title and status rules are listed without counts because they are evaluated per sheet during the run. Qlik Sense Cloud has no sheet tags, so its plans show only number, title and status rules.)
+- **The `WILL OVERWRITE` line is the warning there was no room for before.** There is no undo for a thumbnail update. On a dry run the same line reads `WOULD OVERWRITE`. For `qscloud remove-sheet-icons` it reads `WILL REMOVE sheet icons and thumbnail media files from N app(s)`.
+- **Progress is countable.** A run that hangs now hangs somewhere nameable. Sheet lines print when a sheet *completes* — they state facts, not intentions — so a hang is on the sheet **after** the last printed line: a log ending at `sheet  7/11  captured ...` means the run is stuck working on sheet 8 (a log with an `app 2/3` line and no sheet lines yet is stuck opening that app or capturing its first sheet). Every sheet line names the option responsible for a non-default decision.
+- **The RESULT block is new.** There was previously no success summary at all. `RESULT  FAILED` with `1 ok, 1 failed` also appears when some apps failed — the per-app error lines above it carry the details. A selection that matched nothing ends with `RESULT  FAILED` and `apps  0 selected - nothing was done`, and the run exits 1 as before. **Scope of the guarantee:** the PLAN and RESULT blocks render once app processing is reached. A run that aborts before that point — a failed connection test, missing certificates, a missing content library, an invalid option — exits 1 with the header and the error lines but **no RESULT block**, so a wrapper script should treat exit code 1 as the failure signal and the RESULT line as a summary, not as the only marker.
+- **The `browser` line shows the version as requested** (for example `recommended` or a pinned build id). The build actually used is still logged at launch, since resolving it may involve the download cache or the network.
+- The PLAN block appears after the first few connection lines (certificate check, content library check, tag lookup) because the app selection has to be resolved first — but always **before anything is written**.
+
+## Plain ASCII on purpose
+
+The frame — headings, rules, labels — is deliberately plain ASCII with no colour, so the run card survives legacy Windows consoles, non-UTF-8 code pages, and redirection to files, byte for byte. App and sheet names are your data and are printed exactly as they are, including any non-ASCII characters.
+
+## Interaction with BSI_LOG_TIMESTAMPS
+
+Each line goes through the normal log stream, so by default it carries the timestamp-and-level prefix. The blocks line up either way, but the card is easiest to read with the prefix off, which is what the samples above show:
+
+::: code-group
+
+```powershell [PowerShell]
+$env:BSI_LOG_TIMESTAMPS = "false"
+butler-sheet-icons.exe qseow create-sheet-thumbnails --host sense.company.com ...
+```
+
+```bash [Bash]
+BSI_LOG_TIMESTAMPS=false ./butler-sheet-icons qseow create-sheet-thumbnails --host sense.company.com ...
+```
+
+:::
+
+Cross-link this to the existing `BSI_LOG_TIMESTAMPS` documentation. In a scheduler that already timestamps every captured line, disabling the built-in prefix avoids double timestamps and keeps the plan and verdict columns aligned.
+
+## Log levels
+
+- On a **dry run**, the plan and the dry-run report are the product of the command, so they are printed even at `--log-level warn` or `error` (unchanged from the dry-run feature).
+- On a **real run**, the whole run card — header, PLAN, progress and RESULT — logs at `info`. A real run of the three thumbnail commands at `--log-level warn` stays quiet — choosing a quiet level is respected. (The other commands — `browser`, `doctor`, `qscloud list-collections` — print their header regardless of level, as the `App version:` line always did.)
+- At `--log-level verbose` and below, the detailed per-sheet lines (sheet id, engine sheet id, description, approved, published, hidden) are still available — they moved there rather than being removed.
+
+## Breaking change: log lines that scripts may grep for
+
+This is worth a release-note callout and a troubleshooting entry. Anyone parsing Butler Sheet Icons logs should note:
+
+| Before | Now |
+| --- | --- |
+| `App version: <version>` (printed by every command) | The framed header: `BUTLER SHEET ICONS <version> -- <job>` |
+| `--------------------------------------------------` + `About to process app <id>` | `app 1/3  <id>` (dry runs: `plan app 1/3  <id>`) |
+| `App name: "..."` / `App is published: ...` / `Number of sheets in app: N` at info | One line: `"App name" -- N sheet(s), published` (individual lines still at verbose) |
+| `Processing sheet 1: '...', sheet id '...', engine sheet id '...', ...` (~230 columns) | `sheet  1/11  captured  '...'` (long form at verbose) |
+| `Excluded sheet: 1: '...'` | `sheet  1/11  excluded  '...'  (--exclude-sheet-...)` |
+| `Done processing app <id>` at info | At verbose; the RESULT block closes the run instead |
+| `Uploading images to Qlik Sense content library: ...` / `Uploading images in folder: ...` (QSEoW) | `uploaded N image file(s) to content library "..."` (details at verbose) |
+| `Uploading images in folder: ...` / `Uploading file: <name>` (Cloud, per file at info) | `uploaded thumbnails for N sheet(s) to the app's media library` (per-file lines at verbose) |
+| `Number of sheets: N` / `Using blurred thumbnail for sheet N: ...` / `Using regular thumbnail for sheet N: ...` / `Skipping update of sheet N: ...` (update step, both platforms) | `updated N of M sheet(s) with new thumbnails` (per-sheet choices at verbose; the sheet lines above already say `blurred`) |
+| `Removing icon for sheet N: Name '...', ID ..., description '...'` (qscloud remove-sheet-icons, per sheet at info) | `sheet  1/9  cleared  '...'` or `sheet  2/9  no icon  '...'  (no icon currently set)` (long form at verbose) |
+| nothing (remove-sheet-icons media cleanup was silent at info) | `deleted N thumbnail media file(s) from the app media library` per app |
+| nothing | `RESULT ok` / `RESULT FAILED` block closing every real run **that reaches app processing** (pre-loop aborts exit 1 with error lines and no RESULT — key wrappers on the exit code) |
+
+Exit codes are unchanged: 0 on success, 1 when anything failed or the selection was empty.
+
+## Publisher notes
+
+- Samples in this draft were generated from the real renderer (`renderRunPlanLines` / `renderRunVerdictLines`); regenerate rather than hand-edit if the renderer changes before publication. The version in the header sample is deliberately `x.y.z` — keep it a placeholder or trim the header, per the no-version-bearing-lines rule.
+- **No CLI options were added, removed or changed by this feature**, so no generated `<!-- generated:cli-options -->` table goes stale from it. Run the usual `--check` across touched reference pages anyway before merging.
+- The pending drafts `dry-run.md` and `log-timestamps-switch.md` in this folder describe the same commands and both remain unpublished. `dry-run.md` has already been updated for this change (its `App selection:` line moved into the PLAN block, which dry runs print before the app loop). Publish in dependency order: `log-timestamps-switch.md`, then `dry-run.md`, then this page — each later page links to concepts the earlier ones introduce.

--- a/src/__tests__/butler-sheet-icons.test.js
+++ b/src/__tests__/butler-sheet-icons.test.js
@@ -126,13 +126,13 @@ describe('butler-sheet-icons CLI', () => {
         // line through the logger: no network, no config, read-only. No
         // assertion on exit status - a corrupt entry in the host's browser
         // cache fails the command for reasons unrelated to timestamps, and
-        // the App version line is emitted before any cache work happens.
+        // the run header is emitted before any cache work happens.
         test('BSI_LOG_TIMESTAMPS=false drops the prefix but keeps level and message', () => {
             const result = execCLI(['browser', 'list-installed'], {
                 env: { ...scrubbedEnv, BSI_LOG_TIMESTAMPS: 'false' },
                 timeout: 20000,
             });
-            expect(result.stdout).toMatch(/^info: App version:/m);
+            expect(result.stdout).toMatch(/^info: +BUTLER SHEET ICONS /m);
             // No line anywhere in the output may still carry the stamp.
             expect(result.stdout).not.toMatch(new RegExp(`^${STAMP}`, 'm'));
         });

--- a/src/lib/cloud/__tests__/cloud_create_thumbnails_app_loop.test.js
+++ b/src/lib/cloud/__tests__/cloud_create_thumbnails_app_loop.test.js
@@ -275,7 +275,10 @@ describe('qscloudCreateThumbnails app loop', () => {
 
             const infoLog = logger.info.mock.calls.map((call) => String(call[0])).join('\n');
             expect(infoLog).toContain('DRY RUN of qscloud create-sheet-thumbnails');
-            expect(infoLog).toContain('Re-run without --dry-run to apply.');
+            // The mocked planner records nothing onto the report, so the
+            // renderer honestly reports an incomplete plan and withholds the
+            // apply invite; "Nothing was changed." is the constant closing.
+            expect(infoLog).toContain('Nothing was changed.');
         });
 
         test('a real run hands runOverApps the processor, never the planner', async () => {
@@ -289,7 +292,8 @@ describe('qscloudCreateThumbnails app loop', () => {
             expect(processCloudApp).toHaveBeenCalledWith(
                 'app-under-test',
                 expect.any(Object),
-                expect.any(Object)
+                expect.any(Object),
+                expect.objectContaining({ dryRun: false })
             );
             expect(cloudPlanApp).not.toHaveBeenCalled();
         });

--- a/src/lib/cloud/__tests__/cloud_updatesheets.test.js
+++ b/src/lib/cloud/__tests__/cloud_updatesheets.test.js
@@ -218,9 +218,10 @@ describe('qscloudUpdateSheetThumbnails', () => {
     test('handles an app with no sheets', async () => {
         const { session } = wireEnigma([]);
 
+        // Resolves to the number of sheets updated - zero here, there are none.
         await expect(
             qscloudUpdateSheetThumbnails(CREATED_FILES, APP_ID, BASE_OPTIONS)
-        ).resolves.toBeUndefined();
+        ).resolves.toBe(0);
 
         expect(session.close).toHaveBeenCalledTimes(1);
     });

--- a/src/lib/cloud/__tests__/process_cloud_app.test.js
+++ b/src/lib/cloud/__tests__/process_cloud_app.test.js
@@ -54,6 +54,9 @@ const mockGlobals = jest.unstable_mockModule('../../../globals.js', () => ({
     // rather than an undefined.
     sendConsoleLogToStderr: () => {},
     isSea: false,
+    // run-report.js (imported for the report recorders) links these two.
+    getLoggingLevel: jest.fn().mockReturnValue('info'),
+    setLoggingLevel: jest.fn(),
 }));
 
 const mockCloudEnigma = jest.unstable_mockModule('../cloud-enigma.js', () => ({
@@ -65,7 +68,7 @@ const mockCloudUpload = jest.unstable_mockModule('../cloud-upload.js', () => ({
 }));
 
 const mockCloudUpdateSheets = jest.unstable_mockModule('../cloud-updatesheets.js', () => ({
-    qscloudUpdateSheetThumbnails: jest.fn().mockResolvedValue(true),
+    qscloudUpdateSheetThumbnails: jest.fn().mockResolvedValue(1),
 }));
 
 const mockBrowserInstall = jest.unstable_mockModule('../../browser/browser-install.js', () => ({
@@ -514,7 +517,7 @@ describe('process-cloud-app.js — puppeteer launch and click options', () => {
             });
             browserInstall.mockReset();
             qscloudUploadToApp.mockResolvedValue(true);
-            qscloudUpdateSheetThumbnails.mockResolvedValue(true);
+            qscloudUpdateSheetThumbnails.mockResolvedValue(1);
         });
 
         test('releases the session when the browser cannot be installed', async () => {
@@ -656,7 +659,7 @@ describe('process-cloud-app.js — a sheet with no metadata does not abort the a
         });
         takeSheetScreenshot.mockResolvedValue(true);
         qscloudUploadToApp.mockResolvedValue(true);
-        qscloudUpdateSheetThumbnails.mockResolvedValue(true);
+        qscloudUpdateSheetThumbnails.mockResolvedValue(1);
 
         const mockApp = {
             createSessionObject: jest.fn().mockResolvedValue({
@@ -756,7 +759,7 @@ describe('process-cloud-app.js — a failed upload must not update the sheets', 
             buildId: 'system-installed',
         });
         takeSheetScreenshot.mockResolvedValue(true);
-        qscloudUpdateSheetThumbnails.mockResolvedValue(true);
+        qscloudUpdateSheetThumbnails.mockResolvedValue(1);
 
         const mockApp = {
             createSessionObject: jest.fn().mockResolvedValue({
@@ -864,7 +867,7 @@ describe('process-cloud-app.js — a sheet whose thumbnail cannot be produced', 
             buildId: 'system-installed',
         });
         qscloudUploadToApp.mockResolvedValue(true);
-        qscloudUpdateSheetThumbnails.mockResolvedValue(true);
+        qscloudUpdateSheetThumbnails.mockResolvedValue(1);
 
         const mockApp = {
             createSessionObject: jest.fn().mockResolvedValue({

--- a/src/lib/cloud/cloud-create-thumbnails.js
+++ b/src/lib/cloud/cloud-create-thumbnails.js
@@ -5,8 +5,14 @@ import { qscloudTestConnection } from './cloud-test-connection.js';
 import { processCloudApp } from './process-cloud-app.js';
 import { cloudPlanApp } from './cloud-plan-app.js';
 import { resolveCloudAppSelection } from './cloud-app-selection.js';
-import { runOverAppsWithReport, announceDryRun } from '../util/run-report.js';
-import { CLOUD_SHEET_PARTS } from './sheet-parts.js';
+import {
+    runOverAppsWithReport,
+    announceDryRun,
+    buildSheetRules,
+    buildSheetPartSection,
+    buildBrowserPlanSection,
+} from '../util/run-report.js';
+import { CLOUD_SHEET_PARTS, CLOUD_SHEET_PART_LABELS } from './sheet-parts.js';
 import { logError } from '../util/log-error.js';
 
 /**
@@ -115,10 +121,25 @@ export const qscloudCreateThumbnails = async (options) => {
             command: 'qscloud create-sheet-thumbnails',
             dryRun,
             ...selection,
+            plan: {
+                target: { platform: 'cloud', tenantUrl: options.tenanturl },
+                auth: {
+                    apiKey: true,
+                    logonUserId: options.logonuserid ?? null,
+                    skipLogin: options.skipLogin === true,
+                },
+                sheetPart: buildSheetPartSection(options.includesheetpart, CLOUD_SHEET_PART_LABELS),
+                // No tag rules: Cloud cannot tag individual sheets, and the
+                // warning above already covers a tag option that was supplied.
+                rules: buildSheetRules(options),
+                browser: buildBrowserPlanSection(options),
+                output: { imageDir: options.imagedir, platformDir: 'cloud' },
+                writes: { kind: 'thumbnails', contentLibrary: null, publishedAppCount: null },
+            },
             logPrefix: { plan: 'CLOUD PLAN APP', process: 'CLOUD PROCESS APP' },
             emptySelectionHint: 'Check the --appid and --collectionid options.',
             planApp: (appId, report) => cloudPlanApp(appId, saasInstance, options, report),
-            processApp: (appId) => processCloudApp(appId, saasInstance, options),
+            processApp: (appId, report) => processCloudApp(appId, saasInstance, options, report),
         });
     } catch (err) {
         logError('CLOUD CREATE THUMBNAILS 2', err);

--- a/src/lib/cloud/cloud-plan-app.js
+++ b/src/lib/cloud/cloud-plan-app.js
@@ -11,6 +11,7 @@ import {
 } from '../util/sheet-list.js';
 import { CloudError } from '../util/errors.js';
 import { addAppToReport, recordPlannedSheet } from '../util/run-report.js';
+import { appProgressLine } from '../util/run-report-render.js';
 
 /**
  * Plans one Qlik Sense Cloud app without changing anything: the dry-run twin
@@ -55,12 +56,21 @@ export const cloudPlanApp = async (appId, saasInstance, options, report) => {
         },
         async (global) => {
             const app = await global.openDoc(appId, '', '', '', false);
-            logger.info(`Opened app ${appId}`);
-            logger.info(`App name: "${appMetadata.attributes.name}"`);
-            logger.info(`App is published: ${appIsPublished}`);
+            logger.verbose(`Opened app ${appId}`);
+            logger.verbose(`App name: "${appMetadata.attributes.name}"`);
+            logger.verbose(`App is published: ${appIsPublished}`);
 
             const sheets = await getSheetList(app, SHEET_LIST_FIELDS_WITH_SHOW_CONDITION);
-            logger.info(`Number of sheets in app: ${sheets.length}`);
+
+            // Same fold as the real processor: one countable line, the
+            // individual facts at verbose.
+            logger.info(
+                appProgressLine({
+                    name: appMetadata.attributes.name,
+                    sheetCount: sheets.length,
+                    published: appIsPublished,
+                })
+            );
 
             const appEntry = addAppToReport(report, {
                 id: appId,

--- a/src/lib/cloud/cloud-remove-sheet-icons.js
+++ b/src/lib/cloud/cloud-remove-sheet-icons.js
@@ -21,6 +21,7 @@ import {
     addAppToReport,
     recordSheetDecision,
 } from '../util/run-report.js';
+import { sheetProgressLine, appProgressLine } from '../util/run-report-render.js';
 import { logError } from '../util/log-error.js';
 
 /**
@@ -32,6 +33,8 @@ import { logError } from '../util/log-error.js';
  * @param {string} options.tenanturl - Host address of the Qlik Sense Cloud tenant.
  * @param {string} options.apikey - API key for the Qlik Sense Cloud tenant.
  * @param {string} options.loglevel - The level of logging to output. Valid values are 'error', 'warn', 'info', 'verbose', 'debug', 'silly'.
+ * @param {object} [report] - Run report from `createRunReport`; per-sheet
+ *     decisions and the media-file deletion count are recorded onto it.
  *
  * @returns {Promise<void>} Resolves once every sheet's icon has been removed, or the app has
  *     no sheets.
@@ -40,8 +43,9 @@ import { logError } from '../util/log-error.js';
  *     attempted first and the engine session is always released.
  * @throws {Error} Whatever the engine or media API threw, if the session itself was lost.
  */
-const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
+const removeSheetIconsCloudApp = async (appId, saasInstance, options, report = null) => {
     let sheetRun;
+    let appEntry = null;
 
     try {
         // Configure Enigma.js
@@ -59,15 +63,18 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
             },
             async (global) => {
                 const app = await global.openDoc(appId, '', '', '', false);
-                logger.info(`Opened app ${appId}`);
+                logger.verbose(`Opened app ${appId}`);
 
                 // Get list of app sheets
                 const sheets = await getSheetList(app, SHEET_LIST_FIELDS_EXTENDED);
 
-                if (sheets.length > 0) {
-                    // sheets[] now contains array of app sheets.
-                    logger.info(`Number of sheets in app: ${sheets.length}`);
+                logger.info(`  ${sheets.length} sheet(s)`);
 
+                if (report) {
+                    appEntry = addAppToReport(report, { id: appId, sheetCount: sheets.length });
+                }
+
+                if (sheets.length > 0) {
                     // Sort sheets
                     sortSheetsByRank(sheets);
 
@@ -80,7 +87,7 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
                             ErrorClass: CloudError,
                         },
                         async (sheet, iSheetNum) => {
-                            logger.info(
+                            logger.verbose(
                                 `Removing icon for sheet ${iSheetNum}: Name '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
                             );
 
@@ -93,8 +100,22 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
                             // no-op into an error, and made the dry run predict
                             // success for exactly the input that broke the run.
                             if (!sheetProperties?.thumbnail?.qStaticContentUrlDef) {
-                                logger.verbose(
-                                    `Sheet ${iSheetNum} has no thumbnail structure - nothing to clear`
+                                if (appEntry) {
+                                    recordSheetDecision(appEntry, {
+                                        n: iSheetNum,
+                                        title: sheet?.qMeta?.title,
+                                        action: 'clear',
+                                        reason: CLEAR_REASON.NO_ICON,
+                                    });
+                                }
+                                logger.info(
+                                    sheetProgressLine({
+                                        n: iSheetNum,
+                                        total: sheets.length,
+                                        label: 'no icon',
+                                        title: sheet?.qMeta?.title,
+                                        reason: CLEAR_REASON.NO_ICON,
+                                    })
                                 );
 
                                 return SHEET_SKIPPED;
@@ -105,6 +126,24 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
 
                             const res = await sheetObj.setProperties(sheetProperties);
                             logger.debug(`Set thumbnail result: ${JSON.stringify(res, null, 2)}`);
+
+                            // Recorded only after the write went through, so
+                            // the row states a fact.
+                            if (appEntry) {
+                                recordSheetDecision(appEntry, {
+                                    n: iSheetNum,
+                                    title: sheet?.qMeta?.title,
+                                    action: 'clear',
+                                });
+                            }
+                            logger.info(
+                                sheetProgressLine({
+                                    n: iSheetNum,
+                                    total: sheets.length,
+                                    label: 'cleared',
+                                    title: sheet?.qMeta?.title,
+                                })
+                            );
                         }
                     );
                 }
@@ -130,6 +169,7 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
         // reference and then removing the file is the order that degrades safely.
         // Does the app have a thumbnail folder in its media library?
         const mediaList = await saasInstance.Get(`apps/${appId}/media/list`);
+        let mediaFilesDeleted = 0;
 
         if (
             mediaList.find((item) => {
@@ -154,11 +194,21 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options) => {
                             thumbnailImg.name
                         )}, result=${JSON.stringify(result)}`
                     );
+                    mediaFilesDeleted += 1;
                 }
             }
         }
 
-        logger.info(`Done processing app ${appId}`);
+        if (appEntry) {
+            appEntry.mediaFilesDeleted = mediaFilesDeleted;
+        }
+        logger.info(
+            `  deleted ${mediaFilesDeleted} thumbnail media file(s) from the app media library`
+        );
+
+        // The run card's verdict now closes the run; this line stays for
+        // anyone debugging at verbose.
+        logger.verbose(`Done processing app ${appId}`);
     } catch (err) {
         logError('CLOUD REMOVE SHEET ICONS 1', err);
         // Rethrow so the app loop can count this app as failed. Logging and returning
@@ -204,10 +254,17 @@ const planRemoveSheetIconsCloudApp = async (appId, saasInstance, options, report
         },
         async (global) => {
             const app = await global.openDoc(appId, '', '', '', false);
-            logger.info(`Opened app ${appId}`);
+            logger.verbose(`Opened app ${appId}`);
 
             const sheets = await getSheetList(app, SHEET_LIST_FIELDS_EXTENDED);
-            logger.info(`Number of sheets in app: ${sheets.length}`);
+            // Through the shared renderer, with the id as the name fallback -
+            // a missing attributes.name must not print "undefined".
+            logger.info(
+                appProgressLine({
+                    name: appMetadata?.attributes?.name ?? appId,
+                    sheetCount: sheets.length,
+                })
+            );
 
             const appEntry = addAppToReport(report, {
                 id: appId,
@@ -335,11 +392,19 @@ export const qscloudRemoveSheetIcons = async (options) => {
             command: 'qscloud remove-sheet-icons',
             dryRun,
             ...selection,
+            plan: {
+                target: { platform: 'cloud', tenantUrl: options.tenanturl },
+                // API key only: this command never drives a browser, so there
+                // is no logon identity to report.
+                auth: { apiKey: true },
+                writes: { kind: 'clear-icons' },
+            },
             logPrefix: { plan: 'CLOUD PLAN REMOVE ICONS', process: 'CLOUD REMOVE SHEET ICONS' },
             emptySelectionHint: 'Check the --appid and --collectionid options.',
             planApp: (appId, report) =>
                 planRemoveSheetIconsCloudApp(appId, saasInstance, options, report),
-            processApp: (appId) => removeSheetIconsCloudApp(appId, saasInstance, options),
+            processApp: (appId, report) =>
+                removeSheetIconsCloudApp(appId, saasInstance, options, report),
         });
     } catch (err) {
         logError('CLOUD REMOVE THUMBNAILS 3', err);

--- a/src/lib/cloud/cloud-updatesheets.js
+++ b/src/lib/cloud/cloud-updatesheets.js
@@ -9,6 +9,7 @@ import {
     sortSheetsByRank,
     saveIfChanged,
     getSheetList,
+    logUpdatedSheetSummary,
 } from '../util/sheet-list.js';
 import { determineSheetBlurStatus } from './determine-sheet-blur-status.js';
 
@@ -28,8 +29,8 @@ import { determineSheetBlurStatus } from './determine-sheet-blur-status.js';
  * @param {Array<string>} [options.blurSheetNumber] - Array of sheet numbers to be blurred.
  * @param {Array<string>} [options.blurSheetTitle] - Array of sheet titles to be blurred.
  *
- * @returns {Promise<void>} Resolves when every sheet that had a generated thumbnail was
- *     updated.
+ * @returns {Promise<number>} How many sheets were given a new thumbnail - the number the
+ *     run card's verdict reports.
  *
  * @throws {CloudError} When any sheet could not be updated, or when thumbnails were created
  *     but no sheet matched one. Other sheets are still attempted first and the engine
@@ -61,7 +62,7 @@ export const qscloudUpdateSheetThumbnails = async (createdFiles, appId, options)
 
                 if (sheets.length > 0) {
                     // dimObj.qAppObjectList.qItems[] now contains array of app sheets.
-                    logger.info(`Number of sheets: ${sheets.length}`);
+                    logger.verbose(`Number of sheets: ${sheets.length}`);
 
                     // Sort sheets
                     sortSheetsByRank(sheets);
@@ -83,7 +84,7 @@ export const qscloudUpdateSheetThumbnails = async (createdFiles, appId, options)
                                 // Guarded: this line is inside the counted region, so an unguarded
                                 // dereference here would fail the app over a sheet nobody was
                                 // going to touch.
-                                logger.info(
+                                logger.verbose(
                                     `Skipping update of sheet ${iSheetNum}: Name '${sheet?.qMeta?.title}', ID ${sheet?.qInfo?.qId}, description '${sheet?.qMeta?.description}'`
                                 );
 
@@ -104,13 +105,13 @@ export const qscloudUpdateSheetThumbnails = async (createdFiles, appId, options)
                                 const sheetProperties = await sheetObj.getProperties();
 
                                 if (blurSheet === true && createdFile.fileNameShortBlurred) {
-                                    logger.info(
+                                    logger.verbose(
                                         `Using blurred thumbnail for sheet ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
                                     );
 
                                     sheetProperties.thumbnail.qStaticContentUrlDef.qUrl = `/api/v1/apps/${appId}/media/files/thumbnails/${createdFile.fileNameShortBlurred}`;
                                 } else {
-                                    logger.info(
+                                    logger.verbose(
                                         `Using regular thumbnail for sheet ${iSheetNum}: '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}'`
                                     );
 
@@ -146,5 +147,12 @@ export const qscloudUpdateSheetThumbnails = async (createdFiles, appId, options)
         throw new CloudError(`Failed to update sheet thumbnails in app ${appId}`, { cause: err });
     }
 
+    // Summary BEFORE the assert: when one sheet failed, the others' writes
+    // were already persisted by saveIfChanged, and the operator must learn
+    // about them even as the app is counted failed.
+    const changed = logUpdatedSheetSummary(sheetRun);
+
     sheetRun?.assertAllProcessed();
+
+    return changed;
 };

--- a/src/lib/cloud/cloud-upload.js
+++ b/src/lib/cloud/cloud-upload.js
@@ -47,7 +47,7 @@ export const qscloudUploadToApp = async (filesToUpload, appId, options) => {
 
         const iconFolderAbsolute = path.resolve(`${options.imagedir}/cloud/${appId}`);
 
-        logger.info(
+        logger.verbose(
             `Uploading images in folder: ${iconFolderAbsolute} to Qlik Sense Cloud app ${appId}`
         );
 
@@ -58,7 +58,7 @@ export const qscloudUploadToApp = async (filesToUpload, appId, options) => {
             // Each file is isolated so one bad image does not skip the ones after it.
             // Failures are counted rather than ignored - see the throw below the loop.
             try {
-                logger.info(`Uploading file: ${file.fileNameShort}`);
+                logger.verbose(`Uploading file: ${file.fileNameShort}`);
 
                 // Get complete path for file
                 const fileFullPath = path.join(iconFolderAbsolute, file.fileNameShort);
@@ -133,4 +133,8 @@ export const qscloudUploadToApp = async (filesToUpload, appId, options) => {
             `Failed to upload ${failedCount} of ${failedCount + uploadedCount} thumbnail image(s) to Qlik Sense Cloud app ${appId}`
         );
     }
+
+    // The countable line the per-file lines above used to approximate. Counted
+    // per sheet - each upload carries its blurred variant alongside.
+    logger.info(`  uploaded thumbnails for ${uploadedCount} sheet(s) to the app's media library`);
 };

--- a/src/lib/cloud/process-cloud-app.js
+++ b/src/lib/cloud/process-cloud-app.js
@@ -16,6 +16,9 @@ import {
 import { withEngineSession } from '../util/engine-session.js';
 import { createAppImageDir } from '../util/image-dir.js';
 import { determineSheetExcludeStatus } from './determine-sheet-exclude-status.js';
+import { determineSheetBlurStatus } from './determine-sheet-blur-status.js';
+import { addAppToReport, recordPlannedSheet, recordAppOutcome } from '../util/run-report.js';
+import { appProgressLine, sheetProgressLine } from '../util/run-report-render.js';
 import { logError } from '../util/log-error.js';
 
 // Selector paths to elements on login page
@@ -29,10 +32,13 @@ const selectorLoginPageLoginButton = '[id="\u0031-submit"]';
  * @param {string} appId - App ID of the app to process.
  * @param {import('./cloud-test-connection.js').QlikSaasInstance} saasInstance - QlikSaas object.
  * @param {object} options - Options object.
+ * @param {object} [report] - Run report from `createRunReport`; per-sheet
+ *     decisions and outcome counts are recorded onto it as they happen. The
+ *     progress lines and the run verdict render from these records.
  *
  * @returns {Promise<void>} Resolves when thumbnail generation, upload, and property updates for the app have completed (or thrown, which is logged by the caller).
  */
-export const processCloudApp = async (appId, saasInstance, options) => {
+export const processCloudApp = async (appId, saasInstance, options, report = null) => {
     // Get page timeout from options
     let pageTimeout = 90000; // 90 seconds
     if (options.browserPageTimeout && options.browserPageTimeout > 0) {
@@ -40,6 +46,7 @@ export const processCloudApp = async (appId, saasInstance, options) => {
     }
 
     let sheetRun;
+    let appEntry = null;
 
     // Create image directory on disk for this app
     createAppImageDir({
@@ -109,17 +116,33 @@ export const processCloudApp = async (appId, saasInstance, options) => {
             },
             async (global) => {
                 const app = await global.openDoc(appId, '', '', '', false);
-                logger.info(`Opened app ${appId}`);
-                logger.info(`App name: "${appMetadata.attributes.name}"`);
-                logger.info(`App is published: ${appMetadata.attributes.published}`);
+                logger.verbose(`Opened app ${appId}`);
+                logger.verbose(`App name: "${appMetadata.attributes.name}"`);
+                logger.verbose(`App is published: ${appIsPublished}`);
 
                 // Get list of app sheets
                 const sheets = await getSheetList(app, SHEET_LIST_FIELDS_WITH_SHOW_CONDITION);
 
-                if (sheets.length > 0) {
-                    // sheets[] now contains array of app sheets.
-                    logger.info(`Number of sheets in app: ${sheets.length}`);
+                // One line where four used to be: the name, count and publish
+                // state under the `app i/n` line the app loop printed. The
+                // individual facts moved to verbose above.
+                logger.info(
+                    appProgressLine({
+                        name: appMetadata.attributes.name,
+                        sheetCount: sheets.length,
+                        published: appIsPublished,
+                    })
+                );
 
+                if (report) {
+                    appEntry = addAppToReport(report, {
+                        id: appId,
+                        name: appMetadata.attributes.name,
+                        sheetCount: sheets.length,
+                    });
+                }
+
+                if (sheets.length > 0) {
                     const browser = await launchBrowserForApp(options, {
                         appId,
                         logPrefix: 'CLOUD APP',
@@ -206,7 +229,7 @@ export const processCloudApp = async (appId, saasInstance, options) => {
                                 // --exclude-sheet-number <number...>
                                 // --exclude-sheet-title <title...>
                                 // --exclude-sheet-status <status...>
-                                const { excludeSheet, sheetIsHidden } =
+                                const { excludeSheet, excludeReason, sheetIsHidden } =
                                     await determineSheetExcludeStatus(
                                         app,
                                         sheet,
@@ -216,17 +239,46 @@ export const processCloudApp = async (appId, saasInstance, options) => {
                                         logger
                                     );
 
+                                // The blur decision is applied later, in
+                                // updatesheets - computed here as well, from
+                                // the same module and the same inputs, so the
+                                // progress line and the report can say
+                                // `blurred` where the update step will use the
+                                // blurred file.
+                                const { blurSheet, blurReason } = excludeSheet
+                                    ? { blurSheet: false, blurReason: null }
+                                    : determineSheetBlurStatus(sheet, options, iSheetNum, logger);
+
+                                // The ~230-column line with the sheet id, description,
+                                // approved/published/hidden fields lives at verbose now;
+                                // the info line is the countable one-liner.
+                                logger.verbose(
+                                    `${excludeSheet === true ? 'Excluded' : 'Processing'} sheet ${iSheetNum}: '${sheet?.qMeta?.title}', ID ${sheet?.qInfo?.qId}, description '${sheet?.qMeta?.description}', approved '${sheet?.qMeta?.approved === true}', published '${sheet?.qMeta?.published === true}', hidden '${sheetIsHidden}'`
+                                );
+
                                 if (excludeSheet === true) {
+                                    if (appEntry) {
+                                        recordPlannedSheet(appEntry, {
+                                            n: iSheetNum,
+                                            title: sheet?.qMeta?.title,
+                                            excludeSheet,
+                                            excludeReason,
+                                            blurSheet,
+                                            blurReason,
+                                        });
+                                    }
                                     logger.info(
-                                        `Excluded sheet: ${iSheetNum}: '${sheet?.qMeta?.title}', ID ${sheet?.qInfo?.qId}, description '${sheet?.qMeta?.description}', approved '${sheet?.qMeta?.approved === true}', published '${sheet?.qMeta?.published === true}', hidden '${sheetIsHidden}'`
+                                        sheetProgressLine({
+                                            n: iSheetNum,
+                                            total: sheets.length,
+                                            label: 'excluded',
+                                            title: sheet?.qMeta?.title,
+                                            reason: excludeReason,
+                                        })
                                     );
 
                                     return SHEET_SKIPPED;
                                 }
-
-                                logger.info(
-                                    `Processing sheet ${iSheetNum}: '${sheet?.qMeta?.title}', ID ${sheet?.qInfo?.qId}, description '${sheet?.qMeta?.description}', approved '${sheet?.qMeta?.approved === true}', published '${sheet?.qMeta?.published === true}', hidden '${sheetIsHidden}'`
-                                );
 
                                 const createdFile = await takeSheetScreenshot(
                                     page,
@@ -245,6 +297,29 @@ export const processCloudApp = async (appId, saasInstance, options) => {
                                 // does not exist - it keeps the icon it already had.
                                 createdFiles.push(createdFile);
 
+                                // Recorded and logged only now, for the same
+                                // reason: `captured` must be a fact, not an
+                                // intention.
+                                if (appEntry) {
+                                    recordPlannedSheet(appEntry, {
+                                        n: iSheetNum,
+                                        title: sheet?.qMeta?.title,
+                                        excludeSheet,
+                                        excludeReason,
+                                        blurSheet,
+                                        blurReason,
+                                    });
+                                }
+                                logger.info(
+                                    sheetProgressLine({
+                                        n: iSheetNum,
+                                        total: sheets.length,
+                                        label: blurSheet ? 'blurred' : 'captured',
+                                        title: sheet?.qMeta?.title,
+                                        reason: blurReason,
+                                    })
+                                );
+
                                 return undefined;
                             }
                         );
@@ -262,8 +337,19 @@ export const processCloudApp = async (appId, saasInstance, options) => {
         await qscloudUploadToApp(createdFiles, appId, options);
 
         // Update sheets in app
-        await qscloudUpdateSheetThumbnails(createdFiles, appId, options);
-        logger.info(`Done processing app ${appId}`);
+        const sheetsUpdated = await qscloudUpdateSheetThumbnails(createdFiles, appId, options);
+
+        recordAppOutcome(appEntry, {
+            sheetsUpdated,
+            imagesDir: `${imgDir}/cloud/${appId}`,
+            imageFileNames: createdFiles.flatMap((file) =>
+                [file.fileNameShort, file.fileNameShortBlurred].filter(Boolean)
+            ),
+        });
+
+        // The run card's verdict now closes the run; this line stays for
+        // anyone debugging at verbose.
+        logger.verbose(`Done processing app ${appId}`);
     } catch (err) {
         logError('CLOUD APP', err);
         // Rethrow so the app loop can count this app as failed. Logging and returning

--- a/src/lib/cloud/sheet-parts.js
+++ b/src/lib/cloud/sheet-parts.js
@@ -25,6 +25,19 @@ export const CLOUD_SHEET_PART_SELECTORS = Object.freeze({
 });
 
 /**
+ * Human-readable descriptions of the Cloud sheet parts, keyed like the
+ * selector map above so the two cannot list different values. Shown in the
+ * run card's PLAN block, where a bare `2` would send the operator to the docs.
+ *
+ * @type {Readonly<Record<string, string>>}
+ */
+export const CLOUD_SHEET_PART_LABELS = Object.freeze({
+    1: 'sheet objects only',
+    2: 'objects + sheet title',
+    4: 'entire sheet',
+});
+
+/**
  * Values `--includesheetpart` accepts on Qlik Sense Cloud, in ascending order. Frozen.
  *
  * Passed to Commander's `.choices()`, which both validates and makes the values discoverable in

--- a/src/lib/commands/browser/check.js
+++ b/src/lib/commands/browser/check.js
@@ -1,5 +1,6 @@
 import { Command, Option } from 'commander';
 import { logger, appVersion } from '../../../globals.js';
+import { logRunHeader } from '../../util/run-report-render.js';
 import { browserCheck } from '../../browser/browser-check.js';
 import { runCommand } from '../run-command.js';
 import { buildBrowserDiagnosticOptions } from '../browser-diagnostic-options.js';
@@ -30,7 +31,7 @@ import { buildBrowserDiagnosticOptions } from '../browser-diagnostic-options.js'
  * @returns {Promise<boolean>} Whether the machine passed.
  */
 const handleBrowserCheck = async (options = {}) => {
-    logger.info(`App version: ${appVersion}`);
+    logRunHeader(logger, appVersion, 'browser check');
 
     return runCommand('BROWSER MAIN 11', async () => {
         const report = await browserCheck(options);

--- a/src/lib/commands/browser/install.js
+++ b/src/lib/commands/browser/install.js
@@ -1,5 +1,6 @@
 import { Command, Option } from 'commander';
 import { logger, appVersion } from '../../../globals.js';
+import { logRunHeader } from '../../util/run-report-render.js';
 import { browserInstall } from '../../browser/browser-install.js';
 import {
     VERSION_RECOMMENDED,
@@ -19,7 +20,7 @@ import { addInteractiveOption } from '../../interactive/interactive-option.js';
  * @returns {Promise<void>} Resolves after attempting the install and logging any failures.
  */
 const handleBrowserInstall = async (options = {}, cmd) => {
-    logger.info(`App version: ${appVersion}`);
+    logRunHeader(logger, appVersion, 'browser install');
 
     // Optional chaining, not `options.interactive`: the default parameter only
     // covers `undefined`, and a null options bag has to keep reaching

--- a/src/lib/commands/browser/list-available.js
+++ b/src/lib/commands/browser/list-available.js
@@ -1,5 +1,6 @@
 import { Command, Option } from 'commander';
 import { logger, appVersion } from '../../../globals.js';
+import { logRunHeader } from '../../util/run-report-render.js';
 import { browserListAvailable } from '../../browser/browser-list-available.js';
 import { runCommand } from '../run-command.js';
 
@@ -12,7 +13,7 @@ import { runCommand } from '../run-command.js';
  * @returns {Promise<void>} Resolves when the worker returns or errors are logged.
  */
 const handleBrowserListAvailable = async (options = {}, cmd) => {
-    logger.info(`App version: ${appVersion}`);
+    logRunHeader(logger, appVersion, 'browser list-available');
 
     return runCommand(
         'BROWSER MAIN 10',

--- a/src/lib/commands/browser/list-installed.js
+++ b/src/lib/commands/browser/list-installed.js
@@ -1,5 +1,6 @@
 import { Command, Option } from 'commander';
 import { logger, appVersion } from '../../../globals.js';
+import { logRunHeader } from '../../util/run-report-render.js';
 import { browserInstalled } from '../../browser/browser-installed.js';
 import { runCommand } from '../run-command.js';
 import { buildBrowserCacheDirOption } from '../helpers.js';
@@ -13,7 +14,7 @@ import { buildBrowserCacheDirOption } from '../helpers.js';
  * @returns {Promise<void>} Resolves when browserInstalled completes or errors are logged.
  */
 const handleBrowserListInstalled = async (options = {}, cmd) => {
-    logger.info(`App version: ${appVersion}`);
+    logRunHeader(logger, appVersion, 'browser list-installed');
 
     return runCommand('BROWSER MAIN 6', () => browserInstalled(options, cmd));
 };

--- a/src/lib/commands/browser/uninstall-all.js
+++ b/src/lib/commands/browser/uninstall-all.js
@@ -1,5 +1,6 @@
 import { Command, Option } from 'commander';
 import { logger, appVersion } from '../../../globals.js';
+import { logRunHeader } from '../../util/run-report-render.js';
 import { browserUninstallAll } from '../../browser/browser-uninstall.js';
 import { runCommand } from '../run-command.js';
 import { buildBrowserCacheDirOption } from '../helpers.js';
@@ -13,7 +14,7 @@ import { buildBrowserCacheDirOption } from '../helpers.js';
  * @returns {Promise<void>} Resolves after the uninstall-all worker finishes or errors are logged.
  */
 const handleBrowserUninstallAll = async (options = {}, cmd) => {
-    logger.info(`App version: ${appVersion}`);
+    logRunHeader(logger, appVersion, 'browser uninstall-all');
 
     return runCommand('BROWSER MAIN 8', () => browserUninstallAll(options, cmd));
 };

--- a/src/lib/commands/browser/uninstall.js
+++ b/src/lib/commands/browser/uninstall.js
@@ -1,5 +1,6 @@
 import { Command, Option } from 'commander';
 import { logger, appVersion } from '../../../globals.js';
+import { logRunHeader } from '../../util/run-report-render.js';
 import { browserUninstall } from '../../browser/browser-uninstall.js';
 import { runCommand } from '../run-command.js';
 import { buildBrowserCacheDirOption } from '../helpers.js';
@@ -14,7 +15,7 @@ import { addInteractiveOption } from '../../interactive/interactive-option.js';
  * @returns {Promise<void>} Resolves after attempting the uninstall and logging any failures.
  */
 const handleBrowserUninstall = async (options = {}, cmd) => {
-    logger.info(`App version: ${appVersion}`);
+    logRunHeader(logger, appVersion, 'browser uninstall');
 
     // Optional chaining, not `options.interactive`: the default parameter only
     // covers `undefined`, and a null options bag has to keep reaching

--- a/src/lib/commands/doctor/check.js
+++ b/src/lib/commands/doctor/check.js
@@ -1,5 +1,6 @@
 import { Command, Option } from 'commander';
 import { logger, appVersion } from '../../../globals.js';
+import { logRunHeader } from '../../util/run-report-render.js';
 import { doctorCheck } from '../../doctor/doctor-check.js';
 import { CHECK_AREAS } from '../../doctor/run-checks.js';
 import { runCommand } from '../run-command.js';
@@ -18,7 +19,7 @@ import { booleanOptionParser } from '../../util/boolean-option.js';
  * as a failure rather than letting it escape to the top-level handler and be written out as a
  * crash dump. A machine with a problem is an operational finding, not a crash.
  *
- * The `App version:` line is skipped in JSON mode. The document has to be the whole of stdout for
+ * The run header is skipped in JSON mode. The document has to be the whole of stdout for
  * anything to parse it, and the version is a field inside it instead.
  *
  * @param {object} [options] - CLI options. Defaults to `{}`. Commander passes its own `Command` as
@@ -28,7 +29,7 @@ import { booleanOptionParser } from '../../util/boolean-option.js';
  */
 const handleDoctorCheck = async (options = {}) => {
     if (options.outputformat !== 'json') {
-        logger.info(`App version: ${appVersion}`);
+        logRunHeader(logger, appVersion, 'doctor check');
     }
 
     return runCommand('DOCTOR MAIN 1', async () => {

--- a/src/lib/commands/qscloud/create-sheet-thumbnails.js
+++ b/src/lib/commands/qscloud/create-sheet-thumbnails.js
@@ -1,5 +1,6 @@
 import { Command, Option } from 'commander';
-import { logger, appVersion } from '../../../globals.js';
+import { logger, appVersion, setLoggingLevel } from '../../../globals.js';
+import { logRunHeader } from '../../util/run-report-render.js';
 import { qscloudCreateThumbnails } from '../../cloud/cloud-create-thumbnails.js';
 import { CLOUD_SHEET_PARTS } from '../../cloud/sheet-parts.js';
 import {
@@ -28,7 +29,14 @@ import { runCommand } from '../run-command.js';
  * @returns {Promise<void>} Resolves after delegating to qscloudCreateThumbnails and logging any errors.
  */
 const handleCloudCreateSheetThumbnails = async (options = {}, cmd) => {
-    logger.info(`App version: ${appVersion}`);
+    // Level set before the header, not only in the worker: a run at
+    // --log-level warn asked for a quiet log, and the run card - header
+    // included - respects that. Guarded for programmatic callers without the
+    // option; the worker sets the level again, which is idempotent.
+    if (options.loglevel) {
+        setLoggingLevel(options.loglevel);
+    }
+    logRunHeader(logger, appVersion, 'Qlik Sense Cloud sheet thumbnails');
 
     // Joined explicitly: --appid is variadic, and letting a template literal coerce the
     // array reads as one strange id rather than as several.

--- a/src/lib/commands/qscloud/list-collections.js
+++ b/src/lib/commands/qscloud/list-collections.js
@@ -1,5 +1,6 @@
 import { Command, Option } from 'commander';
 import { logger, appVersion } from '../../../globals.js';
+import { logRunHeader } from '../../util/run-report-render.js';
 import { qscloudListCollections } from '../../cloud/cloud-collections.js';
 import { runCommand } from '../run-command.js';
 
@@ -12,7 +13,7 @@ import { runCommand } from '../run-command.js';
  * @returns {Promise<void>} Resolves after the worker completes or errors are logged.
  */
 const handleCloudListCollections = async (options = {}, cmd) => {
-    logger.info(`App version: ${appVersion}`);
+    logRunHeader(logger, appVersion, 'Qlik Sense Cloud collections');
 
     return runCommand('CLOUD MAIN 4', () => qscloudListCollections(options, cmd));
 };

--- a/src/lib/commands/qscloud/remove-sheet-icons.js
+++ b/src/lib/commands/qscloud/remove-sheet-icons.js
@@ -1,6 +1,7 @@
 import { Command, Option } from 'commander';
 import { addDryRunOption } from '../dry-run-option.js';
-import { logger, appVersion } from '../../../globals.js';
+import { logger, appVersion, setLoggingLevel } from '../../../globals.js';
+import { logRunHeader } from '../../util/run-report-render.js';
 import { qscloudRemoveSheetIcons } from '../../cloud/cloud-remove-sheet-icons.js';
 import { runCommand } from '../run-command.js';
 import { collectAppIds } from '../helpers.js';
@@ -14,7 +15,11 @@ import { collectAppIds } from '../helpers.js';
  * @returns {Promise<void>} Resolves once the worker reports success or the error is logged.
  */
 const handleCloudRemoveSheetIcons = async (options = {}, cmd) => {
-    logger.info(`App version: ${appVersion}`);
+    // Level set before the header - see create-sheet-thumbnails.js for why.
+    if (options.loglevel) {
+        setLoggingLevel(options.loglevel);
+    }
+    logRunHeader(logger, appVersion, 'Qlik Sense Cloud sheet icon removal');
 
     return runCommand('CLOUD MAIN 5', () => qscloudRemoveSheetIcons(options, cmd));
 };

--- a/src/lib/commands/qseow/index.js
+++ b/src/lib/commands/qseow/index.js
@@ -1,5 +1,6 @@
 import { Command, Option } from 'commander';
-import { logger, appVersion } from '../../../globals.js';
+import { logger, appVersion, setLoggingLevel } from '../../../globals.js';
+import { logRunHeader } from '../../util/run-report-render.js';
 import { qseowCreateThumbnails } from '../../qseow/qseow-create-thumbnails.js';
 import { QSEOW_SHEET_PARTS } from '../../qseow/sheet-parts.js';
 import { DEFAULT_QSEOW_SENSE_VERSION, QSEOW_SENSE_VERSIONS } from '../../qseow/qseow-selectors.js';
@@ -29,7 +30,14 @@ import { runCommand } from '../run-command.js';
  * @returns {Promise<void>} Resolves when the worker call finishes (successfully or after logging errors).
  */
 const handleQseowCreateSheetThumbnails = async (options = {}, command) => {
-    logger.info(`App version: ${appVersion}`);
+    // Level set before the header, not only in the worker: a run at
+    // --log-level warn asked for a quiet log, and the run card - header
+    // included - respects that. Guarded for programmatic callers without the
+    // option; the worker sets the level again, which is idempotent.
+    if (options.loglevel) {
+        setLoggingLevel(options.loglevel);
+    }
+    logRunHeader(logger, appVersion, 'QSEoW sheet thumbnails');
 
     // Joined explicitly: --appid is variadic, and letting a template literal coerce the
     // array reads as one strange id rather than as several.

--- a/src/lib/interactive/interactive-command.js
+++ b/src/lib/interactive/interactive-command.js
@@ -1,5 +1,6 @@
 import { Command, Option } from 'commander';
 import { logger, appVersion } from '../../globals.js';
+import { logRunHeader } from '../util/run-report-render.js';
 import { runCommand } from '../commands/run-command.js';
 import { assertInteractiveCapable } from './tty.js';
 import { isPromptCancellation } from './prompt-runtime.js';
@@ -72,7 +73,7 @@ const runWizardUnlessCancelled = async () => {
  * @returns {Promise<boolean>} `true` on success, `false` on failure.
  */
 const handleInteractive = async (options = {}, _cmd) => {
-    logger.info(`App version: ${appVersion}`);
+    logRunHeader(logger, appVersion, 'interactive wizard');
 
     return runCommand(
         'INTERACTIVE MAIN 11',

--- a/src/lib/qseow/__tests__/qseow_create_thumbnails_app_loop.test.js
+++ b/src/lib/qseow/__tests__/qseow_create_thumbnails_app_loop.test.js
@@ -248,7 +248,10 @@ describe('qseowCreateThumbnails app loop', () => {
 
             const infoLog = logger.info.mock.calls.map((call) => String(call[0])).join('\n');
             expect(infoLog).toContain('DRY RUN of qseow create-sheet-thumbnails');
-            expect(infoLog).toContain('Re-run without --dry-run to apply.');
+            // The mocked planner records nothing onto the report, so the
+            // renderer honestly reports an incomplete plan and withholds the
+            // apply invite; "Nothing was changed." is the constant closing.
+            expect(infoLog).toContain('Nothing was changed.');
         });
 
         test('a real run hands runOverApps the processor, never the planner', async () => {
@@ -259,7 +262,11 @@ describe('qseowCreateThumbnails app loop', () => {
             const processor = runOverApps.mock.calls[0][2];
             await processor('app-under-test');
 
-            expect(qseowProcessApp).toHaveBeenCalledWith('app-under-test', expect.any(Object));
+            expect(qseowProcessApp).toHaveBeenCalledWith(
+                'app-under-test',
+                expect.any(Object),
+                expect.objectContaining({ dryRun: false })
+            );
             expect(qseowPlanApp).not.toHaveBeenCalled();
         });
     });

--- a/src/lib/qseow/__tests__/qseow_process_app.test.js
+++ b/src/lib/qseow/__tests__/qseow_process_app.test.js
@@ -58,6 +58,9 @@ const mockGlobals = jest.unstable_mockModule('../../../globals.js', () => ({
     // rather than an undefined.
     sendConsoleLogToStderr: () => {},
     isSea: false,
+    // run-report.js (imported for the report recorders) links these two.
+    getLoggingLevel: jest.fn().mockReturnValue('info'),
+    setLoggingLevel: jest.fn(),
 }));
 
 const mockQseowEnigma = jest.unstable_mockModule('../qseow-enigma.js', () => ({
@@ -69,7 +72,7 @@ const mockQseowUpload = jest.unstable_mockModule('../qseow-upload.js', () => ({
 }));
 
 const mockQseowUpdateSheets = jest.unstable_mockModule('../qseow-updatesheets.js', () => ({
-    qseowUpdateSheetThumbnails: jest.fn().mockResolvedValue(true),
+    qseowUpdateSheetThumbnails: jest.fn().mockResolvedValue(1),
 }));
 
 const mockQseowLogout = jest.unstable_mockModule('../qseow-logout.js', () => ({
@@ -495,7 +498,7 @@ describe('qseow-process-app.js — puppeteer launch and click options', () => {
             qrsInteract.mockImplementation(() => ({ Get: mockGet }));
             wireEnigmaSession();
             puppeteer.launch.mockResolvedValue(buildMockBrowser());
-            qseowUpdateSheetThumbnails.mockResolvedValue(true);
+            qseowUpdateSheetThumbnails.mockResolvedValue(1);
 
             await qseowProcessApp('test-app-id', {
                 ...defaultOptions,
@@ -795,7 +798,7 @@ describe('qseow-process-app.js — puppeteer launch and click options', () => {
             });
             browserInstall.mockReset();
             qseowUploadToContentLibrary.mockResolvedValue(true);
-            qseowUpdateSheetThumbnails.mockResolvedValue(true);
+            qseowUpdateSheetThumbnails.mockResolvedValue(1);
         });
 
         /**
@@ -931,7 +934,7 @@ describe('qseow-process-app.js — a sheet with no metadata does not abort the a
             sheetIsHidden: false,
         });
         qseowUploadToContentLibrary.mockResolvedValue(true);
-        qseowUpdateSheetThumbnails.mockResolvedValue(true);
+        qseowUpdateSheetThumbnails.mockResolvedValue(1);
 
         const mockGet = jest.fn().mockImplementation((encodedPath) => {
             // Match on the decoded filter, i.e. what QRS parses, rather than on the wire
@@ -1063,7 +1066,7 @@ describe('qseow-process-app.js — a blurred thumbnail that cannot be created', 
             sheetIsHidden: false,
         });
         qseowUploadToContentLibrary.mockResolvedValue(true);
-        qseowUpdateSheetThumbnails.mockResolvedValue(true);
+        qseowUpdateSheetThumbnails.mockResolvedValue(1);
 
         const mockGet = jest.fn().mockImplementation((encodedPath) => {
             // Match on the decoded filter, i.e. what QRS parses, rather than on the wire
@@ -1216,7 +1219,7 @@ describe('qseow-process-app.js — a QRS reply that is not a list', () => {
             buildId: 'system-installed',
         });
         qseowUploadToContentLibrary.mockResolvedValue(true);
-        qseowUpdateSheetThumbnails.mockResolvedValue(true);
+        qseowUpdateSheetThumbnails.mockResolvedValue(1);
 
         const mockGet = jest.fn().mockImplementation((encodedPath) => {
             const path = decodeURIComponent(encodedPath);

--- a/src/lib/qseow/__tests__/qseow_updatesheets.test.js
+++ b/src/lib/qseow/__tests__/qseow_updatesheets.test.js
@@ -93,12 +93,13 @@ describe('qseowUpdateSheetThumbnails — --blur-sheet-tag handling (issue #840)'
         // because the identifier did not exist in the function at all.
         wireEnigmaWithOneSheet();
 
+        // Resolves to the number of sheets updated (the run card's verdict number).
         await expect(
             qseowUpdateSheetThumbnails(CREATED_FILES, 'test-app-id', {
                 ...BASE_OPTIONS,
                 blurSheetTag: 'some-tag',
             })
-        ).resolves.toBeUndefined();
+        ).resolves.toBe(1);
     });
 
     test('no longer warns that the option is unimplemented, now that the caller looks it up', async () => {

--- a/src/lib/qseow/qrs-filter.js
+++ b/src/lib/qseow/qrs-filter.js
@@ -35,22 +35,10 @@
  */
 export const qrsFilterValue = (value) => String(value).replace(/\\/g, '\\\\').replace(/'/g, "\\'");
 
-/**
- * Normalises a CLI option into the list of values worth querying for.
- *
- * Commander hands the same option over in several shapes: absent options arrive as `undefined`,
- * a variadic option set from an empty environment variable arrives as `['']`, and a plain one
- * arrives as a bare string. None of the empty shapes name a real tag, so they all collapse to an
- * empty list and let the caller skip the query rather than ask QRS about nothing.
- *
- * @param {string|string[]|undefined} values - Raw option value.
- *
- * @returns {string[]} The values worth querying for, possibly empty.
- */
-export const toFilterValueList = (values) =>
-    (Array.isArray(values) ? values : [values]).filter(
-        (value) => value !== undefined && value !== null && value !== ''
-    );
+// The Commander-shape normalisation is shared with the run report (both need
+// the same "absent / ['']-from-empty-env / bare string" rules); re-exported
+// under the established name so existing callers and tests are unaffected.
+export { toOptionValueList as toFilterValueList } from '../util/option-values.js';
 
 /**
  * Builds a filter term matching a field against any one of the supplied values.

--- a/src/lib/qseow/qrs-response.js
+++ b/src/lib/qseow/qrs-response.js
@@ -48,3 +48,43 @@ export const qrsGetList = async (qrsInteractInstance, apiUrl) => {
 
     return result.body;
 };
+
+/**
+ * Reads a QRS `count` endpoint (`.../count?filter=...`) and returns the number.
+ *
+ * The count endpoints answer `{ "value": N }` - constant-size, however many
+ * entities match - which is what makes them the right tool when only a number
+ * is wanted: asking `app/object/full` for hundreds of full repository
+ * entities in order to take `.length` moves kilobytes per counted sheet.
+ *
+ * Same interpretation discipline as {@link qrsGetList}: a non-success status
+ * or a body without a numeric `value` throws rather than reading as zero -
+ * "nothing matched" and "the answer is unusable" are different answers.
+ *
+ * @param {object} qrsInteractInstance - A configured `qrs-interact` instance.
+ * @param {string} apiUrl - QRS count path, e.g. `app/object/count?filter=...`.
+ *
+ * @returns {Promise<number>} The count.
+ *
+ * @throws {QseowError} When the status is not a success, or the body carries
+ *   no numeric `value`.
+ */
+export const qrsGetCount = async (qrsInteractInstance, apiUrl) => {
+    const result = await qrsInteractInstance.Get(apiUrl);
+
+    const status = result?.statusCode;
+    if (status !== undefined && (status < 200 || status > 299)) {
+        throw new QseowError(`QRS returned status ${status} for "${apiUrl}"`);
+    }
+
+    const value = result?.body?.value;
+    if (typeof value !== 'number') {
+        const shape = result?.body === null ? 'null' : typeof result?.body;
+
+        throw new QseowError(
+            `QRS returned an unusable response for "${apiUrl}": expected a count, got ${shape}`
+        );
+    }
+
+    return value;
+};

--- a/src/lib/qseow/qseow-create-thumbnails.js
+++ b/src/lib/qseow/qseow-create-thumbnails.js
@@ -5,10 +5,17 @@ import { qseowVerifyCertificatesExist } from './qseow-certificates.js';
 import { qseowProcessApp } from './qseow-process-app.js';
 import { qseowPlanApp } from './qseow-plan-app.js';
 import { listAppsByTag } from './qseow-app-lookup.js';
+import { readQseowPlanFacts } from './qseow-tagged-sheets.js';
 import { toAppIdList } from '../util/app-ids.js';
-import { QSEOW_SHEET_PARTS } from './sheet-parts.js';
+import { QSEOW_SHEET_PARTS, QSEOW_SHEET_PART_LABELS } from './sheet-parts.js';
 import { logError } from '../util/log-error.js';
-import { runOverAppsWithReport, announceDryRun } from '../util/run-report.js';
+import {
+    runOverAppsWithReport,
+    announceDryRun,
+    buildSheetRules,
+    buildSheetPartSection,
+    buildBrowserPlanSection,
+} from '../util/run-report.js';
 
 /**
  * Create thumbnails for Qlik Sense Enterprise on Windows (QSEoW).
@@ -99,6 +106,11 @@ export const qseowCreateThumbnails = async (options) => {
             appIdsToProcess.push(...taggedAppIds);
         }
 
+        // Plan-time facts for the run card: published-app count and the tag
+        // rules' match counts across the selected apps. Read-only, and
+        // degrades to nulls rather than failing the run.
+        const planFacts = await readQseowPlanFacts(options, appIdsToProcess);
+
         return await runOverAppsWithReport({
             command: 'qseow create-sheet-thumbnails',
             dryRun,
@@ -106,10 +118,40 @@ export const qseowCreateThumbnails = async (options) => {
             namedAppIds,
             selectorAppIds: taggedAppIds,
             selector: useTag ? { option: 'qliksensetag', value: options.qliksensetag } : null,
+            plan: {
+                target: {
+                    platform: 'qseow',
+                    host: options.host,
+                    port: options.port ?? null,
+                    secure: options.secure,
+                    prefix: options.prefix ?? '',
+                    enginePort: options.engineport,
+                    qrsPort: options.qrsport,
+                    schemaVersion: options.schemaversion,
+                },
+                auth: {
+                    apiUser: { directory: options.apiuserdir, userId: options.apiuserid },
+                    certFile: options.certfile,
+                    logonUser: { directory: options.logonuserdir, userId: options.logonuserid },
+                },
+                sheetPart: buildSheetPartSection(options.includesheetpart, QSEOW_SHEET_PART_LABELS),
+                rules: buildSheetRules(options, {
+                    includeTagRules: true,
+                    excludeTagSheetCount: planFacts.excludeTagSheetCount,
+                    blurTagSheetCount: planFacts.blurTagSheetCount,
+                }),
+                browser: buildBrowserPlanSection(options),
+                output: { imageDir: options.imagedir, platformDir: 'qseow' },
+                writes: {
+                    kind: 'thumbnails',
+                    contentLibrary: options.contentlibrary,
+                    publishedAppCount: planFacts.publishedAppCount,
+                },
+            },
             logPrefix: { plan: 'QSEOW PLAN APP', process: 'QSEOW PROCESS APP' },
             emptySelectionHint: 'Check the --appid and --qliksensetag options.',
             planApp: (appId, report) => qseowPlanApp(appId, options, report),
-            processApp: (appId) => qseowProcessApp(appId, options),
+            processApp: (appId, report) => qseowProcessApp(appId, options, report),
         });
     } catch (err) {
         logError('QSEOW CREATE THUMBNAILS 2', err);

--- a/src/lib/qseow/qseow-plan-app.js
+++ b/src/lib/qseow/qseow-plan-app.js
@@ -10,6 +10,7 @@ import {
     SHEET_LIST_FIELDS_WITH_SHOW_CONDITION,
 } from '../util/sheet-list.js';
 import { addAppToReport, recordPlannedSheet } from '../util/run-report.js';
+import { appProgressLine } from '../util/run-report-render.js';
 
 /**
  * Plans one QSEoW app without changing anything: the dry-run twin of
@@ -61,12 +62,21 @@ export const qseowPlanApp = async (appId, options, report) => {
         },
         async (global) => {
             const app = await global.openDoc(appId, '', '', '', false);
-            logger.info(`Opened app ${appId}`);
-            logger.info(`App name: "${appMetadata[0].name}"`);
-            logger.info(`App is published: ${appMetadata[0].published}`);
+            logger.verbose(`Opened app ${appId}`);
+            logger.verbose(`App name: "${appMetadata[0].name}"`);
+            logger.verbose(`App is published: ${appMetadata[0].published}`);
 
             const sheets = await getSheetList(app, SHEET_LIST_FIELDS_WITH_SHOW_CONDITION);
-            logger.info(`Number of sheets in app: ${sheets.length}`);
+
+            // Same fold as the real processor: one countable line, the
+            // individual facts at verbose.
+            logger.info(
+                appProgressLine({
+                    name: appMetadata[0].name,
+                    sheetCount: sheets.length,
+                    published: appMetadata[0].published,
+                })
+            );
 
             const appEntry = addAppToReport(report, {
                 id: appId,

--- a/src/lib/qseow/qseow-process-app.js
+++ b/src/lib/qseow/qseow-process-app.js
@@ -5,6 +5,7 @@ import { logger, sleep } from '../../globals.js';
 import { qseowUploadToContentLibrary } from './qseow-upload.js';
 import { qseowUpdateSheetThumbnails } from './qseow-updatesheets.js';
 import { determineSheetExcludeStatus } from './determine-sheet-exclude-status.js';
+import { determineSheetBlurStatus } from './determine-sheet-blur-status.js';
 import { readQseowAppContext } from './qseow-tagged-sheets.js';
 import { QseowError } from '../util/errors.js';
 import { launchBrowserForApp, closeBrowserQuietly } from '../browser/browser-launch.js';
@@ -15,6 +16,8 @@ import {
 } from '../util/sheet-list.js';
 import { withEngineSession } from '../util/engine-session.js';
 import { createAppImageDir } from '../util/image-dir.js';
+import { addAppToReport, recordPlannedSheet, recordAppOutcome } from '../util/run-report.js';
+import { appProgressLine, sheetProgressLine } from '../util/run-report-render.js';
 import { QSEOW_SHEET_PART_SELECTORS } from './sheet-parts.js';
 import { qseowLogout } from './qseow-logout.js';
 import { getQseowHubSelectors } from './qseow-selectors.js';
@@ -50,10 +53,13 @@ const selectorLoginPageLoginButton = '#loginbtn';
  * @param {string} options.prefix - URL prefix for accessing Qlik services.
  * @param {boolean|string} options.headless - Whether to run the browser in headless mode.
  * @param {number} options.blurFactor - Factor by which to blur images.
+ * @param {object} [report] - Run report from `createRunReport`; per-sheet
+ *     decisions and outcome counts are recorded onto it as they happen. The
+ *     progress lines and the run verdict render from these records.
  *
  * @returns {Promise<void>} Resolves when thumbnail generation, upload, and sheet-property updates for the app are complete.
  */
-export const qseowProcessApp = async (appId, options) => {
+export const qseowProcessApp = async (appId, options, report = null) => {
     // Get page timeout from options
     let pageTimeout = 90000; // 90 seconds
     if (options.browserPageTimeout && options.browserPageTimeout > 0) {
@@ -92,6 +98,7 @@ export const qseowProcessApp = async (appId, options) => {
         const configEnigma = setupEnigmaConnection(appId, options);
         const imgDir = options.imagedir;
         const createdFiles = [];
+        let appEntry = null;
 
         await withEngineSession(
             configEnigma,
@@ -105,17 +112,33 @@ export const qseowProcessApp = async (appId, options) => {
             },
             async (global) => {
                 const app = await global.openDoc(appId, '', '', '', false);
-                logger.info(`Opened app ${appId}`);
-                logger.info(`App name: "${appMetadata[0].name}"`);
-                logger.info(`App is published: ${appMetadata[0].published}`);
+                logger.verbose(`Opened app ${appId}`);
+                logger.verbose(`App name: "${appMetadata[0].name}"`);
+                logger.verbose(`App is published: ${appMetadata[0].published}`);
 
                 // Get list of app sheets
                 const sheets = await getSheetList(app, SHEET_LIST_FIELDS_WITH_SHOW_CONDITION);
 
-                if (sheets.length > 0) {
-                    // sheets[] now contains array of app sheets.
-                    logger.info(`Number of sheets in app: ${sheets.length}`);
+                // One line where four used to be: the name, count and publish
+                // state under the `app i/n` line the app loop printed. The
+                // individual facts moved to verbose above.
+                logger.info(
+                    appProgressLine({
+                        name: appMetadata[0].name,
+                        sheetCount: sheets.length,
+                        published: appMetadata[0].published,
+                    })
+                );
 
+                if (report) {
+                    appEntry = addAppToReport(report, {
+                        id: appId,
+                        name: appMetadata[0].name,
+                        sheetCount: sheets.length,
+                    });
+                }
+
+                if (sheets.length > 0) {
                     let iSheetNum = 1;
 
                     const browser = await launchBrowserForApp(options, {
@@ -232,26 +255,63 @@ export const qseowProcessApp = async (appId, options) => {
                             // --exclude-sheet-title <title...>
                             // --exclude-sheet-status <status...>
 
-                            let { excludeSheet, sheetIsHidden } = await determineSheetExcludeStatus(
-                                app,
-                                sheet,
-                                options,
-                                tagSheetAppMetadata,
-                                iSheetNum,
-                                repoDbSheetId,
-                                engineSheetId,
-                                logger
+                            const { excludeSheet, excludeReason, sheetIsHidden } =
+                                await determineSheetExcludeStatus(
+                                    app,
+                                    sheet,
+                                    options,
+                                    tagSheetAppMetadata,
+                                    iSheetNum,
+                                    repoDbSheetId,
+                                    engineSheetId,
+                                    logger
+                                );
+
+                            // The blur decision is applied later, in
+                            // updatesheets - computed here as well, from the
+                            // same module and the same inputs, so the progress
+                            // line and the report can say `blurred` where the
+                            // update step will use the blurred file.
+                            const { blurSheet, blurReason } = excludeSheet
+                                ? { blurSheet: false, blurReason: null }
+                                : determineSheetBlurStatus(
+                                      sheet,
+                                      options,
+                                      blurTagSheetAppMetadata,
+                                      iSheetNum,
+                                      logger
+                                  );
+
+                            // The ~230-column line with the sheet ids, description,
+                            // approved/published/hidden fields lives at verbose now;
+                            // the info line is the countable one-liner.
+                            logger.verbose(
+                                `${excludeSheet === true ? 'Excluded' : 'Processing'} sheet ${iSheetNum}: '${sheet.qMeta.title}', sheet id '${repoDbSheetId}', engine sheet id '${engineSheetId}', description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}', hidden '${sheetIsHidden}'`
                             );
 
                             if (excludeSheet === true) {
+                                // Recorded and logged immediately - the exclusion
+                                // is already a fact.
+                                if (appEntry) {
+                                    recordPlannedSheet(appEntry, {
+                                        n: iSheetNum,
+                                        title: sheet.qMeta.title,
+                                        excludeSheet,
+                                        excludeReason,
+                                        blurSheet,
+                                        blurReason,
+                                    });
+                                }
                                 logger.info(
-                                    `Excluded sheet: ${iSheetNum}: '${sheet.qMeta.title}', sheet id '${repoDbSheetId}', engine sheet id '${engineSheetId}', description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}', hidden '${sheetIsHidden}'`
+                                    sheetProgressLine({
+                                        n: iSheetNum,
+                                        total: sheets.length,
+                                        label: 'excluded',
+                                        title: sheet.qMeta.title,
+                                        reason: excludeReason,
+                                    })
                                 );
                             } else {
-                                logger.info(
-                                    `Processing sheet ${iSheetNum}: '${sheet.qMeta.title}', sheet id '${repoDbSheetId}', engine sheet id '${engineSheetId}', description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}', hidden '${sheetIsHidden}'`
-                                );
-
                                 // Build URL to current sheet
                                 const sheetUrl = `${appUrl}/sheet/${sheet.qInfo.qId}`;
                                 logger.debug(`Sheet URL: ${sheetUrl}`);
@@ -315,6 +375,31 @@ export const qseowProcessApp = async (appId, options) => {
                                         fileNameShort: fileNameShortBlurred,
                                     });
                                     logger.verbose(`Created blurred image: ${fileNameBlurred}`);
+
+                                    // Recorded and logged only now: both files
+                                    // exist, so `captured` (or `blurred`) is a
+                                    // fact rather than an intention. A sheet
+                                    // whose capture or blur failed leaves no
+                                    // row - the error lines tell that story.
+                                    if (appEntry) {
+                                        recordPlannedSheet(appEntry, {
+                                            n: iSheetNum,
+                                            title: sheet.qMeta.title,
+                                            excludeSheet,
+                                            excludeReason,
+                                            blurSheet,
+                                            blurReason,
+                                        });
+                                    }
+                                    logger.info(
+                                        sheetProgressLine({
+                                            n: iSheetNum,
+                                            total: sheets.length,
+                                            label: blurSheet ? 'blurred' : 'captured',
+                                            title: sheet.qMeta.title,
+                                            reason: blurReason,
+                                        })
+                                    );
                                 } catch (err) {
                                     logError(
                                         'QSEOW CREATE BLURRED IMAGE: Failed to create blurred image',
@@ -380,9 +465,22 @@ export const qseowProcessApp = async (appId, options) => {
         // The blur-tag metadata is passed, never the exclude-tag metadata: they are queried on
         // different options, and handing the exclude set to the blur rule would blur sheets
         // carrying the *exclude* tag. See issue #840.
-        await qseowUpdateSheetThumbnails(createdFiles, appId, options, blurTagSheetAppMetadata);
+        const sheetsUpdated = await qseowUpdateSheetThumbnails(
+            createdFiles,
+            appId,
+            options,
+            blurTagSheetAppMetadata
+        );
 
-        logger.info(`Done processing app ${appId}`);
+        recordAppOutcome(appEntry, {
+            sheetsUpdated,
+            imagesDir: `${imgDir}/qseow/${appId}`,
+            imageFileNames: createdFiles.map((file) => file.fileNameShort),
+        });
+
+        // The run card's verdict now closes the run; this line stays for
+        // anyone debugging at verbose.
+        logger.verbose(`Done processing app ${appId}`);
     } catch (err) {
         logError('QSEOW: qseowProcessApp', err);
         // Rethrow so the app loop can count this app as failed. Logging and returning

--- a/src/lib/qseow/qseow-tagged-sheets.js
+++ b/src/lib/qseow/qseow-tagged-sheets.js
@@ -3,7 +3,7 @@ import { logger } from '../../globals.js';
 import { setupQseowQrsConnection } from './qseow-qrs.js';
 import { QseowError } from '../util/errors.js';
 import { qrsFilterAnyOf, qrsPathWithFilter, toFilterValueList } from './qrs-filter.js';
-import { qrsGetList } from './qrs-response.js';
+import { qrsGetList, qrsGetCount } from './qrs-response.js';
 
 /**
  * Looks up the sheets in an app that carry any of the supplied tags.
@@ -67,6 +67,130 @@ export const getSheetsTaggedWith = async (
     );
 
     return taggedSheets;
+};
+
+/**
+ * How many app ids go into one QRS filter or-group.
+ *
+ * Each id contributes ~55-60 percent-encoded characters to the query string,
+ * and QRS sits behind http.sys, whose default request limits reject URLs
+ * around 16 KB - roughly 250-300 ids in one group. Chunking at 50 keeps every
+ * request comfortably small while still counting a large tag selection in a
+ * handful of constant-size responses.
+ */
+const PLAN_FACT_ID_CHUNK = 50;
+
+/**
+ * Splits a list into chunks of at most {@link PLAN_FACT_ID_CHUNK} entries.
+ *
+ * @param {string[]} values - The list.
+ *
+ * @returns {string[][]} The chunks, in order.
+ */
+const chunked = (values) => {
+    const chunks = [];
+    for (let i = 0; i < values.length; i += PLAN_FACT_ID_CHUNK) {
+        chunks.push(values.slice(i, i + PLAN_FACT_ID_CHUNK));
+    }
+
+    return chunks;
+};
+
+/**
+ * A parenthesised or-group over app ids for a QRS filter.
+ *
+ * App ids are interpolated unquoted, matching every other GUID filter in this
+ * file (`app.id eq ${appId}` below) - QRS parses bare GUIDs.
+ *
+ * @param {string} field - The QRS field, e.g. `id` or `app.id`.
+ * @param {string[]} ids - The app ids.
+ *
+ * @returns {string} A parenthesised filter term.
+ */
+const idGroup = (field, ids) => `(${ids.map((id) => `${field} eq ${id}`).join(' or ')})`;
+
+/**
+ * The plan-time facts the run card's PLAN block shows for a QSEoW run: how
+ * many of the selected apps are published, and how many sheets each tag rule
+ * matches across all of them.
+ *
+ * The tag counts are the anti-#840 line: `tag "no-thumbnail" (0 sheets)`
+ * printed before the first write is the cheapest possible fix for a mistyped
+ * tag silently matching nothing. The per-app lookups still happen inside each
+ * app's processing, through {@link getSheetsTaggedWith}, and remain the
+ * counts the decisions are actually made from.
+ *
+ * Everything goes through the QRS `count` endpoints in id chunks: only
+ * numbers are wanted, so fetching full repository entities to take `.length`
+ * would move kilobytes per counted sheet, and one giant or-group over every
+ * selected app would exceed the server's URL limits on exactly the mass tag
+ * runs these counts exist for. The three fact groups are independent and run
+ * in parallel.
+ *
+ * Failures degrade to nulls rather than failing the run: these numbers
+ * decorate the plan, and a filter QRS rejects must not stop work the operator
+ * asked for. The QRS being unreachable is not masked - every caller has
+ * already talked to QRS to resolve its selection before calling this.
+ *
+ * @param {object} options - The run's options bag.
+ * @param {string[]} appIds - The selected app ids, deduplicated or not.
+ *
+ * @returns {Promise<{publishedAppCount: number|null, excludeTagSheetCount: number|null, blurTagSheetCount: number|null}>}
+ *     The counts; tag counts are null when the corresponding option was not used.
+ */
+export const readQseowPlanFacts = async (options, appIds) => {
+    const facts = {
+        publishedAppCount: null,
+        excludeTagSheetCount: null,
+        blurTagSheetCount: null,
+    };
+
+    const uniqueAppIds = [...new Set(appIds)];
+    if (uniqueAppIds.length === 0) {
+        return facts;
+    }
+
+    try {
+        const qrsInteractInstance = new qrsInteract(setupQseowQrsConnection(options));
+
+        const sumCounts = async (endpoint, filterForChunk) => {
+            let sum = 0;
+            for (const chunk of chunked(uniqueAppIds)) {
+                sum += await qrsGetCount(
+                    qrsInteractInstance,
+                    qrsPathWithFilter(endpoint, filterForChunk(chunk))
+                );
+            }
+
+            return sum;
+        };
+
+        const countTagged = (tagOption) => {
+            const tags = toFilterValueList(tagOption);
+            if (tags.length === 0) {
+                return null;
+            }
+
+            return sumCounts(
+                'app/object/count',
+                (chunk) =>
+                    `objectType eq 'sheet' and ${idGroup('app.id', chunk)} and ${qrsFilterAnyOf('tags.name', tags)}`
+            );
+        };
+
+        [facts.publishedAppCount, facts.excludeTagSheetCount, facts.blurTagSheetCount] =
+            await Promise.all([
+                sumCounts('app/count', (chunk) => `${idGroup('id', chunk)} and published eq true`),
+                countTagged(options.excludeSheetTag),
+                countTagged(options.blurSheetTag),
+            ]);
+    } catch (err) {
+        logger.verbose(
+            `Could not read plan facts from QRS - the plan block will omit them: ${err?.message ?? err}`
+        );
+    }
+
+    return facts;
 };
 
 /**

--- a/src/lib/qseow/qseow-updatesheets.js
+++ b/src/lib/qseow/qseow-updatesheets.js
@@ -9,6 +9,7 @@ import {
     sortSheetsByRank,
     saveIfChanged,
     getSheetList,
+    logUpdatedSheetSummary,
 } from '../util/sheet-list.js';
 import { determineSheetBlurStatus } from './determine-sheet-blur-status.js';
 
@@ -24,8 +25,8 @@ import { determineSheetBlurStatus } from './determine-sheet-blur-status.js';
  * the exclude-tag one: passing the latter would blur every sheet the operator asked to skip.
  * Defaults to empty so the tag rule matches nothing when the caller has not looked it up.
  *
- * @returns {Promise<void>} Resolves when every sheet that had a generated thumbnail was
- *     updated.
+ * @returns {Promise<number>} How many sheets were given a new thumbnail - the number the
+ *     run card's verdict reports.
  *
  * @throws {QseowError} When any sheet could not be updated, or when thumbnails were created
  *     but no sheet matched one. Other sheets are still attempted first and the engine
@@ -62,7 +63,7 @@ export const qseowUpdateSheetThumbnails = async (
 
                 if (sheets.length > 0) {
                     // dimObj.qAppObjectList.qItems[] now contains array of app sheets.
-                    logger.info(`Number of sheets: ${sheets.length}`);
+                    logger.verbose(`Number of sheets: ${sheets.length}`);
 
                     // Sort sheets
                     sortSheetsByRank(sheets);
@@ -86,8 +87,8 @@ export const qseowUpdateSheetThumbnails = async (
                                 // No thumbnail for this sheet, skip. Guarded: this line is inside
                                 // the counted region, so an unguarded dereference here would fail
                                 // the app over a sheet nobody was going to touch.
-                                logger.info(
-                                    `Skipping update of sheet sheet ${iSheetNum}: Name '${sheet?.qMeta?.title}', ID ${sheet?.qInfo?.qId}, description '${sheet?.qMeta?.description}'`
+                                logger.verbose(
+                                    `Skipping update of sheet ${iSheetNum}: Name '${sheet?.qMeta?.title}', ID ${sheet?.qInfo?.qId}, description '${sheet?.qMeta?.description}'`
                                 );
 
                                 return SHEET_SKIPPED;
@@ -108,14 +109,14 @@ export const qseowUpdateSheetThumbnails = async (
                                 const sheetProperties = await sheetObj.getProperties();
 
                                 if (blurSheet === true) {
-                                    logger.info(
+                                    logger.verbose(
                                         `Using blurred thumbnail for sheet ${iSheetNum}: Name '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
                                     );
 
                                     // Set new sheet thumbnail
                                     sheetProperties.thumbnail.qStaticContentUrlDef.qUrl = `/content/${options.contentlibrary}/thumbnail-${appId}-${iSheetNum}-blurred.png`;
                                 } else {
-                                    logger.info(
+                                    logger.verbose(
                                         `Using regular thumbnail for sheet ${iSheetNum}: Name '${sheet.qMeta.title}', ID ${sheet.qInfo.qId}, description '${sheet.qMeta.description}'`
                                     );
 
@@ -152,5 +153,12 @@ export const qseowUpdateSheetThumbnails = async (
         throw new QseowError(`Failed to update sheet thumbnails in app ${appId}`, { cause: err });
     }
 
+    // Summary BEFORE the assert: when one sheet failed, the others' writes
+    // were already persisted by saveIfChanged, and the operator must learn
+    // about them even as the app is counted failed.
+    const changed = logUpdatedSheetSummary(sheetRun);
+
     sheetRun?.assertAllProcessed();
+
+    return changed;
 };

--- a/src/lib/qseow/qseow-upload.js
+++ b/src/lib/qseow/qseow-upload.js
@@ -53,8 +53,8 @@ export const qseowUploadToContentLibrary = async (filesToUpload, appId, options)
 
         const { contentlibrary } = options;
 
-        logger.info(`Uploading images in folder: ${iconFolderAbsolute}`);
-        logger.info(`Uploading images to Qlik Sense content library: ${contentlibrary}`);
+        logger.verbose(`Uploading images in folder: ${iconFolderAbsolute}`);
+        logger.verbose(`Uploading images to Qlik Sense content library: ${contentlibrary}`);
 
         logger.debug(`Files to be uploaded to QSEoW`);
         filesToUpload.forEach((file) => logger.debug(JSON.stringify(file)));
@@ -116,4 +116,10 @@ export const qseowUploadToContentLibrary = async (filesToUpload, appId, options)
             `Failed to upload ${failedCount} of ${failedCount + uploadedCount} thumbnail image(s) to content library ${options.contentlibrary}`
         );
     }
+
+    // The countable line the two verbose lines above used to approximate:
+    // what went where, once, with a number.
+    logger.info(
+        `  uploaded ${uploadedCount} image file(s) to content library "${options.contentlibrary}"`
+    );
 };

--- a/src/lib/qseow/sheet-parts.js
+++ b/src/lib/qseow/sheet-parts.js
@@ -27,6 +27,20 @@ export const QSEOW_SHEET_PART_SELECTORS = Object.freeze({
 });
 
 /**
+ * Human-readable descriptions of the QSEoW sheet parts, keyed like the
+ * selector map above so the two cannot list different values. Shown in the
+ * run card's PLAN block, where a bare `2` would send the operator to the docs.
+ *
+ * @type {Readonly<Record<string, string>>}
+ */
+export const QSEOW_SHEET_PART_LABELS = Object.freeze({
+    1: 'sheet objects only',
+    2: 'objects + sheet title',
+    3: 'objects + title + selection bar',
+    4: 'entire sheet incl. menus',
+});
+
+/**
  * Values `--includesheetpart` accepts on QSEoW, in ascending order. Frozen.
  *
  * Passed to Commander's `.choices()`, which both validates and makes the values discoverable in

--- a/src/lib/util/__tests__/run-report-flow.test.js
+++ b/src/lib/util/__tests__/run-report-flow.test.js
@@ -1,0 +1,200 @@
+import { describe, test, expect, beforeEach, jest } from '@jest/globals';
+
+/**
+ * Flow tests for `runOverAppsWithReport` as extended by issue #1073: the plan
+ * block must be emitted before the first per-app worker runs (ordering is the
+ * safety property - the plan exists to be read before the first write), a
+ * real run must close with a verdict, and failures must be counted on the
+ * report before the verdict renders.
+ *
+ * The logger and the per-app workers write into one shared timeline array, so
+ * ordering can be asserted rather than inferred.
+ */
+
+const timeline = [];
+
+jest.unstable_mockModule('../../../globals.js', () => ({
+    logger: {
+        info: jest.fn((line) => timeline.push(`LOG ${line}`)),
+        verbose: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn((line) => timeline.push(`ERROR ${line}`)),
+        warn: jest.fn(),
+    },
+    getLoggingLevel: jest.fn().mockReturnValue('info'),
+    setLoggingLevel: jest.fn(),
+}));
+
+const { runOverAppsWithReport } = await import('../run-report.js');
+const { getLoggingLevel, setLoggingLevel } = await import('../../../globals.js');
+
+/**
+ * A minimal but complete run argument bag.
+ *
+ * @param {object} overrides - Fields to override.
+ *
+ * @returns {object} Arguments for `runOverAppsWithReport`.
+ */
+const runArgs = (overrides = {}) => ({
+    command: 'qseow create-sheet-thumbnails',
+    dryRun: false,
+    appIds: ['app-1', 'app-2'],
+    namedAppIds: ['app-1', 'app-2'],
+    selectorAppIds: [],
+    selector: null,
+    plan: {
+        writes: { kind: 'thumbnails', contentLibrary: 'lib', publishedAppCount: 1 },
+    },
+    logPrefix: { plan: 'TEST PLAN', process: 'TEST PROCESS' },
+    emptySelectionHint: 'hint',
+    planApp: jest.fn(async (appId) => {
+        timeline.push(`PLANAPP ${appId}`);
+    }),
+    processApp: jest.fn(async (appId) => {
+        timeline.push(`PROCESS ${appId}`);
+    }),
+    ...overrides,
+});
+
+beforeEach(() => {
+    timeline.length = 0;
+    jest.clearAllMocks();
+    // clearAllMocks clears call records but NOT return values, so a
+    // mockReturnValue('warn') set in one describe would silently leak into
+    // every later test without this reset.
+    getLoggingLevel.mockReturnValue('info');
+});
+
+describe('runOverAppsWithReport - the plan renders before the first write', () => {
+    test('on a real run, PLAN precedes every processApp call', async () => {
+        await runOverAppsWithReport(runArgs());
+
+        const planIndex = timeline.findIndex((entry) => entry === 'LOG PLAN');
+        const firstProcess = timeline.findIndex((entry) => entry.startsWith('PROCESS'));
+
+        expect(planIndex).toBeGreaterThan(-1);
+        expect(firstProcess).toBeGreaterThan(-1);
+        expect(planIndex).toBeLessThan(firstProcess);
+    });
+
+    test('on a dry run, PLAN precedes every planApp call', async () => {
+        await runOverAppsWithReport(runArgs({ dryRun: true }));
+
+        const planIndex = timeline.findIndex((entry) => entry === 'LOG PLAN');
+        const firstPlanApp = timeline.findIndex((entry) => entry.startsWith('PLANAPP'));
+
+        expect(planIndex).toBeGreaterThan(-1);
+        expect(firstPlanApp).toBeGreaterThan(-1);
+        expect(planIndex).toBeLessThan(firstPlanApp);
+    });
+});
+
+describe('runOverAppsWithReport - the verdict', () => {
+    test('a clean real run closes with RESULT ok after the last app', async () => {
+        const result = await runOverAppsWithReport(runArgs());
+
+        expect(result).toBe(true);
+        const verdictIndex = timeline.findIndex((entry) => entry === 'LOG RESULT  ok');
+        const lastProcess = timeline.map((e) => e.startsWith('PROCESS')).lastIndexOf(true);
+        expect(verdictIndex).toBeGreaterThan(lastProcess);
+        expect(timeline).toContain('LOG   apps          2 ok, 0 failed');
+    });
+
+    test('a failed app is counted on the report and fails the verdict', async () => {
+        const args = runArgs({
+            processApp: jest.fn(async (appId) => {
+                if (appId === 'app-2') {
+                    throw new Error('boom');
+                }
+                timeline.push(`PROCESS ${appId}`);
+            }),
+        });
+
+        const result = await runOverAppsWithReport(args);
+
+        expect(result).toBe(false);
+        expect(timeline).toContain('LOG RESULT  FAILED');
+        expect(timeline).toContain('LOG   apps          1 ok, 1 failed');
+    });
+
+    test('an empty real selection still gets a verdict naming the emptiness', async () => {
+        const result = await runOverAppsWithReport(
+            runArgs({ appIds: [], namedAppIds: [], selectorAppIds: [] })
+        );
+
+        expect(result).toBe(false);
+        expect(timeline).toContain('LOG RESULT  FAILED');
+        expect(timeline).toContain('LOG   apps          0 selected - nothing was done');
+    });
+
+    test('a dry run renders the dry-run report, never a RESULT block', async () => {
+        await runOverAppsWithReport(runArgs({ dryRun: true }));
+
+        expect(timeline.some((entry) => entry.startsWith('LOG RESULT'))).toBe(false);
+        expect(timeline.some((entry) => entry.includes('DRY RUN of'))).toBe(true);
+    });
+
+    test('a planner that fails is marked on the dry-run report, and the apply invite is withheld', async () => {
+        // A planner failure after (or before) its rows are recorded must not
+        // render as a clean plan that invites re-running without --dry-run.
+        const result = await runOverAppsWithReport(
+            runArgs({
+                dryRun: true,
+                planApp: jest.fn(async (appId) => {
+                    if (appId === 'app-2') {
+                        throw new Error('media list read failed');
+                    }
+                    timeline.push(`PLANAPP ${appId}`);
+                }),
+            })
+        );
+
+        expect(result).toBe(false);
+        expect(timeline.some((entry) => entry.includes('could not be fully planned'))).toBe(true);
+        expect(
+            timeline.some((entry) => entry.includes('Fix the errors above before applying'))
+        ).toBe(true);
+        expect(timeline.some((entry) => entry.includes('Re-run without --dry-run to apply'))).toBe(
+            false
+        );
+    });
+});
+
+describe('runOverAppsWithReport - visibility at quiet log levels', () => {
+    test('a dry run forces the plan visible at warn', async () => {
+        getLoggingLevel.mockReturnValue('warn');
+
+        await runOverAppsWithReport(runArgs({ dryRun: true }));
+
+        expect(setLoggingLevel).toHaveBeenCalledWith('info');
+        expect(setLoggingLevel).toHaveBeenCalledWith('warn');
+    });
+
+    test("a real run respects the operator's quiet level", async () => {
+        // A real run at warn asked for a quiet log; the run card must not
+        // override that the way the dry-run report deliberately does.
+        getLoggingLevel.mockReturnValue('warn');
+
+        await runOverAppsWithReport(runArgs());
+
+        expect(setLoggingLevel).not.toHaveBeenCalled();
+    });
+});
+
+describe('runOverAppsWithReport - countable app lines', () => {
+    test('each app is announced as i/n before its worker runs', async () => {
+        await runOverAppsWithReport(runArgs());
+
+        const first = timeline.indexOf('LOG app 1/2  app-1');
+        const firstProcess = timeline.indexOf('PROCESS app-1');
+        expect(first).toBeGreaterThan(-1);
+        expect(first).toBeLessThan(firstProcess);
+        expect(timeline).toContain('LOG app 2/2  app-2');
+    });
+
+    test('a dry run keeps its verb in the app line', async () => {
+        await runOverAppsWithReport(runArgs({ dryRun: true }));
+
+        expect(timeline).toContain('LOG plan app 1/2  app-1');
+    });
+});

--- a/src/lib/util/__tests__/run-report-render.test.js
+++ b/src/lib/util/__tests__/run-report-render.test.js
@@ -1,0 +1,469 @@
+import { describe, test, expect } from '@jest/globals';
+import {
+    RUN_FRAME,
+    renderRunHeaderLines,
+    logRunHeader,
+    renderRunPlanLines,
+    renderRunVerdictLines,
+    appProgressLine,
+    sheetProgressLine,
+    formatElapsed,
+    formatBytes,
+    isOptionEnabled,
+} from '../run-report-render.js';
+import {
+    createRunReport,
+    recordSelection,
+    addAppToReport,
+    buildSheetRules,
+} from '../run-report.js';
+import { EXCLUDE_REASON, BLUR_REASON, CLEAR_REASON } from '../sheet-decision-reasons.js';
+
+/**
+ * The frame-only ASCII property from issue #1073, scoped per the comment on
+ * that issue: everything the renderer itself emits must be plain ASCII, while
+ * app and sheet names are user data and pass through untouched.
+ */
+const PURE_ASCII = /^[\x20-\x7e\n]*$/;
+
+/**
+ * A representative QSEoW create report, mirroring the shape the worker
+ * assembles: tag rules with match counts (one of them zero - the anti-#840
+ * number), a published-app count, and the content library destination.
+ *
+ * @param {object} [overrides] - Report fields to override.
+ *
+ * @returns {object} The report.
+ */
+const qseowReport = (overrides = {}) => {
+    const report = createRunReport({ command: 'qseow create-sheet-thumbnails', dryRun: false });
+    recordSelection(report, {
+        namedAppIds: ['app-1', 'app-7'],
+        selectorAppIds: ['app-1', 'app-2', 'app-3', 'app-4', 'app-5', 'app-6'],
+        selector: { option: 'qliksensetag', value: 'sheet-thumbnails' },
+    });
+    report.plan = {
+        target: {
+            platform: 'qseow',
+            host: 'qs-prod-1.company.com',
+            port: null,
+            secure: true,
+            prefix: '',
+            enginePort: '4747',
+            qrsPort: '4242',
+            schemaVersion: '12.612.0',
+        },
+        auth: {
+            apiUser: { directory: 'INTERNAL', userId: 'sa_api' },
+            certFile: './cert/client.pem',
+            logonUser: { directory: 'COMPANY', userId: 'bsi_svc' },
+        },
+        sheetPart: { value: '2', max: '4', label: 'objects + sheet title' },
+        rules: {
+            exclude: [
+                { option: 'exclude-sheet-tag', values: ['no-thumbnail'], matchedSheetCount: 0 },
+                { option: 'exclude-sheet-number', values: ['1'], matchedSheetCount: null },
+            ],
+            blur: [{ option: 'blur-sheet-tag', values: ['confidential'], matchedSheetCount: 3 }],
+        },
+        browser: {
+            name: 'chrome',
+            version: 'recommended',
+            headless: true,
+            pageWaitSeconds: 5,
+        },
+        output: { imageDir: './img', platformDir: 'qseow' },
+        writes: {
+            kind: 'thumbnails',
+            contentLibrary: 'Butler sheet thumbnails',
+            publishedAppCount: 6,
+        },
+    };
+
+    return Object.assign(report, overrides);
+};
+
+describe('renderRunHeaderLines / logRunHeader', () => {
+    test('frames the version and job label', () => {
+        expect(renderRunHeaderLines('9.9.9', 'QSEoW sheet thumbnails')).toEqual([
+            RUN_FRAME,
+            ' BUTLER SHEET ICONS 9.9.9 -- QSEoW sheet thumbnails',
+            RUN_FRAME,
+        ]);
+    });
+
+    test('logRunHeader writes each line through the given logger at info', () => {
+        const lines = [];
+        logRunHeader({ info: (line) => lines.push(line) }, '9.9.9', 'browser install');
+
+        expect(lines).toHaveLength(3);
+        expect(lines[1]).toBe(' BUTLER SHEET ICONS 9.9.9 -- browser install');
+    });
+});
+
+describe('renderRunPlanLines - QSEoW create', () => {
+    test('renders every section of a representative plan', () => {
+        expect(renderRunPlanLines(qseowReport())).toEqual([
+            '',
+            'PLAN',
+            '  server        qs-prod-1.company.com   https, no virtual proxy',
+            '                engine 4747, qrs 4242, schema 12.612.0',
+            '  api user      INTERNAL\\sa_api via ./cert/client.pem',
+            '  logon user    COMPANY\\bsi_svc',
+            '  apps          7   2 named by --appid, 6 matched by --qliksensetag "sheet-thumbnails", 1 selected twice',
+            '  sheet part    2 of 4 -- objects + sheet title',
+            '  exclude       tag "no-thumbnail" (0 sheets), number 1',
+            '  blur          tag "confidential" (3 sheets)',
+            '  browser       chrome (version: recommended), headless, 5s per sheet',
+            '  images        ./img/qseow/<app-id>',
+            '  uploads to    content library "Butler sheet thumbnails"',
+            '  WILL OVERWRITE existing sheet thumbnails in 7 app(s), 6 of them published',
+        ]);
+    });
+
+    test('a zero-match tag count is printed, not omitted', () => {
+        // The one number that matters most: a renderer that silently dropped
+        // "(0 sheets)" would reintroduce the silent no-op from #840.
+        expect(renderRunPlanLines(qseowReport()).join('\n')).toContain(
+            'tag "no-thumbnail" (0 sheets)'
+        );
+    });
+
+    test('a dry run says WOULD, a real run says WILL', () => {
+        expect(renderRunPlanLines(qseowReport()).join('\n')).toContain('WILL OVERWRITE');
+        expect(renderRunPlanLines(qseowReport({ dryRun: true })).join('\n')).toContain(
+            'WOULD OVERWRITE'
+        );
+    });
+
+    test('absent rules are stated as none rather than omitted', () => {
+        const report = qseowReport();
+        report.plan.rules = { exclude: [], blur: [] };
+
+        const text = renderRunPlanLines(report).join('\n');
+        expect(text).toContain('exclude       none');
+        expect(text).toContain('blur          none');
+    });
+
+    test('a report without a plan renders nothing', () => {
+        const report = createRunReport({ command: 'x', dryRun: false });
+
+        expect(renderRunPlanLines(report)).toEqual([]);
+    });
+
+    test('port and virtual proxy render when set', () => {
+        const report = qseowReport();
+        report.plan.target.port = '8443';
+        report.plan.target.prefix = 'form';
+
+        expect(renderRunPlanLines(report).join('\n')).toContain(
+            'qs-prod-1.company.com:8443   https, virtual proxy "form"'
+        );
+    });
+
+    test('the headless label follows the launch semantics: unknown values mean headless', () => {
+        // The launch path (parseHeadlessOption) treats everything except an
+        // explicit false as headless. The plan must say what the launch will
+        // do, not apply a stricter rule of its own.
+        for (const value of ['1', 'yes', 'TRUE', '', undefined]) {
+            const report = qseowReport();
+            report.plan.browser.headless = value;
+            expect(renderRunPlanLines(report).join('\n')).toContain('headless');
+            expect(renderRunPlanLines(report).join('\n')).not.toContain('visible window');
+        }
+
+        const report = qseowReport();
+        report.plan.browser.headless = 'false';
+        expect(renderRunPlanLines(report).join('\n')).toContain('visible window');
+    });
+
+    test('an empty selection suppresses the overwrite warning', () => {
+        // "WILL OVERWRITE ... 0 app(s)" in capitals right before the no-apps
+        // error would describe a write that was never possible.
+        const report = qseowReport();
+        recordSelection(report, { namedAppIds: [], selectorAppIds: [], selector: null });
+
+        const text = renderRunPlanLines(report).join('\n');
+        expect(text).not.toContain('OVERWRITE');
+        expect(text).not.toContain('uploads to');
+    });
+});
+
+describe('renderRunPlanLines - Cloud', () => {
+    test('renders tenant, API key auth and the media-library destination', () => {
+        const report = createRunReport({
+            command: 'qscloud create-sheet-thumbnails',
+            dryRun: false,
+        });
+        recordSelection(report, {
+            namedAppIds: ['app-a'],
+            selectorAppIds: [],
+            selector: null,
+        });
+        report.plan = {
+            target: { platform: 'cloud', tenantUrl: 'tenant.eu.qlikcloud.com' },
+            auth: { apiKey: true, logonUserId: 'bsi@company.com', skipLogin: false },
+            sheetPart: { value: '1', max: '4', label: 'sheet objects only' },
+            rules: buildSheetRules({ excludeSheetStatus: ['private'] }),
+            browser: {
+                name: 'chrome',
+                version: 'recommended',
+                headless: 'true',
+                pageWaitSeconds: 5,
+            },
+            output: { imageDir: './img', platformDir: 'cloud' },
+            writes: { kind: 'thumbnails', contentLibrary: null, publishedAppCount: null },
+        };
+
+        expect(renderRunPlanLines(report)).toEqual([
+            '',
+            'PLAN',
+            '  tenant        tenant.eu.qlikcloud.com',
+            '  auth          API key',
+            '  logon user    bsi@company.com',
+            '  apps          1   1 named by --appid',
+            '  sheet part    1 of 4 -- sheet objects only',
+            '  exclude       status private',
+            '  blur          none',
+            '  browser       chrome (version: recommended), headless, 5s per sheet',
+            '  images        ./img/cloud/<app-id>',
+            '  uploads to    each app\'s media library, "thumbnails" folder',
+            '  WILL OVERWRITE existing sheet thumbnails in 1 app(s)',
+        ]);
+    });
+
+    test('remove-sheet-icons plans the removal warning and skips the thumbnail sections', () => {
+        const report = createRunReport({ command: 'qscloud remove-sheet-icons', dryRun: true });
+        recordSelection(report, { namedAppIds: ['a', 'b'], selectorAppIds: [], selector: null });
+        report.plan = {
+            target: { platform: 'cloud', tenantUrl: 'tenant.eu.qlikcloud.com' },
+            auth: { apiKey: true },
+            writes: { kind: 'clear-icons' },
+        };
+
+        const text = renderRunPlanLines(report).join('\n');
+        expect(text).toContain('WOULD REMOVE sheet icons and thumbnail media files from 2 app(s)');
+        expect(text).not.toContain('sheet part');
+        expect(text).not.toContain('browser');
+        expect(text).not.toContain('uploads to');
+    });
+});
+
+describe('renderRunVerdictLines', () => {
+    /**
+     * A finished two-app create run: one app fully processed, one failed
+     * before its section opened.
+     *
+     * @returns {object} The report.
+     */
+    const finishedCreateReport = () => {
+        const report = qseowReport();
+        report.startedAt = 1_000_000;
+        report.finishedAt = 1_000_000 + 6 * 60_000 + 12_000;
+        report.succeeded = false;
+
+        const app = addAppToReport(report, { id: 'app-1', name: 'Sales', sheetCount: 4 });
+        app.sheets.push(
+            { n: 1, title: 'Overview', action: 'update', reason: null },
+            { n: 2, title: 'Board pack', action: 'blur', reason: BLUR_REASON.TAG },
+            { n: 3, title: 'Scratch', action: 'skip', reason: EXCLUDE_REASON.NUMBER },
+            { n: 4, title: 'Revenue', action: 'update', reason: null }
+        );
+        app.sheetsUpdated = 3;
+        app.imagesKeptFiles = 6;
+        app.imagesKeptBytes = 4_300_000;
+
+        addAppToReport(report, { id: 'app-2' }).failed = true;
+
+        return report;
+    };
+
+    test('renders the create verdict with counts, destination, images and elapsed time', () => {
+        expect(renderRunVerdictLines(finishedCreateReport())).toEqual([
+            '',
+            'RESULT  FAILED',
+            '  apps          1 ok, 1 failed',
+            '  sheets        4 seen, 3 captured (1 blurred), 1 excluded',
+            '  thumbnails    3 sheet(s) given new thumbnails in content library "Butler sheet thumbnails"',
+            '  images kept   ./img/qseow   6 file(s), 4.1 MB',
+            '  elapsed       6m 12s',
+            RUN_FRAME,
+        ]);
+    });
+
+    test('a clean run says ok', () => {
+        const report = finishedCreateReport();
+        report.succeeded = true;
+        report.apps.pop();
+
+        const lines = renderRunVerdictLines(report);
+        expect(lines[1]).toBe('RESULT  ok');
+        expect(lines).toContain('  apps          1 ok, 0 failed');
+    });
+
+    test('an empty selection is a failure that says nothing was done', () => {
+        const report = createRunReport({ command: 'qseow create-sheet-thumbnails', dryRun: false });
+        recordSelection(report, { namedAppIds: [], selectorAppIds: [], selector: null });
+        report.succeeded = false;
+
+        expect(renderRunVerdictLines(report)).toEqual([
+            '',
+            'RESULT  FAILED',
+            '  apps          0 selected - nothing was done',
+            RUN_FRAME,
+        ]);
+    });
+
+    test('a removal run reports cleared icons, no-icon sheets and deleted media files', () => {
+        const report = createRunReport({ command: 'qscloud remove-sheet-icons', dryRun: false });
+        recordSelection(report, { namedAppIds: ['app-1'], selectorAppIds: [], selector: null });
+        report.plan = { writes: { kind: 'clear-icons' } };
+        report.succeeded = true;
+
+        const app = addAppToReport(report, { id: 'app-1', sheetCount: 3 });
+        app.sheets.push(
+            { n: 1, title: 'Main', action: 'clear', reason: null },
+            { n: 2, title: 'Notes', action: 'clear', reason: CLEAR_REASON.NO_ICON },
+            { n: 3, title: 'KPI', action: 'clear', reason: null }
+        );
+        app.mediaFilesDeleted = 4;
+
+        const text = renderRunVerdictLines(report).join('\n');
+        expect(text).toContain('RESULT  ok');
+        expect(text).toContain('3 seen, 2 icon(s) cleared, 1 had no icon');
+        expect(text).toContain('4 thumbnail file(s) deleted from app media libraries');
+    });
+
+    test('a removal run keeps its vocabulary even with no plan on the report', () => {
+        // The mode comes from report.command, never from the optional plan
+        // sections - the next removal caller may legally supply no plan.
+        const report = createRunReport({ command: 'qscloud remove-sheet-icons', dryRun: false });
+        recordSelection(report, { namedAppIds: ['app-1'], selectorAppIds: [], selector: null });
+        report.succeeded = true;
+
+        const app = addAppToReport(report, { id: 'app-1', sheetCount: 1 });
+        app.sheets.push({ n: 1, title: 'Main', action: 'clear', reason: null });
+
+        const text = renderRunVerdictLines(report).join('\n');
+        expect(text).toContain('1 icon(s) cleared');
+        expect(text).not.toContain('captured');
+    });
+
+    test('sums recorded per-app fields and omits lines nothing recorded', () => {
+        const report = qseowReport();
+        report.succeeded = true;
+        // Two apps that never reached the update step: no thumbnails line,
+        // no images line, rather than a fabricated zero.
+        addAppToReport(report, { id: 'a' });
+        addAppToReport(report, { id: 'b' });
+
+        const text = renderRunVerdictLines(report).join('\n');
+        expect(text).not.toContain('thumbnails');
+        expect(text).not.toContain('images kept');
+    });
+});
+
+describe('the ASCII frame property (issue #1073)', () => {
+    test('header, plan and verdict are pure ASCII when the content is', () => {
+        const report = finishedAsciiReport();
+
+        const everything = [
+            ...renderRunHeaderLines('9.9.9', 'QSEoW sheet thumbnails'),
+            ...renderRunPlanLines(report),
+            ...renderRunVerdictLines(report),
+        ].join('\n');
+
+        expect(PURE_ASCII.test(everything)).toBe(true);
+    });
+
+    test('non-ASCII app and sheet names pass through untouched', () => {
+        // User data is exempt from the ASCII rule and must never be
+        // "purified" - the operator has to recognise their own app names.
+        const line = sheetProgressLine({
+            n: 3,
+            total: 9,
+            label: 'captured',
+            title: 'Försäljning Södertälje',
+        });
+        expect(line).toContain('Försäljning Södertälje');
+
+        const appLine = appProgressLine({
+            name: 'Ekonomiöversikt',
+            sheetCount: 9,
+            published: true,
+        });
+        expect(appLine).toContain('Ekonomiöversikt');
+    });
+
+    /**
+     * A finished report whose user data is all-ASCII, so any non-ASCII byte
+     * in the output would have to come from the frame itself.
+     *
+     * @returns {object} The report.
+     */
+    function finishedAsciiReport() {
+        const report = qseowReport();
+        report.succeeded = true;
+        report.finishedAt = report.startedAt + 45_000;
+        const app = addAppToReport(report, { id: 'app-1', name: 'Sales', sheetCount: 1 });
+        app.sheets.push({ n: 1, title: 'Overview', action: 'update', reason: null });
+        app.sheetsUpdated = 1;
+        app.imagesKeptFiles = 2;
+        app.imagesKeptBytes = 1024;
+
+        return report;
+    }
+});
+
+describe('progress lines', () => {
+    test('a missing title or name never prints the literal undefined', () => {
+        expect(sheetProgressLine({ n: 2, total: 5, label: 'no icon', title: undefined })).toBe(
+            "  sheet  2/5  no icon   ''"
+        );
+        expect(appProgressLine({ name: undefined, sheetCount: 3 })).toBe('  "" -- 3 sheet(s)');
+    });
+
+    test('sheet lines are countable and name the responsible option', () => {
+        expect(
+            sheetProgressLine({
+                n: 2,
+                total: 11,
+                label: 'excluded',
+                title: 'Scratch pad',
+                reason: EXCLUDE_REASON.NUMBER,
+            })
+        ).toBe("  sheet  2/11  excluded  'Scratch pad'  (--exclude-sheet-number)");
+
+        expect(sheetProgressLine({ n: 1, total: 11, label: 'captured', title: 'Overview' })).toBe(
+            "  sheet  1/11  captured  'Overview'"
+        );
+    });
+
+    test('app lines carry name, sheet count and publish state', () => {
+        expect(appProgressLine({ name: 'Sales', sheetCount: 11, published: true })).toBe(
+            '  "Sales" -- 11 sheet(s), published'
+        );
+        expect(appProgressLine({ name: 'Sales', sheetCount: 0 })).toBe('  "Sales" -- 0 sheet(s)');
+    });
+});
+
+describe('formatters', () => {
+    test('formatElapsed picks the right unit pair', () => {
+        expect(formatElapsed(45_000)).toBe('45s');
+        expect(formatElapsed(6 * 60_000 + 12_000)).toBe('6m 12s');
+        expect(formatElapsed(3_600_000 + 2 * 60_000)).toBe('1h 2m');
+    });
+
+    test('formatBytes picks the right unit', () => {
+        expect(formatBytes(512)).toBe('512 B');
+        expect(formatBytes(2048)).toBe('2.0 KB');
+        expect(formatBytes(4_300_000)).toBe('4.1 MB');
+    });
+
+    test('isOptionEnabled accepts boolean true and the string Commander delivers', () => {
+        expect(isOptionEnabled(true)).toBe(true);
+        expect(isOptionEnabled('true')).toBe(true);
+        expect(isOptionEnabled(false)).toBe(false);
+        expect(isOptionEnabled('false')).toBe(false);
+    });
+});

--- a/src/lib/util/__tests__/run-report.test.js
+++ b/src/lib/util/__tests__/run-report.test.js
@@ -7,6 +7,7 @@ import {
     reportTotals,
     renderDryRunReport,
 } from '../run-report.js';
+import { renderRunPlanLines } from '../run-report-render.js';
 import { EXCLUDE_REASON, BLUR_REASON } from '../sheet-decision-reasons.js';
 
 const fakeLogger = () => {
@@ -97,24 +98,47 @@ describe('renderDryRunReport', () => {
         expect(text).toMatch(/Overview\s+update\n/);
     });
 
-    test('reports the app selection provenance', () => {
-        const log = fakeLogger();
-        renderDryRunReport(sampleReport(), log);
+    test('the selection provenance lives in the plan block, not the dry-run report', () => {
+        // Moved with #1073: the PLAN block renders the provenance before the
+        // app loop, and the dry-run report must not state it a second time.
+        const report = sampleReport();
+        report.plan = {};
 
-        expect(log.text()).toContain(
-            'App selection: 7 app(s) - 2 named by --appid, 6 matched by --qliksensetag "sheet-thumbnails", 1 selected twice'
+        expect(renderRunPlanLines(report).join('\n')).toContain(
+            'apps          7   2 named by --appid, 6 matched by --qliksensetag "sheet-thumbnails", 1 selected twice'
         );
+
+        const log = fakeLogger();
+        renderDryRunReport(report, log);
+        expect(log.text()).not.toContain('App selection:');
     });
 
-    test('summarises and says how to apply', () => {
+    test('summarises and says how to apply when every selected app was planned', () => {
+        // The invite to apply is only earned by a complete plan, so this
+        // report's selection matches its planned apps exactly.
+        const report = sampleReport();
+        recordSelection(report, { namedAppIds: ['app-1'], selectorAppIds: [], selector: null });
+
         const log = fakeLogger();
-        renderDryRunReport(sampleReport(), log);
+        renderDryRunReport(report, log);
 
         const text = log.text();
         expect(text).toContain(
             'Summary: 1 app(s), 4 sheets. 2 would be updated (1 blurred), 2 skipped.'
         );
         expect(text).toContain('Nothing was changed. Re-run without --dry-run to apply.');
+    });
+
+    test('an incomplete plan withholds the apply invite', () => {
+        // sampleReport's selection names 7 apps but only one was planned -
+        // the report must say so and must not invite applying it.
+        const log = fakeLogger();
+        renderDryRunReport(sampleReport(), log);
+
+        const text = log.text();
+        expect(text).toContain('6 app(s) could not be fully planned');
+        expect(text).toContain('Fix the errors above before applying');
+        expect(text).not.toContain('Re-run without --dry-run to apply.');
     });
 
     test('clear-mode reports cleared icons instead of updates', () => {

--- a/src/lib/util/image-dir.js
+++ b/src/lib/util/image-dir.js
@@ -48,6 +48,38 @@ export const createAppImageDir = ({ imagedir, platform, appId, logPrefix, ErrorC
 };
 
 /**
+ * Measures the image files a run left on disk: how many exist, and their
+ * total size. Feeds the run card's `images kept` verdict line.
+ *
+ * Best-effort by design - a file that cannot be statted is simply not
+ * counted. The images were already written and uploaded by the time this
+ * runs, so a filesystem hiccup here must not fail the app.
+ *
+ * @param {string} dir - The per-app image directory.
+ * @param {string[]} fileNames - File names (without path) to measure.
+ *
+ * @returns {{files: number, bytes: number}} Count and total size of the files found.
+ */
+export const measureImageFiles = (dir, fileNames) => {
+    let files = 0;
+    let bytes = 0;
+
+    for (const name of fileNames) {
+        try {
+            const stat = fs.statSync(`${dir}/${name}`);
+            if (stat.isFile()) {
+                files += 1;
+                bytes += stat.size;
+            }
+        } catch {
+            // Not counted; see above.
+        }
+    }
+
+    return { files, bytes };
+};
+
+/**
  * Explains why the image directory could not be created, and what to do about it.
  *
  * Message shape follows `logUnusableBrowser` in `browser-launch.js`: what failed, then the thing to

--- a/src/lib/util/option-values.js
+++ b/src/lib/util/option-values.js
@@ -1,0 +1,21 @@
+/**
+ * Normalises a CLI option into the list of values actually supplied.
+ *
+ * Commander hands the same option over in several shapes: absent options
+ * arrive as `undefined`, a variadic option set from an empty environment
+ * variable arrives as `['']`, and a plain one arrives as a bare string. None
+ * of the empty shapes name a real value, so they all collapse to an empty
+ * list and let the caller skip whatever the values would have driven.
+ *
+ * One copy on purpose: the QRS filter builder and the run report both apply
+ * these rules, and two forks of the subtle empty-shape handling had already
+ * appeared before this module existed.
+ *
+ * @param {string|string[]|undefined} values - Raw option value.
+ *
+ * @returns {string[]} The values worth acting on, possibly empty.
+ */
+export const toOptionValueList = (values) =>
+    (Array.isArray(values) ? values : [values]).filter(
+        (value) => value !== undefined && value !== null && value !== ''
+    );

--- a/src/lib/util/run-over-apps.js
+++ b/src/lib/util/run-over-apps.js
@@ -57,11 +57,19 @@ export const runOverApps = async (
     }
 
     let failed = 0;
+    let appNumber = 0;
 
     for (const appId of uniqueAppIds) {
+        appNumber += 1;
         try {
-            logger.info(`--------------------------------------------------`);
-            logger.info(`About to ${action} app ${appId}`);
+            // Countable, and printed before the worker runs, so a run that
+            // hangs hangs somewhere nameable: `app 3/7 <id>` with no line
+            // after it says exactly where. A dry run keeps its verb - `plan
+            // app 3/7` - so its log stays distinguishable from a real run.
+            logger.info('');
+            logger.info(
+                `${action === 'process' ? 'app' : `${action} app`} ${appNumber}/${uniqueAppIds.length}  ${appId}`
+            );
 
             await processApp(appId);
 

--- a/src/lib/util/run-report-render.js
+++ b/src/lib/util/run-report-render.js
@@ -1,0 +1,540 @@
+import { CLEAR_REASON } from './sheet-decision-reasons.js';
+import { parseHeadlessOption } from './headless-option.js';
+
+/**
+ * Rung A of the run-output ladder (issue #1073): the plain renderer.
+ *
+ * Pure functions from a run report to arrays of strings - no API calls, no
+ * config reading, no I/O, no imports from globals. That is what makes every
+ * block snapshot-testable, and it is also what keeps this module importable
+ * from anywhere (leaf commands included) without dragging the logger's module
+ * graph into sixty test mock factories.
+ *
+ * Everything this module itself emits - headings, rules, labels - is pure
+ * ASCII, deliberately: this is the rung that has to survive a legacy Windows
+ * console and a non-UTF-8 code page without `symbols.js` being consulted at
+ * all. App and sheet *names* are user data and are passed through untouched;
+ * ASCII-purifying them would corrupt the one thing the operator needs to
+ * recognise (see the scope note on #1073).
+ */
+
+/**
+ * The horizontal rule framing the header and closing the verdict.
+ */
+export const RUN_FRAME = '='.repeat(60);
+
+/**
+ * Width of the label column in the plan and verdict blocks. Two leading
+ * spaces plus this padding puts every value in the same column.
+ */
+const LABEL_WIDTH = 14;
+
+/**
+ * One aligned `label value` line for the plan and verdict blocks.
+ *
+ * @param {string} label - Left-hand label, e.g. `apps`.
+ * @param {string} value - The value text.
+ *
+ * @returns {string} The padded line.
+ */
+const row = (label, value) => `  ${label.padEnd(LABEL_WIDTH)}${value}`;
+
+/**
+ * The run header: what is running and on which platform.
+ *
+ * This subsumes the former `App version: x.y.z` line, which was logged from
+ * eleven separate call sites - the version lives here now, next to what the
+ * command is about to do, rather than as a bare number.
+ *
+ * @param {string} version - The Butler Sheet Icons version.
+ * @param {string} jobLabel - Short job description, e.g. `QSEoW sheet thumbnails`.
+ *
+ * @returns {string[]} The header lines.
+ */
+export const renderRunHeaderLines = (version, jobLabel) => [
+    RUN_FRAME,
+    ` BUTLER SHEET ICONS ${version} -- ${jobLabel}`,
+    RUN_FRAME,
+];
+
+/**
+ * Emit the run header through a logger.
+ *
+ * The logger is a parameter, not an import: every call site already has one,
+ * and taking it keeps this module free of the globals dependency.
+ *
+ * @param {object} log - Logger exposing `info`.
+ * @param {string} version - The Butler Sheet Icons version.
+ * @param {string} jobLabel - Short job description.
+ *
+ * @returns {void}
+ */
+export const logRunHeader = (log, version, jobLabel) => {
+    for (const line of renderRunHeaderLines(version, jobLabel)) {
+        log.info(line);
+    }
+};
+
+/**
+ * `true`/'true' handling for boolean-ish CLI options: Commander delivers a
+ * boolean from a default and a string from the command line or an env var.
+ *
+ * Used for `secure`, whose connection-side consumer applies exactly this test
+ * (`qseow-enigma.js`). NOT used for `headless`: the launch path interprets
+ * unknown values as headless-on via `parseHeadlessOption`, and the plan must
+ * describe what the launch will do, not apply its own rule.
+ *
+ * @param {boolean|string} value - The option value.
+ *
+ * @returns {boolean} Whether the option is on.
+ */
+export const isOptionEnabled = (value) => value === true || value === 'true';
+
+/**
+ * Whether the report describes an icon-removal command.
+ *
+ * Decided from `report.command`, never sniffed from recorded rows or from the
+ * optional plan sections: a remove run over zero sheets - or one whose caller
+ * supplied no plan at all - must still summarise in remove vocabulary.
+ *
+ * @param {object} report - The report.
+ *
+ * @returns {boolean} True for remove-sheet-icons reports.
+ */
+export const isRemovalReport = (report) => (report.command ?? '').includes('remove-sheet-icons');
+
+/**
+ * The provenance parts of the app-selection line, shared wording with the
+ * pre-#1073 dry-run report: named count, selector count, overlap.
+ *
+ * @param {object} selection - `report.selection` from `recordSelection`.
+ *
+ * @returns {string[]} The parts, ready to join with `, `.
+ */
+const selectionParts = (selection) => {
+    const parts = [`${selection.named} named by --appid`];
+
+    if (selection.selector) {
+        parts.push(
+            `${selection.fromSelector} matched by --${selection.selector.option} "${selection.selector.value}"`
+        );
+    }
+
+    const overlap = selection.named + selection.fromSelector - selection.total;
+    if (overlap > 0) {
+        parts.push(`${overlap} selected twice`);
+    }
+
+    return parts;
+};
+
+/**
+ * Renders one sheet rule for the plan block, e.g. `tag "confidential" (3 sheets)`.
+ *
+ * The match count is the anti-#840 payload: a tag rule always prints how many
+ * sheets it matched across the selected apps, zero included - a zero next to a
+ * tag the operator typed is the cheapest possible "check your spelling".
+ *
+ * @param {object} rule - A rule from the plan's `rules` section.
+ * @param {string} rule.option - The long option name without dashes.
+ * @param {string[]} rule.values - The rule's values.
+ * @param {number|null} [rule.matchedSheetCount] - Sheets matched across the
+ *     selected apps, when a cheap server-side count exists (QSEoW tags only).
+ *
+ * @returns {string} The rendered rule.
+ */
+const describeRule = ({ option, values, matchedSheetCount = null }) => {
+    // The option name ends in the rule kind: exclude-sheet-tag -> tag.
+    const kind = option.split('-').pop();
+    const quoted = kind === 'tag' || kind === 'title';
+    const list = quoted ? values.map((v) => `"${v}"`).join(', ') : values.join(', ');
+    const count = matchedSheetCount === null ? '' : ` (${matchedSheetCount} sheets)`;
+
+    return `${kind} ${list}${count}`;
+};
+
+/**
+ * A rules line for the plan block: every rule, or an explicit `none`.
+ *
+ * `none` is printed rather than the line being omitted, because the absence
+ * of a rule is exactly what an operator checking "did my exclude flag
+ * register?" needs stated.
+ *
+ * @param {Array<object>} rules - Rules of one kind (exclude or blur).
+ *
+ * @returns {string} The joined rule descriptions.
+ */
+const describeRules = (rules) => (rules.length === 0 ? 'none' : rules.map(describeRule).join(', '));
+
+/**
+ * The target lines: which server or tenant the run talks to.
+ *
+ * @param {object} target - The plan's `target` section.
+ *
+ * @returns {string[]} One line for Cloud, two for QSEoW.
+ */
+const renderTarget = (target) => {
+    if (target.platform !== 'qseow') {
+        return [row('tenant', target.tenantUrl)];
+    }
+
+    const scheme = isOptionEnabled(target.secure) ? 'https' : 'http';
+    const hostPort = target.port ? `${target.host}:${target.port}` : target.host;
+    const proxy = target.prefix ? `virtual proxy "${target.prefix}"` : 'no virtual proxy';
+
+    return [
+        row('server', `${hostPort}   ${scheme}, ${proxy}`),
+        row(
+            '',
+            `engine ${target.enginePort}, qrs ${target.qrsPort}, schema ${target.schemaVersion}`
+        ),
+    ];
+};
+
+/**
+ * The auth lines: which identities the run uses. Never a password or key value.
+ *
+ * @param {object} auth - The plan's `auth` section.
+ *
+ * @returns {string[]} The auth lines.
+ */
+const renderAuth = (auth) => {
+    if (auth.apiUser) {
+        return [
+            row(
+                'api user',
+                `${auth.apiUser.directory}\\${auth.apiUser.userId} via ${auth.certFile}`
+            ),
+            row('logon user', `${auth.logonUser.directory}\\${auth.logonUser.userId}`),
+        ];
+    }
+
+    const lines = [row('auth', 'API key')];
+    if (auth.skipLogin) {
+        lines.push(row('logon', 'skipped (--skip-login)'));
+    } else if (auth.logonUserId) {
+        lines.push(row('logon user', auth.logonUserId));
+    }
+
+    return lines;
+};
+
+/**
+ * The writes warning: the one line in the plan block written in capitals,
+ * because it is the part with no undo.
+ *
+ * @param {object} report - The report; `dryRun` decides WILL vs WOULD.
+ *
+ * @returns {string} The warning line.
+ */
+const renderWrites = (report) => {
+    const { writes } = report.plan;
+    const appCount = report.selection?.total ?? report.apps.length;
+
+    if (writes.kind === 'clear-icons') {
+        const verb = report.dryRun ? 'WOULD REMOVE' : 'WILL REMOVE';
+
+        return `  ${verb} sheet icons and thumbnail media files from ${appCount} app(s)`;
+    }
+
+    const verb = report.dryRun ? 'WOULD OVERWRITE' : 'WILL OVERWRITE';
+    const published =
+        writes.publishedAppCount === null || writes.publishedAppCount === undefined
+            ? ''
+            : `, ${writes.publishedAppCount} of them published`;
+
+    return `  ${verb} existing sheet thumbnails in ${appCount} app(s)${published}`;
+};
+
+/**
+ * The plan block: everything the run resolved, rendered before the first write.
+ *
+ * Sheet selection fails silently where connection problems fail loudly (issue
+ * #993), so the app count with its provenance and the rule match counts -
+ * zeroes included - are the safety content here; the rest is orientation.
+ *
+ * @param {object} report - A report whose `plan` section has been recorded.
+ *
+ * @returns {string[]} The block's lines, empty when the report carries no plan.
+ */
+export const renderRunPlanLines = (report) => {
+    const { plan, selection } = report;
+
+    if (!plan) {
+        return [];
+    }
+
+    const lines = ['', 'PLAN'];
+
+    if (plan.target) {
+        lines.push(...renderTarget(plan.target));
+    }
+    if (plan.auth) {
+        lines.push(...renderAuth(plan.auth));
+    }
+    if (selection) {
+        lines.push(row('apps', `${selection.total}   ${selectionParts(selection).join(', ')}`));
+    }
+    if (plan.sheetPart) {
+        lines.push(
+            row(
+                'sheet part',
+                `${plan.sheetPart.value} of ${plan.sheetPart.max} -- ${plan.sheetPart.label}`
+            )
+        );
+    }
+    if (plan.rules) {
+        lines.push(row('exclude', describeRules(plan.rules.exclude)));
+        lines.push(row('blur', describeRules(plan.rules.blur)));
+    }
+    if (plan.browser) {
+        // parseHeadlessOption, not isOptionEnabled: the label must match what
+        // the launch will actually do, and the launch treats every value
+        // except an explicit false as headless.
+        const window = parseHeadlessOption(plan.browser.headless) ? 'headless' : 'visible window';
+        lines.push(
+            row(
+                'browser',
+                `${plan.browser.name} (version: ${plan.browser.version}), ${window}, ${plan.browser.pageWaitSeconds}s per sheet`
+            )
+        );
+    }
+    if (plan.output) {
+        // No dimensions stated: the files on disk are the raw element
+        // screenshots from a 1230x810 viewport, not the 410x270 the hub
+        // displays them at - a size claim here would be wrong about the
+        // artifacts the run leaves behind.
+        lines.push(row('images', `${plan.output.imageDir}/${plan.output.platformDir}/<app-id>`));
+    }
+    // The writes warning is suppressed for an empty selection: "WILL
+    // OVERWRITE ... 0 app(s)" in capitals right before the no-apps error
+    // would describe a write that was never possible.
+    if (plan.writes && (report.selection?.total ?? report.apps.length) > 0) {
+        if (plan.writes.contentLibrary) {
+            lines.push(row('uploads to', `content library "${plan.writes.contentLibrary}"`));
+        } else if (plan.writes.kind === 'thumbnails') {
+            lines.push(row('uploads to', `each app's media library, "thumbnails" folder`));
+        }
+        lines.push(renderWrites(report));
+    }
+
+    // No trailing blank: the app loop prints its own separator before each
+    // `app i/n` line, and two blanks in a row read as an accident.
+    return lines;
+};
+
+/**
+ * The per-app progress line logged once an app's name and sheet count are
+ * known, under the `app i/n` line the app loop already printed.
+ *
+ * @param {object} app - App facts.
+ * @param {string} app.name - App name.
+ * @param {number} app.sheetCount - Number of sheets.
+ * @param {boolean} [app.published] - Whether the app is published, when known.
+ *
+ * @returns {string} The line.
+ */
+export const appProgressLine = ({ name, sheetCount, published }) => {
+    const publishedNote =
+        published === undefined || published === null
+            ? ''
+            : `, ${published ? 'published' : 'not published'}`;
+
+    // A missing name must not print the literal "undefined" - callers fall
+    // back to the app id where they have one; this is the last resort.
+    return `  "${name ?? ''}" -- ${sheetCount} sheet(s)${publishedNote}`;
+};
+
+/**
+ * The per-sheet progress line: countable, and short enough for a terminal.
+ *
+ * Replaces a ~230-column line; the sheet id, engine sheet id, description,
+ * approved, published and hidden fields move to `verbose`, where they are
+ * still available to anyone debugging.
+ *
+ * @param {object} sheet - Sheet facts.
+ * @param {number} sheet.n - 1-based sheet number.
+ * @param {number} sheet.total - Number of sheets in the app.
+ * @param {string} sheet.label - What happened: `captured`, `blurred`, `excluded`, `cleared`, `no icon`.
+ * @param {string} sheet.title - Sheet title, user data, passed through untouched.
+ * @param {string|null} [sheet.reason] - The responsible option, when there is one.
+ *
+ * @returns {string} The line.
+ */
+export const sheetProgressLine = ({ n, total, label, title, reason = null }) =>
+    // `title ?? ''`: a sheet with no qMeta prints empty quotes, never the
+    // literal "undefined" - matching the dry-run renderer's guard.
+    `  sheet ${String(n).padStart(2)}/${total}  ${label.padEnd(8)}  '${title ?? ''}'${reason ? `  (${reason})` : ''}`;
+
+/**
+ * Elapsed time as `1h 2m`, `6m 12s` or `45s`.
+ *
+ * @param {number} ms - Elapsed milliseconds.
+ *
+ * @returns {string} The human-readable duration.
+ */
+export const formatElapsed = (ms) => {
+    const totalSeconds = Math.round(ms / 1000);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+
+    if (hours > 0) {
+        return `${hours}h ${minutes}m`;
+    }
+    if (minutes > 0) {
+        return `${minutes}m ${seconds}s`;
+    }
+
+    return `${seconds}s`;
+};
+
+/**
+ * A byte count as `n B`, `n.n KB` or `n.n MB`.
+ *
+ * @param {number} bytes - The byte count.
+ *
+ * @returns {string} The human-readable size.
+ */
+export const formatBytes = (bytes) => {
+    if (bytes < 1024) {
+        return `${bytes} B`;
+    }
+    if (bytes < 1024 * 1024) {
+        return `${(bytes / 1024).toFixed(1)} KB`;
+    }
+
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+};
+
+/**
+ * Sums a nullable per-app numeric field, returning null when no app recorded it.
+ *
+ * @param {object} report - The report.
+ * @param {string} field - The per-app field name.
+ *
+ * @returns {number|null} The sum, or null when the field was never recorded.
+ */
+const sumAppField = (report, field) => {
+    let sum = null;
+
+    for (const app of report.apps) {
+        if (typeof app[field] === 'number') {
+            sum = (sum ?? 0) + app[field];
+        }
+    }
+
+    return sum;
+};
+
+/**
+ * The verdict block: what actually changed, and whether the run worked.
+ *
+ * This is the part that does not exist at all today - a run in which 66
+ * thumbnails were uploaded and a run in which a mistyped tag matched nothing
+ * both used to end silently and identically. Rendered from the report alone,
+ * so every number here is a number that was recorded while it happened.
+ *
+ * @param {object} report - The report, after the app loop has finished and
+ *     `succeeded`/`finishedAt` have been set on it.
+ *
+ * @returns {string[]} The block's lines.
+ */
+export const renderRunVerdictLines = (report) => {
+    const lines = ['', `RESULT  ${report.succeeded ? 'ok' : 'FAILED'}`];
+
+    const failedApps = report.apps.filter((app) => app.failed).length;
+    const okApps = report.apps.length - failedApps;
+
+    if ((report.selection?.total ?? 0) === 0 && report.apps.length === 0) {
+        lines.push(row('apps', '0 selected - nothing was done'));
+        lines.push(RUN_FRAME);
+
+        return lines;
+    }
+
+    lines.push(row('apps', `${okApps} ok, ${failedApps} failed`));
+
+    // Per-sheet rows recorded by the processors while each sheet happened.
+    let seen = 0;
+    let captured = 0;
+    let blurred = 0;
+    let excluded = 0;
+    let cleared = 0;
+    let noIcon = 0;
+
+    for (const app of report.apps) {
+        for (const sheet of app.sheets) {
+            seen += 1;
+            if (sheet.action === 'skip') {
+                excluded += 1;
+            } else if (sheet.action === 'blur') {
+                captured += 1;
+                blurred += 1;
+            } else if (sheet.action === 'update') {
+                captured += 1;
+            } else if (sheet.action === 'clear') {
+                if (sheet.reason === CLEAR_REASON.NO_ICON) {
+                    noIcon += 1;
+                } else {
+                    cleared += 1;
+                }
+            }
+        }
+    }
+
+    // Decided from report.command via isRemovalReport, never from the
+    // optional plan sections: a removal run whose caller supplied no plan
+    // must still summarise in remove vocabulary.
+    if (isRemovalReport(report)) {
+        const noIconNote = noIcon > 0 ? `, ${noIcon} had no icon` : '';
+        lines.push(row('sheets', `${seen} seen, ${cleared} icon(s) cleared${noIconNote}`));
+
+        const mediaFilesDeleted = sumAppField(report, 'mediaFilesDeleted');
+        if (mediaFilesDeleted !== null) {
+            lines.push(
+                row(
+                    'media',
+                    `${mediaFilesDeleted} thumbnail file(s) deleted from app media libraries`
+                )
+            );
+        }
+    } else {
+        const blurNote = blurred > 0 ? ` (${blurred} blurred)` : '';
+        lines.push(
+            row('sheets', `${seen} seen, ${captured} captured${blurNote}, ${excluded} excluded`)
+        );
+
+        const sheetsUpdated = sumAppField(report, 'sheetsUpdated');
+        if (sheetsUpdated !== null) {
+            const destination = report.plan?.writes?.contentLibrary
+                ? `content library "${report.plan.writes.contentLibrary}"`
+                : 'app media libraries';
+            lines.push(
+                row(
+                    'thumbnails',
+                    `${sheetsUpdated} sheet(s) given new thumbnails in ${destination}`
+                )
+            );
+        }
+
+        const imagesKeptFiles = sumAppField(report, 'imagesKeptFiles');
+        if (imagesKeptFiles !== null && report.plan?.output) {
+            const bytes = sumAppField(report, 'imagesKeptBytes') ?? 0;
+            lines.push(
+                row(
+                    'images kept',
+                    `${report.plan.output.imageDir}/${report.plan.output.platformDir}   ${imagesKeptFiles} file(s), ${formatBytes(bytes)}`
+                )
+            );
+        }
+    }
+
+    if (typeof report.startedAt === 'number' && typeof report.finishedAt === 'number') {
+        lines.push(row('elapsed', formatElapsed(report.finishedAt - report.startedAt)));
+    }
+
+    lines.push(RUN_FRAME);
+
+    return lines;
+};

--- a/src/lib/util/run-report.js
+++ b/src/lib/util/run-report.js
@@ -1,5 +1,13 @@
 import { logger, getLoggingLevel, setLoggingLevel } from '../../globals.js';
 import { runOverApps } from './run-over-apps.js';
+import {
+    RUN_FRAME,
+    renderRunPlanLines,
+    renderRunVerdictLines,
+    isRemovalReport,
+} from './run-report-render.js';
+import { toOptionValueList } from './option-values.js';
+import { measureImageFiles } from './image-dir.js';
 
 /**
  * The run report: one object holding what a run resolved and decided, read by
@@ -56,7 +64,7 @@ const withReportVisible = (emit) => {
  * Announce, before any connection is made, that this run is a dry run.
  *
  * Without this line the log of a dry run opens exactly like a real run -
- * "Starting removal of sheet icons", "About to process app ..." - and the one
+ * "Starting removal of sheet icons", "app 1/3 ..." - and the one
  * line saying nothing was changed arrives only after the last app. An operator
  * watching a destructive-looking scroll for two minutes has no reason to wait
  * for it.
@@ -67,9 +75,9 @@ const withReportVisible = (emit) => {
  */
 export const announceDryRun = (command) => {
     withReportVisible(() => {
-        logger.info('==================================================');
+        logger.info(RUN_FRAME);
         logger.info(`DRY RUN of ${command}: planning only - NOTHING WILL BE CHANGED`);
-        logger.info('==================================================');
+        logger.info(RUN_FRAME);
     });
 };
 
@@ -86,8 +94,131 @@ export const createRunReport = ({ command, dryRun }) => ({
     command,
     dryRun,
     selection: null,
+    plan: null,
     apps: [],
+    startedAt: Date.now(),
+    finishedAt: null,
+    succeeded: null,
 });
+
+/**
+ * Build the plan's `rules` section from the command's options bag.
+ *
+ * One builder for both platform twins, so the two cannot disagree about which
+ * options constitute a rule. Tag rules are included only where the platform
+ * honours them - Qlik Sense Cloud cannot tag individual sheets, and a plan
+ * listing a rule the run ignores would be the plan lying.
+ *
+ * @param {object} options - The command's options bag.
+ * @param {object} [facts] - Server-side facts, where available.
+ * @param {boolean} [facts.includeTagRules] - Whether tag rules apply on this platform.
+ * @param {number|null} [facts.excludeTagSheetCount] - Sheets matched by the
+ *     exclude tag(s) across the selected apps, or null when not counted.
+ * @param {number|null} [facts.blurTagSheetCount] - Same for the blur tag(s).
+ *
+ * @returns {{exclude: Array<object>, blur: Array<object>}} The rules, each as
+ *     `{option, values, matchedSheetCount}` - structural, never pre-rendered.
+ */
+export const buildSheetRules = (
+    options,
+    { includeTagRules = false, excludeTagSheetCount = null, blurTagSheetCount = null } = {}
+) => {
+    const rule = (option, values, matchedSheetCount = null) => ({
+        option,
+        values,
+        matchedSheetCount,
+    });
+
+    const collect = (prefix, tagOption, tagCount) => {
+        const rules = [];
+
+        if (includeTagRules) {
+            const tags = toOptionValueList(tagOption);
+            if (tags.length > 0) {
+                rules.push(rule(`${prefix}-sheet-tag`, tags, tagCount));
+            }
+        }
+        for (const kind of ['number', 'title', 'status']) {
+            const optionName = `${prefix}-sheet-${kind}`;
+            const camel = `${prefix}Sheet${kind[0].toUpperCase()}${kind.slice(1)}`;
+            const values = toOptionValueList(options[camel]).map(String);
+            if (values.length > 0) {
+                rules.push(rule(optionName, values));
+            }
+        }
+
+        return rules;
+    };
+
+    return {
+        exclude: collect('exclude', options.excludeSheetTag, excludeTagSheetCount),
+        blur: collect('blur', options.blurSheetTag, blurTagSheetCount),
+    };
+};
+
+/**
+ * The plan's `sheetPart` section, from the option value and the platform's
+ * label map. Shared by the twins so neither can render a value the other maps
+ * differently.
+ *
+ * @param {string|number} value - The `--includesheetpart` value.
+ * @param {Record<string, string>} labels - The platform's sheet-part labels.
+ *
+ * @returns {{value: string, max: string, label: string}} The section.
+ */
+export const buildSheetPartSection = (value, labels) => {
+    const keys = Object.keys(labels);
+
+    return {
+        value: String(value),
+        max: keys[keys.length - 1],
+        label: labels[String(value)],
+    };
+};
+
+/**
+ * The plan's `browser` section, identical on both platforms.
+ *
+ * The version is the *requested* one - a keyword like `recommended` or a
+ * pinned build - never a resolved build id: resolution happens at launch and
+ * may involve the network, and the plan block must stay a pure read of what
+ * was asked for. The launch still logs the build it actually uses.
+ *
+ * @param {object} options - The command's options bag.
+ *
+ * @returns {{name: string, version: string, headless: boolean|string, pageWaitSeconds: number|string}} The section.
+ */
+export const buildBrowserPlanSection = (options) => ({
+    name: options.browser,
+    version: options.browserVersion,
+    headless: options.headless,
+    pageWaitSeconds: options.pagewait,
+});
+
+/**
+ * Mark an app as failed on the report.
+ *
+ * Called by the app loop when a processor or planner threw. The entry may
+ * already exist (the app failed after opening its section) or not (it failed
+ * before `openDoc` resolved); either way the verdict must count it.
+ *
+ * Not exported: recording failures is the loop's job, and an outside caller
+ * mutating reports would bypass the one place ordering is guaranteed.
+ *
+ * @param {object} report - The report.
+ * @param {string} appId - The app that failed.
+ *
+ * @returns {void}
+ */
+const markAppFailed = (report, appId) => {
+    const entry = report.apps.find((app) => app.id === appId);
+
+    if (entry) {
+        entry.failed = true;
+    } else {
+        addAppToReport(report, { id: appId }).failed = true;
+    }
+};
 
 /**
  * Record how the app selection resolved.
@@ -126,6 +257,12 @@ export const recordSelection = (report, { namedAppIds, selectorAppIds, selector 
 /**
  * Open a per-app section in the report.
  *
+ * Real runs additionally record outcome fields directly on the entry as they
+ * happen: `sheetsUpdated`, `imagesKeptFiles`, `imagesKeptBytes`,
+ * `mediaFilesDeleted`. They stay absent on entries that never reached that
+ * step, and the verdict renderer sums only what was recorded - so a number in
+ * the verdict is always a number that happened.
+ *
  * @param {object} report - The report.
  * @param {object} app - App facts.
  * @param {string} app.id - App id.
@@ -141,6 +278,7 @@ export const addAppToReport = (report, { id, name, sheetCount }) => {
         sheetCount: sheetCount ?? null,
         sheets: [],
         mediaFilesToDelete: null,
+        failed: false,
     };
     report.apps.push(entry);
 
@@ -164,6 +302,35 @@ export const addAppToReport = (report, { id, name, sheetCount }) => {
  */
 export const recordSheetDecision = (appEntry, { n, title, action, reason = null }) => {
     appEntry.sheets.push({ n, title, action, reason });
+};
+
+/**
+ * Record a real run's per-app outcome: how many sheets were given new
+ * thumbnails, and what the kept image files on disk amount to.
+ *
+ * One recorder for both platform twins - a future outcome field added here
+ * reaches both verdicts, instead of landing in one processor's inline block
+ * and silently missing from the other's.
+ *
+ * @param {object|null} appEntry - From {@link addAppToReport}, or null when
+ *     the processor runs without a report.
+ * @param {object} outcome - The outcome.
+ * @param {number} outcome.sheetsUpdated - Sheets given a new thumbnail.
+ * @param {string} outcome.imagesDir - The per-app image directory.
+ * @param {string[]} outcome.imageFileNames - Image file names (no path) the run created.
+ *
+ * @returns {void}
+ */
+export const recordAppOutcome = (appEntry, { sheetsUpdated, imagesDir, imageFileNames }) => {
+    if (!appEntry) {
+        return;
+    }
+
+    appEntry.sheetsUpdated = sheetsUpdated;
+
+    const kept = measureImageFiles(imagesDir, imageFileNames);
+    appEntry.imagesKeptFiles = kept.files;
+    appEntry.imagesKeptBytes = kept.bytes;
 };
 
 /**
@@ -199,18 +366,6 @@ const ACTION_LABEL = Object.freeze({
 });
 
 /**
- * Whether the report describes an icon-removal command.
- *
- * Decided from `report.command`, never sniffed from the recorded rows: a
- * remove run over zero sheets must still summarise in remove vocabulary.
- *
- * @param {object} report - The report.
- *
- * @returns {boolean} True for remove-sheet-icons reports.
- */
-const isRemovalReport = (report) => (report.command ?? '').includes('remove-sheet-icons');
-
-/**
  * Render the dry-run report through the logger.
  *
  * Through winston at `info` rather than straight to stdout (issue #993 open
@@ -240,25 +395,13 @@ export const renderDryRunReport = (report, log = logger) => {
             return;
         }
 
+        // The app-selection provenance line that used to open this report now
+        // lives in the PLAN block, which renders before the app loop - stating
+        // it again here would be the "do not end up with both" mistake #1073
+        // warns about for the version line.
         log.info('');
         log.info(`DRY RUN of ${report.command} - nothing will be changed`);
         log.info('');
-
-        if (report.selection) {
-            const s = report.selection;
-            const parts = [`${s.named} named by --appid`];
-            if (s.selector) {
-                parts.push(
-                    `${s.fromSelector} matched by --${s.selector.option} "${s.selector.value}"`
-                );
-            }
-            const overlap = s.named + s.fromSelector - s.total;
-            if (overlap > 0) {
-                parts.push(`${overlap} selected twice`);
-            }
-            log.info(`App selection: ${s.total} app(s) - ${parts.join(', ')}`);
-            log.info('');
-        }
 
         const width = report.apps.reduce(
             (max, app) =>
@@ -291,6 +434,16 @@ export const renderDryRunReport = (report, log = logger) => {
                 );
             }
 
+            // A planner that failed after its rows were recorded (or before
+            // any were) must not read as a clean plan: the row count alone
+            // cannot tell "fully planned" from "failed on the step after the
+            // last sheet".
+            if (app.failed) {
+                log.info(
+                    `  PLANNING FAILED for this app - the rows above may be incomplete. See the errors above.`
+                );
+            }
+
             if (app.mediaFilesToDelete !== null && app.mediaFilesToDelete > 0) {
                 log.info(
                     `  ${app.mediaFilesToDelete} thumbnail media file(s) would also be deleted from the app media library`
@@ -301,12 +454,15 @@ export const renderDryRunReport = (report, log = logger) => {
 
         const t = reportTotals(report);
 
-        // Apps that failed before their section opened are invisible in the
-        // rows, so the count mismatch with the selection is stated explicitly.
-        const unplanned = (report.selection?.total ?? report.apps.length) - report.apps.length;
+        // Failed planners now always leave a marked entry, but the selection
+        // count is still cross-checked so an app that vanished entirely (a
+        // future recording bug) cannot pass silently.
+        const failedApps = report.apps.filter((app) => app.failed).length;
+        const unplanned =
+            (report.selection?.total ?? report.apps.length) - report.apps.length + failedApps;
         if (unplanned > 0) {
             log.info(
-                `${unplanned} app(s) could not be planned at all - see the errors above. They are not included in the summary.`
+                `${unplanned} app(s) could not be fully planned - see the errors above. Their rows are missing or incomplete.`
             );
         }
 
@@ -320,7 +476,17 @@ export const renderDryRunReport = (report, log = logger) => {
                 `Summary: ${t.apps} app(s), ${t.sheets} sheets. ${t.update + t.blur} would be updated${blurNote}, ${t.skip} skipped.`
             );
         }
-        log.info('Nothing was changed. Re-run without --dry-run to apply.');
+
+        // The invitation to apply is earned, not automatic: a dry run that
+        // could not plan everything must send the operator to the errors, not
+        // to the real run.
+        if (unplanned > 0) {
+            log.info(
+                'Nothing was changed. Fix the errors above before applying - this plan is incomplete.'
+            );
+        } else {
+            log.info('Nothing was changed. Re-run without --dry-run to apply.');
+        }
     };
 
     // Only force visibility on the real logger; an injected test logger has no
@@ -367,13 +533,23 @@ export const recordPlannedSheet = (
 
 /**
  * The report-carrying app loop every dry-run-capable worker shares: build the
- * report, record the selection, run the loop against the planner or the
- * processor, and render the report when planning.
+ * report, record the selection and the plan, render the plan block, run the
+ * loop against the planner or the processor, and render the verdict.
  *
  * One function rather than a block pasted into each worker - the three copies
  * had already been flagged by review and by the duplication gate, and a
  * report field added in one worker but not the others is exactly the drift
  * the report exists to prevent.
+ *
+ * The plan block renders here, before the loop starts, which is what makes
+ * "the plan is emitted before any write" a structural property rather than a
+ * convention: the first write any worker performs happens inside its per-app
+ * processor, and the loop has not been entered yet.
+ *
+ * Visibility differs by mode on purpose. On a dry run the plan is the
+ * command's product, so it is forced visible even at `--log-level warn`. On a
+ * real run the plan and verdict log at plain `info`: an operator who chose
+ * `warn` asked for a quiet run, and the run card respects that.
  *
  * @param {object} run - The run.
  * @param {string} run.command - The command, e.g. `qseow create-sheet-thumbnails`.
@@ -382,10 +558,12 @@ export const recordPlannedSheet = (
  * @param {string[]} run.namedAppIds - The `--appid` subset.
  * @param {string[]} run.selectorAppIds - The tag/collection subset.
  * @param {{option: string, value: string}|null} run.selector - The selector used, if any.
+ * @param {object} [run.plan] - Structural plan sections (target, auth, sheetPart,
+ *     rules, browser, output, writes), assembled by the worker.
  * @param {{plan: string, process: string}} run.logPrefix - Per-mode log prefixes.
  * @param {string} run.emptySelectionHint - Guidance when nothing was selected.
  * @param {(appId: string, report: object) => Promise<void>} run.planApp - The per-app planner.
- * @param {(appId: string) => Promise<unknown>} run.processApp - The per-app processor.
+ * @param {(appId: string, report: object) => Promise<unknown>} run.processApp - The per-app processor.
  *
  * @returns {Promise<boolean>} The verdict from the app loop.
  */
@@ -396,6 +574,7 @@ export const runOverAppsWithReport = async ({
     namedAppIds,
     selectorAppIds,
     selector,
+    plan = null,
     logPrefix,
     emptySelectionHint,
     planApp,
@@ -403,6 +582,18 @@ export const runOverAppsWithReport = async ({
 }) => {
     const report = createRunReport({ command, dryRun });
     recordSelection(report, { namedAppIds, selectorAppIds, selector });
+    report.plan = plan;
+
+    const emitPlan = () => {
+        for (const line of renderRunPlanLines(report)) {
+            logger.info(line);
+        }
+    };
+    if (dryRun) {
+        withReportVisible(emitPlan);
+    } else {
+        emitPlan();
+    }
 
     const result = await runOverApps(
         appIds,
@@ -411,14 +602,52 @@ export const runOverAppsWithReport = async ({
             action: dryRun ? 'plan' : 'process',
             emptySelectionHint,
         },
-        dryRun ? (appId) => planApp(appId, report) : processApp
+        dryRun
+            ? async (appId) => {
+                  try {
+                      return await planApp(appId, report);
+                  } catch (err) {
+                      // A planner that failed after recording its rows would
+                      // otherwise render as a clean, fully-planned app - on
+                      // the mode whose report is the entire product.
+                      markAppFailed(report, appId);
+                      throw err;
+                  }
+              }
+            : async (appId) => {
+                  try {
+                      const result = await processApp(appId, report);
+
+                      // Every attempted app must have an entry, or the
+                      // verdict's ok-count silently undercounts a processor
+                      // that recorded nothing.
+                      if (!report.apps.some((app) => app.id === appId)) {
+                          addAppToReport(report, { id: appId });
+                      }
+
+                      return result;
+                  } catch (err) {
+                      // Recorded before the loop's own catch logs it, so the
+                      // verdict's failed-app count cannot disagree with the
+                      // error lines above it.
+                      markAppFailed(report, appId);
+                      throw err;
+                  }
+              }
     );
+
+    report.finishedAt = Date.now();
+    report.succeeded = result;
 
     // Rendered even when some apps failed to plan: the decisions that were
     // reached belong next to the per-app error lines already logged, and the
     // renderer itself marks incomplete and unplanned apps.
     if (dryRun) {
         renderDryRunReport(report);
+    } else {
+        for (const line of renderRunVerdictLines(report)) {
+            logger.info(line);
+        }
     }
 
     return result;

--- a/src/lib/util/sheet-list.js
+++ b/src/lib/util/sheet-list.js
@@ -357,6 +357,31 @@ export const runOverSheets = async (sheets, ctx, processSheet) => {
 };
 
 /**
+ * Logs the run card's per-app closing line for a thumbnail-update pass and
+ * returns the count of sheets changed.
+ *
+ * One helper for both platform twins - the wording and the derivation must
+ * not drift between them. Call it BEFORE `assertAllProcessed()`: the line
+ * states writes that have already been persisted, and when the app is about
+ * to be failed over one bad sheet, the operator must still learn that the
+ * other sheets were changed - those writes are irreversible whether or not
+ * the app is counted as failed.
+ *
+ * @param {{changed: number, attempted: number, skipped: number}|undefined} sheetRun -
+ *     The result from {@link runOverSheets}, or undefined when the app had no sheets.
+ *
+ * @returns {number} How many sheets were changed.
+ */
+export const logUpdatedSheetSummary = (sheetRun) => {
+    const changed = sheetRun?.changed ?? 0;
+    const total = (sheetRun?.attempted ?? 0) + (sheetRun?.skipped ?? 0);
+
+    logger.info(`  updated ${changed} of ${total} sheet(s) with new thumbnails`);
+
+    return changed;
+};
+
+/**
  * Persists an app, but only when a sheet was actually changed.
  *
  * `app.doSave()` used to be called once per sheet, from inside the loop. That wrote the app


### PR DESCRIPTION
Closes #1073. Also closes #1072 — its remaining scope (the fuller plan sections on the RunReport, and threading the report through the real processors) ships here.

## What

Every `qseow create-sheet-thumbnails`, `qscloud create-sheet-thumbnails` and `qscloud remove-sheet-icons` run now prints the **run card**: a framed header, a **PLAN** block before anything is written, countable progress during, and a **RESULT** verdict after. Plain ASCII frame through winston, so it lands byte-for-byte in a redirected `run.log` from Task Scheduler and in `docker logs`; app and sheet names pass through untouched.

```text
============================================================
 BUTLER SHEET ICONS x.y.z -- QSEoW sheet thumbnails
============================================================

PLAN
  server        sense.company.com   https, virtual proxy "form"
                engine 4747, qrs 4242, schema 12.612.0
  api user      INTERNAL\sa_api via ./cert/client.pem
  logon user    COMPANY\bsi_svc
  apps          1   1 named by --appid
  sheet part    1 of 4 -- sheet objects only
  exclude       tag "no-thumbnail" (0 sheets)
  blur          none
  browser       chrome (version: recommended), headless, 5s per sheet
  images        ./img/qseow/<app-id>
  uploads to    content library "abc 123"
  WILL OVERWRITE existing sheet thumbnails in 1 app(s), 1 of them published

app 1/1  a3e0f5d2-000a-464f-998d-33d333b175d7
  "Sheet thumbnails demo app" -- 9 sheet(s), published
  sheet  1/9  excluded  'Sheet 0 (hidden)'  (hidden by show condition)
  sheet  2/9  captured  'Sheet 1'
  ...
  uploaded 16 image file(s) to content library "abc 123"
  updated 8 of 9 sheet(s) with new thumbnails

RESULT  ok
  apps          1 ok, 0 failed
  sheets        9 seen, 8 captured, 1 excluded
  thumbnails    8 sheet(s) given new thumbnails in content library "abc 123"
  images kept   ./img/qseow   16 file(s), 521.9 KB
  elapsed       4m 20s
============================================================
```

The safety content per #993/#1071: the app selection with provenance, the tag rules' match counts **including zeroes** (counted server-side via chunked QRS `count` endpoints), and the capitalised overwrite warning with the published-app count. The verdict is the part that did not exist at all before — a run that uploaded 66 thumbnails and a run whose mistyped tag matched nothing no longer end identically.

## Design

- The plan sections live **structurally on the RunReport** (#1072), rendered by a new pure module `run-report-render.js` — no I/O, no globals imports, snapshot-testable, importable from every leaf command without touching the ~60 globals mock factories.
- The report is threaded through the real processors, which record per-sheet rows **only once they are facts** (excluded immediately; captured only after both image files exist; cleared only after the write went through).
- The eleven `App version:` call sites (twelve, counting `browser check`) fold into the header. Doctor's JSON mode still skips it. On the three thumbnail commands the log level is set before the header, so a real run at `--log-level warn` is genuinely silent — dry runs still force their plan and report visible.
- The ~230-column per-sheet lines moved to `verbose`, replaced by one-liners naming the responsible option.

## Review provenance

A max-effort review (10 finder angles + gap sweep, verification pass) ran against this diff before commit; **all 15 findings are fixed in these commits**, including three the first implementation had: the plan's headless label contradicting the actual launch semantics, a partially-failed app's already-persisted sheet updates vanishing from log and verdict, and a dry-run planner failure after its last recorded row rendering as a clean plan that invited applying it.

## Verification

- Unit suite: 3081 tests, exit code 0 measured directly. Lint clean.
- Integration: all three slices green run serially (qseow 3 suites/7 tests, cloud 3/10, browser 6/34).
- Live QSEoW lab: dry run proven write-free by identical QRS snapshots before/after; real run's 16 uploads proven server-side by fresh `staticcontentreference` timestamps while the excluded hidden sheet's file kept its old date; a warn-level run prints only error lines — no header, no plan, no verdict.
- The new QRS `app/count` / `app/object/count` plan-fact queries verified against the live repository.

## Breaking change (log lines)

Anyone grepping `App version:`, `About to process app`, `Done processing app` or the long per-sheet `Processing sheet N:` lines needs to adjust — worth a release-note line. The staged doc page (`docs/to-doc-site/thumbnail-run-card.md`) carries the full old-to-new migration table for both platforms and all three commands, plus the scope note that pre-loop aborts exit 1 without a RESULT block. `docs/to-doc-site/dry-run.md` (pending) is updated for the PLAN block its output now opens with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
