### PR TITLE
Add the live run view, the top rung of the output ladder

### DIFF
--- a/docs/to-doc-site/run-output-live-view.md
+++ b/docs/to-doc-site/run-output-live-view.md
@@ -1,0 +1,138 @@
+# Live run view: watching a thumbnail run as it happens
+
+> **Publisher note:** new page — it needs a sidebar entry in
+> `docs/.vitepress/config.js`, suggested next to the contact-sheet page it builds on
+> (`run-output-contact-sheet`). No generated CLI option tables are affected: this
+> feature adds no command-line option and no new environment variable — `live` was
+> already a documented `BSI_OUTPUT` value on the contact-sheet page, and that page's
+> "today it renders as the board" wording should be updated to point here. Establish
+> the version for the gate below from the open release-please PR title at publication
+> time, per this folder's README (it read 5.0.0 when this draft was written — re-check,
+> do not trust the draft). The samples below are taken from a real recorded run against
+> a lab server, with server and account names substituted — do not re-align them by
+> hand.
+
+::: warning Requires BSI X.Y.Z or later
+Earlier versions show the contact sheet in interactive terminals. The animated live
+view arrives in this version.
+:::
+
+When you run `qseow create-sheet-thumbnails` or `qscloud create-sheet-thumbnails` in an
+interactive terminal, Butler Sheet Icons now shows a **live view** of the run: each
+connection step resolves on screen as it actually completes, a progress bar follows the
+sheets of the app being processed, and the display collapses into the familiar verdict
+line when the run ends.
+
+A thumbnail run spends most of its time waiting — on a browser, on a login, on each
+sheet rendering. With `--pagewait` at its default of 5 seconds, a seven-app run is six
+minutes during which the only question that matters is *"is it alive, and how far in is
+it?"* The live view answers that at a glance, which the scrolling log lines never did.
+
+## What it looks like
+
+The run opens with the same wordmark frame as the contact sheet. The preflight steps
+then resolve one at a time, each with a spinner while its real work is in flight and a
+check mark when it has actually finished. The first three rows — certificates, content
+library, app list — appear before the `PLAN` block (the plan can only be stated once
+the app list is known); the browser and sign-in rows resolve below it, as the first
+app starts:
+
+```
+  ✓ certificates      client.pem · client_key.pem
+  ✓ content library   "Butler sheet thumbnails" exists
+  ✓ app list          3 apps · 1 named · 2 tagged
+  ✓ browser           chrome · from cache
+  ⠹ signed in
+```
+
+These rows are not an animation played over the log — each one is tied to the real
+operation behind it. The `certificates` row resolves when the certificate files have
+been read, `content library` when the Qlik Sense server has confirmed the library
+exists, `browser` when the browser has started **and answered its first command**, and
+`signed in` only once the login has completed and the app has loaded. If a run hangs,
+the row that never resolves tells you exactly which step it is stuck on — that is the
+main reason this view exists.
+
+While each app is processed, a progress bar follows its sheets, driven by the same
+per-sheet records the final summary is counted from:
+
+```
+  app 2/3  Executive KPIs · 9 sheets
+  ██████████████░░░░░░░░░░░░  5/9  'Sheet 4'
+  ░████
+```
+
+The short row of blocks under the bar is the app's **sheet strip** growing in real
+time, with the same meaning as on the contact sheet: `█` captured, `▓` blurred, `░`
+excluded by one of your rules. As each app finishes, its strip row is written
+permanently to the terminal, exactly as the contact sheet prints it:
+
+```
+  ✓ 1/3  Sales Discovery       ░████████     8/9 up        1m 8s
+```
+
+And at the end the animation stops, the cursor comes back, and the run closes with the
+verdict:
+
+```
+  ────────────────────────────────────────────────────────────────
+
+  ❯ done in 2m 21s  ·  3 app(s) ok  ·  24 thumbnails uploaded
+    █ 24 captured   ▓ 2 blurred   ░ 3 excluded
+    images in ./img/qseow · 48 file(s) · 2.5 MB
+```
+
+If the browser needs to be downloaded mid-run — the first run on a new machine, or
+after changing `--browser-version` — the download shows up as a
+`downloading browser 42%` label in the same display. There is no separate download
+progress bar fighting the live view for the terminal.
+
+Warnings and errors are not hidden by the animation: they are written permanently above
+it, in order, as they happen. An app that fails mid-run shows a red row in the list and
+is counted in the verdict, just as on the contact sheet.
+
+## When you get it — and when you deliberately do not
+
+The live view has the strictest requirements of Butler Sheet Icons' output styles,
+because a repainting display is only safe on a real terminal. You get it when **all**
+of these hold:
+
+- output goes to an interactive terminal (not a file, a pipe, or a scheduler),
+- the terminal is at least 80 characters wide and 24 rows tall, supports colour, and
+  is not `TERM=dumb`,
+- the log level is the default `info` — at `--log-level verbose` or `debug` you asked
+  to read log lines, and at `warn` or `error` you asked for quiet,
+- the browser runs headless (with `--headless false` a visible browser window is the
+  thing you chose to watch),
+- it is a real run, not `--dry-run` — a dry run finishes in seconds and its product is
+  the plan text.
+
+When a condition is not met, the output falls back to the **contact sheet** where the
+terminal can still render static colour, and otherwise to the **plain run card**. Two
+of the conditions skip the contact sheet entirely: any log level other than `info`,
+and a stream that is not an interactive terminal, both go straight to the plain run
+card — so redirected and scheduled output never contains a single repaint frame, and
+`docker logs`, cron mail and captured log files stay readable. `qscloud
+remove-sheet-icons` keeps the contact sheet: an icon removal run has no browser and no
+page waits, so there is nothing to watch.
+
+The `BSI_OUTPUT` environment variable works as documented on the contact-sheet page:
+`off`, `plain` and `board` are absolute and always honoured, and `BSI_OUTPUT=live`
+remains a *permission*, not a force — it can never point cursor animation at a stream
+that cannot render it.
+
+The view was verified on the oldest console Butler Sheet Icons supports: Windows
+Server 2019's conhost renders the in-place updates cleanly under both PowerShell 5.1
+and cmd.exe, so no special terminal is needed on Windows.
+
+## If the terminal ever looks wrong
+
+The live view restores the terminal — cursor visible, output back to normal — when a
+run completes, when it fails, and when Butler Sheet Icons crashes. One case is not yet
+covered: **stopping a run with Ctrl-C** (or killing the process any other way) ends it
+before the cleanup can run, and can leave the cursor invisible. The standard `reset`
+command restores the terminal; graceful Ctrl-C handling is planned separately.
+
+If your console renders the animation as garbage (an unusual terminal emulator, an
+over-SSH session with a broken `TERM`), set `BSI_OUTPUT=board` or `BSI_OUTPUT=plain`
+for that environment and the run will use the static styles instead.

--- a/src/lib/browser/__tests__/browser_install.test.js
+++ b/src/lib/browser/__tests__/browser_install.test.js
@@ -35,10 +35,23 @@ const { logger, sleep } = await import('../../../globals.js');
 
 // Stub the cli-progress SingleBar so the test does not write to a real TTY.
 /**
+ * Constructed FakeSingleBar count, for the live-view mutual exclusion tests:
+ * with a live view active the real code must never construct a bar at all.
+ */
+let singleBarInstances = 0;
+
+/**
  * Inert test double for the cli-progress SingleBar constructor. All methods
  * are no-ops so the install code can call start/update/stop freely.
  */
 class FakeSingleBar {
+    /**
+     * Record the construction - see {@link singleBarInstances}.
+     */
+    constructor() {
+        singleBarInstances += 1;
+    }
+
     /**
      * No-op stub for cli-progress SingleBar.start.
      *
@@ -67,6 +80,10 @@ jest.unstable_mockModule('cli-progress', () => ({
 }));
 
 const { browserInstall } = await import('../browser-install.js');
+// The real registry, not a mock: browser-install reads the active view
+// through it, and the mutual exclusion below is only proven if the very
+// same lookup path the product uses is exercised.
+const { activateLiveView, restoreLiveTerminal } = await import('../../util/run-live.js');
 
 // Ambient, and behaviour-affecting since the cache directory became configurable. Without
 // this, the retry assertion below fails on any machine whose shell happens to have
@@ -320,5 +337,53 @@ describe('browserInstall — retry logic', () => {
 
         // Cleanup runs before each retry, never after the final attempt.
         expect(uninstall).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe('browserInstall — live view mutual exclusion (issue #1075)', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        singleBarInstances = 0;
+        delete process.env.BSI_BROWSER_CACHE_DIR;
+        delete process.env.PUPPETEER_CACHE_DIR;
+        detectBrowserPlatform.mockResolvedValue('mac_arm');
+        canDownload.mockResolvedValue(true);
+        resolveBuildId.mockResolvedValue('123.0.0.0');
+    });
+
+    afterEach(() => {
+        restoreLiveTerminal();
+    });
+
+    test('with a live view active, no cli-progress bar is ever constructed and progress routes into the view', async () => {
+        const view = { downloadProgress: jest.fn(), stop: jest.fn() };
+        activateLiveView(view);
+
+        install.mockImplementation((opts) => {
+            // The download reports progress mid-install, exactly where the
+            // two writers would have collided.
+            opts.downloadProgressCallback(50, 100);
+
+            return { browser: 'chrome', buildId: '123.0.0.0', executablePath: '/p/chrome' };
+        });
+
+        await browserInstall({ browser: 'chrome', browserVersion: '123.0.0.0', loglevel: 'error' });
+
+        expect(singleBarInstances).toBe(0);
+        // start (0), the 50% update, the install code's final update(100),
+        // stop (null): the whole bar lifecycle went through the view instead.
+        expect(view.downloadProgress.mock.calls).toEqual([[0], [50], [100], [null]]);
+    });
+
+    test('without a live view the cli-progress bar is used, exactly as before', async () => {
+        install.mockResolvedValue({
+            browser: 'chrome',
+            buildId: '123.0.0.0',
+            executablePath: '/p/chrome',
+        });
+
+        await browserInstall({ browser: 'chrome', browserVersion: '123.0.0.0', loglevel: 'error' });
+
+        expect(singleBarInstances).toBe(1);
     });
 });

--- a/src/lib/browser/browser-install.js
+++ b/src/lib/browser/browser-install.js
@@ -8,6 +8,7 @@ import {
 } from './browser-paths.js';
 import { getBrowserInventory, hasUsableExecutable } from './browser-inventory.js';
 import cliProgress from 'cli-progress';
+import { activeLiveView, liveDownloadBar } from '../util/run-live.js';
 
 import { logger, setLoggingLevel, bsiExecutablePath, isSea, sleep } from '../../globals.js';
 import { redactOptions } from '../util/redact-secrets.js';
@@ -167,13 +168,22 @@ export const browserInstall = async (options, _command, resolvedBuildId) => {
         logger.debug(`BSI executable path: ${bsiExecutablePath}`);
         logger.debug(`Options: ${JSON.stringify(redactOptions(options), null, 2)}`);
 
-        // Create a new progress bar instance using cli-progress
-        const progressBar = new cliProgress.SingleBar(
-            {
-                format: ' {bar} {percentage}% | ETA: {eta_formatted}',
-            },
-            cliProgress.Presets.shades_classic
-        );
+        // The download progress bar. Two writers repainting one cursor is
+        // mojibake, so while the live run view (issue #1075) is active the
+        // cli-progress bar is never constructed - the download reports into
+        // the live view's phase label instead, and the two can never be
+        // active at once. `activeLiveView()` is read once here: the view
+        // starts before the app loop and stops after it, so it cannot appear
+        // or vanish while this install runs.
+        const live = activeLiveView();
+        const progressBar = live
+            ? liveDownloadBar(live)
+            : new cliProgress.SingleBar(
+                  {
+                      format: ' {bar} {percentage}% | ETA: {eta_formatted}',
+                  },
+                  cliProgress.Presets.shades_classic
+              );
 
         // Install browser. The writing resolver, so a standalone build reading from the
         // previous default location still installs beside its own executable.

--- a/src/lib/browser/browser-launch.js
+++ b/src/lib/browser/browser-launch.js
@@ -16,6 +16,7 @@ import {
     VERSION_RECOMMENDED,
 } from './browser-version.js';
 import { parseHeadlessOption } from '../util/headless-option.js';
+import { activeLiveView } from '../util/run-live.js';
 import { markReported } from '../util/reported-error.js';
 import { logError } from '../util/log-error.js';
 
@@ -391,6 +392,12 @@ const reportSlowLaunch = (elapsedMs, logPrefix, { timedOut = false } = {}) => {
  * launched, with the original error attached as `cause`.
  */
 export const launchBrowserForApp = async (options, { appId, logPrefix, appLabel, ErrorClass }) => {
+    // The live `browser` row (issue #1075) is bound to this resolve-and-launch
+    // sequence. Living here rather than in the processors keeps the two
+    // platform twins wired identically by construction. No-op off rung C.
+    activeLiveView()?.beginStep('browser');
+    activeLiveView()?.appPhase('browser');
+
     let browserInfo;
     try {
         browserInfo = await resolveBrowserExecutablePath(options);
@@ -480,6 +487,16 @@ export const launchBrowserForApp = async (options, { appId, logPrefix, appLabel,
     try {
         const version = await browser.version();
         logger.verbose(`Browser responded to version query: ${version}`);
+
+        // Resolved only now: the browser is not just found and started but
+        // has answered a protocol call - the same bar the launch itself sets.
+        const live = activeLiveView();
+        live?.stepDone(
+            'browser',
+            [`${browserInfo.browser} ${browserInfo.buildId}`, `from ${browserInfo.source}`].join(
+                live.sep
+            )
+        );
     } catch (err) {
         logUnusableBrowser(buildId, logPrefix, err);
 

--- a/src/lib/cloud/cloud-create-thumbnails.js
+++ b/src/lib/cloud/cloud-create-thumbnails.js
@@ -9,10 +9,12 @@ import {
     runOverAppsWithReport,
     announceDryRun,
     emitRunHeader,
+    startLiveRunView,
     buildSheetRules,
     buildSheetPartSection,
     buildBrowserPlanSection,
 } from '../util/run-report.js';
+import { restoreLiveTerminal } from '../util/run-live.js';
 import { CLOUD_SHEET_PARTS, CLOUD_SHEET_PART_LABELS } from './sheet-parts.js';
 import { logError } from '../util/log-error.js';
 
@@ -59,6 +61,10 @@ export const qscloudCreateThumbnails = async (options) => {
             // Before anything connects - mirrors the QSEoW twin.
             announceDryRun('qscloud create-sheet-thumbnails', rung);
         }
+
+        // The live view (rung C, issue #1075) - wired at the same time as the
+        // QSEoW twin, with the platform's own preflight sequence.
+        const live = startLiveRunView({ rung, dryRun });
 
         logger.info('Starting creation of thumbnails for Qlik Sense Cloud');
         logger.verbose(`Running as standalone app: ${isSea}`);
@@ -108,13 +114,21 @@ export const qscloudCreateThumbnails = async (options) => {
         };
         const saasInstance = new QlikSaas(cloudConfig);
 
-        // Test connection to QS Cloud by getting info about the user associated with the API key
+        // Test connection to QS Cloud by getting info about the user associated with the API key.
+        // The live row is bound to this await - the Cloud twin of the QSEoW
+        // certificate/library rows.
+        live?.beginStep('tenant', options.tenanturl);
         try {
             const res = await qscloudTestConnection(options, saasInstance);
+            live?.stepDone('tenant', options.tenanturl);
             logger.verbose(
                 `Connection to tenant ${options.tenanturl} successful: ${JSON.stringify(res)}`
             );
         } catch (err) {
+            // Restore before the error lines so they land on a sane terminal;
+            // this branch returns without reaching the outer catch.
+            live?.stepFailed('tenant', options.tenanturl);
+            restoreLiveTerminal();
             logError('TEST CONNECTIVITY 1', err);
             if (err?.status && err?.statusText) {
                 logger.error(`TEST CONNECTIVITY 1 (error code): ${err.status}="${err.statusText}"`);
@@ -125,7 +139,18 @@ export const qscloudCreateThumbnails = async (options) => {
 
         // Selection resolution is shared with the other Cloud command; the
         // provenance it returns feeds the run report directly.
+        live?.beginStep('app list');
         const selection = await resolveCloudAppSelection(saasInstance, options);
+        live?.stepDone(
+            'app list',
+            [
+                `${new Set(selection.appIds).size} apps`,
+                `${selection.namedAppIds.length} named`,
+                ...(selection.selector
+                    ? [`${selection.selectorAppIds.length} from collection`]
+                    : []),
+            ].join(live.sep)
+        );
 
         return await runOverAppsWithReport({
             command: 'qscloud create-sheet-thumbnails',
@@ -153,6 +178,10 @@ export const qscloudCreateThumbnails = async (options) => {
             processApp: (appId, report) => processCloudApp(appId, saasInstance, options, report),
         });
     } catch (err) {
+        // First, unconditionally: a throw mid-animation must hand the cursor
+        // and the console transport back before anything else is logged.
+        restoreLiveTerminal();
+
         logError('CLOUD CREATE THUMBNAILS 2', err);
 
         return false;

--- a/src/lib/cloud/process-cloud-app.js
+++ b/src/lib/cloud/process-cloud-app.js
@@ -15,6 +15,7 @@ import {
 } from '../util/sheet-list.js';
 import { withEngineSession } from '../util/engine-session.js';
 import { createAppImageDir } from '../util/image-dir.js';
+import { activeLiveView } from '../util/run-live.js';
 import { determineSheetExcludeStatus } from './determine-sheet-exclude-status.js';
 import { determineSheetBlurStatus } from './determine-sheet-blur-status.js';
 import { addAppToReport, recordPlannedSheet, recordAppOutcome } from '../util/run-report.js';
@@ -151,6 +152,11 @@ export const processCloudApp = async (appId, saasInstance, options, report = nul
                     });
 
                     try {
+                        // The live `signed in` row (issue #1075) is bound to
+                        // the real login below - mirrors the QSEoW twin.
+                        activeLiveView()?.beginStep('signed in');
+                        activeLiveView()?.appPhase('signin');
+
                         const page = await browser.newPage();
                         // Thumbnails should be 410x270 pixels, so set the viewport to a multiple of this.
                         await page.setViewport({
@@ -177,6 +183,7 @@ export const processCloudApp = async (appId, saasInstance, options, report = nul
                         // run-together spelling gave `undefined`, so this branch was unreachable
                         // and login was always attempted - see issue #890.
                         if (options.skipLogin === true) {
+                            activeLiveView()?.stepDone('signed in', 'skipped (--skip-login)');
                             logger.info('Skipping login as --skip-login is set to true');
                         } else {
                             // Enter credentials
@@ -208,7 +215,12 @@ export const processCloudApp = async (appId, saasInstance, options, report = nul
                                 }),
                             ]);
                             await sleep(options.pagewait * 1000);
+
+                            // Only now is the session real: the login click
+                            // has navigated and the page has settled.
+                            activeLiveView()?.stepDone('signed in', options.logonuserid ?? '');
                         }
+                        activeLiveView()?.appPhase('sheets');
                         // Take screenshot of app overview page
                         await page.screenshot({ path: `${imgDir}/cloud/${appId}/overview-1.png` });
                         // Sort sheets

--- a/src/lib/commands/run-command.js
+++ b/src/lib/commands/run-command.js
@@ -1,5 +1,6 @@
 import { logger } from '../../globals.js';
 import { logError } from '../util/log-error.js';
+import { restoreLiveTerminal } from '../util/run-live.js';
 
 /**
  * Runs a command implementation on behalf of a Commander action handler, and makes its
@@ -47,5 +48,12 @@ export const runCommand = async (logPrefix, run, onError) => {
         logError(logPrefix, err);
 
         return false;
+    } finally {
+        // The completion half of the live view's terminal-restore hook
+        // (issue #1075): whatever the command did or threw, the cursor and
+        // the console transport are back before control returns to the
+        // shell. A no-op for every command that never started a live view;
+        // the crash half lives in installFatalHandlers.
+        restoreLiveTerminal();
     }
 };

--- a/src/lib/qseow/qseow-create-thumbnails.js
+++ b/src/lib/qseow/qseow-create-thumbnails.js
@@ -1,5 +1,8 @@
+import path from 'node:path';
+
 import { logger, appVersion, setLoggingLevel, bsiExecutablePath, isSea } from '../../globals.js';
 import { redactOptions } from '../util/redact-secrets.js';
+import { restoreLiveTerminal } from '../util/run-live.js';
 import { qseowVerifyContentLibraryExists } from './qseow-contentlibrary.js';
 import { qseowVerifyCertificatesExist } from './qseow-certificates.js';
 import { qseowProcessApp } from './qseow-process-app.js';
@@ -13,6 +16,7 @@ import {
     runOverAppsWithReport,
     announceDryRun,
     emitRunHeader,
+    startLiveRunView,
     buildSheetRules,
     buildSheetPartSection,
     buildBrowserPlanSection,
@@ -60,6 +64,11 @@ export const qseowCreateThumbnails = async (options) => {
             announceDryRun('qseow create-sheet-thumbnails', rung);
         }
 
+        // The live view (rung C, issue #1075). Null on every other rung and
+        // on dry runs; every use below is optional-chained so this worker
+        // reads identically with and without it.
+        const live = startLiveRunView({ rung, dryRun });
+
         logger.info('Starting creation of thumbnails for Qlik Sense Enterprise on Windows (QSEoW)');
         logger.verbose(`Running as standalone app: ${isSea}`);
         logger.debug(`BSI executable path: ${bsiExecutablePath}`);
@@ -83,21 +92,32 @@ export const qseowCreateThumbnails = async (options) => {
             throw Error('Invalid --includesheetpart paramater');
         }
 
-        // Verify QSEoW certificates exist
+        // Verify QSEoW certificates exist. The live rows here and below are
+        // bound to these awaits - each resolves only when its real call has
+        // returned, so a hang shows as the row that never resolves.
+        live?.beginStep('certificates');
         const certsExist = await qseowVerifyCertificatesExist(options);
         if (certsExist === false) {
+            live?.stepFailed('certificates');
             logger.error('Missing certificate file(s). Aborting');
             throw Error('Missing certificate file(s)');
         } else {
+            live?.stepDone(
+                'certificates',
+                [path.basename(options.certfile), path.basename(options.certkeyfile)].join(live.sep)
+            );
             logger.verbose(`Certificate files found`);
         }
 
         // Verify content library exists
+        live?.beginStep('content library');
         const contentLibraryExists = await qseowVerifyContentLibraryExists(options);
         if (contentLibraryExists === false) {
+            live?.stepFailed('content library', `"${options.contentlibrary}"`);
             logger.error(`Content library '${options.contentlibrary}' does not exist - aborting`);
             throw Error('Content library does not exist');
         } else {
+            live?.stepDone('content library', `"${options.contentlibrary}" exists`);
             logger.verbose(`Content library '${options.contentlibrary}' exists`);
         }
 
@@ -108,6 +128,7 @@ export const qseowCreateThumbnails = async (options) => {
         // --appid and --qliksensetag are additive, not alternatives: apps named either
         // way are all processed. runOverApps() dedupes, so an app that is both named by
         // --appid and carries the tag is still processed once.
+        live?.beginStep('app list');
         let taggedAppIds = [];
         const useTag = Boolean(options.qliksensetag && options.qliksensetag.length > 0);
         if (useTag) {
@@ -122,6 +143,17 @@ export const qseowCreateThumbnails = async (options) => {
         // rules' match counts across the selected apps. Read-only, and
         // degrades to nulls rather than failing the run.
         const planFacts = await readQseowPlanFacts(options, appIdsToProcess);
+
+        // Resolved only now, after every pre-run read: the row states what the
+        // loop will actually iterate, not an intermediate list.
+        live?.stepDone(
+            'app list',
+            [
+                `${new Set(appIdsToProcess).size} apps`,
+                `${namedAppIds.length} named`,
+                ...(useTag ? [`${taggedAppIds.length} tagged`] : []),
+            ].join(live.sep)
+        );
 
         return await runOverAppsWithReport({
             command: 'qseow create-sheet-thumbnails',
@@ -167,6 +199,11 @@ export const qseowCreateThumbnails = async (options) => {
             processApp: (appId, report) => qseowProcessApp(appId, options, report),
         });
     } catch (err) {
+        // First, unconditionally: a throw mid-animation must hand the cursor
+        // and the console transport back before anything else is logged.
+        // No-op when no live view is active.
+        restoreLiveTerminal();
+
         logError('QSEOW CREATE THUMBNAILS 2', err);
 
         return false;

--- a/src/lib/qseow/qseow-process-app.js
+++ b/src/lib/qseow/qseow-process-app.js
@@ -16,6 +16,7 @@ import {
 } from '../util/sheet-list.js';
 import { withEngineSession } from '../util/engine-session.js';
 import { createAppImageDir } from '../util/image-dir.js';
+import { activeLiveView } from '../util/run-live.js';
 import { addAppToReport, recordPlannedSheet, recordAppOutcome } from '../util/run-report.js';
 import { appProgressLine, sheetProgressLine } from '../util/run-report-render.js';
 import { QSEOW_SHEET_PART_SELECTORS } from './sheet-parts.js';
@@ -149,6 +150,12 @@ export const qseowProcessApp = async (appId, options, report = null) => {
                     });
 
                     try {
+                        // The live `signed in` row (issue #1075) is bound to
+                        // the real login below: it begins here and resolves
+                        // only once the post-login navigation has settled.
+                        activeLiveView()?.beginStep('signed in');
+                        activeLiveView()?.appPhase('signin');
+
                         const page = await browser.newPage();
 
                         // Thumbnails should be 410x270 pixels, so set the viewport to a multiple of this.
@@ -235,6 +242,14 @@ export const qseowProcessApp = async (appId, options, report = null) => {
                         ]);
 
                         await sleep(options.pagewait * 1000);
+
+                        // Only now is the session real: the login click has
+                        // navigated and the page has settled.
+                        activeLiveView()?.stepDone(
+                            'signed in',
+                            `${options.logonuserdir}\\${options.logonuserid}`
+                        );
+                        activeLiveView()?.appPhase('sheets');
 
                         // Take screenshot of app overview page
                         await page.screenshot({ path: `${imgDir}/qseow/${appId}/overview-1.png` });

--- a/src/lib/util/__tests__/fatal-handlers.test.js
+++ b/src/lib/util/__tests__/fatal-handlers.test.js
@@ -140,6 +140,60 @@ describe('happy path', () => {
         expect(logger.error).toHaveBeenCalledTimes(1);
         expect(logger.error).toHaveBeenCalledWith('FATAL: Unhandled promise rejection: the reason');
     });
+
+    test('restores the terminal before the FATAL line is logged (issue #1075)', async () => {
+        // Order matters: while the live view is active the console transport
+        // is silenced, so a FATAL line logged before the restore would be
+        // invisible - on exactly the run whose crash the operator most needs
+        // to see.
+        const restoreTerminal = jest.fn();
+        install({ writeCrashDump: jest.fn().mockResolvedValue(undefined), restoreTerminal });
+
+        target.emit('uncaughtException', new Error('boom'));
+        await flush();
+
+        expect(restoreTerminal).toHaveBeenCalledTimes(1);
+        expect(restoreTerminal.mock.invocationCallOrder[0]).toBeLessThan(
+            logger.error.mock.invocationCallOrder[0]
+        );
+    });
+
+    test('the exit watchdog is armed before the terminal restore runs', async () => {
+        // The restore writes to the TTY and could stall; the #946 rule is
+        // that the watchdog is armed before anything else on the fatal path,
+        // so an async stall in the restore is still bounded.
+        const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+        let timersWhenRestoreRan = null;
+        install({
+            writeCrashDump: jest.fn().mockResolvedValue(undefined),
+            restoreTerminal: jest.fn(() => {
+                timersWhenRestoreRan = setTimeoutSpy.mock.calls.length;
+            }),
+        });
+        setTimeoutSpy.mockClear();
+
+        target.emit('uncaughtException', new Error('boom'));
+        await flush();
+
+        expect(timersWhenRestoreRan).toBeGreaterThanOrEqual(1);
+        setTimeoutSpy.mockRestore();
+    });
+
+    test('a throwing terminal restore does not stop the crash dump', async () => {
+        const writeCrashDump = jest.fn().mockResolvedValue(undefined);
+        install({
+            writeCrashDump,
+            restoreTerminal: jest.fn(() => {
+                throw new Error('restore failed');
+            }),
+        });
+
+        target.emit('uncaughtException', new Error('boom'));
+        await flush();
+
+        expect(writeCrashDump).toHaveBeenCalledTimes(1);
+        expect(exit).toHaveBeenCalledWith(1);
+    });
 });
 
 describe('a failing crash dump cannot re-enter the handler (issue #946)', () => {
@@ -468,6 +522,23 @@ describe('output pipe closing is not a crash (issue #1019)', () => {
 
             expect(writeCrashDump).not.toHaveBeenCalled();
             expect(exit).toHaveBeenCalledTimes(1);
+            expect(exit).toHaveBeenCalledWith(BROKEN_PIPE_EXIT_CODE);
+        });
+
+        test('the terminal is restored before a broken-pipe exit (issue #1075)', async () => {
+            // stderr's reader going away must not strand a hidden cursor on
+            // a stdout that is still a live TTY - the broken-pipe path is an
+            // exit path like any other for the terminal-restore hook.
+            const restoreTerminal = jest.fn();
+            install({ writeCrashDump: jest.fn().mockResolvedValue(undefined), restoreTerminal });
+
+            stderr.emit('error', brokenPipeError());
+            await flush();
+
+            expect(restoreTerminal).toHaveBeenCalledTimes(1);
+            expect(restoreTerminal.mock.invocationCallOrder[0]).toBeLessThan(
+                exit.mock.invocationCallOrder[0]
+            );
             expect(exit).toHaveBeenCalledWith(BROKEN_PIPE_EXIT_CODE);
         });
 

--- a/src/lib/util/__tests__/run-live.test.js
+++ b/src/lib/util/__tests__/run-live.test.js
@@ -1,0 +1,504 @@
+import { describe, test, expect, afterEach, jest } from '@jest/globals';
+import winston from 'winston';
+import { createPalette } from '../colour.js';
+import { UNICODE_SYMBOLS, ASCII_SYMBOLS } from '../../interactive/symbols.js';
+import {
+    createRunLiveView,
+    activateLiveView,
+    activeLiveView,
+    restoreLiveTerminal,
+    liveDownloadBar,
+} from '../run-live.js';
+
+/**
+ * Tests for the live run view (rung C, issue #1075).
+ *
+ * Everything is injected - stream, palette, symbols, timer, logger - so the
+ * assertions run identically on every CI runner regardless of what its
+ * console claims to support. The stream is a fake TTY with fixed dimensions;
+ * frames are the individual `write` calls it records.
+ */
+
+const ESC = String.fromCharCode(27);
+const SHOW_CURSOR = `${ESC}[?25h`;
+const HIDE_CURSOR = `${ESC}[?25l`;
+
+/**
+ * Strips every CSI sequence - colours and cursor movement alike.
+ *
+ * @param {string} text - Text possibly containing ANSI sequences.
+ *
+ * @returns {string} The text without them.
+ */
+const stripAnsi = (text) => text.replaceAll(new RegExp(`${ESC}\\[[0-9;?]*[A-Za-z]`, 'g'), '');
+
+/**
+ * A fake TTY stream that records each write as one frame.
+ *
+ * @param {object} [overrides] - Stream property overrides.
+ *
+ * @returns {{stream: object, writes: string[]}} The stream and its recording.
+ */
+const fakeTty = (overrides = {}) => {
+    const writes = [];
+
+    return {
+        writes,
+        stream: {
+            isTTY: true,
+            columns: 100,
+            rows: 40,
+            write: (chunk) => {
+                writes.push(String(chunk));
+
+                return true;
+            },
+            ...overrides,
+        },
+    };
+};
+
+/**
+ * A manually driven frame timer, so spinner ticks happen exactly when the
+ * test says so.
+ *
+ * @returns {{start: Function, stop: Function, tick: Function, stopped: boolean}} The timer.
+ */
+const manualTimer = () => {
+    const timer = {
+        fn: null,
+        stopped: false,
+        /**
+         * Record the tick function instead of scheduling it.
+         *
+         * @param {Function} fn - Tick function.
+         *
+         * @returns {void}
+         */
+        start(fn) {
+            timer.fn = fn;
+        },
+        /**
+         * Mark the timer stopped.
+         *
+         * @returns {void}
+         */
+        stop() {
+            timer.stopped = true;
+        },
+        /**
+         * Run one tick.
+         *
+         * @returns {void}
+         */
+        tick() {
+            timer.fn?.();
+        },
+    };
+
+    return timer;
+};
+
+const uniCtx = () => ({ palette: createPalette(false), symbols: UNICODE_SYMBOLS });
+const asciiCtx = () => ({ palette: createPalette(false), symbols: ASCII_SYMBOLS });
+
+/**
+ * A minimal report app entry of the shape `addAppToReport` produces.
+ *
+ * @param {object} [overrides] - Field overrides.
+ *
+ * @returns {object} The entry.
+ */
+const appEntry = (overrides = {}) => ({
+    id: 'app-1',
+    name: 'Executive KPIs',
+    sheetCount: 3,
+    sheets: [],
+    failed: false,
+    ...overrides,
+});
+
+afterEach(() => {
+    // No test may leave a view in the process-wide registry.
+    restoreLiveTerminal();
+});
+
+describe('the docker-logs regression gate', () => {
+    test('a non-TTY stream gets no view and no frames, whatever the rung said', () => {
+        const { stream, writes } = fakeTty({ isTTY: false });
+
+        const view = createRunLiveView({ stream, ctx: uniCtx(), timer: manualTimer() });
+
+        expect(view).toBeNull();
+        expect(writes).toHaveLength(0);
+    });
+
+    test('a missing stream gets no view rather than a crash', () => {
+        expect(createRunLiveView({ stream: undefined, ctx: uniCtx() })).toBeNull();
+    });
+});
+
+describe('frames on a real TTY', () => {
+    test('starting hides the cursor before anything else is written', () => {
+        const { stream, writes } = fakeTty();
+
+        createRunLiveView({ stream, ctx: uniCtx(), timer: manualTimer() });
+
+        expect(writes[0]).toBe(HIDE_CURSOR);
+    });
+
+    test('a preflight step animates, then commits with the done glyph and its detail', () => {
+        const { stream, writes } = fakeTty();
+        const view = createRunLiveView({ stream, ctx: uniCtx(), timer: manualTimer() });
+
+        view.beginStep('certificates');
+        expect(writes.at(-1)).toContain('certificates');
+        expect(writes.at(-1)).toContain(UNICODE_SYMBOLS.spinnerFrames[0]);
+
+        view.stepDone('certificates', 'client.pem');
+        const committed = writes.at(-1);
+        expect(committed).toContain(UNICODE_SYMBOLS.done);
+        expect(committed).toContain('certificates');
+        expect(committed).toContain('client.pem');
+    });
+
+    test('the spinner advances on timer ticks between events', () => {
+        const { stream, writes } = fakeTty();
+        const timer = manualTimer();
+        const view = createRunLiveView({ stream, ctx: uniCtx(), timer });
+
+        view.beginStep('app list');
+        const before = writes.at(-1);
+        timer.tick();
+        const after = writes.at(-1);
+
+        expect(before).toContain(UNICODE_SYMBOLS.spinnerFrames[0]);
+        expect(after).toContain(UNICODE_SYMBOLS.spinnerFrames[1]);
+        expect(after).not.toBe(before);
+    });
+
+    test('a step that failed commits with the failed glyph', () => {
+        const { stream, writes } = fakeTty();
+        const view = createRunLiveView({ stream, ctx: uniCtx(), timer: manualTimer() });
+
+        view.beginStep('content library');
+        view.stepFailed('content library', '"missing"');
+
+        expect(writes.at(-1)).toContain(UNICODE_SYMBOLS.failed);
+        expect(writes.at(-1)).toContain('"missing"');
+    });
+
+    test('a committed step never re-animates - later begin/done calls for it are no-ops', () => {
+        const { stream, writes } = fakeTty();
+        const view = createRunLiveView({ stream, ctx: uniCtx(), timer: manualTimer() });
+
+        view.beginStep('browser');
+        view.stepDone('browser', 'chrome 131');
+        const frameCount = writes.length;
+
+        view.beginStep('browser');
+        view.stepDone('browser', 'chrome 132');
+
+        expect(writes).toHaveLength(frameCount);
+    });
+});
+
+describe('the per-app block', () => {
+    test('renders the id, then the name and sheet count once the entry is attached', () => {
+        const { stream, writes } = fakeTty();
+        const view = createRunLiveView({ stream, ctx: uniCtx(), timer: manualTimer() });
+
+        view.appStarted({ n: 1, total: 2, id: 'app-1' });
+        expect(stripAnsi(writes.at(-1))).toContain('app 1/2');
+        expect(stripAnsi(writes.at(-1))).toContain('app-1');
+
+        view.appOpened(appEntry());
+        expect(stripAnsi(writes.at(-1))).toContain('Executive KPIs');
+        expect(stripAnsi(writes.at(-1))).toContain('3 sheets');
+    });
+
+    test('shows the phase labels before the sheet loop starts', () => {
+        const { stream, writes } = fakeTty();
+        const view = createRunLiveView({ stream, ctx: uniCtx(), timer: manualTimer() });
+
+        view.appStarted({ n: 1, total: 1, id: 'app-1' });
+        expect(stripAnsi(writes.at(-1))).toContain('opening app');
+
+        view.appOpened(appEntry());
+        view.appPhase('browser');
+        expect(stripAnsi(writes.at(-1))).toContain('launching browser');
+
+        view.appPhase('signin');
+        expect(stripAnsi(writes.at(-1))).toContain('signing in');
+    });
+
+    test('the bar and strip render from the entry the verdict counts from', () => {
+        const { stream, writes } = fakeTty();
+        const view = createRunLiveView({ stream, ctx: uniCtx(), timer: manualTimer() });
+        const entry = appEntry();
+
+        view.appStarted({ n: 1, total: 1, id: 'app-1' });
+        view.appOpened(entry);
+        view.appPhase('sheets');
+
+        entry.sheets.push({ n: 1, title: 'Overview', action: 'update', reason: null });
+        view.sheetRecorded(entry);
+        entry.sheets.push({ n: 2, title: 'Board pack', action: 'blur', reason: null });
+        view.sheetRecorded(entry);
+
+        const frame = stripAnsi(writes.at(-1));
+        expect(frame).toContain('2/3');
+        expect(frame).toContain("'Board pack'");
+        // The in-progress strip stops at the last recorded position: the
+        // unreached third sheet is the future, not a failure.
+        expect(frame).toContain(`${UNICODE_SYMBOLS.stripCaptured}${UNICODE_SYMBOLS.stripBlurred}`);
+        expect(frame).not.toContain(UNICODE_SYMBOLS.stripFailed);
+    });
+
+    test('the in-progress strip is capped at the terminal width so it can never wrap', () => {
+        // A wrapped region line breaks the cursor-up erase arithmetic for
+        // every following frame - the docker-logs regression's interactive
+        // cousin. 80 columns is the narrowest terminal the live rung admits.
+        const { stream, writes } = fakeTty({ columns: 80 });
+        const view = createRunLiveView({ stream, ctx: uniCtx(), timer: manualTimer() });
+        const entry = appEntry({ sheetCount: 100 });
+
+        view.appStarted({ n: 1, total: 1, id: 'app-1' });
+        view.appOpened(entry);
+        view.appPhase('sheets');
+        for (let n = 1; n <= 90; n += 1) {
+            entry.sheets.push({ n, title: `S${n}`, action: 'update', reason: null });
+        }
+        view.sheetRecorded(entry);
+
+        const longest = Math.max(
+            ...stripAnsi(writes.at(-1))
+                .split('\n')
+                .map((line) => line.length)
+        );
+        expect(longest).toBeLessThan(80);
+    });
+
+    test('an interior gap in the recorded sheets keeps the failed glyph mid-run', () => {
+        const { stream, writes } = fakeTty();
+        const view = createRunLiveView({ stream, ctx: uniCtx(), timer: manualTimer() });
+        const entry = appEntry();
+
+        view.appStarted({ n: 1, total: 1, id: 'app-1' });
+        view.appOpened(entry);
+        view.appPhase('sheets');
+
+        // Sheet 2 never recorded - the loop survived a mid-app failure.
+        entry.sheets.push({ n: 1, title: 'One', action: 'update', reason: null });
+        entry.sheets.push({ n: 3, title: 'Three', action: 'update', reason: null });
+        view.sheetRecorded(entry);
+
+        expect(stripAnsi(writes.at(-1))).toContain(
+            `${UNICODE_SYMBOLS.stripCaptured}${UNICODE_SYMBOLS.stripFailed}${UNICODE_SYMBOLS.stripCaptured}`
+        );
+    });
+
+    test('finishing an app commits its board row and clears the block', () => {
+        const { stream, writes } = fakeTty();
+        const view = createRunLiveView({ stream, ctx: uniCtx(), timer: manualTimer() });
+        const entry = appEntry();
+
+        view.appStarted({ n: 1, total: 1, id: 'app-1' });
+        view.appOpened(entry);
+        view.appFinished(entry, 'BOARD APP ROW\n');
+
+        const last = writes.at(-1);
+        expect(last).toContain('BOARD APP ROW');
+        // The region is empty after the commit: nothing re-painted below it.
+        expect(last.endsWith('BOARD APP ROW\n')).toBe(true);
+    });
+
+    test('a failed app commits the still-pending step as failed instead of leaving it spinning', () => {
+        const { stream, writes } = fakeTty();
+        const view = createRunLiveView({ stream, ctx: uniCtx(), timer: manualTimer() });
+        const entry = appEntry({ failed: true });
+
+        view.appStarted({ n: 1, total: 1, id: 'app-1' });
+        view.beginStep('signed in');
+        view.appFinished(entry, 'FAILED ROW\n');
+
+        const joined = writes.join('');
+        expect(joined).toContain(`${UNICODE_SYMBOLS.failed} signed in`);
+        expect(joined).toContain('FAILED ROW');
+    });
+});
+
+describe('download progress (the two-writers hazard)', () => {
+    test('replaces the phase label while a download is reported, and clears after', () => {
+        const { stream, writes } = fakeTty();
+        const view = createRunLiveView({ stream, ctx: uniCtx(), timer: manualTimer() });
+
+        view.appStarted({ n: 1, total: 1, id: 'app-1' });
+        view.appPhase('browser');
+        view.downloadProgress(42);
+        expect(stripAnsi(writes.at(-1))).toContain('downloading browser 42%');
+
+        view.downloadProgress(null);
+        expect(stripAnsi(writes.at(-1))).toContain('launching browser');
+    });
+
+    test('shows the percentage on a pending browser preflight row too', () => {
+        const { stream, writes } = fakeTty();
+        const view = createRunLiveView({ stream, ctx: uniCtx(), timer: manualTimer() });
+
+        view.beginStep('browser');
+        view.downloadProgress(97.4);
+
+        expect(stripAnsi(writes.at(-1))).toContain('downloading 97%');
+    });
+
+    test('liveDownloadBar adapts the cli-progress surface onto the view', () => {
+        const view = { downloadProgress: jest.fn() };
+        const bar = liveDownloadBar(view);
+
+        bar.start(100, 0);
+        bar.update(55);
+        bar.stop();
+
+        expect(view.downloadProgress.mock.calls).toEqual([[0], [55], [null]]);
+    });
+});
+
+describe('terminal restore', () => {
+    test('stop erases the region, shows the cursor, and is idempotent', () => {
+        const { stream, writes } = fakeTty();
+        const view = createRunLiveView({ stream, ctx: uniCtx(), timer: manualTimer() });
+
+        view.beginStep('certificates');
+        view.stop();
+
+        expect(writes.at(-1)).toContain(SHOW_CURSOR);
+
+        const frameCount = writes.length;
+        view.stop();
+        view.beginStep('late');
+        view.appStarted({ n: 1, total: 1, id: 'x' });
+
+        // Nothing is written after stop - not by a second stop, not by
+        // late events from an in-flight promise.
+        expect(writes).toHaveLength(frameCount);
+    });
+
+    test('stop stops the spinner timer', () => {
+        const { stream } = fakeTty();
+        const timer = manualTimer();
+        const view = createRunLiveView({ stream, ctx: uniCtx(), timer });
+
+        view.stop();
+
+        expect(timer.stopped).toBe(true);
+    });
+
+    test('restoreLiveTerminal emits the restore sequence on the throw path', () => {
+        const { stream, writes } = fakeTty();
+        const view = createRunLiveView({ stream, ctx: uniCtx(), timer: manualTimer() });
+        activateLiveView(view);
+        view.beginStep('signed in');
+
+        // Simulating a worker catch block: no orderly stop happened.
+        restoreLiveTerminal();
+
+        expect(writes.at(-1)).toContain(SHOW_CURSOR);
+        expect(activeLiveView()).toBeNull();
+    });
+
+    test('restoreLiveTerminal never throws, even over a view whose stop throws', () => {
+        activateLiveView({
+            stop: () => {
+                throw new Error('stream already gone');
+            },
+        });
+
+        expect(() => restoreLiveTerminal()).not.toThrow();
+        expect(activeLiveView()).toBeNull();
+    });
+
+    test('a view stream that throws on write still restores the console side', () => {
+        const consoleTransport = { name: 'console', silent: false };
+        const log = {
+            transports: [consoleTransport],
+            add: jest.fn(),
+            remove: jest.fn(),
+        };
+        const { stream } = fakeTty();
+        const view = createRunLiveView({ stream, ctx: uniCtx(), log, timer: manualTimer() });
+
+        stream.write = () => {
+            throw new Error('EPIPE');
+        };
+
+        expect(() => view.stop()).not.toThrow();
+        expect(consoleTransport.silent).toBe(false);
+        expect(log.remove).toHaveBeenCalled();
+    });
+
+    test('activating a second view stops the first - two views can never share the cursor', () => {
+        const first = { stop: jest.fn() };
+        const second = { stop: jest.fn() };
+
+        activateLiveView(first);
+        activateLiveView(second);
+
+        expect(first.stop).toHaveBeenCalled();
+        expect(activeLiveView()).toBe(second);
+    });
+});
+
+describe('console routing through a real winston logger', () => {
+    test('silences the console transport, commits warn and error lines, drops info, restores on stop', () => {
+        const consoleTransport = new winston.transports.Console({ level: 'info' });
+        consoleTransport.name = 'console';
+        const log = winston.createLogger({
+            level: 'silly',
+            format: winston.format.printf((info) => String(info.message)),
+            transports: [consoleTransport],
+        });
+
+        const { stream, writes } = fakeTty();
+        const view = createRunLiveView({ stream, ctx: uniCtx(), log, timer: manualTimer() });
+
+        expect(consoleTransport.silent).toBe(true);
+
+        log.warn('tag not supported here');
+        log.error('sheet 4 failed');
+        log.info('routine progress line');
+
+        const joined = stripAnsi(writes.join(''));
+        expect(joined).toContain('warn: tag not supported here');
+        expect(joined).toContain('error: sheet 4 failed');
+        expect(joined).not.toContain('routine progress line');
+
+        view.stop();
+        expect(consoleTransport.silent).toBe(false);
+        // The private routing transport is gone again.
+        expect(log.transports).toHaveLength(1);
+    });
+});
+
+describe('the ASCII symbol set', () => {
+    test('a full flow emits only ASCII outside the control sequences', () => {
+        const { stream, writes } = fakeTty();
+        const view = createRunLiveView({ stream, ctx: asciiCtx(), timer: manualTimer() });
+        const entry = appEntry();
+
+        view.beginStep('certificates');
+        view.stepDone('certificates', 'client.pem');
+        view.appStarted({ n: 1, total: 1, id: 'app-1' });
+        view.appOpened(entry);
+        view.appPhase('sheets');
+        entry.sheets.push({ n: 1, title: 'Overview', action: 'update', reason: null });
+        view.sheetRecorded(entry);
+        view.appFinished(entry, 'ROW\n');
+        view.stop();
+
+        const text = stripAnsi(writes.join(''));
+        for (const ch of text) {
+            expect(ch.codePointAt(0)).toBeLessThan(128);
+        }
+    });
+});

--- a/src/lib/util/__tests__/run-report-live-flow.test.js
+++ b/src/lib/util/__tests__/run-report-live-flow.test.js
@@ -1,0 +1,188 @@
+import { describe, test, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import { createPalette } from '../colour.js';
+import { UNICODE_SYMBOLS } from '../../interactive/symbols.js';
+
+/**
+ * Flow tests for the live rung's wiring through `runOverAppsWithReport`
+ * (issue #1075): with a live view active the plan block and app rows are
+ * committed through the view onto its own stream, the view is stopped -
+ * terminal restored - before the verdict, and the verdict then goes to
+ * `process.stdout` through the ordinary board path. Without an active view
+ * the `live` rung falls back to board rendering with zero cursor sequences,
+ * which is the flow-level docker-logs regression gate.
+ */
+
+const timeline = [];
+
+const consoleTransport = { name: 'console', silent: false, level: 'info' };
+
+jest.unstable_mockModule('../../../globals.js', () => ({
+    logger: {
+        info: jest.fn((line) =>
+            timeline.push(`LOG${consoleTransport.silent ? '(silent)' : ''} ${line}`)
+        ),
+        verbose: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+        transports: [consoleTransport],
+    },
+    getLoggingLevel: jest.fn().mockReturnValue('info'),
+    setLoggingLevel: jest.fn(),
+}));
+
+const { runOverAppsWithReport, startLiveRunView, addAppToReport, recordSheetDecision } =
+    await import('../run-report.js');
+const { createRunLiveView, activateLiveView, activeLiveView, restoreLiveTerminal } =
+    await import('../run-live.js');
+
+const ESC = String.fromCharCode(27);
+const SHOW_CURSOR = `${ESC}[?25h`;
+const CURSOR_SEQUENCE = new RegExp(`${ESC}\\[[0-9;?]*[AJhl]`);
+
+const stdoutWrites = [];
+let writeSpy;
+
+beforeEach(() => {
+    timeline.length = 0;
+    stdoutWrites.length = 0;
+    consoleTransport.silent = false;
+    jest.clearAllMocks();
+    writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+        stdoutWrites.push(String(chunk));
+
+        return true;
+    });
+});
+
+afterEach(() => {
+    restoreLiveTerminal();
+    writeSpy.mockRestore();
+});
+
+/**
+ * A real live view on a fake TTY stream, registered as the active one.
+ *
+ * @returns {{view: object, writes: string[]}} The view and its frame recording.
+ */
+const activeFakeTtyView = () => {
+    const writes = [];
+    const view = createRunLiveView({
+        stream: {
+            isTTY: true,
+            columns: 100,
+            rows: 40,
+            write: (chunk) => {
+                writes.push(String(chunk));
+
+                return true;
+            },
+        },
+        ctx: { palette: createPalette(false), symbols: UNICODE_SYMBOLS },
+        timer: { start: () => {}, stop: () => {} },
+    });
+    activateLiveView(view);
+
+    return { view, writes };
+};
+
+/**
+ * Arguments for a two-app live run whose processor records realistic entries.
+ *
+ * @param {object} [overrides] - Fields to override.
+ *
+ * @returns {object} Arguments for `runOverAppsWithReport`.
+ */
+const runArgs = (overrides = {}) => ({
+    command: 'qseow create-sheet-thumbnails',
+    dryRun: false,
+    appIds: ['app-1', 'app-2'],
+    namedAppIds: ['app-1', 'app-2'],
+    selectorAppIds: [],
+    selector: null,
+    rung: 'live',
+    plan: {
+        browser: { name: 'chrome', version: 'recommended', headless: true, pageWaitSeconds: 5 },
+        writes: { kind: 'thumbnails', contentLibrary: 'lib', publishedAppCount: 1 },
+    },
+    logPrefix: { plan: 'TEST PLAN', process: 'TEST PROCESS' },
+    emptySelectionHint: 'hint',
+    planApp: jest.fn(async () => {}),
+    processApp: jest.fn(async (appId, report) => {
+        const entry = addAppToReport(report, { id: appId, name: `Named ${appId}`, sheetCount: 2 });
+        recordSheetDecision(entry, { n: 1, title: 'One', action: 'update' });
+        recordSheetDecision(entry, { n: 2, title: 'Two', action: 'update' });
+    }),
+    ...overrides,
+});
+
+describe('the live rung with an active view', () => {
+    test('plan and app rows go through the view; the verdict goes to stdout after the collapse', async () => {
+        const { writes } = activeFakeTtyView();
+
+        await runOverAppsWithReport(runArgs());
+
+        const frames = writes.join('');
+        // The plan block and both committed board app rows landed on the
+        // view's stream, not on process.stdout.
+        expect(frames).toContain('PLAN');
+        expect(frames).toContain('Named app-1');
+        expect(frames).toContain('Named app-2');
+
+        // The collapse: restore sequence emitted, registry empty, and only
+        // then the verdict - on stdout, through the ordinary board path.
+        expect(frames).toContain(SHOW_CURSOR);
+        expect(activeLiveView()).toBeNull();
+        const stdoutJoined = stdoutWrites.join('');
+        expect(stdoutJoined).toContain('app(s) ok');
+        expect(frames).not.toContain('app(s) ok');
+
+        // The plain blocks still went through the logger with the console
+        // silenced - the tee'd/shipped log stays readable.
+        expect(timeline).toContain('LOG(silent) PLAN');
+        expect(timeline.some((line) => line.startsWith('LOG(silent) RESULT'))).toBe(true);
+    });
+
+    test('a processor throw mid-run still restores the terminal and reaches the verdict', async () => {
+        const { writes } = activeFakeTtyView();
+
+        await runOverAppsWithReport(
+            runArgs({
+                processApp: jest.fn(async (appId, report) => {
+                    if (appId === 'app-1') {
+                        throw new Error('login never completed');
+                    }
+                    addAppToReport(report, { id: appId, name: appId, sheetCount: 1 });
+                }),
+            })
+        );
+
+        expect(writes.join('')).toContain(SHOW_CURSOR);
+        expect(activeLiveView()).toBeNull();
+        expect(stdoutWrites.join('')).toContain('1 failed');
+    });
+});
+
+describe('the live rung without an active view (the fallback split)', () => {
+    test('renders exactly as the board: blocks to stdout, zero cursor sequences', async () => {
+        await runOverAppsWithReport(runArgs());
+
+        const joined = stdoutWrites.join('');
+        expect(joined).toContain('PLAN');
+        expect(joined).toContain('Named app-1');
+        expect(joined).toContain('app(s) ok');
+        expect(joined).not.toMatch(CURSOR_SEQUENCE);
+    });
+});
+
+describe('startLiveRunView', () => {
+    test('declines dry runs and non-live rungs without touching the terminal', () => {
+        // The TTY gate itself is covered in run-live.test.js; asserting it
+        // here would depend on whether this jest run's stdout happens to be
+        // a terminal, which differs between CI and a developer shell.
+        expect(startLiveRunView({ rung: 'live', dryRun: true })).toBeNull();
+        expect(startLiveRunView({ rung: 'board', dryRun: false })).toBeNull();
+        expect(stdoutWrites).toHaveLength(0);
+        expect(activeLiveView()).toBeNull();
+    });
+});

--- a/src/lib/util/fatal-handlers.js
+++ b/src/lib/util/fatal-handlers.js
@@ -81,6 +81,7 @@
 
 import { logger as defaultLogger } from '../../globals.js';
 import { writeCrashDump as defaultWriteCrashDump } from './crash-dump.js';
+import { restoreLiveTerminal } from './run-live.js';
 
 // ---------------------------------------------------------------------------
 // Module-level constants and state
@@ -306,6 +307,17 @@ function handleBrokenOutputPipe(deps) {
     if (handlingFatal) return;
     handlingFatal = true;
 
+    // Restore the terminal before exiting: stdout may still be a live TTY
+    // when it was stderr's reader that went away, and this exit path must
+    // not be the one that strands a hidden cursor. The hook never throws,
+    // and a restore write to the dead stream itself is swallowed inside it -
+    // so this stays consistent with the rule above: nothing is *logged*.
+    try {
+        deps.restoreTerminal();
+    } catch {
+        // Exiting is the one thing this handler must always do.
+    }
+
     exitOnce(BROKEN_PIPE_EXIT_CODE, deps.exit);
 }
 
@@ -335,7 +347,26 @@ function handleFatal(err, source, deps) {
 
     handlingFatal = true;
 
+    // The watchdog is armed before anything else runs on this path - the
+    // #946 rule. The terminal restore below writes to the TTY and could
+    // stall; armed first, the watchdog bounds any async stall it causes.
+    // (A write that blocks the event loop synchronously - a flow-controlled
+    // terminal - is beyond any in-process timer, but that exposure is the
+    // same one every log line on this path already has.)
     armWatchdog(deps);
+
+    // Before anything is logged: if the live run view (issue #1075) owns the
+    // terminal, the console transport is silenced and the cursor hidden - the
+    // FATAL line below would be invisible and the operator's prompt mangled.
+    // A mangled terminal after a failed production run is the worst outcome
+    // available here, so this is the crash half of the terminal-restore hook;
+    // it never throws and is a no-op when no view is active.
+    try {
+        deps.restoreTerminal();
+    } catch {
+        // Restoring must never stop the crash dump from being written.
+    }
+
     logFatalLine(err, source, deps.logger);
 
     try {
@@ -406,12 +437,15 @@ function registerListener(emitter, event, listener) {
  * @param {number} [options.watchdogMs] - Watchdog delay in ms. Defaults to {@link FATAL_EXIT_WATCHDOG_MS}.
  * @param {Array<import('node:stream').Writable>} [options.outputStreams] - Streams to watch for a
  *   broken pipe. Defaults to `process.stdout` and `process.stderr`.
+ * @param {Function} [options.restoreTerminal] - Terminal restore hook, run before the fatal
+ *   line is logged. Defaults to the live run view's {@link restoreLiveTerminal}.
  *
  * @returns {void}
  */
 export function installFatalHandlers({
     logger = defaultLogger,
     writeCrashDump = defaultWriteCrashDump,
+    restoreTerminal = restoreLiveTerminal,
     /**
      * Default exit function: terminate the process with the given code.
      *
@@ -426,7 +460,7 @@ export function installFatalHandlers({
 } = {}) {
     removeInstalledListeners();
 
-    const deps = { logger, writeCrashDump, exit, watchdogMs };
+    const deps = { logger, writeCrashDump, exit, watchdogMs, restoreTerminal };
 
     /**
      * Listener for synchronous uncaught exceptions.

--- a/src/lib/util/run-board.js
+++ b/src/lib/util/run-board.js
@@ -144,12 +144,15 @@ const width = (text) => {
 /**
  * Pad plain text to a target width. Never truncates.
  *
+ * Exported for the live view (issue #1075), which shares this width model so
+ * its animated rows align with the board rows they commit next to.
+ *
  * @param {string} text - Plain text, no ANSI codes.
  * @param {number} target - Target width in columns.
  *
  * @returns {string} The padded text.
  */
-const padTo = (text, target) =>
+export const padTo = (text, target) =>
     width(text) >= target ? text : text + ' '.repeat(target - width(text));
 
 /**
@@ -160,12 +163,14 @@ const padTo = (text, target) =>
  * degenerate `max <= 3` case, where a negative slice index would return the
  * wrong end of the string; callers here use 20+.
  *
+ * Exported for the live view (issue #1075) - same reasoning as {@link padTo}.
+ *
  * @param {string} text - Plain text, no ANSI codes.
  * @param {number} max - Maximum width in columns.
  *
  * @returns {string} The clipped text.
  */
-const clip = (text, max) => {
+export const clip = (text, max) => {
     if (width(text) <= max) {
         return text;
     }
@@ -552,6 +557,33 @@ const STRIP_PAINT = Object.freeze({
     excluded: (palette) => palette.dim,
     failed: (palette) => palette.red,
 });
+
+/**
+ * The coloured sheet strip for one app, unpadded.
+ *
+ * Extracted for the live view (issue #1075), whose per-app block shows the
+ * same strip while the app is still running: one glyph function, so the
+ * animated strip and the committed board row cannot colour the same sheet
+ * two different ways.
+ *
+ * `limit` exists for that in-progress rendering: `stripForApp` gap-fills
+ * every undecided position with the failed glyph, which is right at the end
+ * of an app - those sheets were not processed - and wrong in the middle of
+ * one, where the unreached tail is simply the future. The live view passes
+ * the last recorded position, so interior gaps (a mid-app failure the sheet
+ * loop survived) still show as failed while the tail stays unpainted.
+ *
+ * @param {object} appEntry - A per-app entry from the report.
+ * @param {object} ctx - From {@link boardContext}.
+ * @param {number} [limit] - Render only the first `limit` cells; all by default.
+ *
+ * @returns {string} The painted strip.
+ */
+export const renderSheetStrip = (appEntry, ctx, limit = Infinity) =>
+    stripForApp(appEntry, ctx.symbols)
+        .slice(0, limit)
+        .map(({ glyph, kind }) => STRIP_PAINT[kind](ctx.palette)(glyph))
+        .join('');
 
 /**
  * One per-app strip row, appended to the board as the app finishes.

--- a/src/lib/util/run-live.js
+++ b/src/lib/util/run-live.js
@@ -1,0 +1,716 @@
+import winston from 'winston';
+import { renderSheetStrip, clip, padTo } from './run-board.js';
+
+/**
+ * Rung C of the run-output ladder (issue #1075): the live run view.
+ *
+ * An animated terminal display: preflight rows that resolve as the real
+ * `await`s the run performs resolve, then a per-app progress bar driven by the
+ * per-sheet decisions the processors record, collapsing to the board verdict
+ * at the end. Everything animated lives in a bounded "region" at the bottom of
+ * the screen that is erased and repainted; everything finished is committed
+ * above it as ordinary scrolling text, so the display never needs to reach
+ * back past the visible screen.
+ *
+ * Three properties are load-bearing:
+ *
+ * - **The display renders only what was recorded.** The bar and strip are
+ *   drawn from the same report entry the verdict counts from, and a preflight
+ *   row resolves only when the caller's real `await` has returned. A step
+ *   that hangs is visible as the row that never resolves - which is the
+ *   diagnostic value the view exists for.
+ * - **One cursor writer.** While the view is active the winston console
+ *   transport is silenced and a private transport routes `warn`/`error`
+ *   lines through the view's commit path instead, so an error mid-run lands as a
+ *   committed line above the region rather than tearing through it. The
+ *   browser download bar in `browser-install.js` defers to the view for the
+ *   same reason - see {@link liveDownloadBar}.
+ * - **The terminal is restored on every exit path.** `stop()` erases the
+ *   region, shows the cursor and restores the console transport; it is
+ *   idempotent and never throws, so the crash path (`installFatalHandlers`),
+ *   the completion path (`runCommand`) and the worker error paths can all
+ *   call {@link restoreLiveTerminal} unconditionally. Issue #1107's signal
+ *   handling extends the same hook.
+ *
+ * The view is created only for a real run on the `live` rung and only when
+ * the stream really is a TTY - {@link createRunLiveView} returns `null`
+ * otherwise, so a misrouted caller cannot repaint frames into `docker logs`.
+ * Everywhere else the ladder's LIVE≡board fallback in `rendersAsBoard()`
+ * still applies, untouched.
+ */
+
+/**
+ * ANSI control sequences. Plain CSI sequences only, verified on the oldest
+ * target console (Server 2019 conhost - see the matrix on issue #1071): node
+ * reaches a Windows TTY via WriteConsoleW, so no VT gate beyond the rung
+ * selection is needed.
+ */
+const HIDE_CURSOR = '\u001B[?25l';
+const SHOW_CURSOR = '\u001B[?25h';
+const ERASE_DOWN = '\u001B[0J';
+const cursorUp = (n) => `\u001B[${n}A`;
+
+/**
+ * Width of the preflight-row label column ("content library" is the longest
+ * label either platform uses).
+ */
+const STEP_LABEL_WIDTH = 16;
+
+/**
+ * Width of the per-app progress bar, matching the issue #1075 mockup.
+ */
+const BAR_WIDTH = 26;
+
+/**
+ * Milliseconds between spinner repaints. Events repaint immediately; the
+ * timer only keeps the spinner moving between them, so a hung await is
+ * visibly alive-but-stuck rather than frozen.
+ */
+const FRAME_MS = 120;
+
+/**
+ * Labels for the app block's pre-sheet phases. The `download` entry is not a
+ * phase of its own - it overlays whichever phase is current while
+ * `browser-install.js` reports download progress.
+ */
+const PHASE_LABEL = Object.freeze({
+    opening: 'opening app',
+    browser: 'launching browser',
+    signin: 'signing in',
+});
+
+/**
+ * A winston transport that hands `warn` and `error` lines to the live view.
+ *
+ * While the view owns the cursor the console transport is silenced, but a
+ * silenced error is the one thing a live display must never cost - so this
+ * transport commits those lines above the animated region instead. `info` and
+ * below are represented by the view itself (that is the rung's job), and the
+ * plain run-card blocks still go through the logger for any other transport,
+ * exactly as on the board rung.
+ */
+class LiveViewTransport extends winston.Transport {
+    /**
+     * Build the transport bound to one view.
+     *
+     * @param {object} view - The live view to commit lines into.
+     */
+    constructor(view) {
+        super({ level: 'warn' });
+        this.name = 'live-view';
+        this.view = view;
+    }
+
+    /**
+     * Winston transport hook: route one log record to the view.
+     *
+     * @param {object} info - The winston info object.
+     * @param {Function} callback - Completion callback.
+     *
+     * @returns {void}
+     */
+    log(info, callback) {
+        this.view.commitLogLine(info.level, String(info.message ?? ''));
+        callback();
+    }
+}
+
+/**
+ * The interval driving spinner repaints. Created per view; `unref`'d so the
+ * animation can never by itself keep the process alive.
+ *
+ * @returns {{start: Function, stop: Function}} The timer.
+ */
+const makeFrameTimer = () => {
+    let handle = null;
+
+    return {
+        /**
+         * Start the interval.
+         *
+         * @param {Function} fn - Tick function.
+         * @param {number} ms - Interval in milliseconds.
+         *
+         * @returns {void}
+         */
+        start(fn, ms) {
+            handle = setInterval(fn, ms);
+            handle.unref?.();
+        },
+        /**
+         * Stop the interval.
+         *
+         * @returns {void}
+         */
+        stop() {
+            if (handle !== null) {
+                clearInterval(handle);
+                handle = null;
+            }
+        },
+    };
+};
+
+/**
+ * Create the live run view, already started: the cursor is hidden and the
+ * console transport silenced before this returns.
+ *
+ * Returns `null` when the stream is not a TTY. The rung selection already
+ * guarantees a TTY, but this guard is structural: repainted frames on a
+ * redirected stream are the regression that turns `docker logs` into
+ * thousands of stale frames, and a second, independent gate here means no
+ * future caller can reintroduce it by mis-threading a rung.
+ *
+ * @param {object} run - The view's environment, all injectable.
+ * @param {object} run.stream - The TTY stream to paint on.
+ * @param {object} run.ctx - From `boardContext()`: `{palette, symbols, border}`.
+ * @param {object} [run.log] - Winston-style logger whose console transport is
+ *     silenced while the view runs and restored on stop. Omit for tests that
+ *     only exercise painting.
+ * @param {{start: Function, stop: Function}} [run.timer] - Frame timer.
+ *     Injectable so tests can drive ticks synchronously.
+ *
+ * @returns {object|null} The view, or `null` when the stream cannot host one.
+ */
+export const createRunLiveView = ({ stream, ctx, log = null, timer = makeFrameTimer() }) => {
+    if (!stream?.isTTY) {
+        return null;
+    }
+
+    const { palette, symbols } = ctx;
+    const frames = symbols.spinnerFrames;
+    const sep = ` ${symbols.dot} `;
+
+    let stopped = false;
+    let regionLines = 0;
+    let spinnerIndex = 0;
+    let pendingStep = null; // {label, detail}
+    const committedSteps = new Set();
+    let app = null; // {n, total, id, entry, phase}
+    let downloadPct = null;
+
+    let consoleTransport = null;
+    let previousSilent = false;
+    let logTransport = null;
+
+    /**
+     * Columns available right now. Re-read per paint so a resized terminal
+     * gets clipped correctly on the next frame.
+     *
+     * @returns {number} The column count.
+     */
+    const columns = () => stream.columns ?? 80;
+
+    /**
+     * One preflight row. Padded plain, coloured after - the same width
+     * discipline as the board renderers.
+     *
+     * @param {string} marker - The already-coloured status glyph.
+     * @param {string} label - Row label, plain.
+     * @param {string} [detail] - Dim detail after the label.
+     *
+     * @returns {string} The row.
+     */
+    const stepRow = (marker, label, detail) => {
+        const detailPart = detail
+            ? `  ${palette.dim(clip(detail, Math.max(10, columns() - STEP_LABEL_WIDTH - 10)))}`
+            : '';
+
+        return `  ${marker} ${padTo(label, STEP_LABEL_WIDTH)}${detailPart}`;
+    };
+
+    /**
+     * The animated region's lines for the current state.
+     *
+     * @returns {string[]} The lines, each guaranteed narrower than the terminal.
+     */
+    const renderRegion = () => {
+        const lines = [];
+        const spinner = palette.yellow(frames[spinnerIndex % frames.length]);
+
+        if (pendingStep) {
+            const detail =
+                pendingStep.label === 'browser' && downloadPct !== null
+                    ? `downloading ${downloadPct}%`
+                    : pendingStep.detail;
+            lines.push(stepRow(spinner, pendingStep.label, detail));
+        }
+
+        if (app) {
+            const entry = app.entry;
+            const name = clip(entry?.name ?? app.id ?? '', 32);
+            const sheetNote =
+                typeof entry?.sheetCount === 'number'
+                    ? palette.dim(`${sep}${entry.sheetCount} sheets`)
+                    : '';
+            lines.push('');
+            lines.push(`  app ${app.n}/${app.total}  ${palette.bold(name)}${sheetNote}`);
+
+            const inSheets = app.phase === 'sheets' && entry && (entry.sheetCount ?? 0) > 0;
+            if (inSheets) {
+                const total = entry.sheetCount;
+                const done = Math.min(entry.sheets.length, total);
+                const filled = Math.min(BAR_WIDTH, Math.round((done / total) * BAR_WIDTH));
+                const bar =
+                    palette.green(symbols.stripCaptured.repeat(filled)) +
+                    palette.dim(symbols.stripExcluded.repeat(BAR_WIDTH - filled));
+                const last = entry.sheets[entry.sheets.length - 1];
+                const title = last ? palette.dim(`  '${clip(last.title ?? '', 24)}'`) : '';
+                lines.push(`  ${bar}  ${done}/${total}${title}`);
+                // Clipped at the last recorded position: the unreached tail
+                // is the future, not a failure - only interior gaps (a sheet
+                // the loop really skipped over) keep the failed glyph. The
+                // committed board row shows the full-width strip.
+                //
+                // Also capped at the terminal width: this is the one region
+                // line whose natural length is unbounded (one glyph per
+                // sheet), and a wrapped region line breaks the cursor-up
+                // erase arithmetic for every following frame. The committed
+                // board row still carries the full strip; only the animated
+                // copy is capped.
+                const reached = entry.sheets.reduce(
+                    (max, sheet, i) =>
+                        Math.max(
+                            max,
+                            typeof sheet.n === 'number' && sheet.n >= 1 ? sheet.n : i + 1
+                        ),
+                    0
+                );
+                const stripLimit = Math.min(reached, Math.max(1, columns() - 3));
+                lines.push(`  ${renderSheetStrip(entry, ctx, stripLimit)}`);
+            } else {
+                const label =
+                    downloadPct !== null
+                        ? `downloading browser ${downloadPct}%`
+                        : (PHASE_LABEL[app.phase] ?? PHASE_LABEL.opening);
+                lines.push(`  ${spinner} ${palette.dim(label)}`);
+            }
+        }
+
+        return lines;
+    };
+
+    /**
+     * The erase sequence for the current region, cursor left at its first line.
+     *
+     * @returns {string} The sequence; empty when nothing is on screen.
+     */
+    const eraseRegion = () =>
+        regionLines > 0 ? `${cursorUp(regionLines)}\r${ERASE_DOWN}` : `\r${ERASE_DOWN}`;
+
+    /**
+     * Repaint the animated region in place, in a single write.
+     *
+     * @returns {void}
+     */
+    const paint = () => {
+        if (stopped) {
+            return;
+        }
+
+        const lines = renderRegion();
+        const body = lines.length > 0 ? `${lines.join('\n')}\n` : '';
+        stream.write(`${eraseRegion()}${body}`);
+        regionLines = lines.length;
+    };
+
+    /**
+     * Write finished content above the region: erase, write, repaint - one
+     * stream write, so nothing can interleave between the parts.
+     *
+     * @param {string} text - The static text. A trailing newline is added when missing.
+     *
+     * @returns {void}
+     */
+    const commit = (text) => {
+        if (stopped) {
+            return;
+        }
+
+        const block = text.endsWith('\n') ? text : `${text}\n`;
+        const lines = renderRegion();
+        const body = lines.length > 0 ? `${lines.join('\n')}\n` : '';
+        stream.write(`${eraseRegion()}${block}${body}`);
+        regionLines = lines.length;
+    };
+
+    /**
+     * Commit one resolved preflight row. Each label commits once per run -
+     * the rows record the first resolution; later apps show the same work as
+     * their phase label instead.
+     *
+     * @param {string} label - The step label.
+     * @param {string|undefined} detail - Dim detail text.
+     * @param {boolean} ok - Whether the step succeeded.
+     *
+     * @returns {void}
+     */
+    const commitStep = (label, detail, ok) => {
+        if (committedSteps.has(label)) {
+            return;
+        }
+        committedSteps.add(label);
+        if (pendingStep?.label === label) {
+            pendingStep = null;
+        }
+        const marker = ok ? palette.green(symbols.done) : palette.red(symbols.failed);
+        commit(stepRow(marker, label, detail));
+    };
+
+    const view = {
+        /** Separator matching the symbol set, for callers composing details. */
+        sep,
+
+        /**
+         * Begin an animated preflight row. No-op once the label has committed.
+         *
+         * @param {string} label - The step label.
+         * @param {string} [detail] - Dim detail shown while pending.
+         *
+         * @returns {void}
+         */
+        beginStep(label, detail) {
+            if (stopped || committedSteps.has(label)) {
+                return;
+            }
+            pendingStep = { label, detail };
+            paint();
+        },
+
+        /**
+         * Resolve a preflight row as succeeded.
+         *
+         * @param {string} label - The step label.
+         * @param {string} [detail] - Dim detail on the committed row.
+         *
+         * @returns {void}
+         */
+        stepDone(label, detail) {
+            if (stopped) {
+                return;
+            }
+            commitStep(label, detail, true);
+        },
+
+        /**
+         * Resolve a preflight row as failed.
+         *
+         * @param {string} label - The step label.
+         * @param {string} [detail] - Dim detail on the committed row.
+         *
+         * @returns {void}
+         */
+        stepFailed(label, detail) {
+            if (stopped) {
+                return;
+            }
+            commitStep(label, detail, false);
+        },
+
+        /**
+         * Commit a finished block (plan block, banners) above the region.
+         *
+         * @param {string} text - The rendered block.
+         *
+         * @returns {void}
+         */
+        commitBlock(text) {
+            commit(text);
+        },
+
+        /**
+         * Open the app block as the loop hands an app to its processor.
+         *
+         * @param {object} start - The position.
+         * @param {number} start.n - 1-based app number.
+         * @param {number} start.total - Apps in the run.
+         * @param {string} start.id - App id, shown until the name is known.
+         *
+         * @returns {void}
+         */
+        appStarted({ n, total, id }) {
+            if (stopped) {
+                return;
+            }
+            app = { n, total, id, entry: null, phase: 'opening' };
+            paint();
+        },
+
+        /**
+         * Attach the report entry once the processor has recorded it. From
+         * here the block renders the entry itself - the same object the
+         * verdict counts from - so the bar cannot claim a sheet the report
+         * does not hold.
+         *
+         * @param {object} entry - The per-app report entry.
+         *
+         * @returns {void}
+         */
+        appOpened(entry) {
+            if (stopped || !app || (entry.id && app.id && entry.id !== app.id)) {
+                return;
+            }
+            app.entry = entry;
+            paint();
+        },
+
+        /**
+         * Move the app block to a new pre-sheet phase.
+         *
+         * @param {string} phase - `browser`, `signin` or `sheets`.
+         *
+         * @returns {void}
+         */
+        appPhase(phase) {
+            if (stopped || !app) {
+                return;
+            }
+            app.phase = phase;
+            paint();
+        },
+
+        /**
+         * Repaint after a sheet decision was recorded on the entry.
+         *
+         * @param {object} entry - The entry that grew a sheet row.
+         *
+         * @returns {void}
+         */
+        sheetRecorded(entry) {
+            if (stopped || !app || app.entry !== entry) {
+                return;
+            }
+            paint();
+        },
+
+        /**
+         * Close the app block, committing its final board row.
+         *
+         * A preflight row still pending when a failed app closes is committed
+         * as failed: its `await` threw, and leaving it spinning would show a
+         * run stuck on a step that has already been abandoned.
+         *
+         * @param {object} entry - The per-app report entry.
+         * @param {string} rowText - The rendered board app row.
+         *
+         * @returns {void}
+         */
+        appFinished(entry, rowText) {
+            if (stopped) {
+                return;
+            }
+            if (pendingStep && entry?.failed) {
+                commitStep(pendingStep.label, undefined, false);
+            }
+            pendingStep = null;
+            app = null;
+            downloadPct = null;
+            commit(rowText);
+        },
+
+        /**
+         * Report browser download progress, replacing the phase label.
+         *
+         * @param {number|null} pct - Percentage 0-100, or null when the
+         *     download has finished.
+         *
+         * @returns {void}
+         */
+        downloadProgress(pct) {
+            if (stopped) {
+                return;
+            }
+            downloadPct = pct === null ? null : Math.max(0, Math.min(100, Math.round(pct)));
+            paint();
+        },
+
+        /**
+         * Commit a routed log line above the region.
+         *
+         * @param {string} level - Winston level, decides the paint.
+         * @param {string} message - The message; may span lines.
+         *
+         * @returns {void}
+         */
+        commitLogLine(level, message) {
+            if (stopped) {
+                return;
+            }
+            const paintLine = level === 'error' ? palette.red : palette.yellow;
+            for (const line of message.split('\n')) {
+                commit(`  ${paintLine(`${level}: ${line}`)}`);
+            }
+        },
+
+        /**
+         * Stop the view and restore the terminal: erase the region, show the
+         * cursor, restore the console transport. Idempotent, and never
+         * throws - this runs on crash paths.
+         *
+         * @returns {void}
+         */
+        stop() {
+            if (stopped) {
+                return;
+            }
+            stopped = true;
+
+            try {
+                timer.stop();
+            } catch {
+                // A broken timer must not stop the terminal restore below.
+            }
+            try {
+                stream.write(`${eraseRegion()}${SHOW_CURSOR}`);
+            } catch {
+                // The stream may already be gone (broken pipe); the console
+                // restore below still matters.
+            }
+            regionLines = 0;
+
+            if (log) {
+                try {
+                    if (logTransport) {
+                        log.remove(logTransport);
+                    }
+                } catch {
+                    // Best effort - a logger that cannot remove transports
+                    // still gets its console transport back below.
+                }
+                if (consoleTransport) {
+                    consoleTransport.silent = previousSilent;
+                }
+            }
+
+            if (active === view) {
+                active = null;
+            }
+        },
+    };
+
+    // Start immediately: hide the cursor, take the console, start the spinner.
+    stream.write(HIDE_CURSOR);
+
+    if (log) {
+        consoleTransport = log.transports?.find((transport) => transport.name === 'console');
+        if (consoleTransport) {
+            // Normalised to a boolean: winston leaves `silent` undefined on a
+            // transport that was never silenced, and the restore must hand
+            // back an explicit not-silent, not an accidental undefined.
+            previousSilent = consoleTransport.silent === true;
+            consoleTransport.silent = true;
+        }
+        try {
+            logTransport = new LiveViewTransport(view);
+            log.add(logTransport);
+        } catch {
+            // A logger that cannot take a transport just loses the warn/error
+            // pass-through; the view itself still works.
+            logTransport = null;
+        }
+    }
+
+    timer.start(() => {
+        spinnerIndex += 1;
+        paint();
+    }, FRAME_MS);
+
+    return view;
+};
+
+/**
+ * The process-wide active view, or null.
+ *
+ * Module state on purpose, unlike the report: the live view is inherently
+ * about the one terminal this process owns, and the deep emit sites - the
+ * browser modules, the report recorders - must be able to signal it without
+ * threading a handle through every signature on the way down. Everything
+ * here is a no-op when no view is active, so those sites cost nothing on
+ * every other rung.
+ */
+let active = null;
+
+/**
+ * Register a view as the process's active one. Any previous view is stopped
+ * first, so two views can never share the cursor.
+ *
+ * @param {object} view - From {@link createRunLiveView}.
+ *
+ * @returns {void}
+ */
+export const activateLiveView = (view) => {
+    if (active && active !== view) {
+        active.stop();
+    }
+    active = view;
+};
+
+/**
+ * The active live view, or null. Emit sites call this and optional-chain.
+ *
+ * @returns {object|null} The view.
+ */
+export const activeLiveView = () => active;
+
+/**
+ * Restore the terminal if a live view is active; otherwise do nothing.
+ *
+ * The single reusable restore hook: called on completion (`runCommand`), on
+ * the worker error paths, and on a crash (`installFatalHandlers`) - and the
+ * place issue #1107's signal handling plugs into. Never throws.
+ *
+ * @returns {void}
+ */
+export const restoreLiveTerminal = () => {
+    const view = active;
+    active = null;
+    try {
+        view?.stop();
+    } catch {
+        // Restoring must never mask the failure that triggered it.
+    }
+};
+
+/**
+ * A `cli-progress`-shaped adapter that routes browser download progress into
+ * the live view instead of drawing a second bar.
+ *
+ * Two writers repainting one cursor is the one genuinely new hazard issue
+ * #1075 names: `browser-install.js` draws a `SingleBar` when a requested
+ * build is not cached, and that path runs mid-run. While a live view is
+ * active the install uses this adapter instead, so the download shows up as
+ * the current phase's `downloading browser NN%` label - and the two writers
+ * are never both active, structurally.
+ *
+ * @param {object} view - The active live view.
+ *
+ * @returns {{start: Function, update: Function, stop: Function}} The adapter.
+ */
+export const liveDownloadBar = (view) => ({
+    /**
+     * `SingleBar.start` equivalent.
+     *
+     * @returns {void}
+     */
+    start() {
+        view.downloadProgress(0);
+    },
+    /**
+     * `SingleBar.update` equivalent.
+     *
+     * @param {number} pct - Percentage 0-100.
+     *
+     * @returns {void}
+     */
+    update(pct) {
+        view.downloadProgress(pct);
+    },
+    /**
+     * `SingleBar.stop` equivalent.
+     *
+     * @returns {void}
+     */
+    stop() {
+        view.downloadProgress(null);
+    },
+});

--- a/src/lib/util/run-report.js
+++ b/src/lib/util/run-report.js
@@ -15,6 +15,7 @@ import {
     renderBoardAppRow,
     renderBoardVerdict,
 } from './run-board.js';
+import { createRunLiveView, activateLiveView, activeLiveView } from './run-live.js';
 import { toOptionValueList } from './option-values.js';
 import { measureImageFiles } from './image-dir.js';
 
@@ -164,6 +165,18 @@ const emitBlockOnRung = ({
     forceVisible = false,
     suppressOnOff = true,
 }) => {
+    // The live view owns the cursor, so a block written straight to stdout
+    // would tear through the animated region - it is committed above the
+    // region instead. The console transport is already silenced for the
+    // life of the view; the nested silence below is a harmless no-op.
+    const live = activeLiveView();
+    if (live) {
+        withConsoleSilenced(plainEmit);
+        live.commitBlock(renderBoardBlock());
+
+        return;
+    }
+
     if (rendersAsBoard(rung)) {
         withConsoleSilenced(plainEmit);
         process.stdout.write(renderBoardBlock());
@@ -222,6 +235,46 @@ export const emitRunHeader = ({ version, jobLabel, options = {} }) => {
     });
 
     return rung;
+};
+
+/**
+ * Start the live run view (rung C, issue #1075) when this run qualifies.
+ *
+ * The second composition seam next to {@link decideRung}: the only place the
+ * live view meets the real `process.stdout`, the real board context and the
+ * real logger. Called by the run workers straight after `emitRunHeader`, so
+ * the static header has already been written before the view takes the
+ * cursor.
+ *
+ * Only real runs on the `live` rung get a view. A dry run finishes in
+ * seconds, has no browser and its product is the report text - animating it
+ * would add risk for nothing - so dry runs on the live rung keep the board
+ * rendering via the `rendersAsBoard` fallback, as does any worker that never
+ * calls this. Returns null in every declined case, and callers treat null as
+ * "not live" throughout.
+ *
+ * @param {object} run - The run.
+ * @param {string} run.rung - The rung returned by {@link emitRunHeader}.
+ * @param {boolean} [run.dryRun] - Whether this run stops before the writes.
+ *
+ * @returns {object|null} The active live view, or null.
+ */
+export const startLiveRunView = ({ rung, dryRun = false }) => {
+    if (rung !== RUNG.LIVE || dryRun) {
+        return null;
+    }
+
+    const view = createRunLiveView({
+        stream: process.stdout,
+        ctx: boardContext(),
+        log: logger,
+    });
+
+    if (view) {
+        activateLiveView(view);
+    }
+
+    return view;
 };
 
 /**
@@ -480,6 +533,11 @@ export const addAppToReport = (report, { id, name, sheetCount }) => {
     };
     report.apps.push(entry);
 
+    // The live view (issue #1075) renders its per-app block from this same
+    // entry, so handing it over here is what makes the bar structurally
+    // unable to disagree with the verdict. No-op on every other rung.
+    activeLiveView()?.appOpened(entry);
+
     return entry;
 };
 
@@ -500,6 +558,10 @@ export const addAppToReport = (report, { id, name, sheetCount }) => {
  */
 export const recordSheetDecision = (appEntry, { n, title, action, reason = null }) => {
     appEntry.sheets.push({ n, title, action, reason });
+
+    // Repaint the live per-app block. The row was recorded first, so the
+    // display can only ever show what the report already holds.
+    activeLiveView()?.sheetRecorded(appEntry);
 };
 
 /**
@@ -823,6 +885,11 @@ export const runOverAppsWithReport = async ({
     const totalApps = new Set(appIds).size;
     const removal = isRemovalReport(report);
 
+    // Counted here rather than taken from the report: a failed app may or may
+    // not have an entry yet when its block opens, and the live app number
+    // must match the `app i/n` line the loop logs.
+    let liveAppNumber = 0;
+
     const result = await runOverApps(
         appIds,
         {
@@ -844,6 +911,8 @@ export const runOverAppsWithReport = async ({
               }
             : async (appId) => {
                   const appStartedAt = Date.now();
+                  liveAppNumber += 1;
+                  activeLiveView()?.appStarted({ n: liveAppNumber, total: totalApps, id: appId });
                   try {
                       const result = await processApp(appId, report);
 
@@ -869,15 +938,21 @@ export const runOverAppsWithReport = async ({
                       if (entry) {
                           entry.durationMs = Date.now() - appStartedAt;
                           if (board) {
-                              // Appended as each app finishes - still no
-                              // cursor addressing, nothing repainted.
-                              process.stdout.write(
-                                  renderBoardAppRow(
-                                      entry,
-                                      { n: report.apps.length, total: totalApps, removal },
-                                      ctx
-                                  )
+                              // Appended as each app finishes. With a live
+                              // view active the identical row is committed
+                              // above the animated region instead of being
+                              // appended raw - one renderer, two carriers.
+                              const row = renderBoardAppRow(
+                                  entry,
+                                  { n: report.apps.length, total: totalApps, removal },
+                                  ctx
                               );
+                              const live = activeLiveView();
+                              if (live) {
+                                  live.appFinished(entry, row);
+                              } else {
+                                  process.stdout.write(row);
+                              }
                           }
                       }
                   }
@@ -886,6 +961,12 @@ export const runOverAppsWithReport = async ({
 
     report.finishedAt = Date.now();
     report.succeeded = result;
+
+    // The collapse (issue #1075): the animated region is erased and the
+    // cursor restored *before* the verdict renders, so the verdict below
+    // goes to a quiet terminal through the ordinary board path - the
+    // active-view check in emitBlockOnRung finds nothing and falls through.
+    activeLiveView()?.stop();
 
     // Rendered even when some apps failed to plan: the decisions that were
     // reached belong next to the per-app error lines already logged, and the

--- a/src/lib/util/select-rung.js
+++ b/src/lib/util/select-rung.js
@@ -32,12 +32,13 @@ export const OUTPUT_ENV = 'BSI_OUTPUT';
 /**
  * The rungs, from highest fidelity to none.
  *
- * `LIVE` is rung C of the ladder (issue #1075, not yet implemented) - the
- * selector already reports it so that landing the live view changes only the
- * renderer, and today's consumers treat it as `BOARD`. `OFF` suppresses the
- * plan and verdict blocks entirely for anyone whose log shipper chokes on
- * framed output; the per-app and per-sheet progress lines still print, so a
- * six-minute run is not silent.
+ * `LIVE` is rung C of the ladder (issue #1075): the animated run view in
+ * `run-live.js`, engaged by the create-thumbnails workers on real runs.
+ * Everywhere a live view is not actually running - dry runs, workers that
+ * never start one - the rung renders as `BOARD` via {@link rendersAsBoard}.
+ * `OFF` suppresses the plan and verdict blocks entirely for anyone whose log
+ * shipper chokes on framed output; the per-app and per-sheet progress lines
+ * still print, so a six-minute run is not silent.
  */
 export const RUNG = Object.freeze({
     LIVE: 'live',
@@ -49,11 +50,14 @@ export const RUNG = Object.freeze({
 const RUNG_VALUES = Object.freeze(Object.values(RUNG));
 
 /**
- * Whether a rung renders through the contact-sheet board today.
+ * Whether a rung renders through the contact-sheet board.
  *
- * `LIVE` collapses to the board until rung C (issue #1075) exists. This
- * equivalence lives in exactly one place so that landing the live view means
- * changing one predicate, not hunting the sites that re-encoded it.
+ * With rung C landed this is the *fallback* equivalence: `LIVE` still renders
+ * board blocks wherever no live view is actually active - dry runs, workers
+ * that never start one, and any block emitted before the view starts or
+ * after it stops. The live path itself is selected not here but by
+ * `activeLiveView()` in `run-report.js`, so this predicate stays the single
+ * place the LIVE-means-board rule is encoded.
  *
  * @param {string} rung - A value from {@link RUNG}.
  *


### PR DESCRIPTION
Closes #1075 and completes the #1071 run-output ladder.

## What this adds

On an interactive terminal, `qseow create-sheet-thumbnails` and `qscloud create-sheet-thumbnails` now show a live view: preflight rows (certificates, content library, app list, browser, signed in) that resolve as the real awaits behind them return, a per-app progress bar and sheet strip driven by the per-sheet decisions the processors record, and a collapse to the board verdict at the end. A hang is visible as the row or phase that never resolves — the diagnostic value the issue asked for.

Design notes:

- `rendersAsBoard()` is untouched and becomes the **fallback**: the live path engages only while a view is registered, so dry runs, non-TTY streams, `BSI_OUTPUT` overrides and the removal worker keep the contact sheet. No new options, env values, or exit-code changes (#1101).
- The display renders **from the report entries the verdict counts**, so the bar cannot claim a sheet the report does not hold.
- The `cli-progress` download bar in `browser-install.js` is never constructed while a view is active — download progress routes into the view's phase label instead (the two-writers hazard #1075 names), with tests asserting the mutual exclusion.
- Terminal restore is one reusable hook (`restoreLiveTerminal`), called on completion (`runCommand`), on worker error paths, and on the crash path (`installFatalHandlers`, before the FATAL line, watchdog armed first); the broken-pipe exit restores too. #1107's signal handling extends the same hook — Ctrl-C is documented as the one exit not yet covered.

## Verification

- Unit suite: 116 suites, 3,170 tests, exit 0; lint exit 0. New suites cover: frames into a fake TTY with the final verdict, zero frames when stdout is not a TTY (the docker-logs regression, gated twice), the restore sequence on the throw path, watchdog-before-restore ordering, broken-pipe restore, download-bar mutual exclusion, and the strip width clamp.
- Three live runs against the QSEoW lab from a real PTY (120×40), including one with a genuine mid-run browser download through the live view. Frame analysis of the raw recordings: exactly one hide/show cursor pair per run, zero winston lines leaked into the animated region across ~12,700 repaints, bar walking 0/9→9/9, clean collapse to the verdict. Dry run proven write-free by QRS snapshot diff; real-run writes proven by `staticcontentreference` timestamps.
- A max-effort multi-angle review ran before this PR; its four most severe findings are fixed in these commits, and the remaining eleven (all verified non-blocking) are collected in #1110.

A doc page is staged in `docs/to-doc-site/` with samples taken from the recorded runs. This also unblocks #1001/#1003 — the live view is finally output worth recording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)