### PR TITLE
Make the removal dry run's summary agree with the run it predicts

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -58,6 +58,14 @@ Machine state, not repo state - anyone regenerating assets needs all of it:
    names the sacrificial demo app; never point it at a shared or production
    app. The content library it names must exist on the server.
 
+    It must pin **everything that changes what a recording shows**, not just
+    the credentials. A worktree used for live testing usually has the repo's
+    own `.env` copied into it, and `demo.env` values only win where they are
+    set — anything omitted falls through to `.env`. That is how
+    `BSI_QSEOW_CST_INCLUDE_SHEET_PART` once leaked in at `4` against
+    recordings made at `1`, producing drift that `demo:check` reported as a
+    CLI change when nothing about the CLI had changed.
+
 4. **Keep the log level at the default `info`.** The server name appears
    once at `info`; `verbose` adds session-close lines and `debug` adds full
    app and sheet URLs. A demo has no reason to widen that surface.

--- a/demo/demo.env.example
+++ b/demo/demo.env.example
@@ -48,6 +48,16 @@ BSI_QSEOW_RSI_APP_ID=a3e0f5d2-000a-464f-998d-33d333b175d7
 BSI_QSEOW_CST_CONTENT_LIBRARY="Butler sheet thumbnails"
 
 # --- recording ergonomics --------------------------------------------------
+# Pinned, not left to default. A worktree set up for live testing usually has
+# the repo's own .env copied into it, and that file sets
+# BSI_QSEOW_CST_INCLUDE_SHEET_PART='4' - a different framing from the '1' the
+# committed recordings use. dotenv does not override an already-exported
+# variable, so anything this file sets wins and anything it omits falls through
+# to .env. Omitting this one made demo:check report drift that was not CLI
+# drift, and check-update would then have baked the wrong framing into the
+# snapshot without complaining. Anything that changes what a recording shows
+# belongs here for the same reason.
+BSI_QSEOW_CST_INCLUDE_SHEET_PART=1
 # --pagewait 1 cuts roughly 80% of the sleeping from a real run (#1001).
 BSI_QSEOW_CST_PAGE_WAIT=1
 # Drops the ISO timestamp prefix from console lines. That prefix is around 31

--- a/demo/snapshots/qseow-remove-sheet-icons-dry-run.txt
+++ b/demo/snapshots/qseow-remove-sheet-icons-dry-run.txt
@@ -41,5 +41,5 @@ info:    7  Sheet 7               clear icon
 info:    8  Sheet 1 (1)           clear icon
 info:    9  Sheet 6               clear icon
 info:
-info: Summary: 1 app(s), 9 sheets. 9 icon(s) would be cleared, 0 skipped.
+info: Summary: 1 app(s), 9 sheets. 8 icon(s) would be cleared, 1 with no icon, 0 skipped.
 info: Nothing was changed. Re-run without --dry-run to apply.

--- a/docs/to-doc-site/done/done_qseow-remove-sheet-icons.md
+++ b/docs/to-doc-site/done/done_qseow-remove-sheet-icons.md
@@ -16,6 +16,12 @@ for the thumbnail structure while the planner tested the URL, so a re-run rewrot
 already-cleared sheet (#1113). The sentence was therefore left OUT of the published page. #1113
 was then fixed in the same pull request that merged this draft (#1114), so the claim is now TRUE.
 The live page still omits it; adding it back is a small, safe follow-up.
+
+OUTDATED TRANSCRIPT (#1115). The sample dry-run output below ends in "Summary: 1 app(s), 9
+sheets. 9 icon(s) would be cleared, 0 skipped." That summary was wrong - it counted the one
+sheet with no icon among the nine that would be cleared - and the line now reads "8 icon(s)
+would be cleared, 1 with no icon, 0 skipped." Do not reuse this transcript; see the
+remove-sheet-icons-dry-run-summary-counts.md draft.
 -->
 
 # Removing sheet icons on Qlik Sense Enterprise on Windows

--- a/docs/to-doc-site/remove-sheet-icons-dry-run-summary-counts.md
+++ b/docs/to-doc-site/remove-sheet-icons-dry-run-summary-counts.md
@@ -1,0 +1,62 @@
+# The removal dry run's summary now counts sheets the way the real run does
+
+> **Publisher notes (not for the site):**
+>
+> 1. This is a small correction to pages that already exist. Nothing new is introduced, so it needs **no new page** — the target is one added sentence plus a corrected sample transcript on `/guide/concepts/dry-run` (the `remove-sheet-icons` paragraph, currently near "For the two `remove-sheet-icons` commands the column reads `clear icon` instead") and, if a transcript is shown there, `/reference/qseow.md` and `/reference/qscloud.md`.
+> 2. Both platforms are affected — `qseow remove-sheet-icons` and `qscloud remove-sheet-icons` print the same summary line.
+> 3. The archived draft `done/done_qseow-remove-sheet-icons.md` in this folder contains a sample transcript with the **old, wrong** summary line. Do not reuse that transcript.
+> 4. Version gate: read the open release-please PR title at publish time. As of writing, the pending release was 5.0.0.
+
+## What changed
+
+When `remove-sheet-icons` is run with `--dry-run`, the summary line at the end of the plan used to count every sheet it listed as an icon that would be cleared — including sheets that have no icon at all.
+
+That contradicted the plan's own per-sheet rows, which correctly marked those sheets `(no icon currently set)`, and it contradicted the real run, which reports them separately.
+
+On an app with nine sheets, eight of which carry icons:
+
+**Before**
+
+```
+   #  Sheet                 Would do
+   1  Sheet 0 (hidden)      clear icon  (no icon currently set)
+   2  Sheet 1               clear icon
+   ...
+
+Summary: 1 app(s), 9 sheets. 9 icon(s) would be cleared, 0 skipped.
+```
+
+**Now**
+
+```
+   #  Sheet                 Would do
+   1  Sheet 0 (hidden)      clear icon  (no icon currently set)
+   2  Sheet 1               clear icon
+   ...
+
+Summary: 1 app(s), 9 sheets. 8 icon(s) would be cleared, 1 with no icon, 0 skipped.
+```
+
+The real run on the same app reports the matching split:
+
+```
+  sheets        9 seen, 8 icon(s) cleared, 1 had no icon
+```
+
+The `with no icon` part appears only when there is at least one such sheet, so a plan in which every sheet carries an icon is unchanged: `Summary: 1 app(s), 2 sheets. 2 icon(s) would be cleared, 0 skipped.`
+
+## Why it matters
+
+The summary is the line most likely to be read, quoted in a change request, or pasted into a ticket. A plan promising nine cleared icons followed by a run reporting eight invites a second run to find out what went wrong — when in fact nothing had.
+
+It also matters for the repeat case. Running `remove-sheet-icons` a second time over an app it has already cleared writes nothing, and the plan now says so plainly rather than appearing to promise a fresh sweep:
+
+```
+Summary: 1 app(s), 9 sheets. 0 icon(s) would be cleared, 9 with no icon, 0 skipped.
+```
+
+## What did not change
+
+- No sheet is treated differently. This affects **reporting only** — which sheets get cleared, and what is written to the server, are exactly as before.
+- The per-sheet rows are unchanged.
+- The summary printed by the thumbnail-creation commands (`create-sheet-thumbnails`) is unchanged, in both wording and numbers.

--- a/src/lib/cloud/__tests__/cloud_remove_sheet_icons.test.js
+++ b/src/lib/cloud/__tests__/cloud_remove_sheet_icons.test.js
@@ -935,6 +935,9 @@ describe('qscloudRemoveSheetIcons', () => {
 
             const info = logger.info.mock.calls.map((call) => String(call[0])).join('\n');
             expect(info).toContain('(no icon currently set)');
+            // ...and not counted as an icon that would be cleared (issue
+            // #1115). The row and the summary describe the same sheet.
+            expect(info).toContain('0 icon(s) would be cleared, 1 with no icon, 0 skipped.');
         });
 
         test('the real run still writes when dryRun is absent - the control case', async () => {

--- a/src/lib/qseow/__tests__/qseow_remove_sheet_icons.test.js
+++ b/src/lib/qseow/__tests__/qseow_remove_sheet_icons.test.js
@@ -722,6 +722,9 @@ describe('qseowRemoveSheetIcons', () => {
 
             const info = logger.info.mock.calls.map((call) => String(call[0])).join('\n');
             expect(info).toContain('(no icon currently set)');
+            // ...and not counted as an icon that would be cleared (issue
+            // #1115). The row and the summary describe the same sheet.
+            expect(info).toContain('0 icon(s) would be cleared, 1 with no icon, 0 skipped.');
         });
 
         test('the plan names how many selected apps are published', async () => {

--- a/src/lib/util/__tests__/run-report.test.js
+++ b/src/lib/util/__tests__/run-report.test.js
@@ -4,11 +4,10 @@ import {
     recordSelection,
     addAppToReport,
     recordSheetDecision,
-    reportTotals,
     renderDryRunReport,
 } from '../run-report.js';
-import { renderRunPlanLines } from '../run-report-render.js';
-import { EXCLUDE_REASON, BLUR_REASON } from '../sheet-decision-reasons.js';
+import { renderRunPlanLines, renderRunVerdictLines } from '../run-report-render.js';
+import { EXCLUDE_REASON, BLUR_REASON, CLEAR_REASON } from '../sheet-decision-reasons.js';
 
 const fakeLogger = () => {
     const lines = [];
@@ -57,29 +56,28 @@ const sampleReport = () => {
     return report;
 };
 
-describe('reportTotals', () => {
-    test('totals are derived from the rows, one per action kind', () => {
-        expect(reportTotals(sampleReport())).toEqual({
-            apps: 1,
-            sheets: 4,
-            update: 1,
-            blur: 1,
-            skip: 2,
-            clear: 0,
-        });
-    });
+/**
+ * A removal report over one app whose sheets carry icons, plus one that never
+ * had one - the shape that made the two counting rules disagree (issue #1115).
+ *
+ * @returns {object} The report.
+ */
+const removalReport = () => {
+    const report = createRunReport({ command: 'qseow remove-sheet-icons', dryRun: true });
+    recordSelection(report, { namedAppIds: ['app-1'], selectorAppIds: [], selector: null });
 
-    test('an empty report totals to zeroes', () => {
-        expect(reportTotals(createRunReport({ command: 'x', dryRun: true }))).toEqual({
-            apps: 0,
-            sheets: 0,
-            update: 0,
-            blur: 0,
-            skip: 0,
-            clear: 0,
-        });
+    const app = addAppToReport(report, { id: 'app-1', name: 'Finance operations', sheetCount: 3 });
+    recordSheetDecision(app, {
+        n: 1,
+        title: 'Never themed',
+        action: 'clear',
+        reason: CLEAR_REASON.NO_ICON,
     });
-});
+    recordSheetDecision(app, { n: 2, title: 'Overview', action: 'clear' });
+    recordSheetDecision(app, { n: 3, title: 'Sales detail', action: 'clear' });
+
+    return report;
+};
 
 describe('renderDryRunReport', () => {
     test('names the responsible option next to every non-default decision', () => {
@@ -149,15 +147,74 @@ describe('renderDryRunReport', () => {
             n: 2,
             title: 'Notes',
             action: 'clear',
-            reason: 'no icon currently set',
+            reason: CLEAR_REASON.NO_ICON,
         });
 
         const log = fakeLogger();
         renderDryRunReport(report, log);
 
         const text = log.text();
-        expect(text).toContain('2 icon(s) would be cleared');
+        expect(text).toContain('1 icon(s) would be cleared, 1 with no icon, 0 skipped.');
         expect(text).toContain('(no icon currently set)');
+    });
+
+    test('a no-op clear is not counted as an icon that would be cleared (issue #1115)', () => {
+        // The summary used to bucket on sheet.action alone, so this report's
+        // three rows summarised as "3 icon(s) would be cleared" - two lines
+        // below a row that said the first sheet had no icon to clear.
+        const log = fakeLogger();
+        renderDryRunReport(removalReport(), log);
+
+        const text = log.text();
+        expect(text).toMatch(/Never themed\s+clear icon {2}\(no icon currently set\)/);
+        expect(text).toContain(
+            'Summary: 1 app(s), 3 sheets. 2 icon(s) would be cleared, 1 with no icon, 0 skipped.'
+        );
+    });
+
+    test('the plan and the verdict split the same rows the same way (issue #1115)', () => {
+        // The property the fix is really about: whatever the plan promises for
+        // a set of rows, the run's verdict must report for those same rows.
+        // Both now count through verdictCounts, so a future counting rule
+        // added to one board reaches the other - and this test fails if a
+        // second loop is ever reintroduced.
+        const report = removalReport();
+
+        const log = fakeLogger();
+        renderDryRunReport(report, log);
+
+        report.succeeded = true;
+        const verdict = renderRunVerdictLines(report).join('\n');
+
+        expect(log.text()).toContain('2 icon(s) would be cleared, 1 with no icon');
+        expect(verdict).toContain('3 seen, 2 icon(s) cleared, 1 had no icon');
+    });
+
+    test('a removal with nothing left to clear says so rather than claiming a sweep', () => {
+        // The state a second removal run finds (issue #1113): every row is a
+        // no-op clear, and the summary must not promise a removal.
+        const report = createRunReport({ command: 'qseow remove-sheet-icons', dryRun: true });
+        recordSelection(report, { namedAppIds: ['app-1'], selectorAppIds: [], selector: null });
+        const app = addAppToReport(report, { id: 'app-1', sheetCount: 2 });
+        recordSheetDecision(app, {
+            n: 1,
+            title: 'Main',
+            action: 'clear',
+            reason: CLEAR_REASON.NO_ICON,
+        });
+        recordSheetDecision(app, {
+            n: 2,
+            title: 'Notes',
+            action: 'clear',
+            reason: CLEAR_REASON.NO_ICON,
+        });
+
+        const log = fakeLogger();
+        renderDryRunReport(report, log);
+
+        expect(log.text()).toContain(
+            'Summary: 1 app(s), 2 sheets. 0 icon(s) would be cleared, 2 with no icon, 0 skipped.'
+        );
     });
 
     test('output is plain ASCII so it survives any console', () => {

--- a/src/lib/util/run-report-render.js
+++ b/src/lib/util/run-report-render.js
@@ -498,6 +498,12 @@ const sumAppField = (report, field) => {
  * count from one place - two counting loops would be two chances for the
  * boards to disagree about the same run.
  *
+ * The dry-run summary counts from here too (issue #1115). It used to keep its
+ * own loop, bucketing on `sheet.action` alone, and that second loop did
+ * disagree: a no-op clear was reported as an icon that would be cleared by the
+ * plan and as a sheet that had no icon by the run. A plan and the run it
+ * predicts are counted by one rule or they are two answers about one app.
+ *
  * @param {object} report - The report.
  *
  * @returns {{seen: number, captured: number, blurred: number, excluded: number,

--- a/src/lib/util/run-report.js
+++ b/src/lib/util/run-report.js
@@ -4,6 +4,7 @@ import {
     RUN_FRAME,
     renderRunPlanLines,
     renderRunVerdictLines,
+    verdictCounts,
     isRemovalReport,
     logRunHeader,
 } from './run-report-render.js';
@@ -629,31 +630,6 @@ export const recordAppOutcome = (appEntry, { sheetsUpdated, imagesDir, imageFile
     appEntry.imagesKeptBytes = kept.bytes;
 };
 
-/**
- * Totals over every recorded decision.
- *
- * Derived at render time rather than kept as counters, so the totals cannot
- * disagree with the rows they summarise.
- *
- * @param {object} report - The report.
- *
- * @returns {{apps: number, sheets: number, update: number, blur: number, skip: number, clear: number}} Totals.
- */
-export const reportTotals = (report) => {
-    const totals = { apps: report.apps.length, sheets: 0, update: 0, blur: 0, skip: 0, clear: 0 };
-
-    for (const app of report.apps) {
-        for (const sheet of app.sheets) {
-            totals.sheets += 1;
-            if (Object.hasOwn(totals, sheet.action)) {
-                totals[sheet.action] += 1;
-            }
-        }
-    }
-
-    return totals;
-};
-
 const ACTION_LABEL = Object.freeze({
     update: 'update',
     blur: 'update, blurred',
@@ -748,7 +724,13 @@ export const renderDryRunReport = (report, log = logger) => {
             log.info('');
         });
 
-        const t = reportTotals(report);
+        // Counted by the same rule the real run's verdict uses, from the same
+        // function (issue #1115). The summary used to bucket purely on
+        // `sheet.action`, so a `{action: 'clear', reason: NO_ICON}` row - a
+        // clear that is already a no-op - was counted among the icons that
+        // would be cleared, contradicting both the row printed above it and
+        // the verdict the real run prints for the identical input.
+        const counts = verdictCounts(report);
 
         // Failed planners now always leave a marked entry, but the selection
         // count is still cross-checked so an app that vanished entirely (a
@@ -763,13 +745,19 @@ export const renderDryRunReport = (report, log = logger) => {
         }
 
         if (isRemovalReport(report)) {
+            // The no-op clears are named rather than merely subtracted: with
+            // them dropped from the cleared count and nowhere else, the
+            // summary's numbers would no longer account for every sheet it
+            // just listed. Same split and same order as the verdict's removal
+            // line, so plan and run read against each other directly.
+            const noIconNote = counts.noIcon > 0 ? `, ${counts.noIcon} with no icon` : '';
             log.info(
-                `Summary: ${t.apps} app(s), ${t.sheets} sheets. ${t.clear} icon(s) would be cleared, ${t.skip} skipped.`
+                `Summary: ${report.apps.length} app(s), ${counts.seen} sheets. ${counts.cleared} icon(s) would be cleared${noIconNote}, ${counts.excluded} skipped.`
             );
         } else {
-            const blurNote = t.blur > 0 ? ` (${t.blur} blurred)` : '';
+            const blurNote = counts.blurred > 0 ? ` (${counts.blurred} blurred)` : '';
             log.info(
-                `Summary: ${t.apps} app(s), ${t.sheets} sheets. ${t.update + t.blur} would be updated${blurNote}, ${t.skip} skipped.`
+                `Summary: ${report.apps.length} app(s), ${counts.seen} sheets. ${counts.captured} would be updated${blurNote}, ${counts.excluded} skipped.`
             );
         }
 


### PR DESCRIPTION
Closes #1115.

## The bug

Two counting rules read the same recorded rows and answered differently. `reportTotals` bucketed purely on `sheet.action`, so a `{action: 'clear', reason: NO_ICON}` row — a clear that is already a no-op — was counted among the icons that *would* be cleared. `verdictCounts`, which the real run's verdict uses, is reason-aware and counted it as a sheet with no icon.

So a dry run printed a per-sheet row saying `(no icon currently set)` and then, two lines below, a summary claiming that sheet would be cleared — while the real run reported the opposite split for identical input.

## The fix

The summary now reads `verdictCounts`. The second loop is **deleted** rather than taught the same rule twice, which is what the issue asked for and what `verdictCounts`'s own docstring says it exists to prevent.

The removal line names the no-op clears rather than merely dropping them, so its numbers still account for every sheet it just listed:

```
Summary: 1 app(s), 9 sheets. 8 icon(s) would be cleared, 1 with no icon, 0 skipped.
```

**The thumbnails wording is unchanged.** `captured`, `blurred`, `excluded` and `seen` are arithmetically identical to `update + blur`, `blur`, `skip` and `sheets`, and the existing assertion pinning that exact line still passes untouched.

## Verification

Reproduced against the live lab before fixing, then confirmed in both directions: on the 8-icon demo app the plan now reads `8 would be cleared, 1 with no icon`, matching the run; on a fully cleared app, `0 would be cleared, 9 with no icon`, matching that run's `0 cleared, 9 had no icon`. 116 suites / 3234 tests, lint and prettier clean.

The strongest evidence is `demo:check`: it drifted on the removal snapshot and reported **no drift** on the thumbnails one — the "don't disturb the other vocabulary" constraint proved by execution rather than by reading. A new test renders the plan and the verdict from the same report and asserts they split identically, so a reintroduced second loop fails.

## Also here

- The demo snapshot refresh (one line).
- A staged doc page, since output an operator reads has changed, plus a note on the already-archived draft whose sample transcript now shows the old summary.
- **A pin for `BSI_QSEOW_CST_INCLUDE_SHEET_PART`.** `demo.env` only wins where it sets a value; anything omitted falls through to the repo's `.env`, which sets `4` where the recordings were made at `1`. That made `demo:check` report drift that was not CLI drift, and `check-update` would then have baked the wrong framing into the snapshot silently — turning the staleness alarm into a source of false alarms and then wrong baselines.

## Known, deliberate non-change

The removal summary still ends `, 0 skipped`, a count that is structurally always zero for this command (removals only ever record `clear` rows). It is pre-existing, and dropping it would also make the plan and verdict phrasings match exactly — but it changes published output again, so it is left for a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)