### PR TITLE
Let integration-test log output print plainly

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -67,10 +67,19 @@ const config = {
         'src/lib/util/import-meta-url\\.js$',
     ],
     coverageProvider: 'v8',
-    // Restores `process.exitCode` around every test. Command handlers set it to 1 on failure and
-    // do not rethrow, so a test covering a failure path would otherwise leave the runner's own
-    // exit status at 1 with every suite reported green. See the file for the full account.
-    setupFilesAfterEnv: ['<rootDir>/src/lib/test-helpers/preserve-exit-code.js'],
+    // preserve-exit-code: restores `process.exitCode` around every test. Command handlers set it
+    // to 1 on failure and do not rethrow, so a test covering a failure path would otherwise leave
+    // the runner's own exit status at 1 with every suite reported green.
+    //
+    // restore-plain-console: integration suites swap Jest's buffered console for a real one so
+    // Winston log lines print plainly instead of each being wrapped in a `console.log` frame
+    // blaming winston's transport. Unit suites are left untouched.
+    //
+    // See each file for the full account.
+    setupFilesAfterEnv: [
+        '<rootDir>/src/lib/test-helpers/preserve-exit-code.js',
+        '<rootDir>/src/lib/test-helpers/restore-plain-console.js',
+    ],
     testEnvironment: 'node',
     roots: ['<rootDir>/src'],
     transform: {},

--- a/src/lib/test-helpers/restore-plain-console.js
+++ b/src/lib/test-helpers/restore-plain-console.js
@@ -1,0 +1,27 @@
+/**
+ * Lets integration-suite log output print plainly instead of wrapped in Jest's console frame.
+ *
+ * Winston's console transport writes through `console._stdout` when it exists
+ * (node_modules/winston/lib/winston/transports/console.js:87). In a multi-suite run Jest installs
+ * its BufferedConsole as the test-context `console`, and node's Console constructor points that
+ * object's `_stdout` at Jest's capture buffer - so every Winston line is replayed by the reporter
+ * wrapped in the interception frame: a `console.log` header plus
+ * `at Console.log (node_modules/winston/lib/winston/transports/console.js:87:23)`. The origin is
+ * always that same transport line, so the frame carries no information, and it triples the height
+ * of the log output an integration run exists to show.
+ *
+ * Single-suite runs never show the problem, which makes it look intermittent: Jest auto-enables
+ * verbose mode when exactly one suite is selected and then uses CustomConsole, whose `_stdout` is
+ * the real stream, so Winston bypasses the buffer entirely.
+ *
+ * Giving integration suites a real Console bound to the process streams makes Winston - and direct
+ * `console.log` calls - write straight through, in chronological order. Scoped to
+ * `*.integration.test.js`: unit suites keep Jest's buffered console, whose per-test grouping,
+ * informative origins, and `--silent` muting are worth having there.
+ */
+import { Console } from 'node:console';
+import { expect } from '@jest/globals';
+
+if (/\.integration\.test\.js$/.test(expect.getState().testPath ?? '')) {
+    globalThis.console = new Console({ stdout: process.stdout, stderr: process.stderr });
+}


### PR DESCRIPTION
Integration test runs wrapped every Winston log line in Jest's console interception frame: a `console.log` header, the message, then `at Console.log (node_modules/winston/lib/winston/transports/console.js:87:23)`. That origin is the same on every line — it is always Winston's transport, never the code that logged — so it carries no information while tripling the height of the output an integration run exists to show.

## Why it happens

Winston's console transport writes through `console._stdout` when that property exists. In a multi-suite run Jest installs its `BufferedConsole` as the test-context console, and node's `Console` constructor points that object's `_stdout` at Jest's capture buffer — so Winston's writes land in the buffer and are replayed by the reporter, framed.

Single-suite runs never show the problem, which is what made it look intermittent: Jest auto-enables verbose mode when exactly one suite is selected and then uses `CustomConsole`, whose `_stdout` is the real stream, so Winston bypasses the buffer entirely. Any one-file repro attempt is structurally incapable of reproducing this; two or more suites are required.

## The change

A new `setupFilesAfterEnv` helper gives suites whose path matches `*.integration.test.js` a real `Console` bound to `process.stdout`/`process.stderr`. Winston — and direct `console.log` calls — then write straight through, in chronological order.

Unit suites are deliberately left alone. There, Jest's buffered console earns its keep: per-test grouping, origins that point at the actual call site, and `--silent` muting.

## Verification

- Two integration suites before the change: every Winston line framed with the winston-transport origin. Same run after: lines print plainly, both suites pass.
- Scoping checked in both directions — a probe test run under a unit-test filename still gets `BufferedConsole` and full framing, so unit output is unchanged. The probe was deleted afterwards.
- `npm run test:unit` on the current `main` base: 111 suites, 3081 tests, all passing. `npm run lint` and Prettier clean.
- Re-verified after syncing onto today's `main`, so this sits alongside the new `BSI_LOG_TIMESTAMPS` console-format work rather than fighting it.

The live-lab suites were not run: they mutate the lab server, and per the finding above a single suite cannot exercise the buggy path anyway. The two-suite browser-side run exercises the identical Winston-to-console plumbing through the real `globals.js` logger, which is the whole surface this touches.

Internal test tooling only — no user-facing behaviour changes, so no doc-site page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)