### PR TITLE
Show the app overview before and after a thumbnail run

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -22,15 +22,17 @@ first. So the pipeline is:
 ```
 reset (qseow remove-sheet-icons, recorded)
   -> dry run (recorded)
-  -> real run (recorded; its overview screenshot = "before")
-  -> second real run (its overview screenshot = "after")
+  -> real run (recorded; yields both "before" and "after")
 ```
 
-BSI captures the app overview at the **start** of every real run, before any
-sheet is touched, so run N's screenshot shows the state run N-1 left behind.
-The second real run is an idempotent rewrite of the same thumbnails; it
-exists to harvest the "after" image, and it leaves the app in the "after"
-state, ready for the next `reset` to prove the loop closes.
+Since #735 a real run captures the app overview twice - `overview-before.png`
+before any sheet is touched, `overview-after.png` once the thumbnails are
+applied - so both panels come out of one run. The run leaves the app in the
+"after" state, ready for the next `reset` to prove the loop closes.
+
+Before #735 the "after" panel needed a second real run: the only overview a
+run captured was the one it took at the start, which showed whatever the
+previous run had left behind.
 
 ## Prerequisites
 
@@ -79,7 +81,7 @@ npm run demo:check         # text-only drift check against demo/snapshots/
 ```
 
 Individual steps (each idempotent, so the pipeline is restartable):
-`demo/record.sh reset|dryrun|before|after|render|check|check-update`.
+`demo/record.sh reset|dryrun|run|render|check|check-update`.
 
 | Where             | What                                                          | Committed?      |
 | ----------------- | ------------------------------------------------------------- | --------------- |

--- a/demo/demo.env.example
+++ b/demo/demo.env.example
@@ -66,8 +66,16 @@ BSI_QSEOW_CST_PAGE_WAIT=1
 # better off with it.
 BSI_LOG_TIMESTAMPS=false
 # Must be a relative path under demo/output/ - record.sh deletes this whole
-# directory before the "before" run and refuses anything outside that tree.
+# directory before the real run and refuses anything outside that tree.
 # demo/output is gitignored. The image directory also receives login page
 # screenshots WITH CREDENTIALS TYPED IN - publish nothing from it directly;
 # record.sh copies out the overview images by name.
 BSI_QSEOW_CST_IMAGE_DIR=demo/output/img
+
+# Both overview panels come from one run, so the after-capture must stay on.
+# Pinned rather than left to the default for the same reason the sheet part is
+# pinned: demo.env only wins where it sets a value, and an omitted variable
+# falls through to the repo's own .env. A stray
+# BSI_QSEOW_CST_CAPTURE_OVERVIEW_AFTER=false there would make record.sh fail at
+# the harvest step with a missing overview-after.png.
+BSI_QSEOW_CST_CAPTURE_OVERVIEW_AFTER=true

--- a/demo/record.sh
+++ b/demo/record.sh
@@ -7,13 +7,15 @@
 # captures: a real BSI run must execute between the two overview images,
 # because nothing else changes the sheet icons.
 #
-#   reset (recorded) -> dry run (recorded) -> real run (recorded, yields
-#   "before") -> second real run (yields "after")
+#   reset (recorded) -> dry run (recorded) -> real run (recorded, yields both
+#   "before" and "after")
 #
-# The overview screenshot is taken at the START of every real run, before any
-# sheet is touched, so run N's overview-1.png shows the state run N-1 left
-# behind. That is why the "after" image needs a second real run - which is
-# also a harmless idempotent rewrite of the same thumbnails.
+# Since #735 a single run captures the overview twice - overview-before.png
+# before any sheet is touched, overview-after.png once the thumbnails are
+# applied - so one run yields both panels. Before that, the after image had to
+# come from a second real run, because the only overview a run captured was
+# the one it took at the start, showing whatever the previous run had left
+# behind.
 #
 # Every step is idempotent, so the whole script is restartable: re-run it, or
 # re-run a single step by name.
@@ -27,13 +29,12 @@
 # pairing ships.)
 #
 # Usage:
-#   demo/record.sh [all|reset|dryrun|before|after|render|check|check-update]
+#   demo/record.sh [all|reset|dryrun|run|render|check|check-update]
 #
-#   all     reset + dryrun + before + after + render (the default)
+#   all     reset + dryrun + run + render (the default)
 #   reset   record qseow remove-sheet-icons doing its real removal
 #   dryrun  record qseow create-sheet-thumbnails --dry-run
-#   before  real run, recorded; harvest the "before" overview image
-#   after   second real run, unrecorded; harvest the "after" overview image
+#   run     real run, recorded; harvest both overview images from it
 #   render  re-render shareable GIF/MP4/WebM from the committed .cast
 #           masters - touches no server
 #   check   text-only drift check of every recorded command against
@@ -247,16 +248,17 @@ record_cast() {
 }
 
 overview_png() {
-    printf '%s' "$REPO_ROOT/$BSI_QSEOW_CST_IMAGE_DIR/qseow/$BSI_QSEOW_CST_APP_ID/overview-1.png"
+    printf '%s' "$REPO_ROOT/$BSI_QSEOW_CST_IMAGE_DIR/qseow/$BSI_QSEOW_CST_APP_ID/overview-$1.png"
 }
 
 # Copy ONE named file out of the image directory. Never publish or copy the
 # directory itself: BSI screenshots the Qlik login page with credentials
 # filled in (loginpage-2.png) into the same tree.
 harvest_overview() {
-    local dest="$OUT_DIR/panels/$1"
+    local phase="$1"
+    local dest="$OUT_DIR/panels/$2"
     local src
-    src="$(overview_png)"
+    src="$(overview_png "$phase")"
     [ -f "$src" ] || die "expected overview screenshot not found: $src"
     mkdir -p "$OUT_DIR/panels"
     cp "$src" "$dest"
@@ -277,22 +279,20 @@ step_dryrun() {
     record_cast "$CAST_DIR/qseow-dry-run.cast" asciicast-v2 qseow create-sheet-thumbnails --dry-run
 }
 
-step_before() {
-    log "before: real run, recorded; its overview shows the post-reset state"
+step_run() {
+    log "run: real run, recorded; it captures the overview before and after itself"
     require_cmd asciinema "Install with: brew install asciinema"
 
-    # Fresh image dir so the harvested overview is provably this run's.
+    # Fresh image dir so the harvested overviews are provably this run's.
     rm -rf "${REPO_ROOT:?}/${BSI_QSEOW_CST_IMAGE_DIR:?}"
 
     record_cast "$CAST_DIR/qseow-real-run.cast" asciicast-v2 qseow create-sheet-thumbnails
 
-    harvest_overview app-overview-before.png
-}
-
-step_after() {
-    log "after: second real run (idempotent rewrite); its overview shows the thumbnails"
-    (cd "$REPO_ROOT" && bsi qseow create-sheet-thumbnails)
-    harvest_overview app-overview-after.png
+    # Both panels come out of the one run. The after image only exists if the
+    # run's second sign-in succeeded; harvest_overview fails loudly rather than
+    # leaving a stale panel from an earlier recording in place.
+    harvest_overview before app-overview-before.png
+    harvest_overview after app-overview-after.png
 }
 
 render_one() {
@@ -475,15 +475,13 @@ main() {
         all)
             step_reset
             step_dryrun
-            step_before
-            step_after
+            step_run
             step_render
             log "done. Panels + renders are in demo/output/, cast masters in demo/cast/."
             ;;
         reset) step_reset ;;
         dryrun) step_dryrun ;;
-        before) step_before ;;
-        after) step_after ;;
+        run) step_run ;;
         render) step_render ;;
         check) step_check ;;
         check-update) step_check update ;;

--- a/docs/qseow-demo_1.md
+++ b/docs/qseow-demo_1.md
@@ -5,30 +5,30 @@ Below is an example where BSI is used to create and update sheet icons for a QSE
 - There are three sheets in the app
 - There exists a content library called `abc 123`.
 
-Let's first look at the app overview *before* running BSI:
+Let's first look at the app overview _before_ running BSI:
 
-![Qlik Sense app overview](./img/create-qseow-appoverview_1.png "No customized sheet icons")
+![Qlik Sense app overview](./img/create-qseow-appoverview_1.png 'No customized sheet icons')
 
 Note that there are no sheet icons on any of the 3 sheets.
 
 Same thing when looking at the `abc 123` content library - it's empty:
 
-![Qlik Sense content library](./img/create-qseow-qmc_1.png "Empty content library")
+![Qlik Sense content library](./img/create-qseow-qmc_1.png 'Empty content library')
 
 Now let's run Butler Sheet Icons.
 
 On MacOs it looks like this with INFO level debugging:
 
-![Run Butler Sheet Icons](./img/create-qseow_1.png "Run Butler Sheet Icons on MacOS")
+![Run Butler Sheet Icons](./img/create-qseow_1.png 'Run Butler Sheet Icons on MacOS')
 
 On Windows10 you will see something like below.  
 Note how strings are enclosed with double quotes rather than single quotes, and how the image directory path is specified:
 
-![Run Butler Sheet Icons](./img/create-qseow-win_2.png "Run Butler Sheet Icons on Windows 10")
+![Run Butler Sheet Icons](./img/create-qseow-win_2.png 'Run Butler Sheet Icons on Windows 10')
 
 Once again opening the app's overview page we see that it now has new sheet icons for all sheets.
 
-![Qlik Sense app overview](./img/create-qseow-appoverview_2.png "Customized sheet icons")
+![Qlik Sense app overview](./img/create-qseow-appoverview_2.png 'Customized sheet icons')
 
 Butler Sheet Icons will take screenshots of all sheets, but also of the login page and the app overview page.
 
@@ -38,12 +38,23 @@ Looking in the `abc 123` content library it now has a image for each sheet in th
 
 For example `app-a3e0f5d2-000a-464f-998d-33d333b175d7-sheet-2.png`.
 
-Finally, looking in the ./img directory (as specified by the `--imagedir` option) we find the three sheet screen shots, but also three screenshots associated with the app itself. Two are from the login page when Butler Sheet Icons logs into Qlik Sense and one is from the app overview within the Sense app (before the sheets got new sheet icons!):
+Finally, looking in the ./img directory (as specified by the `--imagedir` option) we find the three sheet screen shots, but also several screenshots associated with the app itself:
 
-![Image files created by Butler Sheet Icons](./img/create-qseow-created-images_1.png "Image files created by Butler Sheet Icons")
+| File                    | What it shows                                             |
+| ----------------------- | --------------------------------------------------------- |
+| `loginpage-1.png`       | the Qlik Sense login page, before credentials are entered |
+| `loginpage-2.png`       | the same page with credentials filled in                  |
+| `overview-before.png`   | the app overview before any sheet icon was changed        |
+| `loginpage-after-1.png` | the login page of the second sign-in                      |
+| `loginpage-after-2.png` | the same, with credentials filled in                      |
+| `overview-after.png`    | the app overview once the new sheet icons are in place    |
 
-![Qlik Sense login page 1](./img/create-qseow-loginpage_1.png "Qlik Sense login page before user credentials are entered")
+The second sign-in and `overview-after.png` are what `--capture-overview-after` controls; set it to `false` and only the first four files are written. Note that the screenshots below were taken with an earlier version, which wrote a single `overview-1.png` instead of the before/after pair:
 
-![Qlik Sense login page 2](./img/create-qseow-loginpage_2.png "Qlik Sense login page with user credentials filled in")
+![Image files created by Butler Sheet Icons](./img/create-qseow-created-images_1.png 'Image files created by Butler Sheet Icons')
 
-![Qlik Sense app overview](./img/create-qseow-appoverview_3.png "App overview screenshot taken by Butler Sheet Icons")
+![Qlik Sense login page 1](./img/create-qseow-loginpage_1.png 'Qlik Sense login page before user credentials are entered')
+
+![Qlik Sense login page 2](./img/create-qseow-loginpage_2.png 'Qlik Sense login page with user credentials filled in')
+
+![Qlik Sense app overview](./img/create-qseow-appoverview_3.png 'App overview screenshot taken by Butler Sheet Icons')

--- a/docs/qseow-demo_1.md
+++ b/docs/qseow-demo_1.md
@@ -49,7 +49,7 @@ Finally, looking in the ./img directory (as specified by the `--imagedir` option
 | `loginpage-after-2.png` | the same, with credentials filled in                      |
 | `overview-after.png`    | the app overview once the new sheet icons are in place    |
 
-The second sign-in and `overview-after.png` are what `--capture-overview-after` controls; set it to `false` and only the first four files are written. Note that the screenshots below were taken with an earlier version, which wrote a single `overview-1.png` instead of the before/after pair:
+The second sign-in and `overview-after.png` are what `--capture-overview-after` controls; set it to `false` and only the first three files are written. Note that the screenshots below were taken with an earlier version, which wrote a single `overview-1.png` instead of the before/after pair:
 
 ![Image files created by Butler Sheet Icons](./img/create-qseow-created-images_1.png 'Image files created by Butler Sheet Icons')
 

--- a/docs/to-doc-site/overview-before-and-after-screenshots.md
+++ b/docs/to-doc-site/overview-before-and-after-screenshots.md
@@ -1,0 +1,84 @@
+# Before/after app overview screenshots on every thumbnail run
+
+**Status:** pending publication
+**Suggested target pages:** `/guide/concepts/` (new page or a section on run output), `/reference/qseow`, `/reference/qscloud`
+**Version gate:** not released yet — read the open release-please PR title for the version before publishing. Do not copy a version number from this draft.
+
+---
+
+## What changed, in one paragraph
+
+`qseow create-sheet-thumbnails` and `qscloud create-sheet-thumbnails` now photograph the app overview page **twice**: once before any sheet is touched, and once after the new thumbnails are in place. The two files are `overview-before.png` and `overview-after.png`, side by side in the same per-app image directory the sheet thumbnails already go to. Together they show what the run actually did to the app, in the form the people who asked for the change will recognise — the app overview as Qlik Sense draws it.
+
+**This renames an existing file.** What used to be written as `overview-1.png` is now `overview-before.png`. If you have a script, a CI job or a report template that reads `overview-1.png` by name, it needs updating.
+
+## Why administrators should care
+
+A thumbnail run overwrites sheet icons in place, with no undo. Its log tells you what it decided — which sheets it updated, which it skipped and why — but a log is not evidence you can hand to the person who requested the change. The before/after pair is: two pictures of the same page, one showing rows of identical grey placeholders, the other showing each sheet carrying a miniature of its own layout.
+
+That matters most in three situations:
+
+| Situation                                  | What the pair gives you                                                                           |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| A change request that has to be signed off | Visual proof the app now looks the way it was supposed to, without asking the requester to log in |
+| A run that partly failed                   | The "after" image shows exactly which sheets ended up with an icon and which did not              |
+| An audit trail in CI                       | Two artifacts per app per run, in a predictable location, with no extra tooling                   |
+
+## Where the files are written
+
+Below the directory named by `--imagedir` (default `./img`), per app:
+
+```
+img/qseow/<app-id>/overview-before.png     (client-managed Qlik Sense)
+img/qseow/<app-id>/overview-after.png
+
+img/cloud/<app-id>/overview-before.png     (Qlik Sense Cloud)
+img/cloud/<app-id>/overview-after.png
+```
+
+::: warning The image directory also holds login screenshots
+The same directory contains `loginpage-1.png`, `loginpage-2.png`, `loginpage-after-1.png` and `loginpage-after-2.png` — screenshots of the Qlik Sense login page, **with the password field filled in**. Copy out the two overview files by name. Never publish or attach the image directory wholesale.
+:::
+
+## The cost: a second sign-in
+
+Getting an honest "after" picture requires a browser session that exists _after_ the thumbnails have been uploaded and assigned — and by that point in a run the first browser session has already logged out and closed. Butler Sheet Icons therefore signs in a second time, purely to take the closing screenshot.
+
+Concretely, per app:
+
+- one extra browser launch and one extra web UI login, roughly ten seconds
+- two extra login-page screenshots, named `loginpage-after-1.png` and `loginpage-after-2.png` so they cannot overwrite the first sign-in's
+
+On a single-app run that is not noticeable. On a run that sweeps fifty apps by tag or collection it is paid fifty times, and that is when you may want it off.
+
+## Turning it off
+
+```bash
+./butler-sheet-icons qseow create-sheet-thumbnails \
+    --host sense.company.com \
+    --appid a1b2c3d4-0000-4a1b-9c8d-000000000001 \
+    --apiuserdir INTERNAL --apiuserid sa_api \
+    --logonuserdir COMPANY --logonuserid svc_bsi --logonpwd password-here \
+    --capture-overview-after false
+```
+
+The option defaults to `true` and can also be set from the environment, as `BSI_QSEOW_CST_CAPTURE_OVERVIEW_AFTER` and `BSI_QSCLOUD_CST_CAPTURE_OVERVIEW_AFTER`. With it off, the run signs in once, writes `overview-before.png` and no `overview-after.png`, and behaves exactly as earlier versions did apart from that file's name.
+
+The interactive wizard asks about it under **Advanced**, alongside the other tuning options; a guided run that accepts the defaults gets the capture.
+
+## What it does not do
+
+- **It never fails a run.** The screenshot is taken after the thumbnails have been created, uploaded and assigned — the work is already done and saved. If the second sign-in cannot be made, the run logs a warning naming the reason and finishes successfully. A missing `overview-after.png` means the picture is missing, never that the thumbnails are.
+- **It does not run on a dry run.** A dry run changes nothing, so there is no "after" state to photograph. Dry runs open no browser at all.
+- **It does not apply to the removal commands.** `qseow remove-sheet-icons` and `qscloud remove-sheet-icons` work entirely over the Qlik Sense APIs and never open a browser, so they have no web UI session to take a screenshot from — and adding one would mean requiring web UI credentials they do not otherwise need.
+- **It photographs the app overview, not the hub.** Thumbnails also appear on the Qlik Sense hub, which is a different page and is not captured.
+
+## Upgrade note
+
+| Before           | Now                                              |
+| ---------------- | ------------------------------------------------ |
+| `overview-1.png` | `overview-before.png`                            |
+| —                | `overview-after.png`                             |
+| —                | `loginpage-after-1.png`, `loginpage-after-2.png` |
+
+Anything reading `overview-1.png` by name should be pointed at `overview-before.png`. The positional name was renamed because, with two overview screenshots per run, a number no longer says which state the picture shows.

--- a/src/lib/cloud/__tests__/process_cloud_app.test.js
+++ b/src/lib/cloud/__tests__/process_cloud_app.test.js
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeAll, beforeEach, jest } from '@jest/globals';
+import { describe, test, expect, beforeAll, beforeEach, afterEach, jest } from '@jest/globals';
 
 // Mock every dependency of processCloudApp using the ESM-native
 // jest.unstable_mockModule + dynamic import pattern. This mirrors the pattern
@@ -26,9 +26,11 @@ const mockFs = jest.unstable_mockModule('fs', () => ({
     default: {
         mkdirSync: jest.fn(),
         existsSync: jest.fn().mockReturnValue(false),
+        rmSync: jest.fn(),
     },
     mkdirSync: jest.fn(),
     existsSync: jest.fn().mockReturnValue(false),
+    rmSync: jest.fn(),
 }));
 
 const mockJimp = jest.unstable_mockModule('jimp', () => ({
@@ -92,6 +94,7 @@ const mockSheetScreenshot = jest.unstable_mockModule('../sheet-screenshot.js', (
     takeSheetScreenshot: jest.fn().mockResolvedValue(true),
 }));
 
+let fs;
 let processCloudApp;
 let puppeteer;
 let enigma;
@@ -125,6 +128,7 @@ beforeAll(async () => {
     ({ browserInstall } = await import('../../browser/browser-install.js'));
     ({ detectAvailableBrowser } = await import('../../browser/browser-detect.js'));
     ({ takeSheetScreenshot } = await import('../sheet-screenshot.js'));
+    fs = (await import('fs')).default;
     ({ qscloudUploadToApp } = await import('../cloud-upload.js'));
     ({ qscloudUpdateSheetThumbnails } = await import('../cloud-updatesheets.js'));
     ({ processCloudApp } = await import('../process-cloud-app.js'));
@@ -149,6 +153,10 @@ describe('process-cloud-app.js — puppeteer launch and click options', () => {
         excludeSheetStatus: ['private'],
         excludeSheetNumber: [],
         excludeSheetTitle: [],
+        // Off in the shared fixture, on by default in the product. The after-capture opens a
+        // *second* browser session, which would double the launch/close counts that the
+        // lifecycle tests in this file assert on. It gets its own describe block below.
+        captureOverviewAfter: false,
     };
 
     const defaultSaasInstance = {
@@ -600,6 +608,178 @@ describe('process-cloud-app.js — puppeteer launch and click options', () => {
         const logged = logger.error.mock.calls.map((call) => String(call[0])).join('\n');
         expect(logged).toContain('Could not obtain a browser for Qlik Sense Cloud app test-app-id');
         expect(puppeteer.launch).not.toHaveBeenCalled();
+    });
+
+    // Issue #735. Mirrors the QSEoW twin: the after-capture is the only part of a run that
+    // opens a second browser session, and it does so after the thumbnails are already
+    // uploaded and assigned - which is precisely why it must never fail the run.
+    describe('app overview captured after the update (#735)', () => {
+        beforeEach(() => {
+            // The enclosing describe has no beforeEach, so both call counts and mock
+            // implementations accumulate across its tests. clearAllMocks resets the counts but
+            // deliberately keeps implementations, so the browser mocks are restored by hand.
+            jest.clearAllMocks();
+            detectAvailableBrowser.mockResolvedValue({
+                executablePath: '/test/browser',
+                source: 'system',
+                browser: 'chrome',
+                buildId: 'system-installed',
+            });
+            browserInstall.mockReset();
+            qscloudUploadToApp.mockResolvedValue(true);
+            qscloudUpdateSheetThumbnails.mockResolvedValue(1);
+        });
+
+        afterEach(() => {
+            // These tests queue one-shot launch outcomes. clearAllMocks keeps queued
+            // implementations, so an unconsumed one would surface in an unrelated test
+            // several describes later, where it makes no sense at all.
+            puppeteer.launch.mockReset();
+        });
+
+        /**
+         * Every path the run passed to `page.screenshot`.
+         *
+         * @param {object} browser - Mock browser returned by setupHappyPath.
+         *
+         * @returns {string[]} Screenshot paths, in the order they were written.
+         */
+        const shotPaths = (browser) => browser._page.screenshot.mock.calls.map(([arg]) => arg.path);
+
+        test('names the main session overview after the state it shows', async () => {
+            const browser = setupHappyPath();
+
+            await processCloudApp('test-app-id', defaultSaasInstance, defaultOptions);
+
+            expect(shotPaths(browser)).toContain('./img/cloud/test-app-id/overview-before.png');
+        });
+
+        test('signs in again and captures the overview when enabled', async () => {
+            const browser = setupHappyPath();
+
+            await processCloudApp('test-app-id', defaultSaasInstance, {
+                ...defaultOptions,
+                // The lone fixture sheet is unpublished and unapproved, so the default
+                // --exclude-sheet-status private skips it and the run creates nothing. The
+                // after-capture is deliberately skipped for a run that changed nothing, so
+                // without this the second session could never be observed here.
+                excludeSheetStatus: [],
+                captureOverviewAfter: true,
+            });
+
+            expect(puppeteer.launch).toHaveBeenCalledTimes(2);
+            expect(browser.close).toHaveBeenCalledTimes(2);
+            expect(shotPaths(browser)).toContain('./img/cloud/test-app-id/overview-after.png');
+        });
+
+        test('captures only after the sheets have been pointed at the new thumbnails', async () => {
+            const browser = setupHappyPath();
+
+            await processCloudApp('test-app-id', defaultSaasInstance, {
+                ...defaultOptions,
+                // The lone fixture sheet is unpublished and unapproved, so the default
+                // --exclude-sheet-status private skips it and the run creates nothing. The
+                // after-capture is deliberately skipped for a run that changed nothing, so
+                // without this the second session could never be observed here.
+                excludeSheetStatus: [],
+                captureOverviewAfter: true,
+            });
+
+            const index = browser._page.screenshot.mock.calls.findIndex(([arg]) =>
+                arg.path.endsWith('overview-after.png')
+            );
+            const capturedAt = browser._page.screenshot.mock.invocationCallOrder[index];
+            const updatedAt = qscloudUpdateSheetThumbnails.mock.invocationCallOrder[0];
+
+            expect(capturedAt).toBeGreaterThan(updatedAt);
+        });
+
+        test('gives the second login its own screenshots rather than overwriting the first', async () => {
+            const browser = setupHappyPath();
+
+            await processCloudApp('test-app-id', defaultSaasInstance, {
+                ...defaultOptions,
+                // The lone fixture sheet is unpublished and unapproved, so the default
+                // --exclude-sheet-status private skips it and the run creates nothing. The
+                // after-capture is deliberately skipped for a run that changed nothing, so
+                // without this the second session could never be observed here.
+                excludeSheetStatus: [],
+                captureOverviewAfter: true,
+            });
+
+            const paths = shotPaths(browser);
+
+            expect(paths).toContain('./img/cloud/test-app-id/loginpage-after-1.png');
+            expect(paths).toContain('./img/cloud/test-app-id/loginpage-after-2.png');
+
+            expect(paths.filter((path) => path.endsWith('/loginpage-1.png'))).toHaveLength(1);
+            expect(paths.filter((path) => path.endsWith('/loginpage-2.png'))).toHaveLength(1);
+        });
+
+        test('opens no second session when switched off', async () => {
+            const browser = setupHappyPath();
+
+            await processCloudApp('test-app-id', defaultSaasInstance, {
+                ...defaultOptions,
+                excludeSheetStatus: [],
+                captureOverviewAfter: false,
+            });
+
+            expect(puppeteer.launch).toHaveBeenCalledTimes(1);
+            expect(shotPaths(browser)).not.toContain('./img/cloud/test-app-id/overview-after.png');
+        });
+
+        test('clears a stale after-image before attempting the capture', async () => {
+            setupHappyPath();
+
+            await processCloudApp('test-app-id', defaultSaasInstance, {
+                ...defaultOptions,
+                excludeSheetStatus: [],
+                captureOverviewAfter: true,
+            });
+
+            expect(fs.rmSync).toHaveBeenCalledWith('./img/cloud/test-app-id/overview-after.png', {
+                force: true,
+            });
+        });
+
+        test('survives a rejection that carries no message', async () => {
+            const browser = setupHappyPath();
+            // The main session gets its page; the after-capture's newPage rejects with a bare
+            // undefined. Nothing between there and the caller's catch wraps it - rejecting the
+            // browser launch instead would be wrapped in a CloudError and prove nothing.
+            browser.newPage.mockResolvedValueOnce(browser._page);
+            browser.newPage.mockRejectedValueOnce(undefined);
+
+            await expect(
+                processCloudApp('test-app-id', defaultSaasInstance, {
+                    ...defaultOptions,
+                    excludeSheetStatus: [],
+                    captureOverviewAfter: true,
+                })
+            ).resolves.not.toThrow();
+
+            const warnings = logger.warn.mock.calls.map((call) => String(call[0])).join('\n');
+            expect(warnings).toContain('Could not capture the app overview after the update');
+        });
+
+        test('warns but does not fail the run when the second session cannot start', async () => {
+            const browser = setupHappyPath();
+            puppeteer.launch.mockResolvedValueOnce(browser);
+            puppeteer.launch.mockRejectedValueOnce(new Error('no browser available'));
+
+            await expect(
+                processCloudApp('test-app-id', defaultSaasInstance, {
+                    ...defaultOptions,
+                    excludeSheetStatus: [],
+                    captureOverviewAfter: true,
+                })
+            ).resolves.not.toThrow();
+
+            const warnings = logger.warn.mock.calls.map((call) => String(call[0])).join('\n');
+            expect(warnings).toContain('Could not capture the app overview after the update');
+            expect(qscloudUpdateSheetThumbnails).toHaveBeenCalled();
+        });
     });
 });
 

--- a/src/lib/cloud/__tests__/process_cloud_app.test.js
+++ b/src/lib/cloud/__tests__/process_cloud_app.test.js
@@ -763,6 +763,25 @@ describe('process-cloud-app.js — puppeteer launch and click options', () => {
             expect(warnings).toContain('Could not capture the app overview after the update');
         });
 
+        test('announces a skipped login once per app, not once per session', async () => {
+            setupHappyPath();
+
+            await processCloudApp('test-app-id', defaultSaasInstance, {
+                ...defaultOptions,
+                excludeSheetStatus: [],
+                skipLogin: true,
+                captureOverviewAfter: true,
+            });
+
+            // The session helper opens both the main session and the after-capture, so a
+            // notice logged inside it is printed twice for every app in a collection.
+            const notices = logger.info.mock.calls
+                .map((call) => String(call[0]))
+                .filter((line) => line.includes('Skipping login'));
+
+            expect(notices).toHaveLength(1);
+        });
+
         test('warns but does not fail the run when the second session cannot start', async () => {
             const browser = setupHappyPath();
             puppeteer.launch.mockResolvedValueOnce(browser);

--- a/src/lib/cloud/cloud-app-session.js
+++ b/src/lib/cloud/cloud-app-session.js
@@ -1,0 +1,163 @@
+import { logger, sleep } from '../../globals.js';
+import { launchBrowserForApp, closeBrowserQuietly } from '../browser/browser-launch.js';
+import { CloudError } from '../util/errors.js';
+import { removeStaleImage } from '../util/image-dir.js';
+
+// Selector paths to elements on login page
+const selectorLoginPageUserName = '[id="\u0031-email"]';
+const selectorLoginPageUserPwd = '[id="\u0031-password"]';
+const selectorLoginPageLoginButton = '[id="\u0031-submit"]';
+
+/**
+ * Builds the app URL for a Qlik Sense Cloud tenant.
+ *
+ * @param {object} options - Command options (`tenanturl`).
+ * @param {string} appId - Qlik Sense app ID.
+ *
+ * @returns {string} The app URL.
+ */
+export const buildCloudAppUrl = (options, appId) =>
+    `https://${options.tenanturl}/sense/app/${appId}`;
+
+/**
+ * Opens a page, signs in to the Qlik Sense Cloud web UI and leaves the browser
+ * sitting on the app overview.
+ *
+ * Shared by the main thumbnail session and the after-capture session so the second
+ * login cannot drift away from the first: a login sequence that exists twice is a
+ * login sequence that gets fixed once.
+ *
+ * `loginPagePrefix` names the two login screenshots. The two sessions must use
+ * different prefixes - reusing `loginpage` for both would have the after-capture
+ * silently overwrite the main session's login evidence, which is exactly the
+ * material an operator needs when diagnosing a failed run.
+ *
+ * @param {object} browser - Puppeteer browser instance.
+ * @param {object} options - Command options.
+ * @param {string} appId - Qlik Sense app ID.
+ * @param {object} params - Capture parameters.
+ * @param {string} params.imgDir - Root image directory.
+ * @param {number} params.pageTimeout - Page operation timeout in milliseconds.
+ * @param {string} params.loginPagePrefix - Basename stem for the login screenshots.
+ *
+ * @returns {Promise<{page: object, appUrl: string, loginSkipped: boolean}>} The page,
+ *     and whether login was skipped so the caller can report it.
+ */
+export const openCloudAppOverviewPage = async (
+    browser,
+    options,
+    appId,
+    { imgDir, pageTimeout, loginPagePrefix }
+) => {
+    const page = await browser.newPage();
+
+    // Thumbnails should be 410x270 pixels, so set the viewport to a multiple of this.
+    await page.setViewport({
+        width: 1230,
+        height: 810,
+        deviceScaleFactor: 1,
+    });
+
+    // Set default timeout for all page operations to 90 seconds
+    await page.setDefaultTimeout(pageTimeout);
+
+    const appUrl = buildCloudAppUrl(options, appId);
+    logger.debug(`App URL: ${appUrl}`);
+
+    await Promise.all([page.goto(appUrl, { waitUntil: 'networkidle2', timeout: pageTimeout })]);
+
+    await sleep(options.pagewait * 1000);
+    await page.screenshot({ path: `${imgDir}/cloud/${appId}/${loginPagePrefix}-1.png` });
+
+    // Should login be skipped?
+    //
+    // `skipLogin`, not `skiplogin`: Commander camel-cases a hyphenated long
+    // flag, so `--skip-login` lands on `options.skipLogin`. Reading the
+    // run-together spelling gave `undefined`, so this branch was unreachable
+    // and login was always attempted - see issue #890.
+    if (options.skipLogin === true) {
+        logger.info('Skipping login as --skip-login is set to true');
+        return { page, appUrl, loginSkipped: true };
+    }
+
+    // Enter credentials
+    // User
+    await page.click(selectorLoginPageUserName, {
+        button: 'left',
+        delay: 10,
+    });
+    const user = `${options.logonuserid}`;
+    await page.keyboard.type(user);
+
+    // Pwd
+    await page.click(selectorLoginPageUserPwd, {
+        button: 'left',
+        delay: 10,
+    });
+    await page.keyboard.type(options.logonpwd);
+
+    await page.screenshot({
+        path: `${imgDir}/cloud/${appId}/${loginPagePrefix}-2.png`,
+    });
+
+    // Click login button and wait for page to load
+    await Promise.all([
+        page.click(selectorLoginPageLoginButton, {
+            button: 'left',
+            delay: 10,
+        }),
+        page.waitForNavigation({
+            waitUntil: 'networkidle2',
+            timeout: pageTimeout,
+        }),
+    ]);
+
+    await sleep(options.pagewait * 1000);
+
+    return { page, appUrl, loginSkipped: false };
+};
+
+/**
+ * Captures the app overview once the run's thumbnails are already in place.
+ *
+ * This runs in its own browser session because the main session has closed by the
+ * time the thumbnails exist: uploading to the app's media library and pointing the
+ * sheets at those images both happen after the browser is gone. A second login is
+ * therefore the cost of showing the result rather than the starting state.
+ *
+ * @param {object} options - Command options.
+ * @param {string} appId - Qlik Sense app ID.
+ * @param {object} params - Capture parameters.
+ * @param {string} params.imgDir - Root image directory.
+ * @param {number} params.pageTimeout - Page operation timeout in milliseconds.
+ *
+ * @returns {Promise<string>} Path of the written screenshot.
+ */
+export const captureCloudOverviewAfter = async (options, appId, { imgDir, pageTimeout }) => {
+    const imagePath = `${imgDir}/cloud/${appId}/overview-after.png`;
+
+    // Cleared before the attempt, not after a failure - see the QSEoW twin for why a
+    // leftover after-image is worse than none.
+    removeStaleImage(imagePath);
+
+    const browser = await launchBrowserForApp(options, {
+        appId,
+        logPrefix: 'CLOUD APP',
+        appLabel: 'Qlik Sense Cloud app',
+        ErrorClass: CloudError,
+    });
+
+    try {
+        const { page } = await openCloudAppOverviewPage(browser, options, appId, {
+            imgDir,
+            pageTimeout,
+            loginPagePrefix: 'loginpage-after',
+        });
+
+        await page.screenshot({ path: imagePath });
+    } finally {
+        await closeBrowserQuietly(browser, 'CLOUD APP');
+    }
+
+    return imagePath;
+};

--- a/src/lib/cloud/cloud-app-session.js
+++ b/src/lib/cloud/cloud-app-session.js
@@ -75,8 +75,9 @@ export const openCloudAppOverviewPage = async (
     // flag, so `--skip-login` lands on `options.skipLogin`. Reading the
     // run-together spelling gave `undefined`, so this branch was unreachable
     // and login was always attempted - see issue #890.
+    // Reported by the caller, not here: this helper opens both the main session and the
+    // after-capture session, so logging it here announced a skipped login twice per app.
     if (options.skipLogin === true) {
-        logger.info('Skipping login as --skip-login is set to true');
         return { page, appUrl, loginSkipped: true };
     }
 

--- a/src/lib/cloud/process-cloud-app.js
+++ b/src/lib/cloud/process-cloud-app.js
@@ -1,5 +1,5 @@
 import { setupEnigmaConnection } from './cloud-enigma.js';
-import { logger, sleep } from '../../globals.js';
+import { logger } from '../../globals.js';
 import { qscloudUploadToApp } from './cloud-upload.js';
 import { qscloudUpdateSheetThumbnails } from './cloud-updatesheets.js';
 import { deleteCloudAppThumbnail } from './cloud-delete-thumbnails.js';
@@ -20,12 +20,9 @@ import { determineSheetExcludeStatus } from './determine-sheet-exclude-status.js
 import { determineSheetBlurStatus } from './determine-sheet-blur-status.js';
 import { addAppToReport, recordPlannedSheet, recordAppOutcome } from '../util/run-report.js';
 import { appProgressLine, sheetProgressLine } from '../util/run-report-render.js';
-import { logError } from '../util/log-error.js';
-
-// Selector paths to elements on login page
-const selectorLoginPageUserName = '[id="\u0031-email"]';
-const selectorLoginPageUserPwd = '[id="\u0031-password"]';
-const selectorLoginPageLoginButton = '[id="\u0031-submit"]';
+import { logError, describeWithCauses } from '../util/log-error.js';
+import { openCloudAppOverviewPage, captureCloudOverviewAfter } from './cloud-app-session.js';
+import { parseTrueFalseOption } from '../util/true-false-option.js';
 
 /**
  * Process a single Qlik Sense Cloud app.
@@ -157,72 +154,28 @@ export const processCloudApp = async (appId, saasInstance, options, report = nul
                         activeLiveView()?.beginStep('signed in');
                         activeLiveView()?.appPhase('signin');
 
-                        const page = await browser.newPage();
-                        // Thumbnails should be 410x270 pixels, so set the viewport to a multiple of this.
-                        await page.setViewport({
-                            width: 1230,
-                            height: 810,
-                            deviceScaleFactor: 1,
-                        });
-                        // Set default timeout for all page operations to 90 seconds
-                        await page.setDefaultTimeout(pageTimeout);
+                        // The same helper opens the after-capture session further down, so
+                        // the two logins cannot drift apart. `loginpage` is this session's
+                        // screenshot stem; the after-capture uses `loginpage-after` so it
+                        // cannot overwrite the evidence from this one.
+                        const { page, appUrl, loginSkipped } = await openCloudAppOverviewPage(
+                            browser,
+                            options,
+                            appId,
+                            { imgDir, pageTimeout, loginPagePrefix: 'loginpage' }
+                        );
 
-                        // Qlik Sense cloud URL format:
-                        // https://<tenant FQDN>/sense/app/<app ID>>
-                        const appUrl = `https://${options.tenanturl}/sense/app/${appId}`;
-                        logger.debug(`App URL: ${appUrl}`);
-                        await Promise.all([
-                            page.goto(appUrl, { waitUntil: 'networkidle2', timeout: pageTimeout }),
-                        ]);
-                        await sleep(options.pagewait * 1000);
-                        await page.screenshot({ path: `${imgDir}/cloud/${appId}/loginpage-1.png` });
-                        // Should login be skipped?
-                        //
-                        // `skipLogin`, not `skiplogin`: Commander camel-cases a hyphenated long
-                        // flag, so `--skip-login` lands on `options.skipLogin`. Reading the
-                        // run-together spelling gave `undefined`, so this branch was unreachable
-                        // and login was always attempted - see issue #890.
-                        if (options.skipLogin === true) {
-                            activeLiveView()?.stepDone('signed in', 'skipped (--skip-login)');
-                            logger.info('Skipping login as --skip-login is set to true');
-                        } else {
-                            // Enter credentials
-                            // User
-                            await page.click(selectorLoginPageUserName, {
-                                button: 'left',
-                                delay: 10,
-                            });
-                            const user = `${options.logonuserid}`;
-                            await page.keyboard.type(user);
-                            // Pwd
-                            await page.click(selectorLoginPageUserPwd, {
-                                button: 'left',
-                                delay: 10,
-                            });
-                            await page.keyboard.type(options.logonpwd);
-                            await page.screenshot({
-                                path: `${imgDir}/cloud/${appId}/loginpage-2.png`,
-                            });
-                            // Click login button and wait for page to load
-                            await Promise.all([
-                                page.click(selectorLoginPageLoginButton, {
-                                    button: 'left',
-                                    delay: 10,
-                                }),
-                                page.waitForNavigation({
-                                    waitUntil: 'networkidle2',
-                                    timeout: pageTimeout,
-                                }),
-                            ]);
-                            await sleep(options.pagewait * 1000);
-
-                            // Only now is the session real: the login click
-                            // has navigated and the page has settled.
-                            activeLiveView()?.stepDone('signed in', options.logonuserid ?? '');
-                        }
+                        // Only now is the session real: the login click has
+                        // navigated and the page has settled.
+                        activeLiveView()?.stepDone(
+                            'signed in',
+                            loginSkipped ? 'skipped (--skip-login)' : (options.logonuserid ?? '')
+                        );
                         activeLiveView()?.appPhase('sheets');
                         // Take screenshot of app overview page
-                        await page.screenshot({ path: `${imgDir}/cloud/${appId}/overview-1.png` });
+                        await page.screenshot({
+                            path: `${imgDir}/cloud/${appId}/overview-before.png`,
+                        });
                         // Sort sheets
                         sortSheetsByRank(sheets);
 
@@ -350,6 +303,33 @@ export const processCloudApp = async (appId, saasInstance, options, report = nul
 
         // Update sheets in app
         const sheetsUpdated = await qscloudUpdateSheetThumbnails(createdFiles, appId, options);
+
+        // The sheets now point at their new thumbnails, which is the first moment an
+        // overview screenshot can show the result rather than the starting state. The
+        // main session closed long before this point - uploading and assigning both
+        // happen after the browser is gone - so showing the result costs a second
+        // sign-in. Opt out with --capture-overview-after false when running over many
+        // apps, where that login is paid once per app.
+        //
+        // Never allowed to fail the run: the thumbnails are already created, uploaded and
+        // assigned by now. Losing the evidence screenshot is worth a warning, not the
+        // failure of work that has already succeeded.
+        if (parseTrueFalseOption(options.captureOverviewAfter) && createdFiles.length > 0) {
+            try {
+                logger.info(
+                    `CLOUD APP: Signing in again to capture the app overview after thumbnails were applied`
+                );
+                const afterImagePath = await captureCloudOverviewAfter(options, appId, {
+                    imgDir,
+                    pageTimeout,
+                });
+                logger.verbose(`CLOUD APP: Wrote after-overview screenshot ${afterImagePath}`);
+            } catch (err) {
+                logger.warn(
+                    `CLOUD APP: Could not capture the app overview after the update. The thumbnails themselves were applied successfully. ${describeWithCauses(err)}`
+                );
+            }
+        }
 
         recordAppOutcome(appEntry, {
             sheetsUpdated,

--- a/src/lib/cloud/process-cloud-app.js
+++ b/src/lib/cloud/process-cloud-app.js
@@ -171,6 +171,9 @@ export const processCloudApp = async (appId, saasInstance, options, report = nul
                             'signed in',
                             loginSkipped ? 'skipped (--skip-login)' : (options.logonuserid ?? '')
                         );
+                        if (loginSkipped) {
+                            logger.info('Skipping login as --skip-login is set to true');
+                        }
                         activeLiveView()?.appPhase('sheets');
                         // Take screenshot of app overview page
                         await page.screenshot({

--- a/src/lib/commands/qscloud/__tests__/qscloud_wizard.test.js
+++ b/src/lib/commands/qscloud/__tests__/qscloud_wizard.test.js
@@ -695,6 +695,7 @@ describe('progressive disclosure', () => {
                 schemaversion: '12.612.0',
                 pagewait: '5',
                 imagedir: './img',
+                captureOverviewAfter: true,
                 browser: 'chrome',
                 browserVersion: 'recommended',
                 browserPageTimeout: '90',

--- a/src/lib/commands/qscloud/create-sheet-thumbnails.interactive.js
+++ b/src/lib/commands/qscloud/create-sheet-thumbnails.interactive.js
@@ -41,6 +41,7 @@ const ADVANCED_KEYS = [
     'schemaversion',
     'pagewait',
     'imagedir',
+    'captureOverviewAfter',
     'browser',
     'browserVersion',
     'browserPageTimeout',

--- a/src/lib/commands/qscloud/create-sheet-thumbnails.js
+++ b/src/lib/commands/qscloud/create-sheet-thumbnails.js
@@ -153,6 +153,18 @@ const buildCloudCreateSheetThumbnailsCommand = () => {
         )
         .addOption(
             new Option(
+                '--capture-overview-after <true|false>',
+                'Capture a second screenshot of the app overview after the thumbnails have been applied, showing the result rather than the starting state. Costs one extra browser login per app'
+            )
+                // Not mandatory, matching --blur-factor and --browser-page-timeout: a tuning
+                // flag with a working default. specsFromCommand() reads option.mandatory to
+                // decide what the interactive wizard asks about, and this is not a question a
+                // guided run should have to answer.
+                .default(true)
+                .env('BSI_QSCLOUD_CST_CAPTURE_OVERVIEW_AFTER')
+        )
+        .addOption(
+            new Option(
                 '--includesheetpart <value>',
                 'Which part of sheets should be used to take screenshots. 1=object area only, 2=1 + sheet title, 3 not used, 4=full screen'
             )

--- a/src/lib/commands/qseow/__tests__/qseow_wizard.test.js
+++ b/src/lib/commands/qseow/__tests__/qseow_wizard.test.js
@@ -921,6 +921,7 @@ describe('progressive disclosure', () => {
                 headless: true,
                 pagewait: '5',
                 imagedir: './img',
+                captureOverviewAfter: true,
                 senseVersion: '2025-Nov',
                 browser: 'chrome',
                 browserVersion: 'recommended',

--- a/src/lib/commands/qseow/create-sheet-thumbnails.interactive.js
+++ b/src/lib/commands/qseow/create-sheet-thumbnails.interactive.js
@@ -64,6 +64,7 @@ const ADVANCED_KEYS = [
     'headless',
     'pagewait',
     'imagedir',
+    'captureOverviewAfter',
     'senseVersion',
     'browser',
     'browserVersion',

--- a/src/lib/commands/qseow/index.js
+++ b/src/lib/commands/qseow/index.js
@@ -172,6 +172,18 @@ const buildQseowCommand = () => {
         )
         .addOption(
             new Option(
+                '--capture-overview-after <true|false>',
+                'Capture a second screenshot of the app overview after the thumbnails have been applied, showing the result rather than the starting state. Costs one extra browser login per app'
+            )
+                // Not mandatory, matching --blur-factor and --browser-page-timeout: a tuning
+                // flag with a working default. specsFromCommand() reads option.mandatory to
+                // decide what the interactive wizard asks about, and this is not a question a
+                // guided run should have to answer.
+                .default(true)
+                .env('BSI_QSEOW_CST_CAPTURE_OVERVIEW_AFTER')
+        )
+        .addOption(
+            new Option(
                 '--contentlibrary <library-name>',
                 'Qlik Sense content library to which thumbnails will be uploaded'
             )

--- a/src/lib/qseow/__tests__/qseow_process_app.test.js
+++ b/src/lib/qseow/__tests__/qseow_process_app.test.js
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeAll, beforeEach, jest } from '@jest/globals';
+import { describe, test, expect, beforeAll, beforeEach, afterEach, jest } from '@jest/globals';
 
 // Mock every dependency of qseowProcessApp using the ESM-native
 // jest.unstable_mockModule + dynamic import pattern. This mirrors the pattern
@@ -26,9 +26,11 @@ const mockFs = jest.unstable_mockModule('fs', () => ({
     default: {
         mkdirSync: jest.fn(),
         existsSync: jest.fn().mockReturnValue(false),
+        rmSync: jest.fn(),
     },
     mkdirSync: jest.fn(),
     existsSync: jest.fn().mockReturnValue(false),
+    rmSync: jest.fn(),
 }));
 
 const mockJimp = jest.unstable_mockModule('jimp', () => ({
@@ -103,6 +105,7 @@ const mockDetermineSheetExcludeStatus = jest.unstable_mockModule(
     })
 );
 
+let fs;
 let qseowProcessApp;
 let puppeteer;
 let enigma;
@@ -146,6 +149,7 @@ beforeAll(async () => {
     ({ qseowUploadToContentLibrary } = await import('../qseow-upload.js'));
     ({ qseowUpdateSheetThumbnails } = await import('../qseow-updatesheets.js'));
     ({ qseowLogout } = await import('../qseow-logout.js'));
+    fs = (await import('fs')).default;
     ({ qseowProcessApp } = await import('../qseow-process-app.js'));
 });
 
@@ -172,6 +176,11 @@ describe('qseow-process-app.js — puppeteer launch and click options', () => {
         headless: true,
         blurFactor: 5,
         loglevel: 'info',
+        // Off in the shared fixture, on by default in the product. The after-capture opens a
+        // *second* browser session, which would double the launch/close counts that the
+        // lifecycle tests in this file assert on. It gets its own describe block below, where
+        // the second session is the subject rather than an unannounced extra.
+        captureOverviewAfter: false,
     };
 
     /**
@@ -867,6 +876,188 @@ describe('qseow-process-app.js — puppeteer launch and click options', () => {
             await qseowProcessApp('test-app-id', defaultOptions);
 
             expect(enigma.create).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    // Issue #735. The after-capture is the only part of a run that opens a second browser
+    // session, and it does so after the thumbnails are already uploaded and assigned - which
+    // is precisely why it must never be able to fail the run.
+    describe('app overview captured after the update (#735)', () => {
+        beforeEach(() => {
+            // The enclosing describe has no beforeEach, so both call counts and mock
+            // implementations accumulate across its tests. clearAllMocks resets the counts but
+            // deliberately keeps implementations, so the browser mocks are restored by hand.
+            jest.clearAllMocks();
+            detectAvailableBrowser.mockResolvedValue({
+                executablePath: '/test/browser',
+                source: 'system',
+                browser: 'chrome',
+                buildId: 'system-installed',
+            });
+            browserInstall.mockReset();
+            qseowUploadToContentLibrary.mockResolvedValue(true);
+            qseowUpdateSheetThumbnails.mockResolvedValue(1);
+        });
+
+        afterEach(() => {
+            // These tests queue one-shot launch and logout outcomes. clearAllMocks keeps
+            // queued implementations, so an unconsumed one would surface in an unrelated
+            // test several describes later, where it makes no sense at all.
+            puppeteer.launch.mockReset();
+            qseowLogout.mockReset();
+            qseowLogout.mockResolvedValue(true);
+        });
+
+        /**
+         * Every path the run passed to `page.screenshot`.
+         *
+         * @param {object} browser - Mock browser returned by setupHappyPath.
+         *
+         * @returns {string[]} Screenshot paths, in the order they were written.
+         */
+        const shotPaths = (browser) => browser._page.screenshot.mock.calls.map(([arg]) => arg.path);
+
+        test('names the main session overview after the state it shows', async () => {
+            const browser = setupHappyPath();
+
+            await qseowProcessApp('test-app-id', defaultOptions);
+
+            // Renamed from overview-1.png: with a second capture in play, a positional
+            // name no longer says which of the two an operator is looking at.
+            expect(shotPaths(browser)).toContain('./img/qseow/test-app-id/overview-before.png');
+        });
+
+        test('signs in again and captures the overview when enabled', async () => {
+            const browser = setupHappyPath();
+
+            await qseowProcessApp('test-app-id', {
+                ...defaultOptions,
+                captureOverviewAfter: true,
+            });
+
+            expect(puppeteer.launch).toHaveBeenCalledTimes(2);
+            expect(browser.close).toHaveBeenCalledTimes(2);
+            expect(shotPaths(browser)).toContain('./img/qseow/test-app-id/overview-after.png');
+        });
+
+        test('captures only after the sheets have been pointed at the new thumbnails', async () => {
+            const browser = setupHappyPath();
+
+            await qseowProcessApp('test-app-id', {
+                ...defaultOptions,
+                captureOverviewAfter: true,
+            });
+
+            // Ordering is the whole point: capture too early and the screenshot shows the
+            // starting state while claiming to show the result.
+            const index = browser._page.screenshot.mock.calls.findIndex(([arg]) =>
+                arg.path.endsWith('overview-after.png')
+            );
+            const capturedAt = browser._page.screenshot.mock.invocationCallOrder[index];
+            const updatedAt = qseowUpdateSheetThumbnails.mock.invocationCallOrder[0];
+
+            expect(capturedAt).toBeGreaterThan(updatedAt);
+        });
+
+        test('gives the second login its own screenshots rather than overwriting the first', async () => {
+            const browser = setupHappyPath();
+
+            await qseowProcessApp('test-app-id', {
+                ...defaultOptions,
+                captureOverviewAfter: true,
+            });
+
+            const paths = shotPaths(browser);
+
+            expect(paths).toContain('./img/qseow/test-app-id/loginpage-after-1.png');
+            expect(paths).toContain('./img/qseow/test-app-id/loginpage-after-2.png');
+
+            // The first session's login evidence is what an operator reads when a run fails
+            // to sign in. A second session reusing those names would erase it.
+            expect(paths.filter((path) => path.endsWith('/loginpage-1.png'))).toHaveLength(1);
+            expect(paths.filter((path) => path.endsWith('/loginpage-2.png'))).toHaveLength(1);
+        });
+
+        test('opens no second session when switched off', async () => {
+            const browser = setupHappyPath();
+
+            await qseowProcessApp('test-app-id', {
+                ...defaultOptions,
+                captureOverviewAfter: false,
+            });
+
+            expect(puppeteer.launch).toHaveBeenCalledTimes(1);
+            expect(shotPaths(browser)).not.toContain('./img/qseow/test-app-id/overview-after.png');
+        });
+
+        test('clears a stale after-image before attempting the capture', async () => {
+            setupHappyPath();
+
+            await qseowProcessApp('test-app-id', {
+                ...defaultOptions,
+                captureOverviewAfter: true,
+            });
+
+            // The run has already overwritten overview-before.png by this point. If the
+            // capture then fails, an after-image left by an earlier run would pair a fresh
+            // before with a stale after and read as one run's evidence.
+            expect(fs.rmSync).toHaveBeenCalledWith('./img/qseow/test-app-id/overview-after.png', {
+                force: true,
+            });
+        });
+
+        test('a logout failure is not reported as a failed capture', async () => {
+            const browser = setupHappyPath();
+            qseowLogout.mockResolvedValueOnce(true);
+            qseowLogout.mockRejectedValueOnce(new Error('QPS DELETE refused'));
+
+            await expect(
+                qseowProcessApp('test-app-id', { ...defaultOptions, captureOverviewAfter: true })
+            ).resolves.not.toThrow();
+
+            const warnings = logger.warn.mock.calls.map((call) => String(call[0])).join('\n');
+
+            // The screenshot is written before the logout is attempted, so the file exists.
+            // Saying it could not be captured would send an operator looking for a file that
+            // is sitting in the image directory.
+            expect(shotPaths(browser)).toContain('./img/qseow/test-app-id/overview-after.png');
+            expect(warnings).toContain('could not log the second session out');
+            expect(warnings).not.toContain('Could not capture the app overview');
+        });
+
+        test('survives a rejection that carries no message', async () => {
+            const browser = setupHappyPath();
+            // The main session gets its page; the after-capture's newPage rejects with a bare
+            // undefined. Nothing between there and the caller's catch wraps it - rejecting the
+            // browser launch instead would be wrapped in a QseowError and prove nothing.
+            browser.newPage.mockResolvedValueOnce(browser._page);
+            browser.newPage.mockRejectedValueOnce(undefined);
+
+            // Reading `.message` off this would throw from inside the very catch block that
+            // exists to keep the capture from failing the run, turning a run whose thumbnails
+            // were fully applied into a failed one.
+            await expect(
+                qseowProcessApp('test-app-id', { ...defaultOptions, captureOverviewAfter: true })
+            ).resolves.not.toThrow();
+
+            const warnings = logger.warn.mock.calls.map((call) => String(call[0])).join('\n');
+            expect(warnings).toContain('Could not capture the app overview after the update');
+        });
+
+        test('warns but does not fail the run when the second session cannot start', async () => {
+            const browser = setupHappyPath();
+            puppeteer.launch.mockResolvedValueOnce(browser);
+            puppeteer.launch.mockRejectedValueOnce(new Error('no browser available'));
+
+            await expect(
+                qseowProcessApp('test-app-id', { ...defaultOptions, captureOverviewAfter: true })
+            ).resolves.not.toThrow();
+
+            const warnings = logger.warn.mock.calls.map((call) => String(call[0])).join('\n');
+            expect(warnings).toContain('Could not capture the app overview after the update');
+
+            // The thumbnails were applied before the capture was attempted, so the run stands.
+            expect(qseowUpdateSheetThumbnails).toHaveBeenCalled();
         });
     });
 });

--- a/src/lib/qseow/qseow-app-session.js
+++ b/src/lib/qseow/qseow-app-session.js
@@ -1,0 +1,212 @@
+import { logger, sleep } from '../../globals.js';
+import { launchBrowserForApp, closeBrowserQuietly } from '../browser/browser-launch.js';
+import { QseowError } from '../util/errors.js';
+import { normalizeVirtualProxyPrefix } from './qseow-prefix.js';
+import { qseowLogout } from './qseow-logout.js';
+import { removeStaleImage } from '../util/image-dir.js';
+import { describeWithCauses } from '../util/log-error.js';
+
+const selectorLoginPageUserName = '#username-input';
+const selectorLoginPageUserPwd = '#password-input';
+const selectorLoginPageLoginButton = '#loginbtn';
+
+/**
+ * Builds the app and hub URLs for a QSEoW server.
+ *
+ * Both are derived from the same origin so they cannot disagree about which host,
+ * scheme or port is being addressed - a class of bug that is invisible until a run
+ * authenticates against one host and then navigates to another.
+ *
+ * @param {object} options - Command options (`host`, `port`, `secure`, `prefix`).
+ * @param {string} appId - Qlik Sense app ID.
+ *
+ * @returns {{appUrl: string, hubUrl: string}} The two URLs.
+ */
+export const buildQseowAppUrls = (options, appId) => {
+    const scheme = options.secure === 'true' || options.secure === true ? 'https://' : 'http://';
+
+    // --port is the web port, distinct from --engineport (4747) and --qrsport
+    // (4242). It was declared and parsed but never reached the URL, so a
+    // server on a non-standard web port could not be reached at all.
+    const origin = options.port
+        ? `${scheme}${options.host}:${options.port}`
+        : `${scheme}${options.host}`;
+
+    // Normalised, not used raw: a prefix written as it appears in the browser
+    // address bar ("/form") produced "https://host//form/sense/app/<id>", which
+    // authenticates fine and then never renders, failing 90 seconds later on a
+    // selector that says nothing about the prefix.
+    const prefix = normalizeVirtualProxyPrefix(options.prefix);
+
+    if (prefix.length > 0) {
+        return {
+            appUrl: `${origin}/${prefix}/sense/app/${appId}`,
+            hubUrl: `${origin}/${prefix}/hub`,
+        };
+    }
+
+    return { appUrl: `${origin}/sense/app/${appId}`, hubUrl: `${origin}/hub` };
+};
+
+/**
+ * Opens a page, signs in to the QSEoW web UI and leaves the browser sitting on the
+ * app overview.
+ *
+ * Shared by the main thumbnail session and the after-capture session so the second
+ * login cannot drift away from the first: a login sequence that exists twice is a
+ * login sequence that gets fixed once.
+ *
+ * `loginPagePrefix` names the two login screenshots. The two sessions must use
+ * different prefixes - reusing `loginpage` for both would have the after-capture
+ * silently overwrite the main session's login evidence, which is exactly the
+ * material an operator needs when diagnosing a failed run.
+ *
+ * @param {object} browser - Puppeteer browser instance.
+ * @param {object} options - Command options.
+ * @param {string} appId - Qlik Sense app ID.
+ * @param {object} params - Capture parameters.
+ * @param {string} params.imgDir - Root image directory.
+ * @param {number} params.pageTimeout - Page operation timeout in milliseconds.
+ * @param {string} params.loginPagePrefix - Basename stem for the login screenshots.
+ *
+ * @returns {Promise<{page: object, appUrl: string, hubUrl: string}>} The signed-in page.
+ */
+export const openQseowAppOverviewPage = async (
+    browser,
+    options,
+    appId,
+    { imgDir, pageTimeout, loginPagePrefix }
+) => {
+    const page = await browser.newPage();
+
+    // Thumbnails should be 410x270 pixels, so set the viewport to a multiple of this.
+    await page.setViewport({
+        width: 1230,
+        height: 810,
+        deviceScaleFactor: 1,
+    });
+
+    // Set default timeout for all page operations to 90 seconds
+    // https://stackoverflow.com/questions/52163547/node-js-puppeteer-how-to-set-navigation-timeout
+    await page.setDefaultTimeout(pageTimeout);
+
+    const { appUrl, hubUrl } = buildQseowAppUrls(options, appId);
+
+    logger.debug(`App URL: ${appUrl}`);
+    logger.debug(`Hub URL: ${hubUrl}`);
+
+    await Promise.all([page.goto(appUrl, { waitUntil: 'networkidle2', timeout: pageTimeout })]);
+
+    await sleep(options.pagewait * 1000);
+    await page.screenshot({ path: `${imgDir}/qseow/${appId}/${loginPagePrefix}-1.png` });
+
+    // Enter credentials
+    // User
+    await page.click(selectorLoginPageUserName, {
+        button: 'left',
+        delay: 10,
+    });
+
+    const user = `${options.logonuserdir}\\${options.logonuserid}`;
+    await page.keyboard.type(user);
+
+    // Pwd
+    await page.click(selectorLoginPageUserPwd, {
+        button: 'left',
+        delay: 10,
+    });
+    await page.keyboard.type(options.logonpwd);
+
+    await page.screenshot({ path: `${imgDir}/qseow/${appId}/${loginPagePrefix}-2.png` });
+
+    // Click login button and wait for page to load
+    await Promise.all([
+        page.click(selectorLoginPageLoginButton, {
+            button: 'left',
+            delay: 10,
+        }),
+        page.waitForNavigation({ waitUntil: 'networkidle2' }),
+    ]);
+
+    await sleep(options.pagewait * 1000);
+
+    return { page, appUrl, hubUrl };
+};
+
+/**
+ * Captures the app overview once the run's thumbnails are already in place.
+ *
+ * This runs in its own browser session because the main session has logged out and
+ * closed by the time the thumbnails exist: uploading to the content library and
+ * pointing the sheets at those images both happen after the browser is gone. A
+ * second login is therefore the cost of showing the result rather than the
+ * starting state.
+ *
+ * @param {object} options - Command options.
+ * @param {string} appId - Qlik Sense app ID.
+ * @param {object} params - Capture parameters.
+ * @param {string} params.imgDir - Root image directory.
+ * @param {number} params.pageTimeout - Page operation timeout in milliseconds.
+ * @param {string} params.userMenuButton - Hub user-menu selector, for the logout fallback.
+ * @param {string} params.legacyLogoutButton - Legacy logout selector, for the logout fallback.
+ *
+ * @returns {Promise<string>} Path of the written screenshot.
+ */
+export const captureQseowOverviewAfter = async (
+    options,
+    appId,
+    { imgDir, pageTimeout, userMenuButton, legacyLogoutButton }
+) => {
+    const imagePath = `${imgDir}/qseow/${appId}/overview-after.png`;
+
+    // Cleared before the attempt, not after a failure: this capture is allowed to fail
+    // without failing the run, and the run has already overwritten overview-before.png.
+    // A leftover after-image from a previous run would pair a fresh before with a stale
+    // after, which reads as one run's evidence and is not.
+    removeStaleImage(imagePath);
+
+    const browser = await launchBrowserForApp(options, {
+        appId,
+        logPrefix: 'QSEOW',
+        appLabel: 'QSEoW app',
+        ErrorClass: QseowError,
+    });
+
+    try {
+        const { page, hubUrl } = await openQseowAppOverviewPage(browser, options, appId, {
+            imgDir,
+            pageTimeout,
+            loginPagePrefix: 'loginpage-after',
+        });
+
+        await page.screenshot({ path: imagePath });
+
+        // The screenshot is this function's product and it is now on disk. Logging out is
+        // cleanup, so its failure is reported on its own terms rather than propagating into
+        // the caller's "could not capture the app overview" warning - which would claim the
+        // file is missing while it sits in the image directory. The session is closed from
+        // the client side by the finally below either way.
+        try {
+            await qseowLogout(
+                page,
+                {
+                    prefix: options.prefix,
+                    hubUrl,
+                    pageTimeout,
+                    pagewait: options.pagewait,
+                    senseVersion: options.senseVersion,
+                },
+                userMenuButton,
+                legacyLogoutButton
+            );
+        } catch (err) {
+            logger.warn(
+                `QSEOW: Captured the after-update app overview, but could not log the second session out cleanly. ${describeWithCauses(err)}`
+            );
+        }
+    } finally {
+        await closeBrowserQuietly(browser, 'QSEOW');
+    }
+
+    return imagePath;
+};

--- a/src/lib/qseow/qseow-process-app.js
+++ b/src/lib/qseow/qseow-process-app.js
@@ -22,12 +22,9 @@ import { appProgressLine, sheetProgressLine } from '../util/run-report-render.js
 import { QSEOW_SHEET_PART_SELECTORS } from './sheet-parts.js';
 import { qseowLogout } from './qseow-logout.js';
 import { getQseowHubSelectors } from './qseow-selectors.js';
-import { logError } from '../util/log-error.js';
-import { normalizeVirtualProxyPrefix } from './qseow-prefix.js';
-
-const selectorLoginPageUserName = '#username-input';
-const selectorLoginPageUserPwd = '#password-input';
-const selectorLoginPageLoginButton = '#loginbtn';
+import { logError, describeWithCauses } from '../util/log-error.js';
+import { openQseowAppOverviewPage, captureQseowOverviewAfter } from './qseow-app-session.js';
+import { parseTrueFalseOption } from '../util/true-false-option.js';
 
 /**
  * Processes a Qlik Sense Enterprise on Windows (QSEoW) application to generate
@@ -156,92 +153,16 @@ export const qseowProcessApp = async (appId, options, report = null) => {
                         activeLiveView()?.beginStep('signed in');
                         activeLiveView()?.appPhase('signin');
 
-                        const page = await browser.newPage();
-
-                        // Thumbnails should be 410x270 pixels, so set the viewport to a multiple of this.
-                        await page.setViewport({
-                            width: 1230,
-                            height: 810,
-                            deviceScaleFactor: 1,
-                        });
-
-                        // Set default timeout for all page operations to 90 seconds
-                        // https://stackoverflow.com/questions/52163547/node-js-puppeteer-how-to-set-navigation-timeout
-                        await page.setDefaultTimeout(pageTimeout);
-
-                        // Assigned unconditionally just below; the empty initialiser was dead. It only passed
-                        // lint before because no-useless-assignment skips code inside a try block, and the
-                        // enclosing try is now the session callback.
-                        let appUrl;
-                        let hubUrl;
-
-                        const scheme =
-                            options.secure === 'true' || options.secure === true
-                                ? 'https://'
-                                : 'http://';
-
-                        // --port is the web port, distinct from --engineport (4747) and --qrsport
-                        // (4242). It was declared and parsed but never reached the URL, so a
-                        // server on a non-standard web port could not be reached at all. Built
-                        // once here rather than in each branch below, so the app and hub URLs
-                        // cannot disagree about which host they are talking to.
-                        const origin = options.port
-                            ? `${scheme}${options.host}:${options.port}`
-                            : `${scheme}${options.host}`;
-
-                        // Normalised, not used raw: a prefix written as it appears in the browser
-                        // address bar ("/form") produced "https://host//form/sense/app/<id>",
-                        // which authenticates fine and then never renders, failing 90 seconds
-                        // later on a selector that says nothing about the prefix.
-                        const prefix = normalizeVirtualProxyPrefix(options.prefix);
-
-                        if (prefix.length > 0) {
-                            appUrl = `${origin}/${prefix}/sense/app/${appId}`;
-                            hubUrl = `${origin}/${prefix}/hub`;
-                        } else {
-                            appUrl = `${origin}/sense/app/${appId}`;
-                            hubUrl = `${origin}/hub`;
-                        }
-
-                        logger.debug(`App URL: ${appUrl}`);
-                        logger.debug(`Hub URL: ${hubUrl}`);
-
-                        await Promise.all([
-                            page.goto(appUrl, { waitUntil: 'networkidle2', timeout: pageTimeout }),
-                        ]);
-
-                        await sleep(options.pagewait * 1000);
-                        await page.screenshot({ path: `${imgDir}/qseow/${appId}/loginpage-1.png` });
-
-                        // Enter credentials
-                        // User
-                        await page.click(selectorLoginPageUserName, {
-                            button: 'left',
-                            delay: 10,
-                        });
-
-                        const user = `${options.logonuserdir}\\${options.logonuserid}`;
-                        await page.keyboard.type(user);
-
-                        // Pwd
-                        await page.click(selectorLoginPageUserPwd, {
-                            button: 'left',
-                            delay: 10,
-                        });
-                        await page.keyboard.type(options.logonpwd);
-
-                        await page.screenshot({ path: `${imgDir}/qseow/${appId}/loginpage-2.png` });
-
-                        // Click login button and wait for page to load
-                        await Promise.all([
-                            page.click(selectorLoginPageLoginButton, {
-                                button: 'left',
-                                delay: 10,
-                            }),
-                            page.waitForNavigation({ waitUntil: 'networkidle2' }),
-                        ]);
-
-                        await sleep(options.pagewait * 1000);
+                        // The same helper opens the after-capture session further down, so
+                        // the two logins cannot drift apart. `loginpage` is this session's
+                        // screenshot stem; the after-capture uses `loginpage-after` so it
+                        // cannot overwrite the evidence from this one.
+                        const { page, appUrl, hubUrl } = await openQseowAppOverviewPage(
+                            browser,
+                            options,
+                            appId,
+                            { imgDir, pageTimeout, loginPagePrefix: 'loginpage' }
+                        );
 
                         // Only now is the session real: the login click has
                         // navigated and the page has settled.
@@ -252,7 +173,9 @@ export const qseowProcessApp = async (appId, options, report = null) => {
                         activeLiveView()?.appPhase('sheets');
 
                         // Take screenshot of app overview page
-                        await page.screenshot({ path: `${imgDir}/qseow/${appId}/overview-1.png` });
+                        await page.screenshot({
+                            path: `${imgDir}/qseow/${appId}/overview-before.png`,
+                        });
 
                         // Sort sheets
                         sortSheetsByRank(sheets);
@@ -486,6 +409,35 @@ export const qseowProcessApp = async (appId, options, report = null) => {
             options,
             blurTagSheetAppMetadata
         );
+
+        // The sheets now point at their new thumbnails, which is the first moment an
+        // overview screenshot can show the result rather than the starting state. The
+        // main session logged out and closed long before this point - uploading and
+        // assigning both happen after the browser is gone - so showing the result costs
+        // a second sign-in. Opt out with --capture-overview-after false when running
+        // over many apps, where that login is paid once per app.
+        //
+        // Never allowed to fail the run: the thumbnails are already created, uploaded and
+        // assigned by now. Losing the evidence screenshot is worth a warning, not the
+        // failure of work that has already succeeded.
+        if (parseTrueFalseOption(options.captureOverviewAfter) && createdFiles.length > 0) {
+            try {
+                logger.info(
+                    `QSEOW APP: Signing in again to capture the app overview after thumbnails were applied`
+                );
+                const afterImagePath = await captureQseowOverviewAfter(options, appId, {
+                    imgDir,
+                    pageTimeout,
+                    userMenuButton: xpathHubUserPageButton,
+                    legacyLogoutButton,
+                });
+                logger.verbose(`QSEOW APP: Wrote after-overview screenshot ${afterImagePath}`);
+            } catch (err) {
+                logger.warn(
+                    `QSEOW APP: Could not capture the app overview after the update. The thumbnails themselves were applied successfully. ${describeWithCauses(err)}`
+                );
+            }
+        }
 
         recordAppOutcome(appEntry, {
             sheetsUpdated,

--- a/src/lib/util/image-dir.js
+++ b/src/lib/util/image-dir.js
@@ -156,3 +156,27 @@ const isProbablyContainer = () => {
         return false;
     }
 };
+
+/**
+ * Removes an image left behind by an earlier run, best-effort.
+ *
+ * Used for outputs that a run may or may not produce. Writing one is not guaranteed - the
+ * after-overview capture is explicitly allowed to fail without failing the run - and a file
+ * from a previous run surviving that failure is worse than no file at all: the run overwrites
+ * its other images, so the leftover would be read as part of this run's output when it belongs
+ * to the previous one.
+ *
+ * Never throws. Failing to clear a stale file leaves things exactly as they were before this
+ * function existed, which is not a reason to fail the run that called it.
+ *
+ * @param {string} filePath - Absolute or relative path of the image to remove.
+ *
+ * @returns {void}
+ */
+export const removeStaleImage = (filePath) => {
+    try {
+        fs.rmSync(filePath, { force: true });
+    } catch (err) {
+        logger.debug(`Could not remove stale image ${filePath}: ${err}`);
+    }
+};

--- a/src/lib/util/log-error.js
+++ b/src/lib/util/log-error.js
@@ -114,10 +114,14 @@ const MAX_CAUSE_DEPTH = 5;
  * A cause already quoted in an enclosing message is skipped: several call sites throw
  * ``new Error(`PREFIX: ${err}`, { cause: err })``, and repeating it would say the same thing twice.
  *
+ * Exported for the handful of `catch` blocks that report a failure at `warn` rather than
+ * `error` - a step that is allowed to fail without failing the run. They need the same
+ * never-throws rendering as `logError`, at a different log level.
+ *
  * @param {Error|unknown} error - The caught value.
  * @returns {string} e.g. `Failed to update sheet thumbnails in app X [caused by: Not connected]`.
  */
-const describeWithCauses = (error) => {
+export const describeWithCauses = (error) => {
     const parts = [describeError(error)];
     const seen = new Set([error]);
 

--- a/src/lib/util/true-false-option.js
+++ b/src/lib/util/true-false-option.js
@@ -1,0 +1,23 @@
+/**
+ * Coerces a `<true|false>` CLI option into a boolean.
+ *
+ * Commander surfaces these options as the strings `'true'` / `'false'` when they
+ * come from the command line or an environment variable, but as a real boolean
+ * when they come from the option's own `.default()`. Every consumer therefore has
+ * to accept both spellings, which is why this lives in one place rather than as a
+ * `x === 'true' || x === true` chain at each call site.
+ *
+ * @param {boolean|string|undefined} value - Raw value supplied via options/CLI/env.
+ * @param {boolean} [defaultValue] - Result for undefined or unrecognised input. Defaults to true.
+ *
+ * @returns {boolean} The coerced value.
+ */
+export const parseTrueFalseOption = (value, defaultValue = true) => {
+    if (value === 'true' || value === true) {
+        return true;
+    }
+    if (value === 'false' || value === false) {
+        return false;
+    }
+    return defaultValue;
+};


### PR DESCRIPTION
Every `create-sheet-thumbnails` run now photographs the app overview twice — once before any sheet is touched, once after the new thumbnails are uploaded and assigned. The pair is the evidence a run could not previously produce: its log said what it *decided*, but nothing showed the result in the form the person who requested the change recognises.

Closes #735, narrowed — see below.

## The second sign-in

Uploading to the content library and pointing the sheets at those images both happen **after** the main browser session has logged out and closed. At the moment the "after" state first exists there is no live session left to photograph it from, so the capture opens its own.

That was a deliberate choice over the alternative of hoisting the upload and assignment inside the existing session. Resequencing the main command would have been one login instead of two, but it reorders the highest-traffic code path in the tool; a second sign-in keeps the blast radius on new code. The cost is one extra browser launch and login per app, which `--capture-overview-after false` removes for bulk runs.

The login sequence and URL building moved into per-platform session modules so both sign-ins go through one path and cannot drift. The second session writes `loginpage-after-*.png` rather than reusing `loginpage-*.png` — those files are what an operator reads when a run fails to sign in, and overwriting them would destroy the first session's evidence.

## Breaking: one file is renamed

`overview-1.png` is now `overview-before.png`. With two overview screenshots per run a positional name no longer says which state the picture shows. Anything reading it by name needs updating; the `feat` commit carries a `BREAKING CHANGE:` footer so it lands in the changelog. Release-please already targets 5.0.0, so no version changes.

## The capture can never fail the run

The thumbnails are created, uploaded and assigned before it is attempted. Three consequences, each covered by a test that was verified to fail against the unfixed code:

- The logout is caught separately from the capture. It runs after the screenshot is already on disk, so letting it propagate would report the file as missing while it sits in the image directory.
- The warning renders the caught value through `describeWithCauses` instead of reading `.message`. A non-Error rejection made the handler itself throw a `TypeError` that escaped the block and failed a run whose thumbnails were fully applied — the exact failure the block exists to prevent. `log-error.js` already had this renderer for the same reason and only needed exporting.
- Any after-image from a previous run is cleared before the attempt. The run has already overwritten `overview-before.png` by then, so a leftover would pair a fresh before with a stale after and read as one run's evidence.

## Scope: thumbnails only

#735 listed all four commands. The two `remove-sheet-icons` commands never open a browser — they clear icon links over the engine/QRS and Qlik Cloud APIs, deliberately, per #894. Giving them an after-overview would mean adding Puppeteer, a web UI login and required `--logonuser*` options to commands built specifically not to need them. The issue's scope and acceptance criteria were narrowed to match, with the reasoning recorded there.

## Verification

Run live against a client-managed Qlik Sense server, not only mocked: reset the demo app's icons, then one real run produced both panels — before showing default placeholder glyphs, after showing the sheets carrying their thumbnails. Exit code 0, no warning. 3251 unit tests pass, lint clean, `demo:check` reports no drift (the new log line is on the real-run path, and dry runs never reach it).

The after-panel immediately surfaced a real pre-existing bug, filed as #1119: with a short `--pagewait`, sheets photographed mid-render have Qlik's "Opening the sheet" loading screen uploaded as their thumbnail, and the run reports success. Not introduced here — but previously invisible, which is rather the point of the feature.

## Also

`demo/record.sh` collapses from two real runs to one. It ran BSI twice only because the single overview a run captured was taken at its start, showing whatever the previous run had left behind.

Note for merge order: this branch is cut from `main` without #1117 or #1118, so it will conflict lightly with #1117 in `demo/README.md` and the removal snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
