### PR TITLE
Archive the two published demo-assets drafts

### DIFF
--- a/docs/to-doc-site/done/done_demo-before-dry-run-after-narrative.md
+++ b/docs/to-doc-site/done/done_demo-before-dry-run-after-narrative.md
@@ -1,3 +1,26 @@
+<!--
+PUBLISHED to `next` on 2026-08-18, butler-sheet-icons-docs PR #110.
+
+Parts 1 and 2 published: the front page now reads before -> plan -> after with the dry-run
+recording as the middle panel, and the 3.5 MB `demo-animated.gif` is replaced by an 83 KB WebM
+with a 109 KB MP4 fallback. The overview screenshots were regenerated from the same pipeline run.
+
+Part 3 (vendoring an asciinema player component) was NOT done. It remains low priority, as the
+parent issue rates it.
+
+CORRECTION. This draft states the published overview screenshots are "hand-made retina grabs
+(roughly 2314x1266)" and warns the regenerated pair must not be visibly worse, citing #735. The
+published images were in fact 1352x611; the regenerated pair is 1230x810 and shows more of the
+sheet list. The premise was wrong, so the concern it raised did not apply and #735 was not a
+blocker for this change.
+
+DECIDED while publishing. The draft does not say what shape the video should be. Rendering the
+short casts into a taller virtual terminal fits a whole dry run in one frame - so the final frame
+holds the full plan block - but makes the asset portrait (1175x1366). That was tried and rejected
+as the wrong shape for a doc-site page; all three renders are landscape 1175x829, and the slow
+reveal plus the held final frame are what let a viewer read the part that scrolls past.
+-->
+
 # Front page: the before / dry-run / after narrative, and retiring the GIF
 
 This draft covers the doc site's front page (`docs/index.md` in the doc site repo) and is the publishing half of issues #1000/#1001/#1003. Unlike most drafts here, the work lands almost entirely in the **doc site repository** — this file describes precisely what changes and where the assets come from, so the change is reproducible.

--- a/docs/to-doc-site/done/done_qseow-remove-sheet-icons.md
+++ b/docs/to-doc-site/done/done_qseow-remove-sheet-icons.md
@@ -1,3 +1,23 @@
+<!--
+PUBLISHED to `next` on 2026-08-18, butler-sheet-icons-docs PR #109. Version gate 5.0.0,
+read from release-please PR #974 at publish time. Publishing this closed #1082.
+
+NOT published as a new page. `docs/reference/qseow.md` already carried a `## remove-sheet-icons`
+section - written before the command existed, which is what #1082 was filed for - so that section
+was replaced rather than a second one added. Its claim that the command "uses the same connection
+and authentication options as create-sheet-thumbnails" was wrong in the other direction and is
+gone: the option set is deliberately narrower. `/guide/concepts/dry-run` was updated in the same
+PR, since it said three commands accept the flag and described the `clear icon` column as
+Cloud-only.
+
+CORRECTION, and it changed twice. This draft says of no-icon sheets: "the real run reports them
+the same way rather than failing over them". That was FALSE when published - the real run tested
+for the thumbnail structure while the planner tested the URL, so a re-run rewrote and saved every
+already-cleared sheet (#1113). The sentence was therefore left OUT of the published page. #1113
+was then fixed in the same pull request that merged this draft (#1114), so the claim is now TRUE.
+The live page still omits it; adding it back is a small, safe follow-up.
+-->
+
 # Removing sheet icons on Qlik Sense Enterprise on Windows
 
 Butler Sheet Icons can now remove sheet icons from Qlik Sense Enterprise on Windows (QSEoW) apps, using the new `qseow remove-sheet-icons` command.


### PR DESCRIPTION
Housekeeping for `docs/to-doc-site`, following that folder's workflow. Refs #1000, #1001, #1003.

Both drafts are live on the doc site's `next` branch, so they move to `done/` with the `done_` prefix. `git mv`, so history follows the files.

| Draft | Published as |
|---|---|
| `qseow-remove-sheet-icons.md` | butler-sheet-icons-docs#109 — replaced the phantom `## remove-sheet-icons` section on `/reference/qseow`, which closed #1082 |
| `demo-before-dry-run-after-narrative.md` | butler-sheet-icons-docs#110 — front page reordered to before → plan → after, GIF replaced by the video |

## The notes matter more than the move

Each archived file carries a comment recording what was corrected on the way out, which is the part that is easy to lose:

- **`qseow-remove-sheet-icons`** claimed a real run reports no-icon sheets the same way the dry run does. That was **false** when published — the run tested for the thumbnail structure while the plan tested the URL, so a repeat rewrote and saved every already-cleared sheet (#1113) — and the sentence was withheld from the live page. #1113 was then fixed in #1114, the same PR that merged the draft, making the claim true; it has since been added back to the live page in butler-sheet-icons-docs#111. The note records that sequence, because "the draft was wrong" and "the page is missing something true" were both accurate at different points.
- **`demo-before-dry-run-after-narrative`** described the published overview screenshots as "roughly 2314x1266" retina grabs and warned the regenerated pair might look worse, citing #735 as a possible blocker. They were 1352x611; the regenerated pair is 1230x810 and shows more of the sheet list. The premise was wrong, so the concern never applied.

That note also records a decision the draft did not make: the videos are landscape (1175x829). Rendering the short casts into a taller virtual terminal fits a whole dry run in one frame, so the final frame holds the entire plan block — that was tried and rejected as the wrong shape for a doc-site page.

Part 3 of the narrative draft, vendoring an asciinema player component, was **not** done and stays low priority as #1003 rates it.

`run-output-live-view.md` is untouched — a separate pending draft, not part of this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)