### PR TITLE
Pick the highest run output the terminal can render, and show a contact-sheet board

### DIFF
--- a/docs/to-doc-site/run-output-contact-sheet.md
+++ b/docs/to-doc-site/run-output-contact-sheet.md
@@ -9,7 +9,8 @@
 > sample board below is generated from the real renderer — do not re-align it by hand.
 
 ::: warning Requires BSI X.Y.Z or later
-Earlier versions always print the plain run card.
+Earlier versions print flat log lines only — the plain run card (the `PLAN` and
+`RESULT` blocks) and the contact sheet both arrive in this version.
 :::
 
 When you run one of the three commands that change Qlik Sense apps —
@@ -21,8 +22,9 @@ and picks the richest presentation that will actually display correctly there:
   you get the **contact sheet**: a colour board with the run plan, one summary row per
   app as it finishes, and a final verdict.
 - **Everywhere else** — Windows Task Scheduler, cron, Docker, CI, output redirected to a
-  file, a very narrow or colour-less console — you get the **plain run card** that
-  earlier versions always printed. Nothing about scheduled or captured logs changes.
+  file, a very narrow or colour-less console — you get the **plain run card**: the same
+  `PLAN` and `RESULT` blocks, as plain ASCII log lines. Captured and scheduled logs never
+  contain the board.
 
 You do not need to configure anything. The selection is automatic, decided once at the
 start of each run, and there is an environment variable to override it if the automatic
@@ -55,9 +57,9 @@ choice is ever wrong for your setup.
 
   ────────────────────────────────────────────────────────────────
 
-  ✓ 1/3  Sales Discovery           ██▓█░██████         10/11 up    52s
-  ✓ 2/3  Operations Monitor        ████████            8/8 up      41s
-  ✓ 3/3  Executive KPIs            ███░██████          9/10 up     48s
+  ✓ 1/3  Sales Discovery       ██▓█░██████   10/11 up      52s
+  ✓ 2/3  Operations Monitor    ████████      8/8 up        41s
+  ✓ 3/3  Executive KPIs        ███░██████    9/10 up       48s
 
   ────────────────────────────────────────────────────────────────
 
@@ -99,8 +101,10 @@ per sheet, so nothing shifts.
 The rules, in the order they are applied:
 
 1. **`BSI_OUTPUT` is set** — see the next section. It wins.
-2. **Log level `verbose`, `debug` or `silly`** — plain run card. At those levels you are
-   debugging, and the debug stream is what you asked for.
+2. **Log level anything other than `info` (the default)** — plain run card. At `verbose`
+   and below you are debugging, and the debug stream is what you asked for; at `warn` or
+   `error` you asked for a quiet run, and the plain run card is the presentation that
+   respects the log level.
 3. **Colour terminal, at least 72 columns wide** — the contact sheet.
 4. **Anything else** — the plain run card.
 
@@ -123,7 +127,8 @@ it describes your console, not one invocation, so it is not a per-command flag.
 
 Values are case-insensitive. An unrecognised value logs a warning and falls back to
 automatic selection — it never stops the run, so a typo in a scheduler's environment
-block cannot break a working nightly job.
+block cannot break a working nightly job. On a `--dry-run`, the plan block always
+prints regardless of `off`: it is part of what a dry run exists to show.
 
 Setting it for a single run:
 
@@ -134,7 +139,7 @@ $env:BSI_OUTPUT = "plain"
 .\butler-sheet-icons.exe qseow create-sheet-thumbnails ...
 ```
 
-```bash [bash]
+```bash [Bash]
 BSI_OUTPUT=plain ./butler-sheet-icons qseow create-sheet-thumbnails ...
 ```
 
@@ -149,7 +154,7 @@ chokes on the framed blocks:
 $env:BSI_OUTPUT = "off"
 ```
 
-```bash [bash]
+```bash [Bash]
 export BSI_OUTPUT=off
 ```
 
@@ -159,7 +164,7 @@ export BSI_OUTPUT=off
 
 The contact sheet is only ever what an interactive terminal *sees*. Redirected output is
 not a terminal, so a redirected or scheduled run selects the plain run card
-automatically — what lands in a file, a Task Scheduler transcript or a captured CI log
-is the same plain output as in earlier versions. And when the contact sheet is shown,
-the plan and verdict are not printed twice: the terminal shows the board instead of the
-card.
+automatically — a file, a Task Scheduler transcript or a captured CI log gets the plain
+run card (itself new in this version), never the board. And when the contact sheet is
+shown, the plan and verdict are not printed twice: the terminal shows the board instead
+of the card.

--- a/docs/to-doc-site/run-output-contact-sheet.md
+++ b/docs/to-doc-site/run-output-contact-sheet.md
@@ -1,0 +1,165 @@
+# Colour run output in the terminal: the contact sheet and BSI_OUTPUT
+
+> **Publisher note:** new page — it needs a sidebar entry in `docs/.vitepress/config.js`,
+> suggested next to the run-card / dry-run pages it builds on. No generated CLI option
+> tables are affected: this feature adds an environment variable, not a command-line
+> option, so no table regeneration is needed. Establish the version for the gate below
+> from the open release-please PR title at publication time, per this folder's README
+> (it read 5.0.0 when this draft was written — re-check, do not trust the draft). The
+> sample board below is generated from the real renderer — do not re-align it by hand.
+
+::: warning Requires BSI X.Y.Z or later
+Earlier versions always print the plain run card.
+:::
+
+When you run one of the three commands that change Qlik Sense apps —
+`qseow create-sheet-thumbnails`, `qscloud create-sheet-thumbnails` or
+`qscloud remove-sheet-icons` — Butler Sheet Icons now looks at where its output is going
+and picks the richest presentation that will actually display correctly there:
+
+- **In an interactive terminal** that supports colour and is at least 72 characters wide,
+  you get the **contact sheet**: a colour board with the run plan, one summary row per
+  app as it finishes, and a final verdict.
+- **Everywhere else** — Windows Task Scheduler, cron, Docker, CI, output redirected to a
+  file, a very narrow or colour-less console — you get the **plain run card** that
+  earlier versions always printed. Nothing about scheduled or captured logs changes.
+
+You do not need to configure anything. The selection is automatic, decided once at the
+start of each run, and there is an environment variable to override it if the automatic
+choice is ever wrong for your setup.
+
+## What the contact sheet looks like
+
+```
+  ┌─ 410 × 270 ──────────────────────────────────────┐
+  │                                                  │
+  │   BUTLER SHEET ICONS                     X.Y.Z   │
+  │   QSEoW sheet thumbnails                         │
+  │                                                  │
+  └──────────────────────────────────────────────────┘
+
+  PLAN  qseow create-sheet-thumbnails
+
+  ● server      sense.company.com       https · engine 4747 · qrs 4242
+  ● api user    INTERNAL\sa_api         cert ./cert/client.pem
+  ● logon user  COMPANY\svc_bsi
+  ● apps        3                       0 named by --appid · 3 matched by --qliksensetag "updateSheetThumbnails"
+  ● sheet part  2 of 4                  objects + sheet title
+  ● exclude     tag "no-thumbnail" (2 sheets)
+  ● blur        tag "confidential" (1 sheets)
+  ● browser     chrome (recommended)    headless · 5s per sheet
+  ○ images      ./img/qseow/<app-id>
+  ● uploads to  content library "Butler sheet thumbnails"
+
+  !  sheet thumbnails will be overwritten in 3 app(s), 2 of them published
+
+  ────────────────────────────────────────────────────────────────
+
+  ✓ 1/3  Sales Discovery           ██▓█░██████         10/11 up    52s
+  ✓ 2/3  Operations Monitor        ████████            8/8 up      41s
+  ✓ 3/3  Executive KPIs            ███░██████          9/10 up     48s
+
+  ────────────────────────────────────────────────────────────────
+
+  ❯ done in 2m 21s  ·  3 app(s) ok  ·  27 thumbnails uploaded
+    █ 27 captured   ▓ 1 blurred   ░ 2 excluded
+    images in ./img/qseow · 27 file(s) · 1.6 MB
+```
+
+The plan block at the top is the same information the plain run card prints: which
+server, which identities, how many apps were selected and by which options, which
+exclude and blur rules are active (with how many sheets each tag matched — a `(0
+sheets)` next to a tag you typed is the fastest way to spot a misspelling), and the one
+line in the block that warns about the write with no undo.
+
+## The sheet strip
+
+The row of block characters after each app name is a **sheet strip**: one character per
+sheet, in sheet order.
+
+| Character | ASCII fallback | Meaning                                   |
+| --------- | -------------- | ----------------------------------------- |
+| `█`       | `#`            | Sheet captured and its thumbnail uploaded |
+| `▓`       | `:`            | Captured, then blurred                    |
+| `░`       | `.`            | Excluded by one of your exclude rules     |
+| `▒`       | `!`            | Not processed — the app failed here       |
+
+This makes selection mistakes visible per app, at a glance. A mistyped
+`--exclude-sheet-tag` shows up as a row of solid blocks where you expected gaps. A
+mistyped `--blur-sheet-tag` shows up as a row with no `▓` in it — in every app, or only
+in some, which also tells you whether the tag is missing everywhere or just applied
+unevenly.
+
+On consoles that cannot display these characters (or when you set `BSI_ASCII_ONLY=1`,
+which also governs this feature), the strip uses the ASCII fallbacks above, one column
+per sheet, so nothing shifts.
+
+## When you get which output
+
+The rules, in the order they are applied:
+
+1. **`BSI_OUTPUT` is set** — see the next section. It wins.
+2. **Log level `verbose`, `debug` or `silly`** — plain run card. At those levels you are
+   debugging, and the debug stream is what you asked for.
+3. **Colour terminal, at least 72 columns wide** — the contact sheet.
+4. **Anything else** — the plain run card.
+
+"Colour terminal" follows the same conventions as the rest of Butler Sheet Icons:
+`NO_COLOR` disables colour, `FORCE_COLOR` forces it, `TERM=dumb` disables it, and
+redirected output never counts as a terminal. A `--dry-run` on a capable terminal shows
+its plan block as a board too; the detailed per-sheet dry-run report itself is unchanged.
+
+## Overriding the choice: BSI_OUTPUT
+
+`BSI_OUTPUT` is an environment variable, like `BSI_ASCII_ONLY` and `BSI_NO_INTERACTIVE`:
+it describes your console, not one invocation, so it is not a per-command flag.
+
+| Value   | Effect                                                                                                                                            |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `board` | Force the contact sheet, even where detection would not pick it (for example, when recording a run, or on a terminal that is detected incorrectly) |
+| `plain` | Force the plain run card                                                                                                                           |
+| `off`   | Suppress the framed plan and verdict blocks entirely. Per-app and per-sheet progress lines still print, so the run is not silent                   |
+| `live`  | Reserved for a future live view; today it behaves like automatic selection                                                                         |
+
+Values are case-insensitive. An unrecognised value logs a warning and falls back to
+automatic selection — it never stops the run, so a typo in a scheduler's environment
+block cannot break a working nightly job.
+
+Setting it for a single run:
+
+::: code-group
+
+```powershell [PowerShell]
+$env:BSI_OUTPUT = "plain"
+.\butler-sheet-icons.exe qseow create-sheet-thumbnails ...
+```
+
+```bash [bash]
+BSI_OUTPUT=plain ./butler-sheet-icons qseow create-sheet-thumbnails ...
+```
+
+:::
+
+Use `off` if a log-collection tool parses Butler Sheet Icons output line by line and
+chokes on the framed blocks:
+
+::: code-group
+
+```powershell [PowerShell]
+$env:BSI_OUTPUT = "off"
+```
+
+```bash [bash]
+export BSI_OUTPUT=off
+```
+
+:::
+
+## Scheduled and redirected runs are unchanged
+
+The contact sheet is only ever what an interactive terminal *sees*. Redirected output is
+not a terminal, so a redirected or scheduled run selects the plain run card
+automatically — what lands in a file, a Task Scheduler transcript or a captured CI log
+is the same plain output as in earlier versions. And when the contact sheet is shown,
+the plan and verdict are not printed twice: the terminal shows the board instead of the
+card.

--- a/docs/to-doc-site/run-output-contact-sheet.md
+++ b/docs/to-doc-site/run-output-contact-sheet.md
@@ -79,12 +79,12 @@ line in the block that warns about the write with no undo.
 The row of block characters after each app name is a **sheet strip**: one character per
 sheet, in sheet order.
 
-| Character | ASCII fallback | Meaning                                   |
-| --------- | -------------- | ----------------------------------------- |
-| `█`       | `#`            | Sheet captured and its thumbnail uploaded |
-| `▓`       | `:`            | Captured, then blurred                    |
-| `░`       | `.`            | Excluded by one of your exclude rules     |
-| `▒`       | `!`            | Not processed — the app failed here       |
+| Character | ASCII fallback | Meaning on a thumbnail run                | Meaning on `remove-sheet-icons`   |
+| --------- | -------------- | ----------------------------------------- | --------------------------------- |
+| `█`       | `#`            | Sheet captured and its thumbnail uploaded | Sheet icon cleared                |
+| `▓`       | `:`            | Captured, then blurred                    | —                                 |
+| `░`       | `.`            | Excluded by one of your exclude rules     | Sheet had no icon to clear        |
+| `▒`       | `!`            | Not processed — the app failed here       | Not processed — the app failed here |
 
 This makes selection mistakes visible per app, at a glance. A mistyped
 `--exclude-sheet-tag` shows up as a row of solid blocks where you expected gaps. A
@@ -101,10 +101,12 @@ per sheet, so nothing shifts.
 The rules, in the order they are applied:
 
 1. **`BSI_OUTPUT` is set** — see the next section. It wins.
-2. **Log level anything other than `info` (the default)** — plain run card. At `verbose`
-   and below you are debugging, and the debug stream is what you asked for; at `warn` or
-   `error` you asked for a quiet run, and the plain run card is the presentation that
-   respects the log level.
+2. **Log level anything other than `info` (the default)** — no contact sheet. At
+   `verbose`, `debug` or `silly` you are debugging, and you get the plain run card
+   inside the debug stream you asked for. At `warn` or `error` you asked for a quiet
+   run, and quiet is what you get: only warnings and errors print (the run card's
+   blocks are informational and stay hidden at those levels — a `--dry-run`'s plan and
+   report are the exception, since they are the whole point of a dry run).
 3. **Colour terminal, at least 72 columns wide** — the contact sheet.
 4. **Anything else** — the plain run card.
 

--- a/src/lib/cloud/__tests__/cloud_create_thumbnails_app_loop.test.js
+++ b/src/lib/cloud/__tests__/cloud_create_thumbnails_app_loop.test.js
@@ -13,6 +13,7 @@ jest.unstable_mockModule('../../../globals.js', () => ({
         warn: jest.fn(),
     },
     setLoggingLevel: jest.fn(),
+    appVersion: '9.9.9-test',
     getLoggingLevel: jest.fn(() => 'info'),
     bsiExecutablePath: '/test/path',
     isSea: false,

--- a/src/lib/cloud/__tests__/cloud_create_thumbnails_empty_selection.test.js
+++ b/src/lib/cloud/__tests__/cloud_create_thumbnails_empty_selection.test.js
@@ -9,6 +9,7 @@ jest.unstable_mockModule('../../../globals.js', () => ({
         warn: jest.fn(),
     },
     setLoggingLevel: jest.fn(),
+    appVersion: '9.9.9-test',
     getLoggingLevel: jest.fn(() => 'info'),
     bsiExecutablePath: '/test/path',
     isSea: false,

--- a/src/lib/cloud/__tests__/cloud_create_thumbnails_validation.test.js
+++ b/src/lib/cloud/__tests__/cloud_create_thumbnails_validation.test.js
@@ -12,6 +12,7 @@ jest.unstable_mockModule('../../../globals.js', () => ({
         warn: jest.fn(),
     },
     setLoggingLevel: jest.fn(),
+    appVersion: '9.9.9-test',
     getLoggingLevel: jest.fn(() => 'info'),
     bsiExecutablePath: '/test/path',
     isSea: false,

--- a/src/lib/cloud/__tests__/cloud_remove_sheet_icons.test.js
+++ b/src/lib/cloud/__tests__/cloud_remove_sheet_icons.test.js
@@ -36,6 +36,7 @@ jest.unstable_mockModule('../../../globals.js', () => ({
         warn: jest.fn(),
     },
     setLoggingLevel: jest.fn(),
+    appVersion: '9.9.9-test',
     getLoggingLevel: jest.fn(() => 'info'),
     bsiExecutablePath: '/opt/bsi',
     isSea: false,

--- a/src/lib/cloud/__tests__/cloud_remove_sheet_icons.test.js
+++ b/src/lib/cloud/__tests__/cloud_remove_sheet_icons.test.js
@@ -317,6 +317,58 @@ describe('qscloudRemoveSheetIcons', () => {
         });
     });
 
+    describe('the app-name lookup for the report', () => {
+        test('a failing apps/{id} read never fails the app - the name is decorative', async () => {
+            wireEnigma([makeSheet('sheet-1', 1)]);
+            const mediaOnly = Get.getMockImplementation();
+            Get.mockImplementation(async (path) => {
+                // Only the metadata endpoint itself - the media-list reads
+                // under apps/{id}/media/... must keep working, or this test
+                // would fail the app through the media path instead.
+                if (path === 'apps/test-app-id') {
+                    throw new Error('429 Too Many Requests');
+                }
+
+                return mediaOnly(path);
+            });
+
+            await expect(qscloudRemoveSheetIcons({ ...BASE_OPTIONS })).resolves.toBe(true);
+        });
+
+        test('the fetched app name reaches the board row', async () => {
+            wireEnigma([makeSheet('sheet-1', 1)]);
+            const mediaOnly = Get.getMockImplementation();
+            Get.mockImplementation(async (path) => {
+                if (path === 'apps/test-app-id') {
+                    return { attributes: { name: 'My Cloud App' } };
+                }
+
+                return mediaOnly(path);
+            });
+
+            const writes = [];
+            const spy = jest.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+                writes.push(String(chunk));
+
+                return true;
+            });
+            const savedOutput = process.env.BSI_OUTPUT;
+            process.env.BSI_OUTPUT = 'board';
+            try {
+                await expect(qscloudRemoveSheetIcons({ ...BASE_OPTIONS })).resolves.toBe(true);
+            } finally {
+                spy.mockRestore();
+                if (savedOutput === undefined) {
+                    delete process.env.BSI_OUTPUT;
+                } else {
+                    process.env.BSI_OUTPUT = savedOutput;
+                }
+            }
+
+            expect(writes.join('')).toContain('My Cloud App');
+        });
+    });
+
     describe('ordering of the media-library cleanup', () => {
         test('deletes the image files only after the app has been saved', async () => {
             // Deleting first meant a failed save left every sheet pointing at images that

--- a/src/lib/cloud/cloud-create-thumbnails.js
+++ b/src/lib/cloud/cloud-create-thumbnails.js
@@ -1,4 +1,4 @@
-import { logger, setLoggingLevel, bsiExecutablePath, isSea } from '../../globals.js';
+import { logger, appVersion, setLoggingLevel, bsiExecutablePath, isSea } from '../../globals.js';
 import { redactOptions } from '../util/redact-secrets.js';
 import QlikSaas from './cloud-repo.js';
 import { qscloudTestConnection } from './cloud-test-connection.js';
@@ -8,6 +8,7 @@ import { resolveCloudAppSelection } from './cloud-app-selection.js';
 import {
     runOverAppsWithReport,
     announceDryRun,
+    emitRunHeader,
     buildSheetRules,
     buildSheetPartSection,
     buildBrowserPlanSection,
@@ -44,10 +45,19 @@ export const qscloudCreateThumbnails = async (options) => {
     try {
         setLoggingLevel(options.loglevel);
 
+        // Emitted here rather than in the command handler: the wizard calls
+        // this worker directly, and the header's rung must be decided from
+        // the options the run actually uses - wizard answers included.
+        const rung = emitRunHeader({
+            version: appVersion,
+            jobLabel: 'Qlik Sense Cloud sheet thumbnails',
+            options,
+        });
+
         const dryRun = Boolean(options.dryRun);
         if (dryRun) {
             // Before anything connects - mirrors the QSEoW twin.
-            announceDryRun('qscloud create-sheet-thumbnails');
+            announceDryRun('qscloud create-sheet-thumbnails', rung);
         }
 
         logger.info('Starting creation of thumbnails for Qlik Sense Cloud');
@@ -120,6 +130,7 @@ export const qscloudCreateThumbnails = async (options) => {
         return await runOverAppsWithReport({
             command: 'qscloud create-sheet-thumbnails',
             dryRun,
+            rung,
             ...selection,
             plan: {
                 target: { platform: 'cloud', tenantUrl: options.tenanturl },

--- a/src/lib/cloud/cloud-remove-sheet-icons.js
+++ b/src/lib/cloud/cloud-remove-sheet-icons.js
@@ -44,6 +44,34 @@ import { logError } from '../util/log-error.js';
  *     attempted first and the engine session is always released.
  * @throws {Error} Whatever the engine or media API threw, if the session itself was lost.
  */
+/**
+ * Best-effort app-name lookup for the run report.
+ *
+ * The name is decorative - the board row and the plan fall back to the app
+ * id - so a failed lookup must never fail the app: a transient 429/5xx on
+ * this read while the engine is healthy would otherwise mark an app failed
+ * with nothing attempted, on the one command with no undo. One helper for
+ * the planner and the real remover, so the two cannot drift on how the name
+ * is fetched or how its absence is handled.
+ *
+ * @param {import('./cloud-test-connection.js').QlikSaasInstance} saasInstance - QlikSaas object.
+ * @param {string} appId - The app to name.
+ *
+ * @returns {Promise<string|null>} The app name, or null when the lookup
+ *     failed or the metadata carries no name.
+ */
+const fetchCloudAppName = async (saasInstance, appId) => {
+    try {
+        const appMetadata = await saasInstance.Get(`apps/${appId}`);
+
+        return appMetadata?.attributes?.name ?? null;
+    } catch (err) {
+        logger.verbose(`Could not read app name for ${appId}: ${err?.message ?? err}`);
+
+        return null;
+    }
+};
+
 const removeSheetIconsCloudApp = async (appId, saasInstance, options, report = null) => {
     let sheetRun;
     let appEntry = null;
@@ -52,8 +80,8 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options, report = n
         // App name for the report - the board's per-app rows (issue #1074)
         // render on real runs too, and a row naming only a clipped GUID
         // cannot be recognised by the operator it exists for, least of all
-        // on the one command with no undo. This read used to be planner-only.
-        const appMetadata = report ? await saasInstance.Get(`apps/${appId}`) : null;
+        // on the one command with no undo.
+        const appName = report ? await fetchCloudAppName(saasInstance, appId) : null;
 
         // Configure Enigma.js
         const configEnigma = setupEnigmaConnection(appId, options);
@@ -80,7 +108,7 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options, report = n
                 if (report) {
                     appEntry = addAppToReport(report, {
                         id: appId,
-                        name: appMetadata?.attributes?.name,
+                        name: appName ?? undefined,
                         sheetCount: sheets.length,
                     });
                 }
@@ -249,9 +277,10 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options, report = n
  */
 const planRemoveSheetIconsCloudApp = async (appId, saasInstance, options, report) => {
     // Get app name - the report is the product here, and a plan listing bare
-    // GUIDs cannot be recognised by the operator it exists for. This is one
-    // read the real remover does not make; that is the right trade.
-    const appMetadata = await saasInstance.Get(`apps/${appId}`);
+    // GUIDs cannot be recognised by the operator it exists for. Best-effort
+    // via the same helper the real remover uses: a failed name lookup
+    // degrades the plan to the app id rather than failing the app's plan.
+    const appName = await fetchCloudAppName(saasInstance, appId);
 
     const configEnigma = setupEnigmaConnection(appId, options);
 
@@ -269,17 +298,17 @@ const planRemoveSheetIconsCloudApp = async (appId, saasInstance, options, report
 
             const sheets = await getSheetList(app, SHEET_LIST_FIELDS_EXTENDED);
             // Through the shared renderer, with the id as the name fallback -
-            // a missing attributes.name must not print "undefined".
+            // a missing name must not print "undefined".
             logger.info(
                 appProgressLine({
-                    name: appMetadata?.attributes?.name ?? appId,
+                    name: appName ?? appId,
                     sheetCount: sheets.length,
                 })
             );
 
             const appEntry = addAppToReport(report, {
                 id: appId,
-                name: appMetadata?.attributes?.name,
+                name: appName ?? undefined,
                 sheetCount: sheets.length,
             });
 

--- a/src/lib/cloud/cloud-remove-sheet-icons.js
+++ b/src/lib/cloud/cloud-remove-sheet-icons.js
@@ -1,5 +1,5 @@
 import { setupEnigmaConnection } from './cloud-enigma.js';
-import { logger, setLoggingLevel, bsiExecutablePath, isSea } from '../../globals.js';
+import { logger, appVersion, setLoggingLevel, bsiExecutablePath, isSea } from '../../globals.js';
 import { redactOptions } from '../util/redact-secrets.js';
 import QlikSaas from './cloud-repo.js';
 import { qscloudTestConnection } from './cloud-test-connection.js';
@@ -18,6 +18,7 @@ import { CLEAR_REASON } from '../util/sheet-decision-reasons.js';
 import {
     runOverAppsWithReport,
     announceDryRun,
+    emitRunHeader,
     addAppToReport,
     recordSheetDecision,
 } from '../util/run-report.js';
@@ -48,6 +49,12 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options, report = n
     let appEntry = null;
 
     try {
+        // App name for the report - the board's per-app rows (issue #1074)
+        // render on real runs too, and a row naming only a clipped GUID
+        // cannot be recognised by the operator it exists for, least of all
+        // on the one command with no undo. This read used to be planner-only.
+        const appMetadata = report ? await saasInstance.Get(`apps/${appId}`) : null;
+
         // Configure Enigma.js
         const configEnigma = setupEnigmaConnection(appId, options);
         await withEngineSession(
@@ -71,7 +78,11 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options, report = n
                 logger.info(`  ${sheets.length} sheet(s)`);
 
                 if (report) {
-                    appEntry = addAppToReport(report, { id: appId, sheetCount: sheets.length });
+                    appEntry = addAppToReport(report, {
+                        id: appId,
+                        name: appMetadata?.attributes?.name,
+                        sheetCount: sheets.length,
+                    });
                 }
 
                 if (sheets.length > 0) {
@@ -344,11 +355,20 @@ export const qscloudRemoveSheetIcons = async (options) => {
     try {
         setLoggingLevel(options.loglevel);
 
+        // Emitted here rather than in the command handler: the wizard calls
+        // this worker directly, and the header's rung must be decided from
+        // the options the run actually uses - wizard answers included.
+        const rung = emitRunHeader({
+            version: appVersion,
+            jobLabel: 'Qlik Sense Cloud sheet icon removal',
+            options,
+        });
+
         const dryRun = Boolean(options.dryRun);
         if (dryRun) {
             // Before anything connects - this command's real mode is the most
             // destructive in the CLI, so the log must not open like it.
-            announceDryRun('qscloud remove-sheet-icons');
+            announceDryRun('qscloud remove-sheet-icons', rung);
         }
 
         logger.info('Starting removal of sheet icons for Qlik Sense Cloud');
@@ -391,6 +411,7 @@ export const qscloudRemoveSheetIcons = async (options) => {
         return await runOverAppsWithReport({
             command: 'qscloud remove-sheet-icons',
             dryRun,
+            rung,
             ...selection,
             plan: {
                 target: { platform: 'cloud', tenantUrl: options.tenanturl },

--- a/src/lib/commands/qscloud/create-sheet-thumbnails.js
+++ b/src/lib/commands/qscloud/create-sheet-thumbnails.js
@@ -1,6 +1,6 @@
 import { Command, Option } from 'commander';
 import { logger, appVersion, setLoggingLevel } from '../../../globals.js';
-import { logRunHeader } from '../../util/run-report-render.js';
+import { emitRunHeader } from '../../util/run-report.js';
 import { qscloudCreateThumbnails } from '../../cloud/cloud-create-thumbnails.js';
 import { CLOUD_SHEET_PARTS } from '../../cloud/sheet-parts.js';
 import {
@@ -36,7 +36,9 @@ const handleCloudCreateSheetThumbnails = async (options = {}, cmd) => {
     if (options.loglevel) {
         setLoggingLevel(options.loglevel);
     }
-    logRunHeader(logger, appVersion, 'Qlik Sense Cloud sheet thumbnails');
+    // Rung-aware (issue #1076): on the board rung the terminal gets the
+    // wordmark frame and the plain header goes to the log underneath.
+    emitRunHeader({ version: appVersion, jobLabel: 'Qlik Sense Cloud sheet thumbnails', options });
 
     // Joined explicitly: --appid is variadic, and letting a template literal coerce the
     // array reads as one strange id rather than as several.

--- a/src/lib/commands/qscloud/create-sheet-thumbnails.js
+++ b/src/lib/commands/qscloud/create-sheet-thumbnails.js
@@ -1,6 +1,5 @@
 import { Command, Option } from 'commander';
-import { logger, appVersion, setLoggingLevel } from '../../../globals.js';
-import { emitRunHeader } from '../../util/run-report.js';
+import { logger, setLoggingLevel } from '../../../globals.js';
 import { qscloudCreateThumbnails } from '../../cloud/cloud-create-thumbnails.js';
 import { CLOUD_SHEET_PARTS } from '../../cloud/sheet-parts.js';
 import {
@@ -29,16 +28,15 @@ import { runCommand } from '../run-command.js';
  * @returns {Promise<void>} Resolves after delegating to qscloudCreateThumbnails and logging any errors.
  */
 const handleCloudCreateSheetThumbnails = async (options = {}, cmd) => {
-    // Level set before the header, not only in the worker: a run at
-    // --log-level warn asked for a quiet log, and the run card - header
-    // included - respects that. Guarded for programmatic callers without the
-    // option; the worker sets the level again, which is idempotent.
+    // Level set before any handler-level logging: a run at --log-level warn
+    // asked for a quiet log. Guarded for programmatic callers without the
+    // option; the worker sets the level again, which is idempotent. The run
+    // header is emitted by the worker, not here - the wizard invokes workers
+    // directly, and the header must come from the same place on both paths,
+    // decided from the options the run actually uses.
     if (options.loglevel) {
         setLoggingLevel(options.loglevel);
     }
-    // Rung-aware (issue #1076): on the board rung the terminal gets the
-    // wordmark frame and the plain header goes to the log underneath.
-    emitRunHeader({ version: appVersion, jobLabel: 'Qlik Sense Cloud sheet thumbnails', options });
 
     // Joined explicitly: --appid is variadic, and letting a template literal coerce the
     // array reads as one strange id rather than as several.

--- a/src/lib/commands/qscloud/remove-sheet-icons.js
+++ b/src/lib/commands/qscloud/remove-sheet-icons.js
@@ -1,7 +1,7 @@
 import { Command, Option } from 'commander';
 import { addDryRunOption } from '../dry-run-option.js';
-import { logger, appVersion, setLoggingLevel } from '../../../globals.js';
-import { logRunHeader } from '../../util/run-report-render.js';
+import { appVersion, setLoggingLevel } from '../../../globals.js';
+import { emitRunHeader } from '../../util/run-report.js';
 import { qscloudRemoveSheetIcons } from '../../cloud/cloud-remove-sheet-icons.js';
 import { runCommand } from '../run-command.js';
 import { collectAppIds } from '../helpers.js';
@@ -19,7 +19,13 @@ const handleCloudRemoveSheetIcons = async (options = {}, cmd) => {
     if (options.loglevel) {
         setLoggingLevel(options.loglevel);
     }
-    logRunHeader(logger, appVersion, 'Qlik Sense Cloud sheet icon removal');
+    // Rung-aware (issue #1076): on the board rung the terminal gets the
+    // wordmark frame and the plain header goes to the log underneath.
+    emitRunHeader({
+        version: appVersion,
+        jobLabel: 'Qlik Sense Cloud sheet icon removal',
+        options,
+    });
 
     return runCommand('CLOUD MAIN 5', () => qscloudRemoveSheetIcons(options, cmd));
 };

--- a/src/lib/commands/qscloud/remove-sheet-icons.js
+++ b/src/lib/commands/qscloud/remove-sheet-icons.js
@@ -1,7 +1,6 @@
 import { Command, Option } from 'commander';
 import { addDryRunOption } from '../dry-run-option.js';
-import { appVersion, setLoggingLevel } from '../../../globals.js';
-import { emitRunHeader } from '../../util/run-report.js';
+import { setLoggingLevel } from '../../../globals.js';
 import { qscloudRemoveSheetIcons } from '../../cloud/cloud-remove-sheet-icons.js';
 import { runCommand } from '../run-command.js';
 import { collectAppIds } from '../helpers.js';
@@ -9,23 +8,21 @@ import { collectAppIds } from '../helpers.js';
 /**
  * Commander action that removes sheet icons from specified Qlik Sense Cloud apps.
  *
+ * The run header is emitted by the worker, not here: the wizard invokes
+ * workers directly, and the header must come from the same place on both
+ * paths - decided from the options the run actually uses.
+ *
  * @param {object} [options] - Options describing tenant, authentication and app selection. Defaults to `{}`.
  * @param {import('commander').Command} cmd - Commander command reference for worker logging.
  *
  * @returns {Promise<void>} Resolves once the worker reports success or the error is logged.
  */
 const handleCloudRemoveSheetIcons = async (options = {}, cmd) => {
-    // Level set before the header - see create-sheet-thumbnails.js for why.
+    // Level set here as well as in the worker: any handler-level logging
+    // before the worker runs must already respect a quiet run.
     if (options.loglevel) {
         setLoggingLevel(options.loglevel);
     }
-    // Rung-aware (issue #1076): on the board rung the terminal gets the
-    // wordmark frame and the plain header goes to the log underneath.
-    emitRunHeader({
-        version: appVersion,
-        jobLabel: 'Qlik Sense Cloud sheet icon removal',
-        options,
-    });
 
     return runCommand('CLOUD MAIN 5', () => qscloudRemoveSheetIcons(options, cmd));
 };

--- a/src/lib/commands/qseow/index.js
+++ b/src/lib/commands/qseow/index.js
@@ -1,6 +1,6 @@
 import { Command, Option } from 'commander';
 import { logger, appVersion, setLoggingLevel } from '../../../globals.js';
-import { logRunHeader } from '../../util/run-report-render.js';
+import { emitRunHeader } from '../../util/run-report.js';
 import { qseowCreateThumbnails } from '../../qseow/qseow-create-thumbnails.js';
 import { QSEOW_SHEET_PARTS } from '../../qseow/sheet-parts.js';
 import { DEFAULT_QSEOW_SENSE_VERSION, QSEOW_SENSE_VERSIONS } from '../../qseow/qseow-selectors.js';
@@ -37,7 +37,9 @@ const handleQseowCreateSheetThumbnails = async (options = {}, command) => {
     if (options.loglevel) {
         setLoggingLevel(options.loglevel);
     }
-    logRunHeader(logger, appVersion, 'QSEoW sheet thumbnails');
+    // Rung-aware (issue #1076): on the board rung the terminal gets the
+    // wordmark frame and the plain header goes to the log underneath.
+    emitRunHeader({ version: appVersion, jobLabel: 'QSEoW sheet thumbnails', options });
 
     // Joined explicitly: --appid is variadic, and letting a template literal coerce the
     // array reads as one strange id rather than as several.

--- a/src/lib/commands/qseow/index.js
+++ b/src/lib/commands/qseow/index.js
@@ -1,6 +1,5 @@
 import { Command, Option } from 'commander';
-import { logger, appVersion, setLoggingLevel } from '../../../globals.js';
-import { emitRunHeader } from '../../util/run-report.js';
+import { logger, setLoggingLevel } from '../../../globals.js';
 import { qseowCreateThumbnails } from '../../qseow/qseow-create-thumbnails.js';
 import { QSEOW_SHEET_PARTS } from '../../qseow/sheet-parts.js';
 import { DEFAULT_QSEOW_SENSE_VERSION, QSEOW_SENSE_VERSIONS } from '../../qseow/qseow-selectors.js';
@@ -30,16 +29,15 @@ import { runCommand } from '../run-command.js';
  * @returns {Promise<void>} Resolves when the worker call finishes (successfully or after logging errors).
  */
 const handleQseowCreateSheetThumbnails = async (options = {}, command) => {
-    // Level set before the header, not only in the worker: a run at
-    // --log-level warn asked for a quiet log, and the run card - header
-    // included - respects that. Guarded for programmatic callers without the
-    // option; the worker sets the level again, which is idempotent.
+    // Level set before any handler-level logging: a run at --log-level warn
+    // asked for a quiet log. Guarded for programmatic callers without the
+    // option; the worker sets the level again, which is idempotent. The run
+    // header is emitted by the worker, not here - the wizard invokes workers
+    // directly, and the header must come from the same place on both paths,
+    // decided from the options the run actually uses.
     if (options.loglevel) {
         setLoggingLevel(options.loglevel);
     }
-    // Rung-aware (issue #1076): on the board rung the terminal gets the
-    // wordmark frame and the plain header goes to the log underneath.
-    emitRunHeader({ version: appVersion, jobLabel: 'QSEoW sheet thumbnails', options });
 
     // Joined explicitly: --appid is variadic, and letting a template literal coerce the
     // array reads as one strange id rather than as several.

--- a/src/lib/interactive/interactive-command.js
+++ b/src/lib/interactive/interactive-command.js
@@ -1,6 +1,5 @@
 import { Command, Option } from 'commander';
 import { logger, appVersion } from '../../globals.js';
-import { logRunHeader } from '../util/run-report-render.js';
 import { runCommand } from '../commands/run-command.js';
 import { assertInteractiveCapable } from './tty.js';
 import { isPromptCancellation } from './prompt-runtime.js';
@@ -73,7 +72,13 @@ const runWizardUnlessCancelled = async () => {
  * @returns {Promise<boolean>} `true` on success, `false` on failure.
  */
 const handleInteractive = async (options = {}, _cmd) => {
-    logRunHeader(logger, appVersion, 'interactive wizard');
+    // One unframed line, not logRunHeader: since the run headers moved into
+    // the workers, a wizard-launched run prints the real header (wordmark
+    // frame included, on the board rung) when it starts - a second framed
+    // banner here would double the branding on every wizard session. The
+    // version stays, because a wizard session that never runs a command is
+    // still a support artefact.
+    logger.info(`Butler Sheet Icons ${appVersion} - interactive wizard`);
 
     return runCommand(
         'INTERACTIVE MAIN 11',

--- a/src/lib/interactive/symbols.js
+++ b/src/lib/interactive/symbols.js
@@ -32,6 +32,26 @@ export const UNICODE_SYMBOLS = Object.freeze({
     rule: '─',
     checked: '◉',
     unchecked: '◯',
+    // The contact-sheet strip (issue #1074): one character per sheet. All four
+    // are Block Elements - none is Extended_Pictographic - and all four ASCII
+    // fallbacks are one column, so the strip keeps its width when the set
+    // switches. U+2592 MEDIUM SHADE marks failure rather than the mockup's
+    // U+259A quadrant: quadrant coverage in older monospace fonts is worse
+    // than the shade characters', and a legacy console is on the ASCII set
+    // anyway.
+    stripCaptured: '█',
+    stripBlurred: '▓',
+    stripExcluded: '░',
+    stripFailed: '▒',
+    // Contact-sheet furniture. `warning` is ASCII in both sets on purpose:
+    // U+26A0 is emoji-presentation-prone, exactly the class this file bans.
+    // `dot` and `times` exist because U+00B7 and U+00D7 read as ASCII but are
+    // not - they leaked into an ASCII rendering once already (issue #1074).
+    bulletOn: '●',
+    bulletOff: '○',
+    warning: '!',
+    dot: '·',
+    times: '×',
     spinnerFrames: Object.freeze(['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']),
 });
 
@@ -49,6 +69,15 @@ export const ASCII_SYMBOLS = Object.freeze({
     rule: '-',
     checked: '[x]',
     unchecked: '[ ]',
+    stripCaptured: '#',
+    stripBlurred: ':',
+    stripExcluded: '.',
+    stripFailed: '!',
+    bulletOn: '*',
+    bulletOff: 'o',
+    warning: '!',
+    dot: '-',
+    times: 'x',
     spinnerFrames: Object.freeze(['-', '\\', '|', '/']),
 });
 

--- a/src/lib/qseow/__tests__/qseow_create_thumbnails_app_loop.test.js
+++ b/src/lib/qseow/__tests__/qseow_create_thumbnails_app_loop.test.js
@@ -14,6 +14,7 @@ jest.unstable_mockModule('../../../globals.js', () => ({
         warn: jest.fn(),
     },
     setLoggingLevel: jest.fn(),
+    appVersion: '9.9.9-test',
     getLoggingLevel: jest.fn(() => 'info'),
     bsiExecutablePath: '/test/path',
     isSea: false,

--- a/src/lib/qseow/__tests__/qseow_create_thumbnails_empty_selection.test.js
+++ b/src/lib/qseow/__tests__/qseow_create_thumbnails_empty_selection.test.js
@@ -9,6 +9,7 @@ jest.unstable_mockModule('../../../globals.js', () => ({
         warn: jest.fn(),
     },
     setLoggingLevel: jest.fn(),
+    appVersion: '9.9.9-test',
     getLoggingLevel: jest.fn(() => 'info'),
     bsiExecutablePath: '/test/path',
     isSea: false,

--- a/src/lib/qseow/__tests__/qseow_create_thumbnails_validation.test.js
+++ b/src/lib/qseow/__tests__/qseow_create_thumbnails_validation.test.js
@@ -12,6 +12,7 @@ jest.unstable_mockModule('../../../globals.js', () => ({
         warn: jest.fn(),
     },
     setLoggingLevel: jest.fn(),
+    appVersion: '9.9.9-test',
     getLoggingLevel: jest.fn(() => 'info'),
     bsiExecutablePath: '/test/path',
     isSea: false,

--- a/src/lib/qseow/qseow-create-thumbnails.js
+++ b/src/lib/qseow/qseow-create-thumbnails.js
@@ -1,4 +1,4 @@
-import { logger, setLoggingLevel, bsiExecutablePath, isSea } from '../../globals.js';
+import { logger, appVersion, setLoggingLevel, bsiExecutablePath, isSea } from '../../globals.js';
 import { redactOptions } from '../util/redact-secrets.js';
 import { qseowVerifyContentLibraryExists } from './qseow-contentlibrary.js';
 import { qseowVerifyCertificatesExist } from './qseow-certificates.js';
@@ -12,6 +12,7 @@ import { logError } from '../util/log-error.js';
 import {
     runOverAppsWithReport,
     announceDryRun,
+    emitRunHeader,
     buildSheetRules,
     buildSheetPartSection,
     buildBrowserPlanSection,
@@ -41,11 +42,22 @@ export const qseowCreateThumbnails = async (options) => {
     try {
         setLoggingLevel(options.loglevel);
 
+        // Emitted here rather than in the command handler: the wizard calls
+        // this worker directly, and the header's rung must be decided from
+        // the options the run actually uses - wizard answers included. The
+        // decided rung is threaded through the whole run so the header and
+        // the blocks cannot disagree.
+        const rung = emitRunHeader({
+            version: appVersion,
+            jobLabel: 'QSEoW sheet thumbnails',
+            options,
+        });
+
         const dryRun = Boolean(options.dryRun);
         if (dryRun) {
             // Before anything connects: without this the log opens exactly like
             // a real run and the first dry-run marker arrives after the last app.
-            announceDryRun('qseow create-sheet-thumbnails');
+            announceDryRun('qseow create-sheet-thumbnails', rung);
         }
 
         logger.info('Starting creation of thumbnails for Qlik Sense Enterprise on Windows (QSEoW)');
@@ -114,6 +126,7 @@ export const qseowCreateThumbnails = async (options) => {
         return await runOverAppsWithReport({
             command: 'qseow create-sheet-thumbnails',
             dryRun,
+            rung,
             appIds: appIdsToProcess,
             namedAppIds,
             selectorAppIds: taggedAppIds,

--- a/src/lib/util/__tests__/run-board.test.js
+++ b/src/lib/util/__tests__/run-board.test.js
@@ -216,6 +216,46 @@ describe('the sheet strip', () => {
         ]);
     });
 
+    test('a decomposed (NFD) Korean name measures like its NFC form', () => {
+        // Hangul Jamo medial vowels and trailing consonants are zero-width:
+        // they combine with the wide leading consonant. If they counted as
+        // one column each, an NFD name would under-pad and shift its row's
+        // strip band relative to the visually identical NFC name.
+        const base = {
+            id: 'k',
+            sheetCount: 1,
+            sheets: [{ n: 1, title: 'x', action: 'update', reason: null }],
+            failed: false,
+        };
+        const nfc = { ...base, name: '한글'.normalize('NFC') };
+        const nfd = { ...base, name: '한글'.normalize('NFD') };
+
+        const ctx = uniCtx();
+        const padRun = (app) =>
+            renderBoardAppRow(app, { n: 1, total: 1, removal: false }, ctx).match(/ +(?=█)/)[0]
+                .length;
+
+        expect(padRun(nfd)).toBe(padRun(nfc));
+    });
+
+    test('a row with a non-positive or missing sheet number cannot corrupt the strip', () => {
+        // n: 0 must not write off the left edge (and then read as a
+        // fabricated failed cell); a missing n falls back to array position.
+        expect(
+            stripForApp(
+                { id: 'z', sheetCount: 1, sheets: [{ n: 0, action: 'update' }], failed: false },
+                UNICODE_SYMBOLS
+            ).map((cell) => cell.kind)
+        ).toEqual(['captured']);
+
+        expect(
+            stripForApp(
+                { id: 'z2', sheetCount: 2, sheets: [{ action: 'update' }, { action: 'blur' }] },
+                UNICODE_SYMBOLS
+            ).map((cell) => cell.kind)
+        ).toEqual(['captured', 'blurred']);
+    });
+
     test('a clear with no icon renders as excluded, matching the legend vocabulary', () => {
         const app = {
             id: 'app-r',
@@ -446,6 +486,22 @@ describe('the verdict block', () => {
         // the failed glyph, and the legend must say two, not one.
         expect(verdict).toContain('2 not processed');
         expect(verdict).not.toContain('app(s) failed');
+    });
+
+    test('an app that failed before sheet enumeration still appears in the legend', () => {
+        // A markAppFailed-shaped entry (no sheetCount, no sheets) contributes
+        // zero cells; the legend must fall back to the app count rather than
+        // showing no failed entry at all.
+        const report = makeReport();
+        report.apps = [
+            report.apps[0],
+            { id: 'app-dead', name: null, sheetCount: null, sheets: [], failed: true },
+        ];
+
+        const verdict = stripAnsi(renderBoardVerdict(report, uniCtx()));
+
+        expect(verdict).toContain('1 app(s) failed');
+        expect(verdict).not.toContain('not processed');
     });
 
     test('counts from the recorded sheets and names the failure', () => {

--- a/src/lib/util/__tests__/run-board.test.js
+++ b/src/lib/util/__tests__/run-board.test.js
@@ -1,0 +1,348 @@
+import { describe, test, expect } from '@jest/globals';
+import { getBorderCharacters } from 'table';
+import { createPalette } from '../colour.js';
+import { UNICODE_SYMBOLS, ASCII_SYMBOLS } from '../../interactive/symbols.js';
+import {
+    renderBoardHeader,
+    renderBoardPlan,
+    renderBoardAppRow,
+    renderBoardVerdict,
+    stripForApp,
+} from '../run-board.js';
+
+/**
+ * Tests for the contact-sheet renderer (issue #1074).
+ *
+ * Everything is injected - palette, symbols, borders, report - so the same
+ * assertions run identically on every CI runner regardless of what its
+ * console claims to support.
+ */
+
+const uniCtx = (colour = false) => ({
+    palette: createPalette(colour),
+    symbols: UNICODE_SYMBOLS,
+    border: getBorderCharacters('norc'),
+});
+
+const asciiCtx = (colour = false) => ({
+    palette: createPalette(colour),
+    symbols: ASCII_SYMBOLS,
+    border: getBorderCharacters('ramac'),
+});
+
+// Built from a char code rather than written as a literal, so the escape
+// character does not appear in the source (no-control-regex) - same pattern
+// as theme.test.js.
+const ESC = String.fromCharCode(27);
+const stripAnsi = (text) => text.replaceAll(new RegExp(`${ESC}\\[[0-9;]*m`, 'g'), '');
+
+const ANSI = new RegExp(`${ESC}\\[`);
+
+/**
+ * A realistic thumbnail-run report: three apps, one with a blur match, one
+ * with none, one failed halfway.
+ *
+ * @returns {object} The report.
+ */
+const makeReport = () => ({
+    command: 'qseow create-sheet-thumbnails',
+    dryRun: false,
+    selection: {
+        named: 1,
+        fromSelector: 3,
+        selector: { option: 'qliksensetag', value: 'updateSheetThumbnails' },
+        total: 3,
+    },
+    plan: {
+        target: {
+            platform: 'qseow',
+            host: 'sense.example.com',
+            port: null,
+            secure: true,
+            prefix: '',
+            enginePort: '4747',
+            qrsPort: '4242',
+            schemaVersion: '12.612.0',
+        },
+        auth: {
+            apiUser: { directory: 'INTERNAL', userId: 'sa_api' },
+            certFile: './cert/client.pem',
+            logonUser: { directory: 'COMPANY', userId: 'svc_bsi' },
+        },
+        sheetPart: { value: '2', max: '4', label: 'objects + sheet title' },
+        rules: {
+            exclude: [
+                { option: 'exclude-sheet-tag', values: ['no-thumbnail'], matchedSheetCount: 1 },
+            ],
+            blur: [{ option: 'blur-sheet-tag', values: ['confidential'], matchedSheetCount: 2 }],
+        },
+        browser: { name: 'chrome', version: 'recommended', headless: true, pageWaitSeconds: 5 },
+        output: { imageDir: './img', platformDir: 'qseow' },
+        writes: {
+            kind: 'thumbnails',
+            contentLibrary: 'Butler sheet thumbnails',
+            publishedAppCount: 2,
+        },
+    },
+    apps: [
+        {
+            id: 'app-1',
+            name: 'Sales Discovery',
+            sheetCount: 4,
+            sheets: [
+                { n: 1, title: 'Overview', action: 'update', reason: null },
+                { n: 2, title: 'Secrets', action: 'blur', reason: 'blur-sheet-tag' },
+                { n: 3, title: 'Old', action: 'skip', reason: 'exclude-sheet-tag' },
+                { n: 4, title: 'Trends', action: 'update', reason: null },
+            ],
+            mediaFilesToDelete: null,
+            failed: false,
+            sheetsUpdated: 3,
+            imagesKeptFiles: 3,
+            imagesKeptBytes: 200000,
+            durationMs: 52000,
+        },
+        {
+            id: 'app-2',
+            name: 'Operations Monitor',
+            sheetCount: 2,
+            sheets: [
+                { n: 1, title: 'Board', action: 'update', reason: null },
+                { n: 2, title: 'Detail', action: 'update', reason: null },
+            ],
+            mediaFilesToDelete: null,
+            failed: false,
+            sheetsUpdated: 2,
+            imagesKeptFiles: 2,
+            imagesKeptBytes: 150000,
+            durationMs: 41000,
+        },
+        {
+            id: 'app-3',
+            name: 'Broken App',
+            sheetCount: 3,
+            sheets: [{ n: 1, title: 'Only', action: 'update', reason: null }],
+            mediaFilesToDelete: null,
+            failed: true,
+            durationMs: 12000,
+        },
+    ],
+    startedAt: 0,
+    finishedAt: 372000,
+    succeeded: false,
+});
+
+const renderWholeBoard = (report, ctx) =>
+    renderBoardHeader({ version: '9.9.9-test', jobLabel: 'QSEoW sheet thumbnails' }, ctx) +
+    renderBoardPlan(report, ctx) +
+    report.apps
+        .map((app, i) =>
+            renderBoardAppRow(app, { n: i + 1, total: report.apps.length, removal: false }, ctx)
+        )
+        .join('') +
+    renderBoardVerdict(report, ctx);
+
+describe('the sheet strip', () => {
+    test('every strip glyph is exactly one column in both symbol sets', () => {
+        for (const symbols of [UNICODE_SYMBOLS, ASCII_SYMBOLS]) {
+            for (const name of ['stripCaptured', 'stripBlurred', 'stripExcluded', 'stripFailed']) {
+                expect(`${name}: ${[...symbols[name]].length}`).toBe(`${name}: 1`);
+            }
+        }
+    });
+
+    test('the strip has the same display width in both symbol sets, per app', () => {
+        // The property that breaks columns when it regresses (issue #1074).
+        for (const app of makeReport().apps) {
+            const uni = stripForApp(app, UNICODE_SYMBOLS);
+            const ascii = stripForApp(app, ASCII_SYMBOLS);
+
+            expect([...uni.map((cell) => cell.glyph).join('')]).toHaveLength(
+                [...ascii.map((cell) => cell.glyph).join('')].length
+            );
+        }
+    });
+
+    test('a zero-match blur tag produces a strip with no blur glyph - per app, not only in totals', () => {
+        const report = makeReport();
+
+        for (const [i, app] of report.apps.entries()) {
+            const hasBlurDecision = app.sheets.some((sheet) => sheet.action === 'blur');
+            for (const ctx of [uniCtx(), asciiCtx()]) {
+                const row = renderBoardAppRow(
+                    app,
+                    { n: i + 1, total: report.apps.length, removal: false },
+                    ctx
+                );
+
+                expect(`app ${app.id}: ${row.includes(ctx.symbols.stripBlurred)}`).toBe(
+                    `app ${app.id}: ${hasBlurDecision}`
+                );
+            }
+        }
+    });
+
+    test('a failed app pads the unrecorded tail of its strip with the failed glyph', () => {
+        const failed = makeReport().apps[2];
+        const cells = stripForApp(failed, UNICODE_SYMBOLS);
+
+        expect(cells).toHaveLength(3);
+        expect(cells.map((cell) => cell.kind)).toEqual(['captured', 'failed', 'failed']);
+    });
+});
+
+describe('colour discipline', () => {
+    test('an inert palette produces no ANSI codes anywhere on the board', () => {
+        for (const ctx of [uniCtx(false), asciiCtx(false)]) {
+            expect(ANSI.test(renderWholeBoard(makeReport(), ctx))).toBe(false);
+        }
+    });
+
+    test('colour changes nothing but the codes: stripping ANSI restores the plain render', () => {
+        // This is the pad-the-plain-string-first property. A renderer that
+        // padded after colouring would count escape codes as width, and the
+        // difference shows up here as shifted columns.
+        expect(stripAnsi(renderWholeBoard(makeReport(), uniCtx(true)))).toBe(
+            renderWholeBoard(makeReport(), uniCtx(false))
+        );
+        expect(stripAnsi(renderWholeBoard(makeReport(), asciiCtx(true)))).toBe(
+            renderWholeBoard(makeReport(), asciiCtx(false))
+        );
+    });
+
+    test('the ASCII set with an inert palette is pure ASCII end to end', () => {
+        // The frame, bullets, strip and separators must all degrade; app
+        // names are user data, and this fixture keeps them ASCII on purpose
+        // so one stray box-drawing character cannot hide behind them.
+        expect(renderWholeBoard(makeReport(), asciiCtx(false))).toMatch(/^[\x20-\x7e\n]*$/);
+    });
+});
+
+describe('the wordmark frame', () => {
+    test('carries the version and the job label inside the frame', () => {
+        const frame = renderBoardHeader(
+            { version: '9.9.9-test', jobLabel: 'QSEoW sheet thumbnails' },
+            uniCtx()
+        );
+
+        expect(frame).toContain('BUTLER SHEET ICONS');
+        expect(frame).toContain('9.9.9-test');
+        expect(frame).toContain('QSEoW sheet thumbnails');
+        expect(frame).toContain('410 × 270');
+    });
+
+    test('every frame line is the same width, both sets, colour on or off', () => {
+        for (const ctx of [uniCtx(true), uniCtx(false), asciiCtx(true), asciiCtx(false)]) {
+            const lines = stripAnsi(
+                renderBoardHeader(
+                    { version: '9.9.9-test', jobLabel: 'QSEoW sheet thumbnails' },
+                    ctx
+                )
+            )
+                .split('\n')
+                .filter((line) => line.trim() !== '');
+
+            const widths = new Set(lines.map((line) => [...line].length));
+            expect([...widths]).toHaveLength(1);
+        }
+    });
+});
+
+describe('the plan block', () => {
+    test('renders nothing without a plan, mirroring the plain renderer', () => {
+        expect(renderBoardPlan({ plan: null, selection: null, apps: [] }, uniCtx())).toBe('');
+    });
+
+    test('states the rules with their match counts, zeroes included', () => {
+        const report = makeReport();
+        report.plan.rules.blur = [
+            { option: 'blur-sheet-tag', values: ['confidential'], matchedSheetCount: 0 },
+        ];
+
+        const plan = renderBoardPlan(report, uniCtx());
+
+        expect(plan).toContain('tag "no-thumbnail" (1 sheets)');
+        expect(plan).toContain('tag "confidential" (0 sheets)');
+    });
+
+    test('warns about the writes, published count included, and marks a dry run', () => {
+        const real = renderBoardPlan(makeReport(), uniCtx());
+        expect(real).toContain(
+            'sheet thumbnails will be overwritten in 3 app(s), 2 of them published'
+        );
+
+        const dry = { ...makeReport(), dryRun: true };
+        const dryPlan = renderBoardPlan(dry, uniCtx());
+        expect(dryPlan).toContain('(dry run)');
+        expect(dryPlan).toContain('would be overwritten');
+    });
+
+    test('suppresses the writes warning for an empty selection', () => {
+        const report = makeReport();
+        report.selection = { named: 0, fromSelector: 0, selector: null, total: 0 };
+        report.apps = [];
+
+        expect(renderBoardPlan(report, uniCtx())).not.toContain('overwritten');
+    });
+});
+
+describe('the verdict block', () => {
+    test('counts from the recorded sheets and names the failure', () => {
+        const verdict = stripAnsi(renderBoardVerdict(makeReport(), uniCtx()));
+
+        expect(verdict).toContain('FAILED');
+        expect(verdict).toContain('2 app(s) ok');
+        expect(verdict).toContain('1 failed');
+        expect(verdict).toContain('5 thumbnails uploaded');
+        expect(verdict).toContain('6 captured');
+        expect(verdict).toContain('1 blurred');
+        expect(verdict).toContain('1 excluded');
+        expect(verdict).toContain('images in ./img/qseow');
+    });
+
+    test('a clean run reads done with its elapsed time', () => {
+        const report = makeReport();
+        report.apps = report.apps.slice(0, 2);
+        report.succeeded = true;
+
+        const verdict = stripAnsi(renderBoardVerdict(report, uniCtx()));
+
+        expect(verdict).toContain('done in 6m 12s');
+        expect(verdict).not.toContain('FAILED');
+    });
+
+    test('an empty selection is a red flag, not a summary', () => {
+        const report = makeReport();
+        report.selection = { named: 0, fromSelector: 0, selector: null, total: 0 };
+        report.apps = [];
+
+        expect(stripAnsi(renderBoardVerdict(report, uniCtx()))).toContain(
+            '0 apps selected - nothing was done'
+        );
+    });
+
+    test('a removal run speaks remove vocabulary', () => {
+        const report = makeReport();
+        report.command = 'qscloud remove-sheet-icons';
+        report.apps = [
+            {
+                id: 'app-1',
+                name: 'Cleaned App',
+                sheetCount: 2,
+                sheets: [
+                    { n: 1, title: 'One', action: 'clear', reason: null },
+                    { n: 2, title: 'Two', action: 'clear', reason: 'no icon currently set' },
+                ],
+                mediaFilesToDelete: null,
+                failed: false,
+                durationMs: 9000,
+            },
+        ];
+        report.succeeded = true;
+
+        const verdict = stripAnsi(renderBoardVerdict(report, uniCtx()));
+
+        expect(verdict).toContain('icon(s) cleared');
+        expect(verdict).not.toContain('thumbnails uploaded');
+    });
+});

--- a/src/lib/util/__tests__/run-board.test.js
+++ b/src/lib/util/__tests__/run-board.test.js
@@ -189,6 +189,86 @@ describe('the sheet strip', () => {
         expect(cells).toHaveLength(3);
         expect(cells.map((cell) => cell.kind)).toEqual(['captured', 'failed', 'failed']);
     });
+
+    test('glyphs sit at the recorded sheet position, not the array position', () => {
+        // The sheet loop survives a mid-app failure and keeps recording the
+        // later sheets - sheet 2 failing must not shift sheets 3..n left and
+        // mark the wrong sheet as failed.
+        const app = {
+            id: 'app-x',
+            name: 'Mid Failure',
+            sheetCount: 5,
+            sheets: [
+                { n: 1, title: 'One', action: 'update', reason: null },
+                { n: 3, title: 'Three', action: 'blur', reason: null },
+                { n: 4, title: 'Four', action: 'update', reason: null },
+                { n: 5, title: 'Five', action: 'update', reason: null },
+            ],
+            failed: true,
+        };
+
+        expect(stripForApp(app, UNICODE_SYMBOLS).map((cell) => cell.kind)).toEqual([
+            'captured',
+            'failed',
+            'blurred',
+            'captured',
+            'captured',
+        ]);
+    });
+
+    test('a clear with no icon renders as excluded, matching the legend vocabulary', () => {
+        const app = {
+            id: 'app-r',
+            name: 'Removal',
+            sheetCount: 3,
+            sheets: [
+                { n: 1, title: 'One', action: 'clear', reason: null },
+                { n: 2, title: 'Two', action: 'clear', reason: 'no icon currently set' },
+                { n: 3, title: 'Three', action: 'clear', reason: null },
+            ],
+            failed: false,
+        };
+
+        expect(stripForApp(app, UNICODE_SYMBOLS).map((cell) => cell.kind)).toEqual([
+            'captured',
+            'excluded',
+            'captured',
+        ]);
+    });
+
+    test('a wide-character app name does not shift the strip column', () => {
+        // width() must count terminal columns, not code points: a CJK name is
+        // two columns per character, and an undercounted name pushes that
+        // row's whole strip band sideways.
+        const total = 2;
+        const ascii = {
+            id: 'a',
+            name: 'Sales Discovery',
+            sheetCount: 2,
+            sheets: [
+                { n: 1, title: 'x', action: 'update', reason: null },
+                { n: 2, title: 'y', action: 'update', reason: null },
+            ],
+            failed: false,
+        };
+        const cjk = { ...ascii, id: 'b', name: '売上ダッシュボード' };
+
+        const ctx = uniCtx();
+        // Terminal columns, not string index: the CJK prefix has fewer
+        // characters but the same rendered width when padding is correct.
+        const columnsOf = (text) =>
+            [...text].reduce(
+                (n, ch) => n + (ch.codePointAt(0) >= 0x1100 && ch.codePointAt(0) <= 0x9fff ? 2 : 1),
+                0
+            );
+        const stripColumn = (app, n) => {
+            const row = renderBoardAppRow(app, { n, total, removal: false }, ctx);
+
+            return columnsOf(row.slice(0, row.indexOf(ctx.symbols.stripCaptured)));
+        };
+
+        expect(stripColumn(cjk, 2)).toBe(stripColumn(ascii, 1));
+    });
 });
 
 describe('colour discipline', () => {
@@ -229,6 +309,17 @@ describe('the wordmark frame', () => {
         expect(frame).toContain('9.9.9-test');
         expect(frame).toContain('QSEoW sheet thumbnails');
         expect(frame).toContain('410 × 270');
+    });
+
+    test('a prerelease-length version is clipped instead of breaking the frame edge', () => {
+        const lines = renderBoardHeader(
+            { version: '5.0.0-beta.20260817+sha.deadbeef', jobLabel: 'QSEoW sheet thumbnails' },
+            uniCtx()
+        )
+            .split('\n')
+            .filter((line) => line.trim() !== '');
+
+        expect(new Set(lines.map((line) => [...line].length)).size).toBe(1);
     });
 
     test('every frame line is the same width, both sets, colour on or off', () => {
@@ -286,7 +377,77 @@ describe('the plan block', () => {
     });
 });
 
+describe('the app-row width budget', () => {
+    test('rows fit the 72-column gate even with the ASCII marker and removal vocabulary', () => {
+        // The board gate admits 72-column terminals; a row wider than that
+        // wraps on exactly the narrowest terminal the board accepts. The
+        // worst admitted case is the ASCII set (4-column markers) with the
+        // wider "cleared" summary and a minutes-long elapsed time.
+        const app = {
+            id: 'app-w',
+            name: 'A name at twenty chars',
+            sheetCount: 12,
+            sheets: Array.from({ length: 12 }, (_, i) => ({
+                n: i + 1,
+                title: `S${i}`,
+                action: 'clear',
+                reason: null,
+            })),
+            failed: false,
+            durationMs: 372000,
+        };
+
+        for (const ctx of [asciiCtx(), uniCtx()]) {
+            const row = renderBoardAppRow(app, { n: 12, total: 12, removal: true }, ctx);
+            expect([...row.replace('\n', '')].length).toBeLessThanOrEqual(72);
+        }
+    });
+});
+
 describe('the verdict block', () => {
+    test("the removal row's cleared count agrees with the verdict beneath it", () => {
+        // One app, three sheets, only one icon actually cleared: the row and
+        // the verdict must state the same number - the drift verdictCounts
+        // was extracted to prevent.
+        const app = {
+            id: 'app-r',
+            name: 'Removal',
+            sheetCount: 3,
+            sheets: [
+                { n: 1, title: 'One', action: 'clear', reason: null },
+                { n: 2, title: 'Two', action: 'clear', reason: 'no icon currently set' },
+                { n: 3, title: 'Three', action: 'clear', reason: 'no icon currently set' },
+            ],
+            failed: false,
+        };
+        const report = {
+            command: 'qscloud remove-sheet-icons',
+            dryRun: false,
+            selection: { named: 1, fromSelector: 0, selector: null, total: 1 },
+            plan: { writes: { kind: 'clear-icons' } },
+            apps: [app],
+            startedAt: 0,
+            finishedAt: 9000,
+            succeeded: true,
+        };
+
+        const row = stripAnsi(renderBoardAppRow(app, { n: 1, total: 1, removal: true }, uniCtx()));
+        const verdict = stripAnsi(renderBoardVerdict(report, uniCtx()));
+
+        expect(row).toContain('1/3 cleared');
+        expect(verdict).toContain('1 icon(s) cleared');
+        expect(verdict).toContain('2 had no icon');
+    });
+
+    test('the failed legend entry counts the failed cells the strips show, not apps', () => {
+        const verdict = stripAnsi(renderBoardVerdict(makeReport(), uniCtx()));
+
+        // app-3 recorded 1 of 3 sheets before failing: two positions render
+        // the failed glyph, and the legend must say two, not one.
+        expect(verdict).toContain('2 not processed');
+        expect(verdict).not.toContain('app(s) failed');
+    });
+
     test('counts from the recorded sheets and names the failure', () => {
         const verdict = stripAnsi(renderBoardVerdict(makeReport(), uniCtx()));
 

--- a/src/lib/util/__tests__/run-report-board-flow.test.js
+++ b/src/lib/util/__tests__/run-report-board-flow.test.js
@@ -1,0 +1,190 @@
+import { describe, test, expect, beforeEach, afterEach, jest } from '@jest/globals';
+
+/**
+ * Flow tests for the board rung's wiring through `runOverAppsWithReport` and
+ * `emitRunHeader` (issues #1074/#1076): on the board rung the board blocks go
+ * to `process.stdout` (never through winston), the equivalent plain blocks
+ * still go through the logger with the console transport silenced, and
+ * `BSI_OUTPUT=off` suppresses the plan and verdict blocks without silencing
+ * the run.
+ *
+ * The rung is forced with `BSI_OUTPUT=board` because jest's stdout is not a
+ * TTY - which is itself the property that makes the forced override the only
+ * way to reach the board here, exactly as on a real misdetected terminal.
+ */
+
+const timeline = [];
+
+// The fake console transport records whether it was silent at the moment each
+// line was logged - that is the observable half of "silence the console for
+// the block's duration rather than emitting it twice".
+const consoleTransport = { name: 'console', silent: false, level: 'info' };
+
+jest.unstable_mockModule('../../../globals.js', () => ({
+    logger: {
+        info: jest.fn((line) =>
+            timeline.push(`LOG${consoleTransport.silent ? '(silent)' : ''} ${line}`)
+        ),
+        verbose: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn((line) => timeline.push(`ERROR ${line}`)),
+        warn: jest.fn((line) => timeline.push(`WARN ${line}`)),
+        transports: [consoleTransport],
+    },
+    getLoggingLevel: jest.fn().mockReturnValue('info'),
+    setLoggingLevel: jest.fn(),
+}));
+
+const { runOverAppsWithReport, emitRunHeader, addAppToReport, recordSheetDecision } =
+    await import('../run-report.js');
+const { logger } = await import('../../../globals.js');
+
+const stdoutWrites = [];
+let writeSpy;
+let savedOutput;
+
+beforeEach(() => {
+    timeline.length = 0;
+    stdoutWrites.length = 0;
+    consoleTransport.silent = false;
+    jest.clearAllMocks();
+    savedOutput = process.env.BSI_OUTPUT;
+    writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+        stdoutWrites.push(String(chunk));
+
+        return true;
+    });
+});
+
+afterEach(() => {
+    writeSpy.mockRestore();
+    if (savedOutput === undefined) {
+        delete process.env.BSI_OUTPUT;
+    } else {
+        process.env.BSI_OUTPUT = savedOutput;
+    }
+});
+
+/**
+ * A run over two apps whose processor records realistic entries.
+ *
+ * @param {object} overrides - Fields to override.
+ *
+ * @returns {object} Arguments for `runOverAppsWithReport`.
+ */
+const runArgs = (overrides = {}) => ({
+    command: 'qseow create-sheet-thumbnails',
+    dryRun: false,
+    appIds: ['app-1', 'app-2'],
+    namedAppIds: ['app-1', 'app-2'],
+    selectorAppIds: [],
+    selector: null,
+    plan: {
+        browser: { name: 'chrome', version: 'recommended', headless: true, pageWaitSeconds: 5 },
+        writes: { kind: 'thumbnails', contentLibrary: 'lib', publishedAppCount: 1 },
+    },
+    logPrefix: { plan: 'TEST PLAN', process: 'TEST PROCESS' },
+    emptySelectionHint: 'hint',
+    planApp: jest.fn(async () => {}),
+    processApp: jest.fn(async (appId, report) => {
+        const entry = addAppToReport(report, { id: appId, name: `Named ${appId}`, sheetCount: 2 });
+        recordSheetDecision(entry, { n: 1, title: 'One', action: 'update' });
+        recordSheetDecision(entry, { n: 2, title: 'Two', action: 'update' });
+    }),
+    ...overrides,
+});
+
+describe('the board rung (BSI_OUTPUT=board)', () => {
+    beforeEach(() => {
+        process.env.BSI_OUTPUT = 'board';
+    });
+
+    test('board blocks go to stdout: plan, one strip row per app, verdict', async () => {
+        await runOverAppsWithReport(runArgs());
+
+        const joined = stdoutWrites.join('');
+        expect(joined).toContain('PLAN');
+        expect(joined).toContain('Named app-1');
+        expect(joined).toContain('Named app-2');
+        expect(joined).toContain('app(s) ok');
+
+        // The strip rows stream as each app completes - separate writes, not
+        // one buffered block at the end.
+        expect(stdoutWrites.filter((chunk) => chunk.includes('Named app-')).length).toBe(2);
+    });
+
+    test('the plain blocks still go through the logger, console silenced, and the silence is lifted after', async () => {
+        await runOverAppsWithReport(runArgs());
+
+        // The plain PLAN block and verdict were logged for any file
+        // transport, but with the console transport silent at that moment.
+        expect(timeline).toContain('LOG(silent) PLAN');
+        expect(timeline.some((line) => line.startsWith('LOG(silent) RESULT'))).toBe(true);
+
+        // The per-app progress lines between the blocks stay audible.
+        expect(consoleTransport.silent).toBe(false);
+    });
+
+    test('emitRunHeader writes the wordmark frame to stdout and logs the plain header silently', () => {
+        emitRunHeader({ version: '9.9.9-test', jobLabel: 'QSEoW sheet thumbnails', options: {} });
+
+        const joined = stdoutWrites.join('');
+        expect(joined).toContain('BUTLER SHEET ICONS');
+        expect(joined).toContain('9.9.9-test');
+        expect(timeline.some((line) => line.startsWith('LOG(silent)'))).toBe(true);
+        expect(consoleTransport.silent).toBe(false);
+    });
+});
+
+describe('the off rung (BSI_OUTPUT=off)', () => {
+    beforeEach(() => {
+        process.env.BSI_OUTPUT = 'off';
+    });
+
+    test('suppresses the plan and verdict blocks entirely on a real run', async () => {
+        await runOverAppsWithReport(runArgs());
+
+        expect(stdoutWrites).toHaveLength(0);
+        expect(timeline.some((line) => line.includes('PLAN'))).toBe(false);
+        expect(timeline.some((line) => line.includes('RESULT'))).toBe(false);
+    });
+
+    test('never suppresses the dry-run report - it is the command product', async () => {
+        await runOverAppsWithReport(
+            runArgs({
+                dryRun: true,
+                planApp: jest.fn(async (appId, report) => {
+                    const entry = addAppToReport(report, { id: appId, name: appId, sheetCount: 1 });
+                    recordSheetDecision(entry, { n: 1, title: 'One', action: 'update' });
+                }),
+            })
+        );
+
+        expect(timeline.some((line) => line.includes('DRY RUN of'))).toBe(true);
+    });
+
+    test('keeps the plain run header - the version line is support material', () => {
+        emitRunHeader({ version: '9.9.9-test', jobLabel: 'QSEoW sheet thumbnails', options: {} });
+
+        expect(stdoutWrites).toHaveLength(0);
+        expect(timeline.some((line) => line.includes('9.9.9-test'))).toBe(true);
+        expect(timeline.some((line) => line.startsWith('LOG(silent)'))).toBe(false);
+    });
+});
+
+describe('an unrecognised BSI_OUTPUT value', () => {
+    test('warns once per process even though the rung is consulted repeatedly', async () => {
+        process.env.BSI_OUTPUT = 'fancy';
+
+        emitRunHeader({ version: '9.9.9-test', jobLabel: 'QSEoW sheet thumbnails', options: {} });
+        await runOverAppsWithReport(runArgs());
+
+        expect(logger.warn).toHaveBeenCalledTimes(1);
+        expect(logger.warn.mock.calls[0][0]).toContain('BSI_OUTPUT="fancy"');
+
+        // And selection fell back to automatic: no TTY under jest, so plain -
+        // the blocks went through the logger, console audible.
+        expect(timeline).toContain('LOG PLAN');
+        expect(stdoutWrites).toHaveLength(0);
+    });
+});

--- a/src/lib/util/__tests__/run-report-board-flow.test.js
+++ b/src/lib/util/__tests__/run-report-board-flow.test.js
@@ -35,8 +35,13 @@ jest.unstable_mockModule('../../../globals.js', () => ({
     setLoggingLevel: jest.fn(),
 }));
 
-const { runOverAppsWithReport, emitRunHeader, addAppToReport, recordSheetDecision } =
-    await import('../run-report.js');
+const {
+    runOverAppsWithReport,
+    emitRunHeader,
+    announceDryRun,
+    addAppToReport,
+    recordSheetDecision,
+} = await import('../run-report.js');
 const { logger } = await import('../../../globals.js');
 
 const stdoutWrites = [];
@@ -125,14 +130,29 @@ describe('the board rung (BSI_OUTPUT=board)', () => {
         expect(consoleTransport.silent).toBe(false);
     });
 
-    test('emitRunHeader writes the wordmark frame to stdout and logs the plain header silently', () => {
-        emitRunHeader({ version: '9.9.9-test', jobLabel: 'QSEoW sheet thumbnails', options: {} });
+    test('emitRunHeader writes the wordmark frame to stdout, logs the plain header silently, and returns the rung', () => {
+        const rung = emitRunHeader({
+            version: '9.9.9-test',
+            jobLabel: 'QSEoW sheet thumbnails',
+            options: {},
+        });
 
         const joined = stdoutWrites.join('');
+        expect(rung).toBe('board');
         expect(joined).toContain('BUTLER SHEET ICONS');
         expect(joined).toContain('9.9.9-test');
         expect(timeline.some((line) => line.startsWith('LOG(silent)'))).toBe(true);
         expect(consoleTransport.silent).toBe(false);
+    });
+
+    test('announceDryRun on the board rung sends one styled line to stdout, banner to the log silently', () => {
+        announceDryRun('qseow create-sheet-thumbnails', 'board');
+
+        // No rung-A `=` furniture on the terminal - one line, no frames.
+        const joined = stdoutWrites.join('');
+        expect(joined).toContain('DRY RUN of qseow create-sheet-thumbnails');
+        expect(joined).not.toContain('====');
+        expect(timeline.some((line) => line.startsWith('LOG(silent) ='))).toBe(true);
     });
 });
 
@@ -161,6 +181,20 @@ describe('the off rung (BSI_OUTPUT=off)', () => {
         );
 
         expect(timeline.some((line) => line.includes('DRY RUN of'))).toBe(true);
+    });
+
+    test('never suppresses a dry run PLAN block - provenance and match counts live only there', async () => {
+        await runOverAppsWithReport(
+            runArgs({
+                dryRun: true,
+                planApp: jest.fn(async (appId, report) => {
+                    const entry = addAppToReport(report, { id: appId, name: appId, sheetCount: 1 });
+                    recordSheetDecision(entry, { n: 1, title: 'One', action: 'update' });
+                }),
+            })
+        );
+
+        expect(timeline).toContain('LOG PLAN');
     });
 
     test('keeps the plain run header - the version line is support material', () => {

--- a/src/lib/util/__tests__/run-report-board-flow.test.js
+++ b/src/lib/util/__tests__/run-report-board-flow.test.js
@@ -84,6 +84,9 @@ const runArgs = (overrides = {}) => ({
     namedAppIds: ['app-1', 'app-2'],
     selectorAppIds: [],
     selector: null,
+    // The rung is a required argument, threaded from emitRunHeader in
+    // production; each describe below passes its own explicitly.
+    rung: 'board',
     plan: {
         browser: { name: 'chrome', version: 'recommended', headless: true, pageWaitSeconds: 5 },
         writes: { kind: 'thumbnails', contentLibrary: 'lib', publishedAppCount: 1 },
@@ -162,7 +165,7 @@ describe('the off rung (BSI_OUTPUT=off)', () => {
     });
 
     test('suppresses the plan and verdict blocks entirely on a real run', async () => {
-        await runOverAppsWithReport(runArgs());
+        await runOverAppsWithReport(runArgs({ rung: 'off' }));
 
         expect(stdoutWrites).toHaveLength(0);
         expect(timeline.some((line) => line.includes('PLAN'))).toBe(false);
@@ -172,6 +175,7 @@ describe('the off rung (BSI_OUTPUT=off)', () => {
     test('never suppresses the dry-run report - it is the command product', async () => {
         await runOverAppsWithReport(
             runArgs({
+                rung: 'off',
                 dryRun: true,
                 planApp: jest.fn(async (appId, report) => {
                     const entry = addAppToReport(report, { id: appId, name: appId, sheetCount: 1 });
@@ -186,6 +190,7 @@ describe('the off rung (BSI_OUTPUT=off)', () => {
     test('never suppresses a dry run PLAN block - provenance and match counts live only there', async () => {
         await runOverAppsWithReport(
             runArgs({
+                rung: 'off',
                 dryRun: true,
                 planApp: jest.fn(async (appId, report) => {
                     const entry = addAppToReport(report, { id: appId, name: appId, sheetCount: 1 });
@@ -206,12 +211,28 @@ describe('the off rung (BSI_OUTPUT=off)', () => {
     });
 });
 
+describe('the rung is a required argument', () => {
+    test('runOverAppsWithReport throws without one instead of silently re-deciding', async () => {
+        await expect(runOverAppsWithReport(runArgs({ rung: undefined }))).rejects.toThrow(
+            /requires the rung/
+        );
+    });
+
+    test('announceDryRun throws without one instead of defaulting to the plain banner', () => {
+        expect(() => announceDryRun('qseow create-sheet-thumbnails')).toThrow(/requires the rung/);
+    });
+});
+
 describe('an unrecognised BSI_OUTPUT value', () => {
     test('warns once per process even though the rung is consulted repeatedly', async () => {
         process.env.BSI_OUTPUT = 'fancy';
 
-        emitRunHeader({ version: '9.9.9-test', jobLabel: 'QSEoW sheet thumbnails', options: {} });
-        await runOverAppsWithReport(runArgs());
+        const rung = emitRunHeader({
+            version: '9.9.9-test',
+            jobLabel: 'QSEoW sheet thumbnails',
+            options: {},
+        });
+        await runOverAppsWithReport(runArgs({ rung }));
 
         expect(logger.warn).toHaveBeenCalledTimes(1);
         expect(logger.warn.mock.calls[0][0]).toContain('BSI_OUTPUT="fancy"');

--- a/src/lib/util/__tests__/run-report-flow.test.js
+++ b/src/lib/util/__tests__/run-report-flow.test.js
@@ -42,6 +42,9 @@ const runArgs = (overrides = {}) => ({
     namedAppIds: ['app-1', 'app-2'],
     selectorAppIds: [],
     selector: null,
+    // The rung is a required argument (workers pass the one emitRunHeader
+    // decided); these tests exercise plain-rung behavior explicitly.
+    rung: 'plain',
     plan: {
         writes: { kind: 'thumbnails', contentLibrary: 'lib', publishedAppCount: 1 },
     },

--- a/src/lib/util/__tests__/run-report-flow.test.js
+++ b/src/lib/util/__tests__/run-report-flow.test.js
@@ -63,6 +63,10 @@ beforeEach(() => {
     // mockReturnValue('warn') set in one describe would silently leak into
     // every later test without this reset.
     getLoggingLevel.mockReturnValue('info');
+    // A BSI_OUTPUT inherited from the developer's shell would change which
+    // rung the loop selects and route the blocks away from the logger these
+    // assertions read. The board rung has its own flow test.
+    delete process.env.BSI_OUTPUT;
 });
 
 describe('runOverAppsWithReport - the plan renders before the first write', () => {

--- a/src/lib/util/__tests__/select-rung.test.js
+++ b/src/lib/util/__tests__/select-rung.test.js
@@ -1,5 +1,5 @@
 import { describe, test, expect, jest } from '@jest/globals';
-import { selectRung, RUNG, OUTPUT_ENV } from '../select-rung.js';
+import { selectRung, rendersAsBoard, RUNG, OUTPUT_ENV } from '../select-rung.js';
 
 /**
  * The gate matrix for rung selection (issue #1076).
@@ -104,6 +104,15 @@ describe('selectRung - automatic selection', () => {
                 ).toBe(RUNG.PLAIN);
             }
         }
+    });
+});
+
+describe('rendersAsBoard', () => {
+    test('live collapses to the board until rung C exists; plain and off do not', () => {
+        expect(rendersAsBoard(RUNG.BOARD)).toBe(true);
+        expect(rendersAsBoard(RUNG.LIVE)).toBe(true);
+        expect(rendersAsBoard(RUNG.PLAIN)).toBe(false);
+        expect(rendersAsBoard(RUNG.OFF)).toBe(false);
     });
 });
 

--- a/src/lib/util/__tests__/select-rung.test.js
+++ b/src/lib/util/__tests__/select-rung.test.js
@@ -1,0 +1,183 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { selectRung, RUNG, OUTPUT_ENV } from '../select-rung.js';
+
+/**
+ * The gate matrix for rung selection (issue #1076).
+ *
+ * Every test injects its stream and environment rather than reading the real
+ * ones: CI runners disagree about TTYs, colour and Unicode (which is why
+ * `BSI_ASCII_ONLY` exists), so a test that consulted the real environment
+ * would assert different things on each runner.
+ */
+
+/**
+ * A stream that passes every terminal gate unless overridden.
+ *
+ * @param {object} overrides - Stream fields to override.
+ *
+ * @returns {object} The fake stream.
+ */
+const tty = (overrides = {}) => ({ isTTY: true, columns: 100, rows: 30, ...overrides });
+
+/**
+ * Shorthand: select with a capable terminal and empty environment.
+ *
+ * @param {object} [overrides] - Any of `stdout`, `env`, `options`, `warn`.
+ *
+ * @returns {string} The selected rung.
+ */
+const select = (overrides = {}) =>
+    selectRung({ stdout: tty(), env: {}, options: {}, ...overrides });
+
+describe('selectRung - automatic selection', () => {
+    test('a fully capable terminal at info level selects live', () => {
+        expect(select()).toBe(RUNG.LIVE);
+    });
+
+    test('the documented gate matrix', () => {
+        const matrix = [
+            // [description, stdout, env, options, expected]
+            ['no TTY, no colour', { isTTY: false }, {}, {}, RUNG.PLAIN],
+            ['TTY but NO_COLOR', tty(), { NO_COLOR: '1' }, {}, RUNG.PLAIN],
+            ['TTY but TERM=dumb (no FORCE_COLOR)', tty(), { TERM: 'dumb' }, {}, RUNG.PLAIN],
+            [
+                'FORCE_COLOR with TERM=dumb: colour is forced but cursor addressing is not',
+                tty(),
+                { FORCE_COLOR: '1', TERM: 'dumb' },
+                {},
+                RUNG.BOARD,
+            ],
+            ['narrow terminal', tty({ columns: 60 }), {}, {}, RUNG.PLAIN],
+            ['short terminal', tty({ rows: 10 }), {}, {}, RUNG.BOARD],
+            [
+                'log level warn fails the live gate only',
+                tty(),
+                {},
+                { logLevel: 'warn' },
+                RUNG.BOARD,
+            ],
+            [
+                'log level error fails the live gate only',
+                tty(),
+                {},
+                { logLevel: 'error' },
+                RUNG.BOARD,
+            ],
+            ['log level verbose drops to plain', tty(), {}, { logLevel: 'verbose' }, RUNG.PLAIN],
+            ['log level debug drops to plain', tty(), {}, { logLevel: 'debug' }, RUNG.PLAIN],
+            ['log level silly drops to plain', tty(), {}, { logLevel: 'silly' }, RUNG.PLAIN],
+            ['visible browser window drops to board', tty(), {}, { headless: 'false' }, RUNG.BOARD],
+            ['visible browser window, boolean form', tty(), {}, { headless: false }, RUNG.BOARD],
+            ['headless browser keeps live', tty(), {}, { headless: 'true' }, RUNG.LIVE],
+            ['no browser at all keeps live', tty(), {}, {}, RUNG.LIVE],
+        ];
+
+        for (const [description, stdout, env, options, expected] of matrix) {
+            expect(`${description}: ${selectRung({ stdout, env, options })}`).toBe(
+                `${description}: ${expected}`
+            );
+        }
+    });
+
+    test('column boundaries: 71 selects plain, 72 selects board', () => {
+        // Off-by-one at a boundary is the likely regression, and it is
+        // invisible in normal use - so the exact edges are pinned.
+        expect(select({ stdout: tty({ columns: 71 }) })).toBe(RUNG.PLAIN);
+        expect(select({ stdout: tty({ columns: 72 }) })).toBe(RUNG.BOARD);
+    });
+
+    test('column boundaries: 79 selects board, 80 selects live', () => {
+        expect(select({ stdout: tty({ columns: 79 }) })).toBe(RUNG.BOARD);
+        expect(select({ stdout: tty({ columns: 80 }) })).toBe(RUNG.LIVE);
+    });
+
+    test('row boundaries: 23 selects board, 24 selects live', () => {
+        expect(select({ stdout: tty({ rows: 23 }) })).toBe(RUNG.BOARD);
+        expect(select({ stdout: tty({ rows: 24 }) })).toBe(RUNG.LIVE);
+    });
+
+    test('a TTY-less stream lands on plain for every combination of the other variables', () => {
+        // The verified matrix on issue #1071: FORCE_COLOR forces colour codes
+        // but must never force a rung - the TTY gate sits above it. The
+        // synthetic columns/rows make the property structural rather than an
+        // accident of pipes having no dimensions.
+        for (const env of [{}, { FORCE_COLOR: '1' }, { FORCE_COLOR: '1', TERM: 'xterm' }]) {
+            for (const options of [{}, { logLevel: 'info' }, { headless: 'true' }]) {
+                expect(
+                    selectRung({
+                        stdout: { isTTY: false, columns: 100, rows: 30 },
+                        env,
+                        options,
+                    })
+                ).toBe(RUNG.PLAIN);
+            }
+        }
+    });
+});
+
+describe('selectRung - the BSI_OUTPUT override', () => {
+    test('off and plain always win, on any terminal', () => {
+        for (const stdout of [tty(), { isTTY: false }]) {
+            expect(selectRung({ stdout, env: { [OUTPUT_ENV]: 'off' } })).toBe(RUNG.OFF);
+            expect(selectRung({ stdout, env: { [OUTPUT_ENV]: 'plain' } })).toBe(RUNG.PLAIN);
+        }
+    });
+
+    test('board is forced even where detection would have dropped it', () => {
+        // The escape hatch for a misdetected terminal - and for recordings
+        // through a pipe. The board is static append-only text, so forcing it
+        // cannot strand a cursor; palette and symbols degrade on their own.
+        expect(selectRung({ stdout: { isTTY: false }, env: { [OUTPUT_ENV]: 'board' } })).toBe(
+            RUNG.BOARD
+        );
+    });
+
+    test('board beats the verbose-level drop; off does too', () => {
+        expect(
+            selectRung({
+                stdout: tty(),
+                env: { [OUTPUT_ENV]: 'board' },
+                options: { logLevel: 'debug' },
+            })
+        ).toBe(RUNG.BOARD);
+        expect(
+            selectRung({
+                stdout: tty(),
+                env: { [OUTPUT_ENV]: 'off' },
+                options: { logLevel: 'debug' },
+            })
+        ).toBe(RUNG.OFF);
+    });
+
+    test('live is a permission, not a force: selection stays automatic', () => {
+        expect(selectRung({ stdout: tty(), env: { [OUTPUT_ENV]: 'live' } })).toBe(RUNG.LIVE);
+        expect(selectRung({ stdout: { isTTY: false }, env: { [OUTPUT_ENV]: 'live' } })).toBe(
+            RUNG.PLAIN
+        );
+    });
+
+    test('values are case-insensitive, empty means unset', () => {
+        expect(selectRung({ stdout: { isTTY: false }, env: { [OUTPUT_ENV]: 'BOARD' } })).toBe(
+            RUNG.BOARD
+        );
+        expect(selectRung({ stdout: tty(), env: { [OUTPUT_ENV]: '' } })).toBe(RUNG.LIVE);
+    });
+
+    test('an unrecognised value warns and falls back to automatic, never throws', () => {
+        const warn = jest.fn();
+
+        expect(selectRung({ stdout: tty(), env: { [OUTPUT_ENV]: 'fancy' }, warn })).toBe(RUNG.LIVE);
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(warn.mock.calls[0][0]).toContain('BSI_OUTPUT="fancy"');
+        expect(warn.mock.calls[0][0]).toContain('live, board, plain, off');
+    });
+
+    test('recognised and unset values never warn', () => {
+        const warn = jest.fn();
+
+        for (const env of [{}, { [OUTPUT_ENV]: 'board' }, { [OUTPUT_ENV]: 'off' }]) {
+            selectRung({ stdout: tty(), env, warn });
+        }
+        expect(warn).not.toHaveBeenCalled();
+    });
+});

--- a/src/lib/util/__tests__/select-rung.test.js
+++ b/src/lib/util/__tests__/select-rung.test.js
@@ -49,20 +49,12 @@ describe('selectRung - automatic selection', () => {
             ],
             ['narrow terminal', tty({ columns: 60 }), {}, {}, RUNG.PLAIN],
             ['short terminal', tty({ rows: 10 }), {}, {}, RUNG.BOARD],
-            [
-                'log level warn fails the live gate only',
-                tty(),
-                {},
-                { logLevel: 'warn' },
-                RUNG.BOARD,
-            ],
-            [
-                'log level error fails the live gate only',
-                tty(),
-                {},
-                { logLevel: 'error' },
-                RUNG.BOARD,
-            ],
+            // warn/error asked for a QUIET run: the board writes to stdout
+            // past winston, so it cannot honour a console level - only the
+            // plain rung's info-logged blocks can. Both directions off info
+            // drop all the way to plain.
+            ['log level warn drops to plain', tty(), {}, { logLevel: 'warn' }, RUNG.PLAIN],
+            ['log level error drops to plain', tty(), {}, { logLevel: 'error' }, RUNG.PLAIN],
             ['log level verbose drops to plain', tty(), {}, { logLevel: 'verbose' }, RUNG.PLAIN],
             ['log level debug drops to plain', tty(), {}, { logLevel: 'debug' }, RUNG.PLAIN],
             ['log level silly drops to plain', tty(), {}, { logLevel: 'silly' }, RUNG.PLAIN],

--- a/src/lib/util/run-board.js
+++ b/src/lib/util/run-board.js
@@ -2,10 +2,13 @@ import { getBorderCharacters } from 'table';
 import { colours } from './colour.js';
 import { getSymbols, tableBorderName } from '../interactive/symbols.js';
 import { parseHeadlessOption } from './headless-option.js';
+import { CLEAR_REASON } from './sheet-decision-reasons.js';
 import {
     selectionParts,
     describeRules,
+    describeWrites,
     verdictCounts,
+    verdictFacts,
     isRemovalReport,
     isOptionEnabled,
     formatElapsed,
@@ -51,16 +54,28 @@ const LABEL_WIDTH = 11;
 const VALUE_WIDTH = 22;
 
 /**
- * Width of the app-name column on strip rows.
+ * App-row column budgets. The row must fit the 72-column terminal the board
+ * gate admits, in the WORST case the gate allows: the ASCII symbol set
+ * (whose `[ok]`/`[!!]` markers are four columns) on exactly 72 columns.
+ * The arithmetic, tested at the boundary:
+ *
+ *     indent 2 + marker 4 + space 1 + counter 5 ("99/99") + gap 2
+ *     + name 20 + gap 2 + strip 12 + gap 2 + summary 12 + elapsed 8  = 70
+ *
+ * An app with more sheets than the strip column simply overflows its own
+ * row - truncating the strip would hide the exact per-sheet signal it
+ * exists to show - and a run of 100+ apps widens the counter; both are
+ * accepted, budgeted overflows rather than silent wraps on every row.
  */
-const NAME_WIDTH = 24;
+const NAME_WIDTH = 20;
+
+const STRIP_WIDTH = 12;
 
 /**
- * Width of the sheet-strip column. An app with more sheets than this simply
- * overflows the column for its own row - truncating the strip would hide the
- * exact per-sheet signal the strip exists to show.
+ * Width of the per-app summary column ("10/11 up", "12/12 cleared"): sized
+ * for the removal vocabulary, which is the wider of the two.
  */
-const STRIP_WIDTH = 18;
+const SUMMARY_WIDTH = 12;
 
 /**
  * Width of the horizontal rules separating the board's sections.
@@ -68,19 +83,57 @@ const STRIP_WIDTH = 18;
 const RULE_WIDTH = 64;
 
 /**
- * Display width of a string, counted in code points.
+ * Whether a code point renders two columns wide in a monospace terminal.
  *
- * Not `.length`, which counts UTF-16 code units and would make a surrogate
- * pair two columns. Deliberately not a full grapheme/East-Asian-width
- * measure either - every symbol this module emits is single-width by the
- * rules `symbols.js` enforces, and app names are user data rendered as-is,
- * matching the plain renderer's behaviour.
+ * The standard wcwidth East-Asian ranges: Hangul Jamo, CJK and its
+ * punctuation/compatibility blocks, Hangul syllables, fullwidth forms, and
+ * the supplementary ideographic planes. Implemented inline rather than
+ * importing `string-width`: nothing in this epic may add a dependency (SEA
+ * build), and `table`'s copy is a transitive dependency this module must not
+ * reach into.
+ *
+ * @param {number} cp - The code point.
+ *
+ * @returns {boolean} True when terminals render it double-width.
+ */
+const isWideCodePoint = (cp) =>
+    cp >= 0x1100 &&
+    (cp <= 0x115f ||
+        (cp >= 0x2e80 && cp <= 0xa4cf && cp !== 0x303f) ||
+        (cp >= 0xac00 && cp <= 0xd7a3) ||
+        (cp >= 0xf900 && cp <= 0xfaff) ||
+        (cp >= 0xfe30 && cp <= 0xfe4f) ||
+        (cp >= 0xff00 && cp <= 0xff60) ||
+        (cp >= 0xffe0 && cp <= 0xffe6) ||
+        (cp >= 0x20000 && cp <= 0x3fffd));
+
+const ZERO_WIDTH = /\p{Mn}|\p{Me}|\u200d/u;
+
+/**
+ * Display width of a string in terminal columns.
+ *
+ * Counts East-Asian wide characters as two columns and combining marks as
+ * zero, because this module - unlike the plain renderer, which never
+ * column-aligns anything after a name - pads names into a column with the
+ * sheet strip after it: a miscounted name shifts that row's entire strip
+ * band, which is exactly the per-app comparison the board exists for.
  *
  * @param {string} text - The text to measure.
  *
  * @returns {number} The width in columns.
  */
-const width = (text) => [...text].length;
+const width = (text) => {
+    let columns = 0;
+
+    for (const ch of text) {
+        if (ZERO_WIDTH.test(ch)) {
+            continue;
+        }
+        columns += isWideCodePoint(ch.codePointAt(0)) ? 2 : 1;
+    }
+
+    return columns;
+};
 
 /**
  * Pad plain text to a target width. Never truncates.
@@ -96,13 +149,32 @@ const padTo = (text, target) =>
 /**
  * Clip plain text to a maximum width, marking the cut with `...`.
  *
+ * Cuts by accumulated display columns, not code points, so a wide character
+ * cannot smuggle two columns past the budget. The budget floor guards the
+ * degenerate `max <= 3` case, where a negative slice index would return the
+ * wrong end of the string; callers here use 20+.
+ *
  * @param {string} text - Plain text, no ANSI codes.
  * @param {number} max - Maximum width in columns.
  *
  * @returns {string} The clipped text.
  */
-const clip = (text, max) =>
-    width(text) <= max ? text : `${[...text].slice(0, max - 3).join('')}...`;
+const clip = (text, max) => {
+    if (width(text) <= max) {
+        return text;
+    }
+
+    const budget = Math.max(1, max - 3);
+    let kept = '';
+    for (const ch of text) {
+        if (width(kept + ch) > budget) {
+            break;
+        }
+        kept += ch;
+    }
+
+    return `${kept}...`;
+};
 
 /**
  * Build the rendering context the board renderers draw from.
@@ -148,13 +220,17 @@ export const renderBoardHeader = ({ version, jobLabel }, ctx) => {
 
     // Padded plain, coloured after: the gap is computed from the unpainted
     // name and version so the right edge cannot drift when colour is on.
+    // The version is clipped like the job label below it - release-please
+    // versions are short, but a prerelease/build-metadata string must not
+    // push the right border out of the frame.
     const name = 'BUTLER SHEET ICONS';
-    const gap = Math.max(1, FRAME_INNER - 3 - width(name) - width(version) - 3);
+    const shownVersion = clip(version, FRAME_INNER - 6 - width(name) - 1);
+    const gap = Math.max(1, FRAME_INNER - 3 - width(name) - width(shownVersion) - 3);
     const label = clip(jobLabel, FRAME_INNER - 6);
 
     const interior = [
         empty,
-        `   ${palette.bold(name)}${' '.repeat(gap)}${palette.dim(version)}   `,
+        `   ${palette.bold(name)}${' '.repeat(gap)}${palette.dim(shownVersion)}   `,
         `   ${palette.dim(padTo(label, FRAME_INNER - 6))}   `,
         empty,
     ];
@@ -222,24 +298,19 @@ const sectionRule = (ctx) => `  ${ctx.palette.dim(ctx.symbols.rule.repeat(RULE_W
  * @returns {string|null} The warning line, or null when there is nothing to warn about.
  */
 const warningLine = (report, ctx) => {
-    const { writes } = report.plan;
-    const appCount = report.selection?.total ?? report.apps.length;
+    // One decision tree with the plain renderer: only the casing and voice
+    // are this renderer's own.
+    const writes = describeWrites(report);
 
-    if (!writes || appCount === 0) {
+    if (!writes) {
         return null;
     }
 
-    const verb = report.dryRun ? 'would' : 'will';
-    let text;
-    if (writes.kind === 'clear-icons') {
-        text = `sheet icons and thumbnail media files ${verb} be removed from ${appCount} app(s)`;
-    } else {
-        const published =
-            writes.publishedAppCount === null || writes.publishedAppCount === undefined
-                ? ''
-                : `, ${writes.publishedAppCount} of them published`;
-        text = `sheet thumbnails ${verb} be overwritten in ${appCount} app(s)${published}`;
-    }
+    const verb = writes.would ? 'would' : 'will';
+    const text =
+        writes.kind === 'clear-icons'
+            ? `sheet icons and thumbnail media files ${verb} be removed from ${writes.appCount} app(s)`
+            : `sheet thumbnails ${verb} be overwritten in ${writes.appCount} app(s)${writes.published}`;
 
     return `  ${ctx.palette.yellow(`${ctx.symbols.warning}  ${text}`)}`;
 };
@@ -421,22 +492,42 @@ export const renderBoardPlan = (report, ctx) => {
  *     with its kind for colouring.
  */
 export const stripForApp = (appEntry, symbols) => {
-    const glyphFor = {
-        update: { glyph: symbols.stripCaptured, kind: 'captured' },
-        blur: { glyph: symbols.stripBlurred, kind: 'blurred' },
-        skip: { glyph: symbols.stripExcluded, kind: 'excluded' },
-        clear: { glyph: symbols.stripCaptured, kind: 'captured' },
+    const failedCell = { glyph: symbols.stripFailed, kind: 'failed' };
+    const cellFor = (sheet) => {
+        // A clear with nothing to clear is the removal run's "excluded":
+        // rendering it as a solid block would show a wall of cleared icons
+        // for an app that was mostly empty, and would contradict the
+        // verdict's cleared count for the same run.
+        if (sheet.action === 'clear') {
+            return sheet.reason === CLEAR_REASON.NO_ICON
+                ? { glyph: symbols.stripExcluded, kind: 'excluded' }
+                : { glyph: symbols.stripCaptured, kind: 'captured' };
+        }
+
+        const glyphFor = {
+            update: { glyph: symbols.stripCaptured, kind: 'captured' },
+            blur: { glyph: symbols.stripBlurred, kind: 'blurred' },
+            skip: { glyph: symbols.stripExcluded, kind: 'excluded' },
+        };
+
+        return glyphFor[sheet.action] ?? failedCell;
     };
 
-    const cells = appEntry.sheets.map(
-        (sheet) => glyphFor[sheet.action] ?? { glyph: symbols.stripFailed, kind: 'failed' }
+    // Placed by the recorded 1-based sheet position, never by array order:
+    // the sheet loop survives a mid-app failure and keeps recording the
+    // later sheets, so row i of the array is not sheet i of the app. Every
+    // position nothing was recorded for renders as failed - "not processed"
+    // - which also covers the failed app's missing tail.
+    const count = Math.max(
+        typeof appEntry.sheetCount === 'number' ? appEntry.sheetCount : 0,
+        appEntry.sheets.length,
+        ...appEntry.sheets.map((sheet) => sheet.n ?? 0)
     );
 
-    if (appEntry.failed && typeof appEntry.sheetCount === 'number') {
-        while (cells.length < appEntry.sheetCount) {
-            cells.push({ glyph: symbols.stripFailed, kind: 'failed' });
-        }
-    }
+    const cells = Array.from({ length: count }, () => failedCell);
+    appEntry.sheets.forEach((sheet, i) => {
+        cells[(sheet.n ?? i + 1) - 1] = cellFor(sheet);
+    });
 
     return cells;
 };
@@ -479,10 +570,15 @@ export const renderBoardAppRow = (appEntry, { n, total, removal }, ctx) => {
 
     const counts = verdictCounts({ apps: [appEntry] });
     const sheetCount = appEntry.sheetCount ?? counts.seen;
+    // Removal counts only the icons actually cleared - the same rule the
+    // verdict applies - so the row and the verdict cannot state two
+    // different numbers for one app; no-icon sheets show in the strip.
     const summary = removal
-        ? `${counts.cleared + counts.noIcon}/${sheetCount} cleared`
+        ? `${counts.cleared}/${sheetCount} cleared`
         : `${appEntry.sheetsUpdated ?? counts.captured}/${sheetCount} up`;
-    const summaryPart = appEntry.failed ? palette.red(padTo('failed', 10)) : padTo(summary, 10);
+    const summaryPart = appEntry.failed
+        ? palette.red(padTo('failed', SUMMARY_WIDTH))
+        : padTo(summary, SUMMARY_WIDTH);
 
     const elapsed =
         typeof appEntry.durationMs === 'number'
@@ -493,29 +589,11 @@ export const renderBoardAppRow = (appEntry, { n, total, removal }, ctx) => {
 };
 
 /**
- * Sums a nullable per-app numeric field, returning null when never recorded.
- * Mirrors the plain verdict's rule: a number on the board is always a number
- * that happened.
- *
- * @param {object} report - The report.
- * @param {string} field - The per-app field name.
- *
- * @returns {number|null} The sum, or null.
- */
-const sumAppField = (report, field) => {
-    let sum = null;
-
-    for (const app of report.apps) {
-        if (typeof app[field] === 'number') {
-            sum = (sum ?? 0) + app[field];
-        }
-    }
-
-    return sum;
-};
-
-/**
  * The board's verdict block: what actually changed, and whether it worked.
+ *
+ * All counts and sums come from {@link verdictFacts} and
+ * {@link verdictCounts}, shared with the plain verdict, so the two cannot
+ * describe different runs.
  *
  * @param {object} report - The report, after the app loop has finished and
  *     `succeeded`/`finishedAt` have been set on it.
@@ -532,7 +610,9 @@ export const renderBoardVerdict = (report, ctx) => {
             ? formatElapsed(report.finishedAt - report.startedAt)
             : null;
 
-    if ((report.selection?.total ?? 0) === 0 && report.apps.length === 0) {
+    const facts = verdictFacts(report);
+
+    if (facts.emptySelection) {
         const lines = [
             '',
             sectionRule(ctx),
@@ -544,8 +624,6 @@ export const renderBoardVerdict = (report, ctx) => {
         return `${lines.join('\n')}\n`;
     }
 
-    const failedApps = report.apps.filter((app) => app.failed).length;
-    const okApps = report.apps.length - failedApps;
     const removal = isRemovalReport(report);
     const counts = verdictCounts(report);
 
@@ -555,18 +633,15 @@ export const renderBoardVerdict = (report, ctx) => {
     } else {
         parts.push(palette.red('FAILED') + (elapsed ? ` ${palette.dim(`after ${elapsed}`)}` : ''));
     }
-    parts.push(`${okApps} app(s) ok`);
-    if (failedApps > 0) {
-        parts.push(palette.red(`${failedApps} failed`));
+    parts.push(`${facts.okApps} app(s) ok`);
+    if (facts.failedApps > 0) {
+        parts.push(palette.red(`${facts.failedApps} failed`));
     }
 
     if (removal) {
         parts.push(`${counts.cleared} icon(s) cleared`);
-    } else {
-        const uploaded = sumAppField(report, 'sheetsUpdated');
-        if (uploaded !== null) {
-            parts.push(`${uploaded} thumbnails uploaded`);
-        }
+    } else if (facts.sheetsUpdated !== null) {
+        parts.push(`${facts.sheetsUpdated} thumbnails uploaded`);
     }
 
     const legendEntry = (kind, count, label) =>
@@ -582,8 +657,18 @@ export const renderBoardVerdict = (report, ctx) => {
               legendEntry('blurred', counts.blurred, 'blurred'),
               legendEntry('excluded', counts.excluded, 'excluded'),
           ];
-    if (failedApps > 0) {
-        legendParts.push(legendEntry('failed', failedApps, 'app(s) failed'));
+
+    // The failed legend entry counts what the strips actually show - cells,
+    // not apps: every other legend number equals its glyph's occurrences on
+    // the strips, and this one must too or the legend disagrees with the
+    // board it explains. The failed-app count is already on the line above.
+    const failedCells = report.apps.reduce(
+        (sum, app) =>
+            sum + stripForApp(app, symbols).filter((cell) => cell.kind === 'failed').length,
+        0
+    );
+    if (failedCells > 0) {
+        legendParts.push(legendEntry('failed', failedCells, 'not processed'));
     }
 
     const lines = [
@@ -594,20 +679,17 @@ export const renderBoardVerdict = (report, ctx) => {
         `    ${legendParts.join('   ')}`,
     ];
 
-    const imagesKeptFiles = sumAppField(report, 'imagesKeptFiles');
-    if (!removal && imagesKeptFiles !== null && report.plan?.output) {
-        const bytes = sumAppField(report, 'imagesKeptBytes') ?? 0;
+    if (!removal && facts.imagesKeptFiles !== null && report.plan?.output) {
         lines.push(
             `    ${palette.dim(
-                `images in ${report.plan.output.imageDir}/${report.plan.output.platformDir}${dotSep(ctx)}${imagesKeptFiles} file(s)${dotSep(ctx)}${formatBytes(bytes)}`
+                `images in ${report.plan.output.imageDir}/${report.plan.output.platformDir}${dotSep(ctx)}${facts.imagesKeptFiles} file(s)${dotSep(ctx)}${formatBytes(facts.imagesKeptBytes ?? 0)}`
             )}`
         );
     }
 
-    const mediaFilesDeleted = sumAppField(report, 'mediaFilesDeleted');
-    if (removal && mediaFilesDeleted !== null) {
+    if (removal && facts.mediaFilesDeleted !== null) {
         lines.push(
-            `    ${palette.dim(`${mediaFilesDeleted} thumbnail media file(s) deleted from app media libraries`)}`
+            `    ${palette.dim(`${facts.mediaFilesDeleted} thumbnail media file(s) deleted from app media libraries`)}`
         );
     }
 

--- a/src/lib/util/run-board.js
+++ b/src/lib/util/run-board.js
@@ -100,6 +100,7 @@ const isWideCodePoint = (cp) =>
     cp >= 0x1100 &&
     (cp <= 0x115f ||
         (cp >= 0x2e80 && cp <= 0xa4cf && cp !== 0x303f) ||
+        (cp >= 0xa960 && cp <= 0xa97f) ||
         (cp >= 0xac00 && cp <= 0xd7a3) ||
         (cp >= 0xf900 && cp <= 0xfaff) ||
         (cp >= 0xfe30 && cp <= 0xfe4f) ||
@@ -107,7 +108,12 @@ const isWideCodePoint = (cp) =>
         (cp >= 0xffe0 && cp <= 0xffe6) ||
         (cp >= 0x20000 && cp <= 0x3fffd));
 
-const ZERO_WIDTH = /\p{Mn}|\p{Me}|\u200d/u;
+// Zero-width: combining marks, the zero-width space/joiner family and BOM,
+// and - easy to miss - Hangul Jamo medial vowels and trailing consonants
+// (U+1160-U+11FF): wcwidth renders them zero because they combine with the
+// wide leading consonant, so a decomposed (NFD) Korean name must measure the
+// same as its NFC form or its row's strip band drifts.
+const ZERO_WIDTH = /\p{Mn}|\p{Me}|[\u1160-\u11ff\u200b-\u200f\ufeff]/u;
 
 /**
  * Display width of a string in terminal columns.
@@ -470,16 +476,20 @@ export const renderBoardPlan = (report, ctx) => {
 };
 
 /**
- * The sheet strip for one app: one glyph per recorded sheet, in sheet order.
+ * The sheet strip for one app: one glyph per sheet *position*, placed by the
+ * recorded 1-based sheet number.
  *
  * A mistyped `--exclude-sheet-tag` shows as a row of solid blocks where the
  * operator expected gaps, and a mistyped `--blur-sheet-tag` as a row with no
  * blur glyph in it - per app, so a tag that matched in two apps and not the
  * other five is obvious at a glance.
  *
- * When the app failed with sheets unrecorded, the missing tail is filled with
- * the failed glyph: those sheets were not captured, and a shortened strip
- * would read as a smaller app rather than a broken run.
+ * Every position no decision was recorded for renders as the failed glyph -
+ * unconditionally, not only on failed apps: those sheets were not processed,
+ * and a shortened or compacted strip would read as a smaller app rather than
+ * a broken run. This covers a failed app's missing tail and, because the
+ * sheet loop survives a mid-app failure and keeps recording later sheets,
+ * gaps in the middle of the strip.
  *
  * Exported for the equal-width property test - the strip must be the same
  * width in both symbol sets, which is what `symbols.js` guarantees per glyph
@@ -493,40 +503,44 @@ export const renderBoardPlan = (report, ctx) => {
  */
 export const stripForApp = (appEntry, symbols) => {
     const failedCell = { glyph: symbols.stripFailed, kind: 'failed' };
-    const cellFor = (sheet) => {
-        // A clear with nothing to clear is the removal run's "excluded":
-        // rendering it as a solid block would show a wall of cleared icons
-        // for an app that was mostly empty, and would contradict the
-        // verdict's cleared count for the same run.
-        if (sheet.action === 'clear') {
-            return sheet.reason === CLEAR_REASON.NO_ICON
-                ? { glyph: symbols.stripExcluded, kind: 'excluded' }
-                : { glyph: symbols.stripCaptured, kind: 'captured' };
-        }
-
-        const glyphFor = {
-            update: { glyph: symbols.stripCaptured, kind: 'captured' },
-            blur: { glyph: symbols.stripBlurred, kind: 'blurred' },
-            skip: { glyph: symbols.stripExcluded, kind: 'excluded' },
-        };
-
-        return glyphFor[sheet.action] ?? failedCell;
+    const capturedCell = { glyph: symbols.stripCaptured, kind: 'captured' };
+    const excludedCell = { glyph: symbols.stripExcluded, kind: 'excluded' };
+    const glyphFor = {
+        update: capturedCell,
+        blur: { glyph: symbols.stripBlurred, kind: 'blurred' },
+        skip: excludedCell,
     };
+
+    // A clear with nothing to clear is the removal run's "excluded":
+    // rendering it as a solid block would show a wall of cleared icons for
+    // an app that was mostly empty, and would contradict the verdict's
+    // cleared count for the same run.
+    const cellFor = (sheet) =>
+        sheet.action === 'clear'
+            ? sheet.reason === CLEAR_REASON.NO_ICON
+                ? excludedCell
+                : capturedCell
+            : (glyphFor[sheet.action] ?? failedCell);
 
     // Placed by the recorded 1-based sheet position, never by array order:
     // the sheet loop survives a mid-app failure and keeps recording the
-    // later sheets, so row i of the array is not sheet i of the app. Every
-    // position nothing was recorded for renders as failed - "not processed"
-    // - which also covers the failed app's missing tail.
+    // later sheets, so row i of the array is not sheet i of the app. A row
+    // without a valid 1-based `n` (every in-repo recorder sets one) falls
+    // back to its array position - the same fallback in the count and the
+    // placement, so a synthetic `n: 0` can neither write off the left edge
+    // nor undercount the strip.
+    const positionOf = (sheet, i) =>
+        typeof sheet.n === 'number' && sheet.n >= 1 ? sheet.n : i + 1;
+
     const count = Math.max(
         typeof appEntry.sheetCount === 'number' ? appEntry.sheetCount : 0,
         appEntry.sheets.length,
-        ...appEntry.sheets.map((sheet) => sheet.n ?? 0)
+        ...appEntry.sheets.map(positionOf)
     );
 
     const cells = Array.from({ length: count }, () => failedCell);
     appEntry.sheets.forEach((sheet, i) => {
-        cells[(sheet.n ?? i + 1) - 1] = cellFor(sheet);
+        cells[positionOf(sheet, i) - 1] = cellFor(sheet);
     });
 
     return cells;
@@ -669,6 +683,12 @@ export const renderBoardVerdict = (report, ctx) => {
     );
     if (failedCells > 0) {
         legendParts.push(legendEntry('failed', failedCells, 'not processed'));
+    } else if (facts.failedApps > 0) {
+        // An app that failed before its sheets were even enumerated has an
+        // empty strip - zero failed cells to count - but the failure must
+        // not vanish from the legend, so this one shape falls back to the
+        // app count.
+        legendParts.push(legendEntry('failed', facts.failedApps, 'app(s) failed'));
     }
 
     const lines = [

--- a/src/lib/util/run-board.js
+++ b/src/lib/util/run-board.js
@@ -1,0 +1,617 @@
+import { getBorderCharacters } from 'table';
+import { colours } from './colour.js';
+import { getSymbols, tableBorderName } from '../interactive/symbols.js';
+import { parseHeadlessOption } from './headless-option.js';
+import {
+    selectionParts,
+    describeRules,
+    verdictCounts,
+    isRemovalReport,
+    isOptionEnabled,
+    formatElapsed,
+    formatBytes,
+} from './run-report-render.js';
+
+/**
+ * Rung B of the run-output ladder (issue #1074): the contact sheet.
+ *
+ * Static colour, written to `process.stdout` by the caller in one `write()`
+ * per block - never through winston, which would prefix every row and break
+ * every box. No cursor addressing, no frame timer, no repainting, so the
+ * output survives being piped somewhere unexpected and there is no interrupt
+ * path to get wrong.
+ *
+ * Every renderer here is a pure function from a run report (issue #1072) to a
+ * string. The report is the single source of facts - a board that gathered
+ * its own would eventually disagree with the run card underneath it, and the
+ * disagreement would surface as a dry run that lies.
+ *
+ * Width discipline, learned from a running prototype: **pad the plain string
+ * first, colour second.** The obvious `pad(colour(text))` counts ANSI escape
+ * codes as width and collapses every column the moment colour is on - and it
+ * passes every colour-off test, failing only on a real terminal.
+ */
+
+/**
+ * Inner width of the wordmark frame, borders excluded. The frame is 410 x 270
+ * in spirit - the real thumbnail size the code produces - but 52 terminal
+ * columns wide in practice, inside the 72-column gate rung B is selected by.
+ */
+const FRAME_INNER = 50;
+
+/**
+ * Width of the label column on plan rows, after the bullet.
+ */
+const LABEL_WIDTH = 11;
+
+/**
+ * Width of the value column on plan rows that carry a dim detail after the
+ * value; rows without a detail are not padded.
+ */
+const VALUE_WIDTH = 22;
+
+/**
+ * Width of the app-name column on strip rows.
+ */
+const NAME_WIDTH = 24;
+
+/**
+ * Width of the sheet-strip column. An app with more sheets than this simply
+ * overflows the column for its own row - truncating the strip would hide the
+ * exact per-sheet signal the strip exists to show.
+ */
+const STRIP_WIDTH = 18;
+
+/**
+ * Width of the horizontal rules separating the board's sections.
+ */
+const RULE_WIDTH = 64;
+
+/**
+ * Display width of a string, counted in code points.
+ *
+ * Not `.length`, which counts UTF-16 code units and would make a surrogate
+ * pair two columns. Deliberately not a full grapheme/East-Asian-width
+ * measure either - every symbol this module emits is single-width by the
+ * rules `symbols.js` enforces, and app names are user data rendered as-is,
+ * matching the plain renderer's behaviour.
+ *
+ * @param {string} text - The text to measure.
+ *
+ * @returns {number} The width in columns.
+ */
+const width = (text) => [...text].length;
+
+/**
+ * Pad plain text to a target width. Never truncates.
+ *
+ * @param {string} text - Plain text, no ANSI codes.
+ * @param {number} target - Target width in columns.
+ *
+ * @returns {string} The padded text.
+ */
+const padTo = (text, target) =>
+    width(text) >= target ? text : text + ' '.repeat(target - width(text));
+
+/**
+ * Clip plain text to a maximum width, marking the cut with `...`.
+ *
+ * @param {string} text - Plain text, no ANSI codes.
+ * @param {number} max - Maximum width in columns.
+ *
+ * @returns {string} The clipped text.
+ */
+const clip = (text, max) =>
+    width(text) <= max ? text : `${[...text].slice(0, max - 3).join('')}...`;
+
+/**
+ * Build the rendering context the board renderers draw from.
+ *
+ * The context is an argument rather than module state so tests can render
+ * both symbol sets and both palettes in one process. The defaults compose
+ * the real detectors: the palette is the load-time `colours` (inert when
+ * colour is off, so no renderer branches), the symbols follow
+ * `BSI_ASCII_ONLY`, and the frame borders follow `tableBorderName()`'s
+ * existing norc/ramac split.
+ *
+ * @param {object} [overrides] - Any of `palette`, `symbols`, `border`.
+ *
+ * @returns {{palette: object, symbols: object, border: object}} The context.
+ */
+export const boardContext = (overrides = {}) => ({
+    palette: overrides.palette ?? colours,
+    symbols: overrides.symbols ?? getSymbols(),
+    border: overrides.border ?? getBorderCharacters(tableBorderName()),
+});
+
+/**
+ * The wordmark frame: a 410 x 270 thumbnail frame, because the frame is the
+ * thing the tool makes. Replaces the plain run header on the terminal; the
+ * plain header still goes to the log underneath.
+ *
+ * @param {object} header - Header facts.
+ * @param {string} header.version - The Butler Sheet Icons version.
+ * @param {string} header.jobLabel - Short job description, e.g. `QSEoW sheet thumbnails`.
+ * @param {object} ctx - From {@link boardContext}.
+ *
+ * @returns {string} The frame, newline-terminated.
+ */
+export const renderBoardHeader = ({ version, jobLabel }, ctx) => {
+    const { palette, symbols, border } = ctx;
+
+    const title = ` 410 ${symbols.times} 270 `;
+    const top = `${border.topLeft}${border.topBody}${title}${border.topBody.repeat(
+        Math.max(1, FRAME_INNER - 1 - width(title))
+    )}${border.topRight}`;
+    const bottom = `${border.bottomLeft}${border.bottomBody.repeat(FRAME_INNER)}${border.bottomRight}`;
+    const empty = ' '.repeat(FRAME_INNER);
+
+    // Padded plain, coloured after: the gap is computed from the unpainted
+    // name and version so the right edge cannot drift when colour is on.
+    const name = 'BUTLER SHEET ICONS';
+    const gap = Math.max(1, FRAME_INNER - 3 - width(name) - width(version) - 3);
+    const label = clip(jobLabel, FRAME_INNER - 6);
+
+    const interior = [
+        empty,
+        `   ${palette.bold(name)}${' '.repeat(gap)}${palette.dim(version)}   `,
+        `   ${palette.dim(padTo(label, FRAME_INNER - 6))}   `,
+        empty,
+    ];
+
+    const edge = palette.dim(border.bodyLeft);
+    const lines = [
+        `  ${palette.dim(top)}`,
+        ...interior.map((content) => `  ${edge}${content}${edge}`),
+        `  ${palette.dim(bottom)}`,
+    ];
+
+    return `\n${lines.join('\n')}\n`;
+};
+
+/**
+ * One plan row: bullet, label, value, optional dim detail.
+ *
+ * @param {object} ctx - From {@link boardContext}.
+ * @param {object} row - The row.
+ * @param {string} row.label - The label.
+ * @param {string} row.value - The value, plain.
+ * @param {string} [row.detail] - Detail rendered dim after the value.
+ * @param {boolean} [row.passive] - Hollow bullet for rows that describe a
+ *     side effect kept for the operator rather than an action taken.
+ *
+ * @returns {string} The row.
+ */
+const planRow = (ctx, { label, value, detail = '', passive = false }) => {
+    const { palette, symbols } = ctx;
+    const bullet = passive ? palette.dim(symbols.bulletOff) : palette.green(symbols.bulletOn);
+
+    const paddedValue = detail === '' ? value : padTo(value, VALUE_WIDTH);
+    const detailPart = detail === '' ? '' : `  ${palette.dim(detail)}`;
+
+    return `  ${bullet} ${padTo(label, LABEL_WIDTH)} ${paddedValue}${detailPart}`;
+};
+
+/**
+ * The separator the strip glyphs and rules join with: ` · ` on Unicode
+ * terminals, ` - ` on ASCII ones.
+ *
+ * @param {object} ctx - From {@link boardContext}.
+ *
+ * @returns {string} The separator.
+ */
+const dotSep = (ctx) => ` ${ctx.symbols.dot} `;
+
+/**
+ * A dim horizontal rule separating the board's sections.
+ *
+ * @param {object} ctx - From {@link boardContext}.
+ *
+ * @returns {string} The rule line.
+ */
+const sectionRule = (ctx) => `  ${ctx.palette.dim(ctx.symbols.rule.repeat(RULE_WIDTH))}`;
+
+/**
+ * The writes warning: the one line on the board that names the part with no
+ * undo. Same suppression rule as the plain renderer - an empty selection must
+ * not warn about a write that was never possible.
+ *
+ * @param {object} report - The report.
+ * @param {object} ctx - From {@link boardContext}.
+ *
+ * @returns {string|null} The warning line, or null when there is nothing to warn about.
+ */
+const warningLine = (report, ctx) => {
+    const { writes } = report.plan;
+    const appCount = report.selection?.total ?? report.apps.length;
+
+    if (!writes || appCount === 0) {
+        return null;
+    }
+
+    const verb = report.dryRun ? 'would' : 'will';
+    let text;
+    if (writes.kind === 'clear-icons') {
+        text = `sheet icons and thumbnail media files ${verb} be removed from ${appCount} app(s)`;
+    } else {
+        const published =
+            writes.publishedAppCount === null || writes.publishedAppCount === undefined
+                ? ''
+                : `, ${writes.publishedAppCount} of them published`;
+        text = `sheet thumbnails ${verb} be overwritten in ${appCount} app(s)${published}`;
+    }
+
+    return `  ${ctx.palette.yellow(`${ctx.symbols.warning}  ${text}`)}`;
+};
+
+/**
+ * The board's plan block: what the run resolved, before the first write.
+ *
+ * The rows render from the report's structural plan sections - the same
+ * object the plain plan block and the dry-run report read - restyled, never
+ * re-derived. Rule rows keep the match counts (zeroes included), because a
+ * zero next to a tag the operator typed is the cheapest possible "check your
+ * spelling", and here it is visible before anything is touched.
+ *
+ * @param {object} report - A report whose `plan` section has been recorded.
+ * @param {object} ctx - From {@link boardContext}.
+ *
+ * @returns {string} The block, newline-terminated; empty when the report carries no plan.
+ */
+export const renderBoardPlan = (report, ctx) => {
+    const { plan, selection } = report;
+    const { palette } = ctx;
+
+    if (!plan) {
+        return '';
+    }
+
+    const sep = dotSep(ctx);
+    const rows = [];
+
+    if (plan.target) {
+        if (plan.target.platform === 'qseow') {
+            const scheme = isOptionEnabled(plan.target.secure) ? 'https' : 'http';
+            const hostPort = plan.target.port
+                ? `${plan.target.host}:${plan.target.port}`
+                : plan.target.host;
+            const proxy = plan.target.prefix ? `${sep}proxy "${plan.target.prefix}"` : '';
+            rows.push(
+                planRow(ctx, {
+                    label: 'server',
+                    value: hostPort,
+                    detail: `${scheme}${sep}engine ${plan.target.enginePort}${sep}qrs ${plan.target.qrsPort}${proxy}`,
+                })
+            );
+        } else {
+            rows.push(planRow(ctx, { label: 'tenant', value: plan.target.tenantUrl }));
+        }
+    }
+
+    if (plan.auth) {
+        if (plan.auth.apiUser) {
+            rows.push(
+                planRow(ctx, {
+                    label: 'api user',
+                    value: `${plan.auth.apiUser.directory}\\${plan.auth.apiUser.userId}`,
+                    detail: `cert ${plan.auth.certFile}`,
+                })
+            );
+            rows.push(
+                planRow(ctx, {
+                    label: 'logon user',
+                    value: `${plan.auth.logonUser.directory}\\${plan.auth.logonUser.userId}`,
+                })
+            );
+        } else {
+            let detail = '';
+            if (plan.auth.skipLogin) {
+                detail = 'logon skipped (--skip-login)';
+            } else if (plan.auth.logonUserId) {
+                detail = `logon ${plan.auth.logonUserId}`;
+            }
+            rows.push(planRow(ctx, { label: 'auth', value: 'API key', detail }));
+        }
+    }
+
+    if (selection) {
+        rows.push(
+            planRow(ctx, {
+                label: 'apps',
+                value: String(selection.total),
+                detail: selectionParts(selection).join(sep),
+            })
+        );
+    }
+
+    if (plan.sheetPart) {
+        rows.push(
+            planRow(ctx, {
+                label: 'sheet part',
+                value: `${plan.sheetPart.value} of ${plan.sheetPart.max}`,
+                detail: plan.sheetPart.label,
+            })
+        );
+    }
+
+    if (plan.rules) {
+        const excluded = describeRules(plan.rules.exclude);
+        const blurred = describeRules(plan.rules.blur);
+        rows.push(
+            planRow(ctx, { label: 'exclude', value: excluded, passive: excluded === 'none' })
+        );
+        rows.push(planRow(ctx, { label: 'blur', value: blurred, passive: blurred === 'none' }));
+    }
+
+    if (plan.browser) {
+        const window = parseHeadlessOption(plan.browser.headless) ? 'headless' : 'visible window';
+        rows.push(
+            planRow(ctx, {
+                label: 'browser',
+                value: `${plan.browser.name} (${plan.browser.version})`,
+                detail: `${window}${sep}${plan.browser.pageWaitSeconds}s per sheet`,
+            })
+        );
+    }
+
+    if (plan.output) {
+        rows.push(
+            planRow(ctx, {
+                label: 'images',
+                value: `${plan.output.imageDir}/${plan.output.platformDir}/<app-id>`,
+                passive: true,
+            })
+        );
+    }
+
+    if (plan.writes && (report.selection?.total ?? report.apps.length) > 0) {
+        if (plan.writes.contentLibrary) {
+            rows.push(
+                planRow(ctx, {
+                    label: 'uploads to',
+                    value: `content library "${plan.writes.contentLibrary}"`,
+                })
+            );
+        } else if (plan.writes.kind === 'thumbnails') {
+            rows.push(
+                planRow(ctx, {
+                    label: 'uploads to',
+                    value: `each app's media library, "thumbnails" folder`,
+                })
+            );
+        }
+    }
+
+    const heading = report.dryRun
+        ? `  ${palette.bold('PLAN')}  ${report.command}  ${palette.dim('(dry run)')}`
+        : `  ${palette.bold('PLAN')}  ${report.command}`;
+
+    const lines = ['', heading, '', ...rows];
+
+    const warning = warningLine(report, ctx);
+    if (warning) {
+        lines.push('', warning);
+    }
+
+    lines.push('', sectionRule(ctx), '');
+
+    return `${lines.join('\n')}\n`;
+};
+
+/**
+ * The sheet strip for one app: one glyph per recorded sheet, in sheet order.
+ *
+ * A mistyped `--exclude-sheet-tag` shows as a row of solid blocks where the
+ * operator expected gaps, and a mistyped `--blur-sheet-tag` as a row with no
+ * blur glyph in it - per app, so a tag that matched in two apps and not the
+ * other five is obvious at a glance.
+ *
+ * When the app failed with sheets unrecorded, the missing tail is filled with
+ * the failed glyph: those sheets were not captured, and a shortened strip
+ * would read as a smaller app rather than a broken run.
+ *
+ * Exported for the equal-width property test - the strip must be the same
+ * width in both symbol sets, which is what `symbols.js` guarantees per glyph
+ * and this function must not break in assembly.
+ *
+ * @param {object} appEntry - A per-app entry from the report.
+ * @param {object} symbols - The symbol set in use.
+ *
+ * @returns {Array<{glyph: string, kind: string}>} One glyph per sheet, tagged
+ *     with its kind for colouring.
+ */
+export const stripForApp = (appEntry, symbols) => {
+    const glyphFor = {
+        update: { glyph: symbols.stripCaptured, kind: 'captured' },
+        blur: { glyph: symbols.stripBlurred, kind: 'blurred' },
+        skip: { glyph: symbols.stripExcluded, kind: 'excluded' },
+        clear: { glyph: symbols.stripCaptured, kind: 'captured' },
+    };
+
+    const cells = appEntry.sheets.map(
+        (sheet) => glyphFor[sheet.action] ?? { glyph: symbols.stripFailed, kind: 'failed' }
+    );
+
+    if (appEntry.failed && typeof appEntry.sheetCount === 'number') {
+        while (cells.length < appEntry.sheetCount) {
+            cells.push({ glyph: symbols.stripFailed, kind: 'failed' });
+        }
+    }
+
+    return cells;
+};
+
+const STRIP_PAINT = Object.freeze({
+    captured: (palette) => palette.green,
+    blurred: (palette) => palette.yellow,
+    excluded: (palette) => palette.dim,
+    failed: (palette) => palette.red,
+});
+
+/**
+ * One per-app strip row, appended to the board as the app finishes.
+ *
+ * Append-only by design (issue #1074's open question, resolved): one line per
+ * app as it completes is still useful during a six-minute run, and it needs
+ * no cursor addressing and repaints nothing.
+ *
+ * @param {object} appEntry - A per-app entry from the report.
+ * @param {object} position - Where in the run this app sits.
+ * @param {number} position.n - 1-based app number.
+ * @param {number} position.total - Number of apps in the run.
+ * @param {boolean} position.removal - Whether this is an icon-removal run.
+ * @param {object} ctx - From {@link boardContext}.
+ *
+ * @returns {string} The row, newline-terminated.
+ */
+export const renderBoardAppRow = (appEntry, { n, total, removal }, ctx) => {
+    const { palette, symbols } = ctx;
+
+    const marker = appEntry.failed ? palette.red(symbols.failed) : palette.green(symbols.done);
+
+    const counter = padTo(`${n}/${total}`, width(`${total}/${total}`));
+    const name = padTo(clip(appEntry.name ?? appEntry.id ?? '', NAME_WIDTH), NAME_WIDTH);
+
+    const cells = stripForApp(appEntry, symbols);
+    const strip =
+        cells.map(({ glyph, kind }) => STRIP_PAINT[kind](palette)(glyph)).join('') +
+        ' '.repeat(Math.max(0, STRIP_WIDTH - cells.length));
+
+    const counts = verdictCounts({ apps: [appEntry] });
+    const sheetCount = appEntry.sheetCount ?? counts.seen;
+    const summary = removal
+        ? `${counts.cleared + counts.noIcon}/${sheetCount} cleared`
+        : `${appEntry.sheetsUpdated ?? counts.captured}/${sheetCount} up`;
+    const summaryPart = appEntry.failed ? palette.red(padTo('failed', 10)) : padTo(summary, 10);
+
+    const elapsed =
+        typeof appEntry.durationMs === 'number'
+            ? `  ${palette.dim(formatElapsed(appEntry.durationMs))}`
+            : '';
+
+    return `  ${marker} ${counter}  ${name}  ${strip}  ${summaryPart}${elapsed}\n`;
+};
+
+/**
+ * Sums a nullable per-app numeric field, returning null when never recorded.
+ * Mirrors the plain verdict's rule: a number on the board is always a number
+ * that happened.
+ *
+ * @param {object} report - The report.
+ * @param {string} field - The per-app field name.
+ *
+ * @returns {number|null} The sum, or null.
+ */
+const sumAppField = (report, field) => {
+    let sum = null;
+
+    for (const app of report.apps) {
+        if (typeof app[field] === 'number') {
+            sum = (sum ?? 0) + app[field];
+        }
+    }
+
+    return sum;
+};
+
+/**
+ * The board's verdict block: what actually changed, and whether it worked.
+ *
+ * @param {object} report - The report, after the app loop has finished and
+ *     `succeeded`/`finishedAt` have been set on it.
+ * @param {object} ctx - From {@link boardContext}.
+ *
+ * @returns {string} The block, newline-terminated.
+ */
+export const renderBoardVerdict = (report, ctx) => {
+    const { palette, symbols } = ctx;
+    const sep = `  ${palette.dim(symbols.dot)}  `;
+
+    const elapsed =
+        typeof report.startedAt === 'number' && typeof report.finishedAt === 'number'
+            ? formatElapsed(report.finishedAt - report.startedAt)
+            : null;
+
+    if ((report.selection?.total ?? 0) === 0 && report.apps.length === 0) {
+        const lines = [
+            '',
+            sectionRule(ctx),
+            '',
+            `  ${symbols.cursor} ${palette.red('0 apps selected - nothing was done')}`,
+            '',
+        ];
+
+        return `${lines.join('\n')}\n`;
+    }
+
+    const failedApps = report.apps.filter((app) => app.failed).length;
+    const okApps = report.apps.length - failedApps;
+    const removal = isRemovalReport(report);
+    const counts = verdictCounts(report);
+
+    const parts = [];
+    if (report.succeeded) {
+        parts.push(palette.green(elapsed ? `done in ${elapsed}` : 'done'));
+    } else {
+        parts.push(palette.red('FAILED') + (elapsed ? ` ${palette.dim(`after ${elapsed}`)}` : ''));
+    }
+    parts.push(`${okApps} app(s) ok`);
+    if (failedApps > 0) {
+        parts.push(palette.red(`${failedApps} failed`));
+    }
+
+    if (removal) {
+        parts.push(`${counts.cleared} icon(s) cleared`);
+    } else {
+        const uploaded = sumAppField(report, 'sheetsUpdated');
+        if (uploaded !== null) {
+            parts.push(`${uploaded} thumbnails uploaded`);
+        }
+    }
+
+    const legendEntry = (kind, count, label) =>
+        `${STRIP_PAINT[kind](palette)(symbols[`strip${kind[0].toUpperCase()}${kind.slice(1)}`])} ${count} ${label}`;
+
+    const legendParts = removal
+        ? [
+              legendEntry('captured', counts.cleared, 'cleared'),
+              legendEntry('excluded', counts.noIcon, 'had no icon'),
+          ]
+        : [
+              legendEntry('captured', counts.captured, 'captured'),
+              legendEntry('blurred', counts.blurred, 'blurred'),
+              legendEntry('excluded', counts.excluded, 'excluded'),
+          ];
+    if (failedApps > 0) {
+        legendParts.push(legendEntry('failed', failedApps, 'app(s) failed'));
+    }
+
+    const lines = [
+        '',
+        sectionRule(ctx),
+        '',
+        `  ${symbols.cursor} ${parts.join(sep)}`,
+        `    ${legendParts.join('   ')}`,
+    ];
+
+    const imagesKeptFiles = sumAppField(report, 'imagesKeptFiles');
+    if (!removal && imagesKeptFiles !== null && report.plan?.output) {
+        const bytes = sumAppField(report, 'imagesKeptBytes') ?? 0;
+        lines.push(
+            `    ${palette.dim(
+                `images in ${report.plan.output.imageDir}/${report.plan.output.platformDir}${dotSep(ctx)}${imagesKeptFiles} file(s)${dotSep(ctx)}${formatBytes(bytes)}`
+            )}`
+        );
+    }
+
+    const mediaFilesDeleted = sumAppField(report, 'mediaFilesDeleted');
+    if (removal && mediaFilesDeleted !== null) {
+        lines.push(
+            `    ${palette.dim(`${mediaFilesDeleted} thumbnail media file(s) deleted from app media libraries`)}`
+        );
+    }
+
+    lines.push('');
+
+    return `${lines.join('\n')}\n`;
+};

--- a/src/lib/util/run-report-render.js
+++ b/src/lib/util/run-report-render.js
@@ -225,6 +225,38 @@ const renderAuth = (auth) => {
 };
 
 /**
+ * The facts behind the writes warning, shared by the plain plan block and the
+ * contact-sheet board (issue #1074): what kind of write, how many apps, the
+ * dry-run tense, and the published-count suffix.
+ *
+ * One decision tree rather than two - the writes warning is the one line
+ * both renderers exist to get right, and a new `writes.kind` or a changed
+ * published-count rule must reach both from a single place. Each renderer
+ * supplies only its own casing and voice.
+ *
+ * @param {object} report - The report.
+ *
+ * @returns {{kind: string, appCount: number, would: boolean, published: string}|null}
+ *     The facts, or null when there is nothing to warn about - no writes
+ *     section, or an empty selection whose write was never possible.
+ */
+export const describeWrites = (report) => {
+    const writes = report.plan?.writes;
+    const appCount = report.selection?.total ?? report.apps.length;
+
+    if (!writes || appCount === 0) {
+        return null;
+    }
+
+    const published =
+        writes.publishedAppCount === null || writes.publishedAppCount === undefined
+            ? ''
+            : `, ${writes.publishedAppCount} of them published`;
+
+    return { kind: writes.kind, appCount, would: Boolean(report.dryRun), published };
+};
+
+/**
  * The writes warning: the one line in the plan block written in capitals,
  * because it is the part with no undo.
  *
@@ -233,22 +265,17 @@ const renderAuth = (auth) => {
  * @returns {string} The warning line.
  */
 const renderWrites = (report) => {
-    const { writes } = report.plan;
-    const appCount = report.selection?.total ?? report.apps.length;
+    const writes = describeWrites(report);
 
     if (writes.kind === 'clear-icons') {
-        const verb = report.dryRun ? 'WOULD REMOVE' : 'WILL REMOVE';
+        const verb = writes.would ? 'WOULD REMOVE' : 'WILL REMOVE';
 
-        return `  ${verb} sheet icons and thumbnail media files from ${appCount} app(s)`;
+        return `  ${verb} sheet icons and thumbnail media files from ${writes.appCount} app(s)`;
     }
 
-    const verb = report.dryRun ? 'WOULD OVERWRITE' : 'WILL OVERWRITE';
-    const published =
-        writes.publishedAppCount === null || writes.publishedAppCount === undefined
-            ? ''
-            : `, ${writes.publishedAppCount} of them published`;
+    const verb = writes.would ? 'WOULD OVERWRITE' : 'WILL OVERWRITE';
 
-    return `  ${verb} existing sheet thumbnails in ${appCount} app(s)${published}`;
+    return `  ${verb} existing sheet thumbnails in ${writes.appCount} app(s)${writes.published}`;
 };
 
 /**
@@ -472,6 +499,36 @@ export const verdictCounts = (report) => {
 };
 
 /**
+ * The verdict's app-level and outcome facts, shared by the plain verdict and
+ * the contact-sheet verdict (issue #1074).
+ *
+ * Extracted for the same reason as {@link verdictCounts}: these were derived
+ * inline by both renderers, and a change to what counts as a failed app or
+ * which apps contribute kept-image bytes must reach both verdicts or they
+ * describe different runs. The sums follow the recorded-or-null rule - a
+ * number in either verdict is always a number that happened.
+ *
+ * @param {object} report - The report.
+ *
+ * @returns {{okApps: number, failedApps: number, emptySelection: boolean,
+ *     sheetsUpdated: number|null, imagesKeptFiles: number|null,
+ *     imagesKeptBytes: number|null, mediaFilesDeleted: number|null}} The facts.
+ */
+export const verdictFacts = (report) => {
+    const failedApps = report.apps.filter((app) => app.failed).length;
+
+    return {
+        okApps: report.apps.length - failedApps,
+        failedApps,
+        emptySelection: (report.selection?.total ?? 0) === 0 && report.apps.length === 0,
+        sheetsUpdated: sumAppField(report, 'sheetsUpdated'),
+        imagesKeptFiles: sumAppField(report, 'imagesKeptFiles'),
+        imagesKeptBytes: sumAppField(report, 'imagesKeptBytes'),
+        mediaFilesDeleted: sumAppField(report, 'mediaFilesDeleted'),
+    };
+};
+
+/**
  * The verdict block: what actually changed, and whether the run worked.
  *
  * This is the part that does not exist at all today - a run in which 66
@@ -487,17 +544,16 @@ export const verdictCounts = (report) => {
 export const renderRunVerdictLines = (report) => {
     const lines = ['', `RESULT  ${report.succeeded ? 'ok' : 'FAILED'}`];
 
-    const failedApps = report.apps.filter((app) => app.failed).length;
-    const okApps = report.apps.length - failedApps;
+    const facts = verdictFacts(report);
 
-    if ((report.selection?.total ?? 0) === 0 && report.apps.length === 0) {
+    if (facts.emptySelection) {
         lines.push(row('apps', '0 selected - nothing was done'));
         lines.push(RUN_FRAME);
 
         return lines;
     }
 
-    lines.push(row('apps', `${okApps} ok, ${failedApps} failed`));
+    lines.push(row('apps', `${facts.okApps} ok, ${facts.failedApps} failed`));
 
     const { seen, captured, blurred, excluded, cleared, noIcon } = verdictCounts(report);
 
@@ -508,12 +564,11 @@ export const renderRunVerdictLines = (report) => {
         const noIconNote = noIcon > 0 ? `, ${noIcon} had no icon` : '';
         lines.push(row('sheets', `${seen} seen, ${cleared} icon(s) cleared${noIconNote}`));
 
-        const mediaFilesDeleted = sumAppField(report, 'mediaFilesDeleted');
-        if (mediaFilesDeleted !== null) {
+        if (facts.mediaFilesDeleted !== null) {
             lines.push(
                 row(
                     'media',
-                    `${mediaFilesDeleted} thumbnail file(s) deleted from app media libraries`
+                    `${facts.mediaFilesDeleted} thumbnail file(s) deleted from app media libraries`
                 )
             );
         }
@@ -523,26 +578,23 @@ export const renderRunVerdictLines = (report) => {
             row('sheets', `${seen} seen, ${captured} captured${blurNote}, ${excluded} excluded`)
         );
 
-        const sheetsUpdated = sumAppField(report, 'sheetsUpdated');
-        if (sheetsUpdated !== null) {
+        if (facts.sheetsUpdated !== null) {
             const destination = report.plan?.writes?.contentLibrary
                 ? `content library "${report.plan.writes.contentLibrary}"`
                 : 'app media libraries';
             lines.push(
                 row(
                     'thumbnails',
-                    `${sheetsUpdated} sheet(s) given new thumbnails in ${destination}`
+                    `${facts.sheetsUpdated} sheet(s) given new thumbnails in ${destination}`
                 )
             );
         }
 
-        const imagesKeptFiles = sumAppField(report, 'imagesKeptFiles');
-        if (imagesKeptFiles !== null && report.plan?.output) {
-            const bytes = sumAppField(report, 'imagesKeptBytes') ?? 0;
+        if (facts.imagesKeptFiles !== null && report.plan?.output) {
             lines.push(
                 row(
                     'images kept',
-                    `${report.plan.output.imageDir}/${report.plan.output.platformDir}   ${imagesKeptFiles} file(s), ${formatBytes(bytes)}`
+                    `${report.plan.output.imageDir}/${report.plan.output.platformDir}   ${facts.imagesKeptFiles} file(s), ${formatBytes(facts.imagesKeptBytes ?? 0)}`
                 )
             );
         }

--- a/src/lib/util/run-report-render.js
+++ b/src/lib/util/run-report-render.js
@@ -267,6 +267,15 @@ export const describeWrites = (report) => {
 const renderWrites = (report) => {
     const writes = describeWrites(report);
 
+    // Null-safe by contract, not by the caller's guard: renderRunPlanLines
+    // happens to pre-filter with the same predicate, but this function must
+    // not crash the plan block if the two ever drift or a new caller skips
+    // the guard - the board's warningLine already honours the null the same
+    // way.
+    if (!writes) {
+        return '';
+    }
+
     if (writes.kind === 'clear-icons') {
         const verb = writes.would ? 'WOULD REMOVE' : 'WILL REMOVE';
 

--- a/src/lib/util/run-report-render.js
+++ b/src/lib/util/run-report-render.js
@@ -107,11 +107,14 @@ export const isRemovalReport = (report) => (report.command ?? '').includes('remo
  * The provenance parts of the app-selection line, shared wording with the
  * pre-#1073 dry-run report: named count, selector count, overlap.
  *
+ * Exported for the contact-sheet renderer (issue #1074), which states the
+ * same provenance on its `apps` row - one wording, two layouts.
+ *
  * @param {object} selection - `report.selection` from `recordSelection`.
  *
  * @returns {string[]} The parts, ready to join with `, `.
  */
-const selectionParts = (selection) => {
+export const selectionParts = (selection) => {
     const parts = [`${selection.named} named by --appid`];
 
     if (selection.selector) {
@@ -158,13 +161,15 @@ const describeRule = ({ option, values, matchedSheetCount = null }) => {
  *
  * `none` is printed rather than the line being omitted, because the absence
  * of a rule is exactly what an operator checking "did my exclude flag
- * register?" needs stated.
+ * register?" needs stated. Exported for the contact-sheet renderer, which
+ * shows the same rules with the same match counts.
  *
  * @param {Array<object>} rules - Rules of one kind (exclude or blur).
  *
  * @returns {string} The joined rule descriptions.
  */
-const describeRules = (rules) => (rules.length === 0 ? 'none' : rules.map(describeRule).join(', '));
+export const describeRules = (rules) =>
+    rules.length === 0 ? 'none' : rules.map(describeRule).join(', ');
 
 /**
  * The target lines: which server or tenant the run talks to.
@@ -428,6 +433,45 @@ const sumAppField = (report, field) => {
 };
 
 /**
+ * Totals over the per-sheet rows the processors recorded while each sheet
+ * happened, in the vocabulary the verdict speaks.
+ *
+ * Extracted so the plain verdict and the contact-sheet verdict (issue #1074)
+ * count from one place - two counting loops would be two chances for the
+ * boards to disagree about the same run.
+ *
+ * @param {object} report - The report.
+ *
+ * @returns {{seen: number, captured: number, blurred: number, excluded: number,
+ *     cleared: number, noIcon: number}} The counts.
+ */
+export const verdictCounts = (report) => {
+    const counts = { seen: 0, captured: 0, blurred: 0, excluded: 0, cleared: 0, noIcon: 0 };
+
+    for (const app of report.apps) {
+        for (const sheet of app.sheets) {
+            counts.seen += 1;
+            if (sheet.action === 'skip') {
+                counts.excluded += 1;
+            } else if (sheet.action === 'blur') {
+                counts.captured += 1;
+                counts.blurred += 1;
+            } else if (sheet.action === 'update') {
+                counts.captured += 1;
+            } else if (sheet.action === 'clear') {
+                if (sheet.reason === CLEAR_REASON.NO_ICON) {
+                    counts.noIcon += 1;
+                } else {
+                    counts.cleared += 1;
+                }
+            }
+        }
+    }
+
+    return counts;
+};
+
+/**
  * The verdict block: what actually changed, and whether the run worked.
  *
  * This is the part that does not exist at all today - a run in which 66
@@ -455,33 +499,7 @@ export const renderRunVerdictLines = (report) => {
 
     lines.push(row('apps', `${okApps} ok, ${failedApps} failed`));
 
-    // Per-sheet rows recorded by the processors while each sheet happened.
-    let seen = 0;
-    let captured = 0;
-    let blurred = 0;
-    let excluded = 0;
-    let cleared = 0;
-    let noIcon = 0;
-
-    for (const app of report.apps) {
-        for (const sheet of app.sheets) {
-            seen += 1;
-            if (sheet.action === 'skip') {
-                excluded += 1;
-            } else if (sheet.action === 'blur') {
-                captured += 1;
-                blurred += 1;
-            } else if (sheet.action === 'update') {
-                captured += 1;
-            } else if (sheet.action === 'clear') {
-                if (sheet.reason === CLEAR_REASON.NO_ICON) {
-                    noIcon += 1;
-                } else {
-                    cleared += 1;
-                }
-            }
-        }
-    }
+    const { seen, captured, blurred, excluded, cleared, noIcon } = verdictCounts(report);
 
     // Decided from report.command via isRemovalReport, never from the
     // optional plan sections: a removal run whose caller supplied no plan

--- a/src/lib/util/run-report.js
+++ b/src/lib/util/run-report.js
@@ -5,7 +5,16 @@ import {
     renderRunPlanLines,
     renderRunVerdictLines,
     isRemovalReport,
+    logRunHeader,
 } from './run-report-render.js';
+import { selectRung, RUNG } from './select-rung.js';
+import {
+    boardContext,
+    renderBoardHeader,
+    renderBoardPlan,
+    renderBoardAppRow,
+    renderBoardVerdict,
+} from './run-board.js';
 import { toOptionValueList } from './option-values.js';
 import { measureImageFiles } from './image-dir.js';
 
@@ -58,6 +67,106 @@ const withReportVisible = (emit) => {
             setLoggingLevel(level);
         }
     }
+};
+
+/**
+ * Warned once per process, not once per emitting call site: the header and
+ * the report loop both consult the rung, and an unrecognised `BSI_OUTPUT`
+ * is the same typo both times.
+ */
+let warnedAboutOutputOverride = false;
+
+/**
+ * The output rung for this process, from the real stream and environment.
+ *
+ * A thin composition seam over the pure {@link selectRung}: this is the only
+ * place the real `process.stdout`, `process.env` and console log level are
+ * read, so every renderer stays injectable. Called at run start - the stream
+ * cannot become a terminal later - and deterministic for the life of the
+ * run, so the header emitter and the report loop cannot disagree.
+ *
+ * @param {boolean|string} [headless] - The run's raw `--headless` value, when
+ *     the command drives a browser.
+ *
+ * @returns {string} A value from {@link RUNG}.
+ */
+const decideRung = (headless) =>
+    selectRung({
+        stdout: process.stdout,
+        env: process.env,
+        options: { logLevel: getLoggingLevel(), headless },
+        warn: (message) => {
+            if (!warnedAboutOutputOverride) {
+                warnedAboutOutputOverride = true;
+                logger.warn(message);
+            }
+        },
+    });
+
+/**
+ * Emit a block through the logger with the console transport silenced.
+ *
+ * This is how the board avoids printing the same facts twice: the plain
+ * run-card block still goes through winston - so a file transport, if one is
+ * ever configured, gets the log the schedulers rely on - while the terminal
+ * gets the board block instead of both.
+ *
+ * @param {Function} emit - Function that writes the block through the logger.
+ *
+ * @returns {void}
+ */
+const withConsoleSilenced = (emit) => {
+    // Optional chaining: injected test loggers have no transports array, and
+    // a missing console transport must mean "nothing to silence", not a crash.
+    const consoleTransport = logger.transports?.find((transport) => transport.name === 'console');
+
+    if (!consoleTransport) {
+        emit();
+
+        return;
+    }
+
+    const previous = consoleTransport.silent;
+    consoleTransport.silent = true;
+    try {
+        emit();
+    } finally {
+        consoleTransport.silent = previous;
+    }
+};
+
+/**
+ * Emit the run header on the rung the terminal gets.
+ *
+ * On the board rung the terminal shows the wordmark frame (issue #1074) and
+ * the plain three-line header goes through the logger with the console
+ * silenced - one branding block, not two. Everywhere else this is exactly
+ * `logRunHeader`. `BSI_OUTPUT=off` keeps the plain header: it predates the
+ * ladder, and the version line it carries is the first thing support asks
+ * for.
+ *
+ * Rung C (issue #1075) does not exist yet, so a `live` verdict renders the
+ * board - today's top of the ladder.
+ *
+ * @param {object} run - The run.
+ * @param {string} run.version - The Butler Sheet Icons version.
+ * @param {string} run.jobLabel - Short job description, e.g. `QSEoW sheet thumbnails`.
+ * @param {object} [run.options] - The command's options bag; `headless` is
+ *     the only key read.
+ *
+ * @returns {void}
+ */
+export const emitRunHeader = ({ version, jobLabel, options = {} }) => {
+    const rung = decideRung(options.headless);
+
+    if (rung === RUNG.BOARD || rung === RUNG.LIVE) {
+        withConsoleSilenced(() => logRunHeader(logger, version, jobLabel));
+        process.stdout.write(renderBoardHeader({ version, jobLabel }, boardContext()));
+
+        return;
+    }
+
+    logRunHeader(logger, version, jobLabel);
 };
 
 /**
@@ -584,16 +693,36 @@ export const runOverAppsWithReport = async ({
     recordSelection(report, { namedAppIds, selectorAppIds, selector });
     report.plan = plan;
 
+    // Decided once, at the start of the run (issue #1076): the stream cannot
+    // become a terminal later. `live` renders as the board until rung C
+    // (issue #1075) exists.
+    const rung = decideRung(plan?.browser?.headless);
+    const board = rung === RUNG.BOARD || rung === RUNG.LIVE;
+    const ctx = board ? boardContext() : null;
+
     const emitPlan = () => {
         for (const line of renderRunPlanLines(report)) {
             logger.info(line);
         }
     };
-    if (dryRun) {
+    if (rung === RUNG.OFF) {
+        // BSI_OUTPUT=off suppresses the plan and verdict blocks only. The
+        // per-app and per-sheet lines still print - someone setting `off`
+        // wants the framed blocks gone, not a six-minute run with no output.
+    } else if (board) {
+        // The plain block still goes through the logger - a file transport,
+        // if one is ever configured, keeps the log schedulers rely on - with
+        // the console silenced so the terminal sees the board, not both.
+        withConsoleSilenced(emitPlan);
+        process.stdout.write(renderBoardPlan(report, ctx));
+    } else if (dryRun) {
         withReportVisible(emitPlan);
     } else {
         emitPlan();
     }
+
+    const totalApps = new Set(appIds).size;
+    const removal = isRemovalReport(report);
 
     const result = await runOverApps(
         appIds,
@@ -615,6 +744,7 @@ export const runOverAppsWithReport = async ({
                   }
               }
             : async (appId) => {
+                  const appStartedAt = Date.now();
                   try {
                       const result = await processApp(appId, report);
 
@@ -632,6 +762,25 @@ export const runOverAppsWithReport = async ({
                       // error lines above it.
                       markAppFailed(report, appId);
                       throw err;
+                  } finally {
+                      // Both paths above guarantee the entry exists by now.
+                      // Stamped by the loop, not the processors: one clock
+                      // for both platform twins.
+                      const entry = report.apps.find((app) => app.id === appId);
+                      if (entry) {
+                          entry.durationMs = Date.now() - appStartedAt;
+                          if (board) {
+                              // Appended as each app finishes - still no
+                              // cursor addressing, nothing repainted.
+                              process.stdout.write(
+                                  renderBoardAppRow(
+                                      entry,
+                                      { n: report.apps.length, total: totalApps, removal },
+                                      ctx
+                                  )
+                              );
+                          }
+                      }
                   }
               }
     );
@@ -642,12 +791,24 @@ export const runOverAppsWithReport = async ({
     // Rendered even when some apps failed to plan: the decisions that were
     // reached belong next to the per-app error lines already logged, and the
     // renderer itself marks incomplete and unplanned apps.
-    if (dryRun) {
-        renderDryRunReport(report);
-    } else {
+    const emitVerdict = () => {
         for (const line of renderRunVerdictLines(report)) {
             logger.info(line);
         }
+    };
+    if (dryRun) {
+        // The report is the entire product of a dry run, so no rung - `off`
+        // included - suppresses it. On the board rung the plan block above
+        // already rendered as a board; the per-sheet decisions stay in the
+        // log, where their reasons are.
+        renderDryRunReport(report);
+    } else if (rung === RUNG.OFF) {
+        // Suppressed together with the plan block.
+    } else if (board) {
+        withConsoleSilenced(emitVerdict);
+        process.stdout.write(renderBoardVerdict(report, ctx));
+    } else {
+        emitVerdict();
     }
 
     return result;

--- a/src/lib/util/run-report.js
+++ b/src/lib/util/run-report.js
@@ -136,7 +136,57 @@ const withConsoleSilenced = (emit) => {
 };
 
 /**
- * Emit the run header on the rung the terminal gets.
+ * Emit one output block on the selected rung.
+ *
+ * The single dispatch point for the rung trichotomy, used by the header, the
+ * plan block and the verdict block - three call sites, one rule, and one
+ * insertion point when rung C (issue #1075) arrives. On the board rung the
+ * plain block still goes through the logger (console silenced, so the
+ * terminal is not told the same facts twice) and the board block goes to
+ * stdout in one write. `off` suppresses the block unless the caller marks it
+ * part of the command's product.
+ *
+ * @param {object} block - The block.
+ * @param {string} block.rung - From {@link selectRung}.
+ * @param {Function} block.plainEmit - Writes the plain block through the logger.
+ * @param {() => string} block.renderBoardBlock - Renders the board block.
+ * @param {boolean} [block.forceVisible] - Raise the console level for the
+ *     plain block (dry-run product semantics; see `withReportVisible`).
+ * @param {boolean} [block.suppressOnOff] - Whether `BSI_OUTPUT=off` may
+ *     suppress this block. False for blocks that are the command's product.
+ *
+ * @returns {void}
+ */
+const emitBlockOnRung = ({
+    rung,
+    plainEmit,
+    renderBoardBlock,
+    forceVisible = false,
+    suppressOnOff = true,
+}) => {
+    if (rung === RUNG.BOARD || rung === RUNG.LIVE) {
+        withConsoleSilenced(plainEmit);
+        process.stdout.write(renderBoardBlock());
+
+        return;
+    }
+
+    if (rung === RUNG.OFF && suppressOnOff) {
+        return;
+    }
+
+    if (forceVisible) {
+        withReportVisible(plainEmit);
+
+        return;
+    }
+
+    plainEmit();
+};
+
+/**
+ * Emit the run header on the rung the terminal gets, and hand the decision
+ * back so the caller can thread it through the rest of the run.
  *
  * On the board rung the terminal shows the wordmark frame (issue #1074) and
  * the plain three-line header goes through the logger with the console
@@ -145,8 +195,12 @@ const withConsoleSilenced = (emit) => {
  * ladder, and the version line it carries is the first thing support asks
  * for.
  *
- * Rung C (issue #1075) does not exist yet, so a `live` verdict renders the
- * board - today's top of the ladder.
+ * Called by the run *workers*, not the command handlers: the wizard invokes
+ * workers directly, so a handler-level header would be skipped on wizard
+ * runs and would be decided from pre-wizard options on `-i` runs. Returning
+ * the rung lets the worker pass the same decision to `announceDryRun` and
+ * `runOverAppsWithReport`, so the header and the blocks cannot disagree -
+ * not by re-deriving the same inputs, but by deciding once.
  *
  * @param {object} run - The run.
  * @param {string} run.version - The Butler Sheet Icons version.
@@ -154,19 +208,20 @@ const withConsoleSilenced = (emit) => {
  * @param {object} [run.options] - The command's options bag; `headless` is
  *     the only key read.
  *
- * @returns {void}
+ * @returns {string} The decided rung, from {@link RUNG}.
  */
 export const emitRunHeader = ({ version, jobLabel, options = {} }) => {
     const rung = decideRung(options.headless);
 
-    if (rung === RUNG.BOARD || rung === RUNG.LIVE) {
-        withConsoleSilenced(() => logRunHeader(logger, version, jobLabel));
-        process.stdout.write(renderBoardHeader({ version, jobLabel }, boardContext()));
+    emitBlockOnRung({
+        rung,
+        plainEmit: () => logRunHeader(logger, version, jobLabel),
+        renderBoardBlock: () => renderBoardHeader({ version, jobLabel }, boardContext()),
+        // `off` keeps the plain header - the version line is support material.
+        suppressOnOff: false,
+    });
 
-        return;
-    }
-
-    logRunHeader(logger, version, jobLabel);
+    return rung;
 };
 
 /**
@@ -178,15 +233,39 @@ export const emitRunHeader = ({ version, jobLabel, options = {} }) => {
  * watching a destructive-looking scroll for two minutes has no reason to wait
  * for it.
  *
+ * Rung-aware: on the board rung the plain `=`-framed banner would land as
+ * rung-A furniture between the wordmark frame and the board plan, so the
+ * terminal gets a single board-styled line instead while the plain banner
+ * still goes through the logger, console silenced - the same both-audiences
+ * split as every other board block.
+ *
  * @param {string} command - The command being planned, e.g. `qseow create-sheet-thumbnails`.
+ * @param {string} [rung] - The rung from {@link emitRunHeader}. Callers
+ *     without one get the plain banner.
  *
  * @returns {void}
  */
-export const announceDryRun = (command) => {
-    withReportVisible(() => {
+export const announceDryRun = (command, rung = RUNG.PLAIN) => {
+    const emit = () => {
         logger.info(RUN_FRAME);
         logger.info(`DRY RUN of ${command}: planning only - NOTHING WILL BE CHANGED`);
         logger.info(RUN_FRAME);
+    };
+
+    emitBlockOnRung({
+        rung,
+        plainEmit: emit,
+        renderBoardBlock: () => {
+            const ctx = boardContext();
+
+            return `\n  ${ctx.palette.yellow(
+                `${ctx.symbols.warning}  DRY RUN of ${command}: planning only - nothing will be changed`
+            )}\n`;
+        },
+        // The announcement is dry-run product: visible at warn/error, and
+        // never suppressed by `off`.
+        forceVisible: true,
+        suppressOnOff: false,
     });
 };
 
@@ -669,6 +748,9 @@ export const recordPlannedSheet = (
  * @param {{option: string, value: string}|null} run.selector - The selector used, if any.
  * @param {object} [run.plan] - Structural plan sections (target, auth, sheetPart,
  *     rules, browser, output, writes), assembled by the worker.
+ * @param {string} [run.rung] - The output rung decided by the worker's
+ *     `emitRunHeader` call, so header and blocks share one decision. Omitted
+ *     by callers without a header; decided fresh then.
  * @param {{plan: string, process: string}} run.logPrefix - Per-mode log prefixes.
  * @param {string} run.emptySelectionHint - Guidance when nothing was selected.
  * @param {(appId: string, report: object) => Promise<void>} run.planApp - The per-app planner.
@@ -684,6 +766,7 @@ export const runOverAppsWithReport = async ({
     selectorAppIds,
     selector,
     plan = null,
+    rung: providedRung = null,
     logPrefix,
     emptySelectionHint,
     planApp,
@@ -693,10 +776,12 @@ export const runOverAppsWithReport = async ({
     recordSelection(report, { namedAppIds, selectorAppIds, selector });
     report.plan = plan;
 
-    // Decided once, at the start of the run (issue #1076): the stream cannot
-    // become a terminal later. `live` renders as the board until rung C
-    // (issue #1075) exists.
-    const rung = decideRung(plan?.browser?.headless);
+    // Decided once, at the start of the run (issue #1076): workers pass the
+    // rung their `emitRunHeader` call decided, so the header and the blocks
+    // cannot disagree even if the terminal changes between them. The
+    // fallback decides fresh for callers without a header. `live` renders as
+    // the board until rung C (issue #1075) exists.
+    const rung = providedRung ?? decideRung(plan?.browser?.headless);
     const board = rung === RUNG.BOARD || rung === RUNG.LIVE;
     const ctx = board ? boardContext() : null;
 
@@ -705,21 +790,17 @@ export const runOverAppsWithReport = async ({
             logger.info(line);
         }
     };
-    if (rung === RUNG.OFF) {
-        // BSI_OUTPUT=off suppresses the plan and verdict blocks only. The
-        // per-app and per-sheet lines still print - someone setting `off`
-        // wants the framed blocks gone, not a six-minute run with no output.
-    } else if (board) {
-        // The plain block still goes through the logger - a file transport,
-        // if one is ever configured, keeps the log schedulers rely on - with
-        // the console silenced so the terminal sees the board, not both.
-        withConsoleSilenced(emitPlan);
-        process.stdout.write(renderBoardPlan(report, ctx));
-    } else if (dryRun) {
-        withReportVisible(emitPlan);
-    } else {
-        emitPlan();
-    }
+    // On a dry run the plan block is half the command's product - the
+    // selection provenance and rule match counts live only here - so
+    // `BSI_OUTPUT=off` may suppress it on real runs only, and dry runs keep
+    // the forced visibility rung A gave them.
+    emitBlockOnRung({
+        rung,
+        plainEmit: emitPlan,
+        renderBoardBlock: () => renderBoardPlan(report, ctx),
+        forceVisible: dryRun,
+        suppressOnOff: !dryRun,
+    });
 
     const totalApps = new Set(appIds).size;
     const removal = isRemovalReport(report);
@@ -791,24 +872,22 @@ export const runOverAppsWithReport = async ({
     // Rendered even when some apps failed to plan: the decisions that were
     // reached belong next to the per-app error lines already logged, and the
     // renderer itself marks incomplete and unplanned apps.
-    const emitVerdict = () => {
-        for (const line of renderRunVerdictLines(report)) {
-            logger.info(line);
-        }
-    };
     if (dryRun) {
         // The report is the entire product of a dry run, so no rung - `off`
         // included - suppresses it. On the board rung the plan block above
         // already rendered as a board; the per-sheet decisions stay in the
         // log, where their reasons are.
         renderDryRunReport(report);
-    } else if (rung === RUNG.OFF) {
-        // Suppressed together with the plan block.
-    } else if (board) {
-        withConsoleSilenced(emitVerdict);
-        process.stdout.write(renderBoardVerdict(report, ctx));
     } else {
-        emitVerdict();
+        emitBlockOnRung({
+            rung,
+            plainEmit: () => {
+                for (const line of renderRunVerdictLines(report)) {
+                    logger.info(line);
+                }
+            },
+            renderBoardBlock: () => renderBoardVerdict(report, ctx),
+        });
     }
 
     return result;

--- a/src/lib/util/run-report.js
+++ b/src/lib/util/run-report.js
@@ -7,7 +7,7 @@ import {
     isRemovalReport,
     logRunHeader,
 } from './run-report-render.js';
-import { selectRung, RUNG } from './select-rung.js';
+import { selectRung, rendersAsBoard, RUNG } from './select-rung.js';
 import {
     boardContext,
     renderBoardHeader,
@@ -164,7 +164,7 @@ const emitBlockOnRung = ({
     forceVisible = false,
     suppressOnOff = true,
 }) => {
-    if (rung === RUNG.BOARD || rung === RUNG.LIVE) {
+    if (rendersAsBoard(rung)) {
         withConsoleSilenced(plainEmit);
         process.stdout.write(renderBoardBlock());
 
@@ -239,13 +239,23 @@ export const emitRunHeader = ({ version, jobLabel, options = {} }) => {
  * still goes through the logger, console silenced - the same both-audiences
  * split as every other board block.
  *
+ * The rung is required, not defaulted: a permissive default here would let a
+ * future worker forget the threading and silently print the `=`-framed plain
+ * banner into the middle of board output - the exact divergence the
+ * rung-threading exists to make impossible.
+ *
  * @param {string} command - The command being planned, e.g. `qseow create-sheet-thumbnails`.
- * @param {string} [rung] - The rung from {@link emitRunHeader}. Callers
- *     without one get the plain banner.
+ * @param {string} rung - The rung returned by {@link emitRunHeader}.
  *
  * @returns {void}
  */
-export const announceDryRun = (command, rung = RUNG.PLAIN) => {
+export const announceDryRun = (command, rung) => {
+    if (!rung) {
+        // Loud, not lenient: a defaulted rung here would print the plain
+        // banner under a board header - divergence with no failing test.
+        throw new Error('announceDryRun requires the rung returned by emitRunHeader');
+    }
+
     const emit = () => {
         logger.info(RUN_FRAME);
         logger.info(`DRY RUN of ${command}: planning only - NOTHING WILL BE CHANGED`);
@@ -748,9 +758,12 @@ export const recordPlannedSheet = (
  * @param {{option: string, value: string}|null} run.selector - The selector used, if any.
  * @param {object} [run.plan] - Structural plan sections (target, auth, sheetPart,
  *     rules, browser, output, writes), assembled by the worker.
- * @param {string} [run.rung] - The output rung decided by the worker's
- *     `emitRunHeader` call, so header and blocks share one decision. Omitted
- *     by callers without a header; decided fresh then.
+ * @param {string} run.rung - The output rung returned by the worker's
+ *     `emitRunHeader` call, so header and blocks share one decision. Required,
+ *     not defaulted: a fallback deciding fresh here would quietly re-derive
+ *     the rung from different inputs, recreating the header/blocks divergence
+ *     the threading exists to eliminate. Callers without a header pass
+ *     `RUNG.PLAIN` explicitly.
  * @param {{plan: string, process: string}} run.logPrefix - Per-mode log prefixes.
  * @param {string} run.emptySelectionHint - Guidance when nothing was selected.
  * @param {(appId: string, report: object) => Promise<void>} run.planApp - The per-app planner.
@@ -766,23 +779,28 @@ export const runOverAppsWithReport = async ({
     selectorAppIds,
     selector,
     plan = null,
-    rung: providedRung = null,
+    rung,
     logPrefix,
     emptySelectionHint,
     planApp,
     processApp,
 }) => {
+    if (!rung) {
+        // Loud, not lenient: re-deciding here from different inputs is the
+        // header/blocks divergence the threading exists to eliminate, and a
+        // silent plain fallback under a board header is the same bug.
+        throw new Error('runOverAppsWithReport requires the rung returned by emitRunHeader');
+    }
+
     const report = createRunReport({ command, dryRun });
     recordSelection(report, { namedAppIds, selectorAppIds, selector });
     report.plan = plan;
 
-    // Decided once, at the start of the run (issue #1076): workers pass the
-    // rung their `emitRunHeader` call decided, so the header and the blocks
-    // cannot disagree even if the terminal changes between them. The
-    // fallback decides fresh for callers without a header. `live` renders as
-    // the board until rung C (issue #1075) exists.
-    const rung = providedRung ?? decideRung(plan?.browser?.headless);
-    const board = rung === RUNG.BOARD || rung === RUNG.LIVE;
+    // Decided once, at the start of the run (issue #1076): the worker's
+    // emitRunHeader call decided the rung and passed it here, so the header
+    // and the blocks cannot disagree even if the terminal changes between
+    // them - structurally, because nothing here re-decides.
+    const board = rendersAsBoard(rung);
     const ctx = board ? boardContext() : null;
 
     const emitPlan = () => {

--- a/src/lib/util/select-rung.js
+++ b/src/lib/util/select-rung.js
@@ -49,12 +49,6 @@ export const RUNG = Object.freeze({
 const RUNG_VALUES = Object.freeze(Object.values(RUNG));
 
 /**
- * Log levels that drop the run to the plain rung. Somebody at these levels is
- * debugging and wants the stream they asked for, not a board printed over it.
- */
-const DEBUGGING_LEVELS = Object.freeze(['verbose', 'debug', 'silly']);
-
-/**
  * Parse the `BSI_OUTPUT` override.
  *
  * An enum, so it does not reuse the "anything other than empty/`0`/`false`"
@@ -105,10 +99,13 @@ const parseOutputOverride = (env, warn) => {
  *
  * Two gates that are not obvious (issue #1076):
  *
- * - Log level `verbose`+ drops to plain. Someone at that level is debugging,
- *   and a board printed over the stream they asked for is actively harmful.
- *   An explicit `BSI_OUTPUT=board` still wins - the operator stated both
- *   wishes, and the board does not repaint.
+ * - Any log level other than `info` drops to plain, in both directions.
+ *   Someone at `verbose`+ is debugging, and a board printed over the stream
+ *   they asked for is actively harmful. Someone at `warn`/`error` asked for
+ *   a *quiet* run - and the board writes to stdout past winston, so it
+ *   cannot honour a console level the way the plain rung's blocks (logged
+ *   at `info`, filtered by the transport) do. An explicit
+ *   `BSI_OUTPUT=board` still wins - the operator stated both wishes.
  * - `--headless false` blocks the live rung only. A real Chrome window is
  *   taking focus, and the operator has said the browser is the thing they
  *   want to watch; the board does not compete for attention, so it stays.
@@ -146,8 +143,12 @@ export const selectRung = ({ stdout, env, options = {}, warn = () => {} }) => {
         return override;
     }
 
+    // Both visual rungs require the default `info` level: above it the
+    // operator is debugging, below it they asked for quiet - and the board,
+    // writing to stdout past winston, could honour neither. The plain
+    // rung's blocks log at `info` and follow the console level naturally.
     const logLevel = options.logLevel ?? 'info';
-    if (DEBUGGING_LEVELS.includes(logLevel)) {
+    if (logLevel !== 'info') {
         return RUNG.PLAIN;
     }
 
@@ -164,7 +165,6 @@ export const selectRung = ({ stdout, env, options = {}, warn = () => {} }) => {
         columns >= 80 &&
         (stdout?.rows ?? 0) >= 24 &&
         env?.TERM !== 'dumb' &&
-        logLevel === 'info' &&
         parseHeadlessOption(options.headless)
     ) {
         return RUNG.LIVE;

--- a/src/lib/util/select-rung.js
+++ b/src/lib/util/select-rung.js
@@ -1,0 +1,178 @@
+import { isColourEnabled } from './colour.js';
+import { parseHeadlessOption } from './headless-option.js';
+
+/**
+ * Rung selection for the run-output ladder (issue #1076): pick the highest
+ * output the terminal can honestly render.
+ *
+ * Pure and injectable - no I/O, no reads of `process` or the real
+ * environment. The caller hands over the stream, the environment and the two
+ * option-derived facts (log level and `--headless`), and gets back a rung
+ * name. The decision is made once, at the start of the run: the stream cannot
+ * become a terminal later, which is the same argument `colour.js` makes for
+ * its own load-time evaluation.
+ *
+ * This module *composes* the existing detectors rather than re-implementing
+ * them. `isColourEnabled()` deliberately overrides picocolors because that
+ * library reports "colour supported" on Windows and in CI even when output is
+ * redirected - a second, hand-rolled colour test here would reintroduce
+ * exactly the bug that function exists to prevent.
+ */
+
+/**
+ * Environment variable overriding automatic rung selection.
+ *
+ * An environment variable rather than a CLI flag, for the same reason as
+ * `BSI_ASCII_ONLY` and `BSI_NO_INTERACTIVE`: this is an ambient presentation
+ * choice, not a per-invocation one, and a flag would have to be declared on
+ * all nine leaf commands (and carried through the wizard's option rebuild).
+ */
+export const OUTPUT_ENV = 'BSI_OUTPUT';
+
+/**
+ * The rungs, from highest fidelity to none.
+ *
+ * `LIVE` is rung C of the ladder (issue #1075, not yet implemented) - the
+ * selector already reports it so that landing the live view changes only the
+ * renderer, and today's consumers treat it as `BOARD`. `OFF` suppresses the
+ * plan and verdict blocks entirely for anyone whose log shipper chokes on
+ * framed output; the per-app and per-sheet progress lines still print, so a
+ * six-minute run is not silent.
+ */
+export const RUNG = Object.freeze({
+    LIVE: 'live',
+    BOARD: 'board',
+    PLAIN: 'plain',
+    OFF: 'off',
+});
+
+const RUNG_VALUES = Object.freeze(Object.values(RUNG));
+
+/**
+ * Log levels that drop the run to the plain rung. Somebody at these levels is
+ * debugging and wants the stream they asked for, not a board printed over it.
+ */
+const DEBUGGING_LEVELS = Object.freeze(['verbose', 'debug', 'silly']);
+
+/**
+ * Parse the `BSI_OUTPUT` override.
+ *
+ * An enum, so it does not reuse the "anything other than empty/`0`/`false`"
+ * test the boolean escape hatches share. An unrecognised value warns and
+ * falls back to automatic selection - never aborts: a typo in a scheduler's
+ * environment block must not turn a working nightly run into a failing one.
+ *
+ * @param {object} env - Environment to read.
+ * @param {(message: string) => void} warn - Called once for an unrecognised value.
+ *
+ * @returns {string|null} A value from {@link RUNG}, or null for automatic selection.
+ */
+const parseOutputOverride = (env, warn) => {
+    const raw = env?.[OUTPUT_ENV];
+
+    if (raw === undefined || raw === '') {
+        return null;
+    }
+
+    const value = raw.toLowerCase();
+    if (RUNG_VALUES.includes(value)) {
+        return value;
+    }
+
+    warn(
+        `${OUTPUT_ENV}="${raw}" is not a recognised value (${RUNG_VALUES.join(', ')}) - using automatic output selection instead.`
+    );
+
+    return null;
+};
+
+/**
+ * Select the output rung for this run.
+ *
+ * The rule: try the live view (C); if the environment cannot honestly render
+ * it, fall to the contact sheet (B); if it cannot render that, fall to the
+ * plain run card (A), which has no gate and always works.
+ *
+ * Overrides, in precedence order: `BSI_OUTPUT=off` and `=plain` always win -
+ * they only ever step down, which every environment can honour. `=board`
+ * forces the contact sheet even where detection would have dropped it; the
+ * board is static append-only text, so forcing it onto a misdetected terminal
+ * (or a pipe, for a recording) cannot leave a cursor stranded - it degrades
+ * to uncoloured, un-glyphed text through the palette and symbol fallbacks
+ * instead. `=live` is a *permission*, not a force: it is one of C's gates,
+ * never a way to point cursor-addressing output at a stream that cannot
+ * render it.
+ *
+ * Two gates that are not obvious (issue #1076):
+ *
+ * - Log level `verbose`+ drops to plain. Someone at that level is debugging,
+ *   and a board printed over the stream they asked for is actively harmful.
+ *   An explicit `BSI_OUTPUT=board` still wins - the operator stated both
+ *   wishes, and the board does not repaint.
+ * - `--headless false` blocks the live rung only. A real Chrome window is
+ *   taking focus, and the operator has said the browser is the thing they
+ *   want to watch; the board does not compete for attention, so it stays.
+ *
+ * `TERM=dumb` is a hard gate on the live rung, independent of colour:
+ * `isColourEnabled()` checks `TERM=dumb` *after* `FORCE_COLOR` by design, so
+ * `FORCE_COLOR=1 TERM=dumb` on a TTY enables colour - correct for colour,
+ * wrong for cursor addressing on a terminal that has declared it cannot move
+ * the cursor. Colour capability and cursor addressing are different
+ * capabilities and get different gates.
+ *
+ * Both visual rungs additionally require a TTY. The `columns` test implies
+ * one on real streams (a pipe has no `columns`), but the verified matrix on
+ * issue #1071 states the stronger property - a TTY-less stream lands on plain
+ * for *every* combination of the other variables, `FORCE_COLOR=1` included -
+ * and this makes it structural rather than incidental.
+ *
+ * @param {object} run - The run's environment, all injectable.
+ * @param {object} run.stdout - Stream the output is destined for.
+ * @param {object} run.env - Environment to read.
+ * @param {{logLevel: string|undefined, headless: boolean|string|undefined}} [run.options] -
+ *     Option-derived facts. `logLevel` is the console level, defaulting to
+ *     `info`. `headless` is the raw `--headless` value, interpreted by
+ *     `parseHeadlessOption` so this gate matches what the browser launch will
+ *     actually do; absent means no browser window opens.
+ * @param {(message: string) => void} [run.warn] - Receives the warning for an
+ *     unrecognised `BSI_OUTPUT` value. Defaults to a no-op.
+ *
+ * @returns {string} A value from {@link RUNG}.
+ */
+export const selectRung = ({ stdout, env, options = {}, warn = () => {} }) => {
+    const override = parseOutputOverride(env, warn);
+
+    if (override === RUNG.OFF || override === RUNG.PLAIN || override === RUNG.BOARD) {
+        return override;
+    }
+
+    const logLevel = options.logLevel ?? 'info';
+    if (DEBUGGING_LEVELS.includes(logLevel)) {
+        return RUNG.PLAIN;
+    }
+
+    const colour = isColourEnabled(stdout, env);
+    const tty = Boolean(stdout?.isTTY);
+    const columns = stdout?.columns ?? 0;
+
+    // Reaching here means BSI_OUTPUT is unset or `live`, which is itself one
+    // of C's gates - the override parse above has already sent every other
+    // recognised value down its own path.
+    if (
+        colour &&
+        tty &&
+        columns >= 80 &&
+        (stdout?.rows ?? 0) >= 24 &&
+        env?.TERM !== 'dumb' &&
+        logLevel === 'info' &&
+        parseHeadlessOption(options.headless)
+    ) {
+        return RUNG.LIVE;
+    }
+
+    if (colour && tty && columns >= 72) {
+        return RUNG.BOARD;
+    }
+
+    return RUNG.PLAIN;
+};

--- a/src/lib/util/select-rung.js
+++ b/src/lib/util/select-rung.js
@@ -49,6 +49,19 @@ export const RUNG = Object.freeze({
 const RUNG_VALUES = Object.freeze(Object.values(RUNG));
 
 /**
+ * Whether a rung renders through the contact-sheet board today.
+ *
+ * `LIVE` collapses to the board until rung C (issue #1075) exists. This
+ * equivalence lives in exactly one place so that landing the live view means
+ * changing one predicate, not hunting the sites that re-encoded it.
+ *
+ * @param {string} rung - A value from {@link RUNG}.
+ *
+ * @returns {boolean} True when the rung renders board blocks.
+ */
+export const rendersAsBoard = (rung) => rung === RUNG.BOARD || rung === RUNG.LIVE;
+
+/**
  * Parse the `BSI_OUTPUT` override.
  *
  * An enum, so it does not reuse the "anything other than empty/`0`/`false`"


### PR DESCRIPTION
Closes #1076. Closes #1074. (#1075, the live run view, is deliberately out of scope — the selector already returns `live` behind the same gates, so landing it later is a renderer-only change.)

## What this adds

Butler Sheet Icons now decides, once at the start of each run, the richest output the terminal can honestly render:

- **The contact sheet (rung B, #1074)** — on a colour terminal ≥ 72 columns at the default log level: the 410 × 270 wordmark frame, the plan as bullet rows, one strip row per app streamed as it finishes (`█▓░▒` per sheet, `#:.!` on ASCII consoles), and a verdict with a glyph legend. Static, append-only colour written to stdout in one `write()` per block — no cursor addressing, nothing to interrupt.
- **Rung selection + `BSI_OUTPUT` (#1076)** — a pure, injectable `selectRung()` composing the existing `isColourEnabled()` / `isUnicodeCapable()` detectors. `off` and `plain` always win; `board` is a true force (recording escape hatch); `live` is a permission, not a force; unrecognised values warn and fall back rather than abort. Any log level other than `info` drops to the plain card — verbose+ is a debugging stream, warn/error asked for quiet. `TERM=dumb` hard-gates the live rung independently of `FORCE_COLOR`, per the prototype findings on #1076.
- The plain run card keeps flowing through winston for schedulers and redirected logs; on the board rung the equivalent plain blocks are logged with the console transport silenced, so the terminal sees one set of facts and any future file transport still gets the card. The board renders exclusively from the `RunReport` object — same facts as the card and the dry run, by construction.
- Strip glyphs and board furniture are `symbols.js` Unicode/ASCII pairs (equal width per pair, nothing Extended_Pictographic), so `BSI_ASCII_ONLY` covers the board for free.
- A doc-site page is staged in `docs/to-doc-site/` (sample generated from the real renderer; version gate placeholder per that folder's workflow).

## How it was verified

- Full gate-matrix table tests with injected streams/env, including the 71/72 and 79/80 column boundaries and 23/24 rows; every environment-dependent test injects its environment.
- Property tests: both symbol sets produce equal-width strips per app; the colour render differs from the colour-off render only by ANSI codes; app rows fit the 72-column gate in the worst admitted case (ASCII markers + removal vocabulary); NFC and NFD Korean names pad identically.
- Two review passes: a max-effort pass on the feature commits (15 findings, all fixed) and a high-effort pass on the fix commits (10 findings, all fixed) — among them a warn/error quiet-run regression, positional strip placement, removal-vocabulary conflation, and a decorative REST read that could fail an app on the destructive command.
- Live checks against a QSEoW lab server: dry runs rendered as a board from real facts (9 sheets incl. one hub-hidden, skip reasons correct), with before/after QRS snapshots of sheet objects and content-library references byte-identical — the board path writes nothing on a dry run. Real-run verdict/strip behaviour exercised by the unit suites.
- 114 suites / 3,135 tests green, lint clean.

## Notes for review

- The run header moved from the command handlers into the three run workers: the wizard invokes workers directly, and the header must be decided from the options the run actually uses (wizard answers included). The decided rung is threaded explicitly through `announceDryRun` and `runOverAppsWithReport`, which now require it — forgetting the threading fails loudly instead of diverging silently.
- `BSI_OUTPUT=off` suppresses the framed plan/verdict blocks on real runs only; a dry run's plan block is part of its product and always prints.
- The QSEoW `remove-sheet-icons` twin is not touched: it has no CLI registration today (#894 tracks it, with migration notes for adopting this seam).

🤖 Generated with [Claude Code](https://claude.com/claude-code)