### PR TITLE
Tighten the live run view's edge cases and rendering seams

### DIFF
--- a/src/lib/cloud/cloud-create-thumbnails.js
+++ b/src/lib/cloud/cloud-create-thumbnails.js
@@ -10,6 +10,7 @@ import {
     announceDryRun,
     emitRunHeader,
     startLiveRunView,
+    selectionCounts,
     buildSheetRules,
     buildSheetPartSection,
     buildBrowserPlanSection,
@@ -141,16 +142,21 @@ export const qscloudCreateThumbnails = async (options) => {
         // provenance it returns feeds the run report directly.
         live?.beginStep('app list');
         const selection = await resolveCloudAppSelection(saasInstance, options);
-        live?.stepDone(
-            'app list',
-            [
-                `${new Set(selection.appIds).size} apps`,
-                `${selection.namedAppIds.length} named`,
-                ...(selection.selector
-                    ? [`${selection.selectorAppIds.length} from collection`]
-                    : []),
-            ].join(live.sep)
-        );
+        // Same deduplicating counts and same empty-selection-is-failure rule
+        // as the QSEoW twin (issue #1110).
+        if (live) {
+            const counts = selectionCounts(selection);
+            const detail = [
+                `${counts.total} apps`,
+                `${counts.named} named`,
+                ...(selection.selector ? [`${counts.fromSelector} from collection`] : []),
+            ].join(live.sep);
+            if (counts.total === 0) {
+                live.stepFailed('app list', detail);
+            } else {
+                live.stepDone('app list', detail);
+            }
+        }
 
         return await runOverAppsWithReport({
             command: 'qscloud create-sheet-thumbnails',

--- a/src/lib/qseow/qseow-create-thumbnails.js
+++ b/src/lib/qseow/qseow-create-thumbnails.js
@@ -17,6 +17,7 @@ import {
     announceDryRun,
     emitRunHeader,
     startLiveRunView,
+    selectionCounts,
     buildSheetRules,
     buildSheetPartSection,
     buildBrowserPlanSection,
@@ -144,16 +145,25 @@ export const qseowCreateThumbnails = async (options) => {
         // degrades to nulls rather than failing the run.
         const planFacts = await readQseowPlanFacts(options, appIdsToProcess);
 
-        // Resolved only now, after every pre-run read: the row states what the
-        // loop will actually iterate, not an intermediate list.
-        live?.stepDone(
-            'app list',
-            [
-                `${new Set(appIdsToProcess).size} apps`,
-                `${namedAppIds.length} named`,
-                ...(useTag ? [`${taggedAppIds.length} tagged`] : []),
-            ].join(live.sep)
-        );
+        // Resolved only now, after every pre-run read: the row states what
+        // the loop will actually iterate. Counts come from the same
+        // deduplicating rule the report's plan block uses, so the two rows
+        // cannot disagree about a repeated --appid - and an empty selection
+        // resolves the row as FAILED, because the very next thing the run
+        // does is abort with "No apps to process" (issue #1110).
+        if (live) {
+            const counts = selectionCounts({ namedAppIds, selectorAppIds: taggedAppIds });
+            const detail = [
+                `${counts.total} apps`,
+                `${counts.named} named`,
+                ...(useTag ? [`${counts.fromSelector} tagged`] : []),
+            ].join(live.sep);
+            if (counts.total === 0) {
+                live.stepFailed('app list', detail);
+            } else {
+                live.stepDone('app list', detail);
+            }
+        }
 
         return await runOverAppsWithReport({
             command: 'qseow create-sheet-thumbnails',

--- a/src/lib/util/__tests__/run-live.test.js
+++ b/src/lib/util/__tests__/run-live.test.js
@@ -313,18 +313,27 @@ describe('the per-app block', () => {
         expect(last.endsWith('BOARD APP ROW\n')).toBe(true);
     });
 
-    test('a failed app commits the still-pending step as failed instead of leaving it spinning', () => {
+    test('a failed app drops its pending step so a later app can still resolve the row', () => {
+        // Committing the row as failed would latch it run-wide and
+        // misattribute one app's timeout to the step itself (issue #1110);
+        // the app's own red board row already carries the failure.
         const { stream, writes } = fakeTty();
         const view = createRunLiveView({ stream, ctx: uniCtx(), timer: manualTimer() });
         const entry = appEntry({ failed: true });
 
-        view.appStarted({ n: 1, total: 1, id: 'app-1' });
+        view.appStarted({ n: 1, total: 2, id: 'app-1' });
         view.beginStep('signed in');
         view.appFinished(entry, 'FAILED ROW\n');
 
-        const joined = writes.join('');
-        expect(joined).toContain(`${UNICODE_SYMBOLS.failed} signed in`);
-        expect(joined).toContain('FAILED ROW');
+        expect(writes.join('')).not.toContain(`${UNICODE_SYMBOLS.failed} signed in`);
+        expect(writes.join('')).toContain('FAILED ROW');
+
+        // App 2 signs in fine and the row resolves honestly.
+        view.appStarted({ n: 2, total: 2, id: 'app-2' });
+        view.beginStep('signed in');
+        view.stepDone('signed in', 'LAB\\user');
+
+        expect(writes.join('')).toContain(`${UNICODE_SYMBOLS.done} signed in`);
     });
 });
 
@@ -350,6 +359,51 @@ describe('download progress (the two-writers hazard)', () => {
         view.downloadProgress(97.4);
 
         expect(stripAnsi(writes.at(-1))).toContain('downloading 97%');
+    });
+
+    test('a non-finite percentage falls back to the plain phase label, never NaN%', () => {
+        // A download response without a Content-Length yields NaN, which the
+        // suppressed cli-progress bar guards against - the view must too
+        // (issue #1110).
+        const { stream, writes } = fakeTty();
+        const view = createRunLiveView({ stream, ctx: uniCtx(), timer: manualTimer() });
+
+        view.appStarted({ n: 1, total: 1, id: 'app-1' });
+        view.appPhase('browser');
+        view.downloadProgress(NaN);
+
+        const frame = stripAnsi(writes.at(-1));
+        expect(frame).not.toContain('NaN');
+        expect(frame).toContain('launching browser');
+    });
+
+    test('a repaint whose rendered frame is unchanged writes nothing', () => {
+        // The per-chunk download callbacks and the frame timer otherwise
+        // rewrite an identical region hundreds of times a second - on
+        // conhost each one a blocking console write (issue #1110).
+        const { stream, writes } = fakeTty();
+        const timer = manualTimer();
+        const view = createRunLiveView({ stream, ctx: uniCtx(), timer });
+        const entry = appEntry();
+
+        view.appStarted({ n: 1, total: 1, id: 'app-1' });
+        view.appOpened(entry);
+        view.appPhase('sheets');
+        entry.sheets.push({ n: 1, title: 'One', action: 'update', reason: null });
+        view.sheetRecorded(entry);
+
+        // The sheets-phase frame has no spinner, so ticks change nothing.
+        const frameCount = writes.length;
+        timer.tick();
+        timer.tick();
+        expect(writes).toHaveLength(frameCount);
+
+        // Same rounded percentage: one write, not one per chunk.
+        view.appPhase('browser');
+        view.downloadProgress(42.2);
+        const afterFirstPct = writes.length;
+        view.downloadProgress(42.4);
+        expect(writes).toHaveLength(afterFirstPct);
     });
 
     test('liveDownloadBar adapts the cli-progress surface onto the view', () => {
@@ -449,6 +503,33 @@ describe('terminal restore', () => {
     });
 });
 
+describe('committed log lines', () => {
+    test('a multi-line message commits in one write, with the timestamp on the first line only', () => {
+        const { stream, writes } = fakeTty();
+        const view = createRunLiveView({ stream, ctx: uniCtx(), timer: manualTimer() });
+
+        const frameCount = writes.length;
+        view.commitLogLine('error', 'boom\n  at somewhere\n  at elsewhere', '2026-08-18T09:00:00Z');
+
+        expect(writes).toHaveLength(frameCount + 1);
+        const text = stripAnsi(writes.at(-1));
+        expect(text).toContain('2026-08-18T09:00:00Z error: boom');
+        expect(text).toContain('at somewhere');
+        // The stamp appears once, not once per line.
+        expect(text.match(/2026-08-18T09:00:00Z/g)).toHaveLength(1);
+    });
+
+    test('a newline-terminated message commits no stray bare level line', () => {
+        const { stream, writes } = fakeTty();
+        const view = createRunLiveView({ stream, ctx: uniCtx(), timer: manualTimer() });
+
+        view.commitLogLine('error', 'boom\n');
+
+        const lines = stripAnsi(writes.at(-1)).split('\n');
+        expect(lines.filter((line) => line.trim() === 'error:')).toHaveLength(0);
+    });
+});
+
 describe('console routing through a real winston logger', () => {
     test('silences the console transport, commits warn and error lines, drops info, restores on stop', () => {
         const consoleTransport = new winston.transports.Console({ level: 'info' });
@@ -481,6 +562,22 @@ describe('console routing through a real winston logger', () => {
 });
 
 describe('the ASCII symbol set', () => {
+    test('pending and committed step rows share a label column despite marker widths', () => {
+        // ASCII spinner frames are 1 column while [ok]/[!!] are 4; without
+        // marker padding a row jumped three columns when it resolved
+        // (issue #1110).
+        const { stream, writes } = fakeTty();
+        const view = createRunLiveView({ stream, ctx: asciiCtx(), timer: manualTimer() });
+
+        view.beginStep('certificates');
+        const pendingCol = stripAnsi(writes.at(-1)).indexOf('certificates');
+        view.stepDone('certificates', 'client.pem');
+        const committedCol = stripAnsi(writes.at(-1)).indexOf('certificates');
+
+        expect(pendingCol).toBeGreaterThan(0);
+        expect(committedCol).toBe(pendingCol);
+    });
+
     test('a full flow emits only ASCII outside the control sequences', () => {
         const { stream, writes } = fakeTty();
         const view = createRunLiveView({ stream, ctx: asciiCtx(), timer: manualTimer() });

--- a/src/lib/util/__tests__/run-over-apps.test.js
+++ b/src/lib/util/__tests__/run-over-apps.test.js
@@ -35,6 +35,21 @@ describe('runOverApps', () => {
         expect(worker.mock.calls.map((call) => call[0])).toEqual(['a', 'b', 'c']);
     });
 
+    test('hands the worker the same position the app n/total log line states', async () => {
+        // One owner for the number (issue #1110): the live view and the
+        // committed board row read this instead of keeping their own
+        // counters that agree by convention. Deduplication applies before
+        // numbering, so the duplicate 'a' does not inflate the total.
+        const worker = jest.fn().mockResolvedValue(true);
+
+        await runOverApps(['a', 'b', 'a'], CTX, worker);
+
+        expect(worker.mock.calls.map((call) => call[1])).toEqual([
+            { n: 1, total: 2 },
+            { n: 2, total: 2 },
+        ]);
+    });
+
     test('reports success when every app was processed', async () => {
         const result = await runOverApps(['a', 'b'], CTX, jest.fn().mockResolvedValue(true));
 

--- a/src/lib/util/__tests__/run-report-live-flow.test.js
+++ b/src/lib/util/__tests__/run-report-live-flow.test.js
@@ -185,4 +185,18 @@ describe('startLiveRunView', () => {
         expect(stdoutWrites).toHaveLength(0);
         expect(activeLiveView()).toBeNull();
     });
+
+    test('stops a stale view before deciding anything, even on a declined path', () => {
+        // A new view constructed while an old one still held the console
+        // would capture "silenced" as the state to restore - permanent
+        // silence after it stops (issue #1110). The stale view is torn down
+        // first, declined paths included.
+        const { view, writes } = activeFakeTtyView();
+
+        expect(startLiveRunView({ rung: 'board', dryRun: false })).toBeNull();
+
+        expect(activeLiveView()).toBeNull();
+        expect(writes.join('')).toContain(SHOW_CURSOR);
+        expect(view).not.toBeNull();
+    });
 });

--- a/src/lib/util/run-board.js
+++ b/src/lib/util/run-board.js
@@ -66,8 +66,12 @@ const VALUE_WIDTH = 22;
  * row - truncating the strip would hide the exact per-sheet signal it
  * exists to show - and a run of 100+ apps widens the counter; both are
  * accepted, budgeted overflows rather than silent wraps on every row.
+ *
+ * Exported for the live view (issue #1075): its animated app header clips
+ * the same name this row will commit, and two widths meant the same app
+ * appeared under two names one frame apart (issue #1110).
  */
-const NAME_WIDTH = 20;
+export const NAME_WIDTH = 20;
 
 const STRIP_WIDTH = 12;
 
@@ -124,11 +128,14 @@ const ZERO_WIDTH = /\p{Mn}|\p{Me}|[\u1160-\u11ff\u200b-\u200f\ufeff]/u;
  * sheet strip after it: a miscounted name shifts that row's entire strip
  * band, which is exactly the per-app comparison the board exists for.
  *
+ * Exported for the live view (issue #1075), which pads its status markers
+ * with the same width model so ASCII and Unicode symbol sets align alike.
+ *
  * @param {string} text - The text to measure.
  *
  * @returns {number} The width in columns.
  */
-const width = (text) => {
+export const width = (text) => {
     let columns = 0;
 
     for (const ch of text) {
@@ -283,11 +290,15 @@ const planRow = (ctx, { label, value, detail = '', passive = false }) => {
  * The separator the strip glyphs and rules join with: ` · ` on Unicode
  * terminals, ` - ` on ASCII ones.
  *
+ * Exported for the live view (issue #1075), so the board rung and the live
+ * rung separate details with one expression rather than two copies that
+ * drift (issue #1110).
+ *
  * @param {object} ctx - From {@link boardContext}.
  *
  * @returns {string} The separator.
  */
-const dotSep = (ctx) => ` ${ctx.symbols.dot} `;
+export const dotSep = (ctx) => ` ${ctx.symbols.dot} `;
 
 /**
  * A dim horizontal rule separating the board's sections.
@@ -481,6 +492,29 @@ export const renderBoardPlan = (report, ctx) => {
 };
 
 /**
+ * The 1-based strip position of a recorded sheet row.
+ *
+ * Placed by the recorded 1-based sheet position, never by array order: the
+ * sheet loop survives a mid-app failure and keeps recording the later
+ * sheets, so row i of the array is not sheet i of the app. A row without a
+ * valid 1-based `n` (every in-repo recorder sets one) falls back to its
+ * array position - the same fallback in the count and the placement, so a
+ * synthetic `n: 0` can neither write off the left edge nor undercount the
+ * strip.
+ *
+ * Exported for the live view (issue #1075), whose in-progress strip clips
+ * at the last recorded position - one placement rule, not two copies that
+ * can disagree about the same sheet (issue #1110).
+ *
+ * @param {object} sheet - A recorded sheet row.
+ * @param {number} i - The row's array index.
+ *
+ * @returns {number} The 1-based strip position.
+ */
+export const positionOf = (sheet, i) =>
+    typeof sheet.n === 'number' && sheet.n >= 1 ? sheet.n : i + 1;
+
+/**
  * The sheet strip for one app: one glyph per sheet *position*, placed by the
  * recorded 1-based sheet number.
  *
@@ -527,16 +561,6 @@ export const stripForApp = (appEntry, symbols) => {
                 : capturedCell
             : (glyphFor[sheet.action] ?? failedCell);
 
-    // Placed by the recorded 1-based sheet position, never by array order:
-    // the sheet loop survives a mid-app failure and keeps recording the
-    // later sheets, so row i of the array is not sheet i of the app. A row
-    // without a valid 1-based `n` (every in-repo recorder sets one) falls
-    // back to its array position - the same fallback in the count and the
-    // placement, so a synthetic `n: 0` can neither write off the left edge
-    // nor undercount the strip.
-    const positionOf = (sheet, i) =>
-        typeof sheet.n === 'number' && sheet.n >= 1 ? sheet.n : i + 1;
-
     const count = Math.max(
         typeof appEntry.sheetCount === 'number' ? appEntry.sheetCount : 0,
         appEntry.sheets.length,
@@ -557,6 +581,19 @@ const STRIP_PAINT = Object.freeze({
     excluded: (palette) => palette.dim,
     failed: (palette) => palette.red,
 });
+
+/**
+ * Paint strip cells into one coloured string. The single place a cell's
+ * `kind` meets its colour - both the committed board row and the live
+ * view's animated strip go through here (issue #1110).
+ *
+ * @param {Array<{glyph: string, kind: string}>} cells - From {@link stripForApp}.
+ * @param {object} palette - The palette in use.
+ *
+ * @returns {string} The painted strip.
+ */
+const paintCells = (cells, palette) =>
+    cells.map(({ glyph, kind }) => STRIP_PAINT[kind](palette)(glyph)).join('');
 
 /**
  * The coloured sheet strip for one app, unpadded.
@@ -580,10 +617,7 @@ const STRIP_PAINT = Object.freeze({
  * @returns {string} The painted strip.
  */
 export const renderSheetStrip = (appEntry, ctx, limit = Infinity) =>
-    stripForApp(appEntry, ctx.symbols)
-        .slice(0, limit)
-        .map(({ glyph, kind }) => STRIP_PAINT[kind](ctx.palette)(glyph))
-        .join('');
+    paintCells(stripForApp(appEntry, ctx.symbols).slice(0, limit), ctx.palette);
 
 /**
  * One per-app strip row, appended to the board as the app finishes.
@@ -610,9 +644,7 @@ export const renderBoardAppRow = (appEntry, { n, total, removal }, ctx) => {
     const name = padTo(clip(appEntry.name ?? appEntry.id ?? '', NAME_WIDTH), NAME_WIDTH);
 
     const cells = stripForApp(appEntry, symbols);
-    const strip =
-        cells.map(({ glyph, kind }) => STRIP_PAINT[kind](palette)(glyph)).join('') +
-        ' '.repeat(Math.max(0, STRIP_WIDTH - cells.length));
+    const strip = paintCells(cells, palette) + ' '.repeat(Math.max(0, STRIP_WIDTH - cells.length));
 
     const counts = verdictCounts({ apps: [appEntry] });
     const sheetCount = appEntry.sheetCount ?? counts.seen;

--- a/src/lib/util/run-live.js
+++ b/src/lib/util/run-live.js
@@ -1,5 +1,14 @@
 import winston from 'winston';
-import { renderSheetStrip, clip, padTo } from './run-board.js';
+import {
+    renderSheetStrip,
+    clip,
+    padTo,
+    positionOf,
+    dotSep,
+    width,
+    NAME_WIDTH,
+} from './run-board.js';
+import { isTimestampEnabled } from './log-timestamps.js';
 
 /**
  * Rung C of the run-output ladder (issue #1075): the live run view.
@@ -80,6 +89,21 @@ const PHASE_LABEL = Object.freeze({
 });
 
 /**
+ * The winston console transport on a logger, or undefined.
+ *
+ * The single answer to "which transport is the console" (issue #1110): the
+ * view silences it for its lifetime, and `withConsoleSilenced` in
+ * run-report.js silences it per block - two callers, one lookup, so the two
+ * mechanisms can never disagree about which transport they are toggling.
+ *
+ * @param {object} log - Winston-style logger.
+ *
+ * @returns {object|undefined} The console transport, when one exists.
+ */
+export const findConsoleTransport = (log) =>
+    log?.transports?.find((transport) => transport.name === 'console');
+
+/**
  * A winston transport that hands `warn` and `error` lines to the live view.
  *
  * While the view owns the cursor the console transport is silenced, but a
@@ -110,7 +134,14 @@ class LiveViewTransport extends winston.Transport {
      * @returns {void}
      */
     log(info, callback) {
-        this.view.commitLogLine(info.level, String(info.message ?? ''));
+        // The timestamp travels with the line so the routed transcript stays
+        // time-correlatable with the shipped log - same rule as the console
+        // transport, which prefixes it only when timestamps are enabled.
+        this.view.commitLogLine(
+            info.level,
+            String(info.message ?? ''),
+            isTimestampEnabled() ? info.timestamp : undefined
+        );
         callback();
     }
 }
@@ -179,7 +210,12 @@ export const createRunLiveView = ({ stream, ctx, log = null, timer = makeFrameTi
 
     const { palette, symbols } = ctx;
     const frames = symbols.spinnerFrames;
-    const sep = ` ${symbols.dot} `;
+    const sep = dotSep(ctx);
+
+    // Markers are padded to the set's widest so a row does not shift three
+    // columns when its 1-column ASCII spinner resolves into a 4-column
+    // `[ok]` (issue #1110). The Unicode set is uniformly 1 column wide.
+    const markerWidth = Math.max(width(symbols.done), width(symbols.failed), width(frames[0]));
 
     let stopped = false;
     let regionLines = 0;
@@ -188,6 +224,7 @@ export const createRunLiveView = ({ stream, ctx, log = null, timer = makeFrameTi
     const committedSteps = new Set();
     let app = null; // {n, total, id, entry, phase}
     let downloadPct = null;
+    let lastRegionBody = null;
 
     let consoleTransport = null;
     let previousSilent = false;
@@ -203,20 +240,21 @@ export const createRunLiveView = ({ stream, ctx, log = null, timer = makeFrameTi
 
     /**
      * One preflight row. Padded plain, coloured after - the same width
-     * discipline as the board renderers.
+     * discipline as the board renderers, the marker column included.
      *
-     * @param {string} marker - The already-coloured status glyph.
+     * @param {string} markerGlyph - The status glyph, plain.
+     * @param {(text: string) => string} paintMarker - Colour for the marker.
      * @param {string} label - Row label, plain.
      * @param {string} [detail] - Dim detail after the label.
      *
      * @returns {string} The row.
      */
-    const stepRow = (marker, label, detail) => {
+    const stepRow = (markerGlyph, paintMarker, label, detail) => {
         const detailPart = detail
             ? `  ${palette.dim(clip(detail, Math.max(10, columns() - STEP_LABEL_WIDTH - 10)))}`
             : '';
 
-        return `  ${marker} ${padTo(label, STEP_LABEL_WIDTH)}${detailPart}`;
+        return `  ${paintMarker(padTo(markerGlyph, markerWidth))} ${padTo(label, STEP_LABEL_WIDTH)}${detailPart}`;
     };
 
     /**
@@ -226,19 +264,22 @@ export const createRunLiveView = ({ stream, ctx, log = null, timer = makeFrameTi
      */
     const renderRegion = () => {
         const lines = [];
-        const spinner = palette.yellow(frames[spinnerIndex % frames.length]);
+        const spinnerGlyph = frames[spinnerIndex % frames.length];
+        const spinner = palette.yellow(spinnerGlyph);
 
         if (pendingStep) {
             const detail =
                 pendingStep.label === 'browser' && downloadPct !== null
                     ? `downloading ${downloadPct}%`
                     : pendingStep.detail;
-            lines.push(stepRow(spinner, pendingStep.label, detail));
+            lines.push(stepRow(spinnerGlyph, palette.yellow, pendingStep.label, detail));
         }
 
         if (app) {
             const entry = app.entry;
-            const name = clip(entry?.name ?? app.id ?? '', 32);
+            // The same clip as the committed board row, so the app appears
+            // under one name in both (issue #1110).
+            const name = clip(entry?.name ?? app.id ?? '', NAME_WIDTH);
             const sheetNote =
                 typeof entry?.sheetCount === 'number'
                     ? palette.dim(`${sep}${entry.sheetCount} sheets`)
@@ -269,11 +310,7 @@ export const createRunLiveView = ({ stream, ctx, log = null, timer = makeFrameTi
                 // board row still carries the full strip; only the animated
                 // copy is capped.
                 const reached = entry.sheets.reduce(
-                    (max, sheet, i) =>
-                        Math.max(
-                            max,
-                            typeof sheet.n === 'number' && sheet.n >= 1 ? sheet.n : i + 1
-                        ),
+                    (max, sheet, i) => Math.max(max, positionOf(sheet, i)),
                     0
                 );
                 const stripLimit = Math.min(reached, Math.max(1, columns() - 3));
@@ -299,40 +336,54 @@ export const createRunLiveView = ({ stream, ctx, log = null, timer = makeFrameTi
         regionLines > 0 ? `${cursorUp(regionLines)}\r${ERASE_DOWN}` : `\r${ERASE_DOWN}`;
 
     /**
-     * Repaint the animated region in place, in a single write.
+     * The one region-write protocol: erase the current region, write any
+     * finished block above it, repaint the region below - a single stream
+     * write, so nothing can interleave between the parts.
+     *
+     * A pure repaint whose rendered body is byte-identical to what is
+     * already on screen is skipped entirely (issue #1110): the frame timer
+     * and the per-chunk download callbacks otherwise rewrite an unchanged
+     * region hundreds of times a second, and on conhost every one of those
+     * is a blocking console write.
+     *
+     * @param {string} [block] - Finished content to commit above the region.
+     *     A trailing newline is added when missing. Empty means repaint only.
      *
      * @returns {void}
      */
-    const paint = () => {
+    const repaint = (block = '') => {
         if (stopped) {
             return;
         }
 
         const lines = renderRegion();
         const body = lines.length > 0 ? `${lines.join('\n')}\n` : '';
-        stream.write(`${eraseRegion()}${body}`);
+
+        if (block === '' && body === lastRegionBody) {
+            return;
+        }
+
+        const blockPart = block === '' || block.endsWith('\n') ? block : `${block}\n`;
+        stream.write(`${eraseRegion()}${blockPart}${body}`);
         regionLines = lines.length;
+        lastRegionBody = body;
     };
 
     /**
-     * Write finished content above the region: erase, write, repaint - one
-     * stream write, so nothing can interleave between the parts.
-     *
-     * @param {string} text - The static text. A trailing newline is added when missing.
+     * Repaint the animated region in place.
      *
      * @returns {void}
      */
-    const commit = (text) => {
-        if (stopped) {
-            return;
-        }
+    const paint = () => repaint();
 
-        const block = text.endsWith('\n') ? text : `${text}\n`;
-        const lines = renderRegion();
-        const body = lines.length > 0 ? `${lines.join('\n')}\n` : '';
-        stream.write(`${eraseRegion()}${block}${body}`);
-        regionLines = lines.length;
-    };
+    /**
+     * Write finished content above the region.
+     *
+     * @param {string} text - The static text.
+     *
+     * @returns {void}
+     */
+    const commit = (text) => repaint(text);
 
     /**
      * Commit one resolved preflight row. Each label commits once per run -
@@ -353,8 +404,9 @@ export const createRunLiveView = ({ stream, ctx, log = null, timer = makeFrameTi
         if (pendingStep?.label === label) {
             pendingStep = null;
         }
-        const marker = ok ? palette.green(symbols.done) : palette.red(symbols.failed);
-        commit(stepRow(marker, label, detail));
+        const glyph = ok ? symbols.done : symbols.failed;
+        const paintMarker = ok ? palette.green : palette.red;
+        commit(stepRow(glyph, paintMarker, label, detail));
     };
 
     const view = {
@@ -486,9 +538,13 @@ export const createRunLiveView = ({ stream, ctx, log = null, timer = makeFrameTi
         /**
          * Close the app block, committing its final board row.
          *
-         * A preflight row still pending when a failed app closes is committed
-         * as failed: its `await` threw, and leaving it spinning would show a
-         * run stuck on a step that has already been abandoned.
+         * A preflight row still pending when the app closes is dropped, not
+         * committed as failed: the app's own board row and the routed error
+         * lines already carry the failure, while a committed red row would
+         * latch run-wide and misattribute one app's timeout to the step
+         * itself even after every later app performs it fine (issue #1110).
+         * Because the label never commits, a later app's beginStep/stepDone
+         * for the same step can still resolve the row honestly.
          *
          * @param {object} entry - The per-app report entry.
          * @param {string} rowText - The rendered board app row.
@@ -498,9 +554,6 @@ export const createRunLiveView = ({ stream, ctx, log = null, timer = makeFrameTi
         appFinished(entry, rowText) {
             if (stopped) {
                 return;
-            }
-            if (pendingStep && entry?.failed) {
-                commitStep(pendingStep.label, undefined, false);
             }
             pendingStep = null;
             app = null;
@@ -520,26 +573,48 @@ export const createRunLiveView = ({ stream, ctx, log = null, timer = makeFrameTi
             if (stopped) {
                 return;
             }
-            downloadPct = pct === null ? null : Math.max(0, Math.min(100, Math.round(pct)));
+            // Number.isFinite, not a null check: a download response without
+            // a Content-Length yields NaN, which survives round/min/max and
+            // would render as "downloading browser NaN%" (issue #1110). A
+            // non-finite value means the progress is unknowable - show the
+            // plain phase label instead.
+            downloadPct = Number.isFinite(pct) ? Math.max(0, Math.min(100, Math.round(pct))) : null;
             paint();
         },
 
         /**
          * Commit a routed log line above the region.
          *
+         * One commit per message, not per line (issue #1110): a stack trace
+         * used to tear the region down once per line, and a message ending
+         * in a newline committed a stray bare `error:` line. The timestamp
+         * prefixes the first line only, matching how the console transport
+         * renders a multi-line message under one stamp.
+         *
          * @param {string} level - Winston level, decides the paint.
          * @param {string} message - The message; may span lines.
+         * @param {string} [timestamp] - Timestamp prefix, when enabled.
          *
          * @returns {void}
          */
-        commitLogLine(level, message) {
+        commitLogLine(level, message, timestamp) {
             if (stopped) {
                 return;
             }
             const paintLine = level === 'error' ? palette.red : palette.yellow;
-            for (const line of message.split('\n')) {
-                commit(`  ${paintLine(`${level}: ${line}`)}`);
+            const messageLines = message.split('\n');
+            while (messageLines.length > 1 && messageLines.at(-1) === '') {
+                messageLines.pop();
             }
+            const prefix = timestamp ? `${timestamp} ` : '';
+            const block = messageLines
+                .map((line, i) =>
+                    i === 0
+                        ? `  ${paintLine(`${prefix}${level}: ${line}`)}`
+                        : `  ${paintLine(line)}`
+                )
+                .join('\n');
+            commit(block);
         },
 
         /**
@@ -592,7 +667,7 @@ export const createRunLiveView = ({ stream, ctx, log = null, timer = makeFrameTi
     stream.write(HIDE_CURSOR);
 
     if (log) {
-        consoleTransport = log.transports?.find((transport) => transport.name === 'console');
+        consoleTransport = findConsoleTransport(log);
         if (consoleTransport) {
             // Normalised to a boolean: winston leaves `silent` undefined on a
             // transport that was never silenced, and the restore must hand

--- a/src/lib/util/run-over-apps.js
+++ b/src/lib/util/run-over-apps.js
@@ -31,7 +31,12 @@ import { logger } from '../../globals.js';
  * @param {string} [ctx.emptySelectionHint] - Extra guidance logged when the list is empty,
  *     e.g. which options to check. An empty list is reported as an error, because it means
  *     the operator asked for work that did not happen.
- * @param {(appId: string) => Promise<unknown>} processApp - Worker invoked once per app.
+ * @param {(appId: string, position: {n: number, total: number}) => Promise<unknown>} processApp -
+ *     Worker invoked once per app. The position is the same 1-based `n` and
+ *     total this loop prints in its `app n/total` line - handed to the worker
+ *     so the log line, the live view's block and the committed board row all
+ *     read one number from one owner (issue #1110), instead of each keeping
+ *     a counter that agrees by convention.
  *
  * @returns {Promise<boolean>} `true` only when at least one app was selected and every one
  *     of them was processed without error. An empty selection is a failure, not a no-op.
@@ -71,7 +76,7 @@ export const runOverApps = async (
                 `${action === 'process' ? 'app' : `${action} app`} ${appNumber}/${uniqueAppIds.length}  ${appId}`
             );
 
-            await processApp(appId);
+            await processApp(appId, { n: appNumber, total: uniqueAppIds.length });
 
             logger.verbose(`Done processing app ${appId}`);
         } catch (err) {

--- a/src/lib/util/run-report.js
+++ b/src/lib/util/run-report.js
@@ -15,7 +15,13 @@ import {
     renderBoardAppRow,
     renderBoardVerdict,
 } from './run-board.js';
-import { createRunLiveView, activateLiveView, activeLiveView } from './run-live.js';
+import {
+    createRunLiveView,
+    activateLiveView,
+    activeLiveView,
+    restoreLiveTerminal,
+    findConsoleTransport,
+} from './run-live.js';
 import { toOptionValueList } from './option-values.js';
 import { measureImageFiles } from './image-dir.js';
 
@@ -117,9 +123,11 @@ const decideRung = (headless) =>
  * @returns {void}
  */
 const withConsoleSilenced = (emit) => {
-    // Optional chaining: injected test loggers have no transports array, and
-    // a missing console transport must mean "nothing to silence", not a crash.
-    const consoleTransport = logger.transports?.find((transport) => transport.name === 'console');
+    // The shared lookup from run-live.js, so this per-block silencing and
+    // the live view's run-long silencing can never disagree about which
+    // transport is the console. A missing transport (injected test loggers)
+    // means "nothing to silence", not a crash.
+    const consoleTransport = findConsoleTransport(logger);
 
     if (!consoleTransport) {
         emit();
@@ -260,6 +268,14 @@ export const emitRunHeader = ({ version, jobLabel, options = {} }) => {
  * @returns {object|null} The active live view, or null.
  */
 export const startLiveRunView = ({ rung, dryRun = false }) => {
+    // Any stale view is stopped before this run decides anything - even on
+    // the declined paths. Creating a new view while an old one still held
+    // the console would make the new one capture "silenced" as the state to
+    // restore, permanently silencing the transport when it stops (issue
+    // #1110). No production flow leaves a view active here; this makes that
+    // a guarantee instead of an observation.
+    restoreLiveTerminal();
+
     if (rung !== RUNG.LIVE || dryRun) {
         return null;
     }
@@ -494,13 +510,33 @@ const markAppFailed = (report, appId) => {
  * @returns {void}
  */
 export const recordSelection = (report, { namedAppIds, selectorAppIds, selector }) => {
+    report.selection = {
+        ...selectionCounts({ namedAppIds, selectorAppIds }),
+        selector,
+    };
+};
+
+/**
+ * Deduplicated selection counts from the raw id lists.
+ *
+ * The one counting rule (issue #1110): `recordSelection` uses it for the
+ * report, and the workers use it for the live `app list` row - previously
+ * the workers counted raw list lengths, so a repeated `--appid` made the
+ * live row and the plan block state different named-counts on one screen.
+ *
+ * @param {object} lists - The raw id lists.
+ * @param {string[]} lists.namedAppIds - Apps named directly by `--appid`.
+ * @param {string[]} lists.selectorAppIds - Apps contributed by the selector.
+ *
+ * @returns {{named: number, fromSelector: number, total: number}} The counts.
+ */
+export const selectionCounts = ({ namedAppIds, selectorAppIds }) => {
     const named = new Set(namedAppIds);
     const fromSelector = new Set(selectorAppIds);
 
-    report.selection = {
+    return {
         named: named.size,
         fromSelector: fromSelector.size,
-        selector,
         total: new Set([...named, ...fromSelector]).size,
     };
 };
@@ -882,13 +918,7 @@ export const runOverAppsWithReport = async ({
         suppressOnOff: !dryRun,
     });
 
-    const totalApps = new Set(appIds).size;
     const removal = isRemovalReport(report);
-
-    // Counted here rather than taken from the report: a failed app may or may
-    // not have an entry yet when its block opens, and the live app number
-    // must match the `app i/n` line the loop logs.
-    let liveAppNumber = 0;
 
     const result = await runOverApps(
         appIds,
@@ -909,10 +939,12 @@ export const runOverAppsWithReport = async ({
                       throw err;
                   }
               }
-            : async (appId) => {
+            : async (appId, position) => {
                   const appStartedAt = Date.now();
-                  liveAppNumber += 1;
-                  activeLiveView()?.appStarted({ n: liveAppNumber, total: totalApps, id: appId });
+                  // The loop's own position, not a re-count: one owner for
+                  // the number the log line, the live block and the committed
+                  // row all state (issue #1110).
+                  activeLiveView()?.appStarted({ n: position.n, total: position.total, id: appId });
                   try {
                       const result = await processApp(appId, report);
 
@@ -944,7 +976,7 @@ export const runOverAppsWithReport = async ({
                               // appended raw - one renderer, two carriers.
                               const row = renderBoardAppRow(
                                   entry,
-                                  { n: report.apps.length, total: totalApps, removal },
+                                  { n: position.n, total: position.total, removal },
                                   ctx
                               );
                               const live = activeLiveView();


### PR DESCRIPTION
Closes #1110 — the eleven verified follow-ups from the max-effort review of the live run view (#1075 / PR #1111).

## What changes

**Behavioral corrections (`fix`):** a download without a Content-Length no longer renders `NaN%`; an empty app selection resolves its `app list` preflight row as failed instead of green-checking the failure the run is about to report; a failed app drops its pending step row rather than latching a red verdict later apps can never correct; ASCII markers are padded so rows no longer shift three columns on resolve; the animated app name is clipped to the same width as the committed board row; routed warn/error lines keep their timestamps, commit multi-line messages in one write, and drop the stray trailing bare line; byte-identical repaints are skipped, removing the per-chunk download flood and the no-op timer frames; selection counts share `recordSelection`'s deduplicating rule; and `startLiveRunView` tears down any stale view before deciding anything.

**Enabling seams (`refactor`):** `positionOf`, `dotSep`, `width`, `NAME_WIDTH` and one `paintCells` are owned by run-board and consumed by run-live instead of re-derived; `runOverApps` hands its worker the `{n, total}` position it already computes, so the log line, the live block and the committed row read one number from one owner.

Deliberately not merged: `stepRow` vs `planRow` — different column models, and one forced abstraction would be worse than two honest layouts.

## Verification

Lint and full unit suite exit 0 (116 suites, 3,177 tests — 7 new covering the position contract, drop-not-latch, NaN, frame dedup, log-line block format, ASCII alignment, and stale-view teardown). A live QSEoW lab run after the changes: exit 0, one hide/show cursor pair, all rows and the verdict intact — and the frame dedup cut the same run's terminal traffic from ~93 KB to 18 KB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)