### PR TITLE
Stop a thumbnail of the loading screen from passing as a real one

### DIFF
--- a/docs/to-doc-site/thumbnail-captured-while-sheet-loading.md
+++ b/docs/to-doc-site/thumbnail-captured-while-sheet-loading.md
@@ -1,0 +1,50 @@
+# When a thumbnail shows the loading screen instead of the sheet
+
+**Status:** pending publication
+**Suggested target pages:** `/guide/troubleshooting`, and a note on `--pagewait` in `/reference/qseow` and `/reference/qscloud`
+**Version gate:** not released yet — read the open release-please PR title for the version before publishing. Do not copy a version number from this draft.
+
+---
+
+## What changed, in one paragraph
+
+Butler Sheet Icons now warns when it photographed a sheet before Qlik Sense had finished drawing it. Previously such a run reported complete success while quietly uploading a picture of Qlik's "opening the sheet" screen as that sheet's thumbnail. Nothing is captured differently and no run outcome changes — the situation simply stops being silent.
+
+## The warning
+
+```
+Sheet 4 ('Regional sales') was still opening when its thumbnail was captured, so the image
+shows Qlik Sense's loading screen rather than the sheet. It was uploaded and assigned anyway.
+Raise --pagewait (currently 1) and run again.
+```
+
+## Why it happens
+
+`--pagewait` is a **fixed wait, not a readiness check**. Butler Sheet Icons navigates to a sheet, waits that many seconds, and takes the picture — whatever is on screen at that moment. It does not know whether the sheet has finished rendering.
+
+How long a sheet takes to draw depends on the chart count, the data volume, the server's load and the network. So the same `--pagewait` can be comfortably enough for one sheet and too short for the next, and the same app can produce good thumbnails one day and loading screens the next. It is a race, and the sheets that lose it are not always the same ones.
+
+## What to do about it
+
+**Raise `--pagewait`.** The default is 5 seconds. If you have lowered it, or your sheets are heavy, raise it until the warning stops appearing:
+
+```bash
+./butler-sheet-icons qseow create-sheet-thumbnails \
+    --host sense.company.com \
+    --appid a1b2c3d4-0000-4a1b-9c8d-000000000001 \
+    --apiuserdir INTERNAL --apiuserid sa_api \
+    --logonuserdir COMPANY --logonuserid svc_bsi --logonpwd password-here \
+    --pagewait 15
+```
+
+The cost is run time, paid once per sheet: `--pagewait 15` over 40 sheets adds about seven minutes.
+
+**Then run again.** A rerun overwrites the bad thumbnails, and the sheets that were captured correctly are simply recaptured. There is nothing to clean up.
+
+## Checking the result
+
+If the after-run overview capture is enabled (`--capture-overview-after`, on by default), `overview-after.png` in the image directory shows the app overview as Qlik Sense draws it once the run has finished — a sheet whose thumbnail is a loading screen is obvious there, because it appears blank or shows a faint monitor icon where the miniature should be.
+
+## Why Butler Sheet Icons does not simply wait longer by itself
+
+Waiting for a definitive "this sheet has finished" signal would be better than a fixed sleep, and may come later. It is not a small change: the signal differs between Qlik Sense versions and between client-managed and Qlik Cloud, and getting it wrong in the other direction — deciding a sheet is ready when it is not, or waiting forever for one that never settles — would be worse than the current honest report. Until then, the warning tells you when the fixed wait was too short for a given sheet, which is the information you need to choose a better value.

--- a/src/lib/cloud/__tests__/process_cloud_app.test.js
+++ b/src/lib/cloud/__tests__/process_cloud_app.test.js
@@ -181,6 +181,9 @@ describe('process-cloud-app.js — puppeteer launch and click options', () => {
      */
     function buildMockPage() {
         return {
+            // Sheet-loading detection (#1119). Defaults to "not loading" so every
+            // existing test describes a sheet that had finished rendering.
+            evaluate: jest.fn().mockResolvedValue(false),
             setViewport: jest.fn().mockResolvedValue(true),
             setDefaultTimeout: jest.fn().mockResolvedValue(true),
             goto: jest.fn().mockResolvedValue(true),

--- a/src/lib/cloud/__tests__/sheet_screenshot.test.js
+++ b/src/lib/cloud/__tests__/sheet_screenshot.test.js
@@ -42,6 +42,9 @@ const createPage = () => {
         goto: jest.fn().mockResolvedValue(undefined),
         waitForSelector: jest.fn().mockResolvedValue(undefined),
         $: jest.fn().mockResolvedValue(elementHandle),
+        // Sheet-loading detection (#1119). Defaults to "not loading", so every existing
+        // test here describes a sheet that had finished rendering.
+        evaluate: jest.fn().mockResolvedValue(false),
         elementHandle,
     };
 };
@@ -241,5 +244,71 @@ describe('takeSheetScreenshot', () => {
 
             await expect(run(page)).rejects.toThrow('Waiting for selector failed');
         });
+    });
+});
+
+// Issue #1119. A short --pagewait can have the shutter fall while Qlik Sense is still opening
+// the sheet, and the loading screen is then uploaded as the thumbnail. The run reported that
+// as a success, which is the part this makes impossible.
+describe('a thumbnail captured while the sheet was still loading', () => {
+    test('says so, naming the sheet and the option that fixes it', async () => {
+        const page = createPage();
+        page.evaluate.mockResolvedValue(true);
+
+        await takeSheetScreenshot(
+            page,
+            APP_URL,
+            IMG_DIR,
+            APP_ID,
+            { ...SHEET, qMeta: { title: 'Regional sales' } },
+            4,
+            { ...BASE_OPTIONS, pagewait: 1 },
+            mockLogger
+        );
+
+        const warnings = mockLogger.warn.mock.calls.map((call) => String(call[0])).join('\n');
+        expect(warnings).toContain('Sheet 4');
+        expect(warnings).toContain('Regional sales');
+        expect(warnings).toContain('--pagewait (currently 1)');
+    });
+
+    test('still captures the thumbnail rather than quietly dropping the sheet', async () => {
+        const page = createPage();
+        page.evaluate.mockResolvedValue(true);
+
+        const created = await takeSheetScreenshot(
+            page,
+            APP_URL,
+            IMG_DIR,
+            APP_ID,
+            SHEET,
+            2,
+            BASE_OPTIONS,
+            mockLogger
+        );
+
+        // Detection reports; it does not change what a run does. Silently skipping the sheet
+        // would trade one invisible outcome for another.
+        expect(page.elementHandle.screenshot).toHaveBeenCalled();
+        expect(created.fileNameShort).toBe('thumbnail-2.png');
+    });
+
+    test('stays quiet when the sheet had finished rendering', async () => {
+        const page = createPage();
+        page.evaluate.mockResolvedValue(false);
+
+        await takeSheetScreenshot(
+            page,
+            APP_URL,
+            IMG_DIR,
+            APP_ID,
+            SHEET,
+            2,
+            BASE_OPTIONS,
+            mockLogger
+        );
+
+        const warnings = mockLogger.warn.mock.calls.map((call) => String(call[0])).join('\n');
+        expect(warnings).not.toContain('still opening');
     });
 });

--- a/src/lib/cloud/sheet-screenshot.js
+++ b/src/lib/cloud/sheet-screenshot.js
@@ -2,6 +2,7 @@ import { Jimp } from 'jimp';
 
 import { sleep } from '../../globals.js';
 import { CLOUD_SHEET_PART_SELECTORS } from './sheet-parts.js';
+import { sheetWasStillLoading, stillLoadingWarning } from '../util/sheet-loading.js';
 
 /**
  * Takes a screenshot of a sheet and creates a blurred version.
@@ -41,6 +42,16 @@ export async function takeSheetScreenshot(
 
     await page.waitForSelector(selector);
     const sheetMainPart = await page.$(selector);
+
+    // Checked before the shutter rather than after: the two are milliseconds apart, and of the
+    // two ways to be wrong, a spurious warning is far cheaper than staying silent about a
+    // thumbnail that shows the loading screen.
+    if (await sheetWasStillLoading(page, logger)) {
+        logger.warn(
+            stillLoadingWarning('CLOUD APP', iSheetNum, sheet?.qMeta?.title, options.pagewait)
+        );
+    }
+
     await sheetMainPart.screenshot({ path: fileName });
 
     logger.verbose(`Saved image: ${fileName}`);

--- a/src/lib/qseow/__tests__/qseow_process_app.test.js
+++ b/src/lib/qseow/__tests__/qseow_process_app.test.js
@@ -201,6 +201,9 @@ describe('qseow-process-app.js — puppeteer launch and click options', () => {
      */
     function buildMockPage() {
         return {
+            // Sheet-loading detection (#1119). Defaults to "not loading" so every
+            // existing test describes a sheet that had finished rendering.
+            evaluate: jest.fn().mockResolvedValue(false),
             setViewport: jest.fn().mockResolvedValue(true),
             setDefaultTimeout: jest.fn().mockResolvedValue(true),
             goto: jest.fn().mockResolvedValue(true),
@@ -876,6 +879,45 @@ describe('qseow-process-app.js — puppeteer launch and click options', () => {
             await qseowProcessApp('test-app-id', defaultOptions);
 
             expect(enigma.create).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    // Issue #1119. A short --pagewait can have the shutter fall while Qlik Sense is still
+    // opening the sheet, and the loading screen is then uploaded as the thumbnail. The run
+    // reported that as a success, which is the part this makes impossible.
+    describe('a thumbnail captured while the sheet was still loading (#1119)', () => {
+        test('says so, naming the sheet and the option that fixes it', async () => {
+            const browser = setupHappyPath();
+            browser._page.evaluate.mockResolvedValue(true);
+
+            await qseowProcessApp('test-app-id', { ...defaultOptions, pagewait: 1 });
+
+            const warnings = logger.warn.mock.calls.map((call) => String(call[0])).join('\n');
+            expect(warnings).toContain('was still opening when its thumbnail was captured');
+            expect(warnings).toContain('--pagewait (currently 1)');
+        });
+
+        test('still captures and uploads it, rather than quietly dropping the sheet', async () => {
+            const browser = setupHappyPath();
+            browser._page.evaluate.mockResolvedValue(true);
+
+            await qseowProcessApp('test-app-id', defaultOptions);
+
+            // Detection reports; it does not change what a run does. Silently skipping the
+            // sheet would trade one invisible outcome for another.
+            expect(browser._page.screenshot).toHaveBeenCalled();
+            expect(qseowUploadToContentLibrary).toHaveBeenCalled();
+            expect(qseowUpdateSheetThumbnails).toHaveBeenCalled();
+        });
+
+        test('stays quiet when the sheet had finished rendering', async () => {
+            const browser = setupHappyPath();
+            browser._page.evaluate.mockResolvedValue(false);
+
+            await qseowProcessApp('test-app-id', defaultOptions);
+
+            const warnings = logger.warn.mock.calls.map((call) => String(call[0])).join('\n');
+            expect(warnings).not.toContain('still opening');
         });
     });
 

--- a/src/lib/qseow/qseow-process-app.js
+++ b/src/lib/qseow/qseow-process-app.js
@@ -25,6 +25,7 @@ import { getQseowHubSelectors } from './qseow-selectors.js';
 import { logError, describeWithCauses } from '../util/log-error.js';
 import { openQseowAppOverviewPage, captureQseowOverviewAfter } from './qseow-app-session.js';
 import { parseTrueFalseOption } from '../util/true-false-option.js';
+import { sheetWasStillLoading, stillLoadingWarning } from '../util/sheet-loading.js';
 
 /**
  * Processes a Qlik Sense Enterprise on Windows (QSEoW) application to generate
@@ -276,6 +277,22 @@ export const qseowProcessApp = async (appId, options, report = null) => {
                                 // Ensure that the element we're interested in is loaded
                                 await page.waitForSelector(selector);
                                 const sheetMainPart = await page.$(selector);
+
+                                // Checked before the shutter rather than after: the two are
+                                // milliseconds apart, and of the two ways to be wrong, a
+                                // spurious warning is far cheaper than staying silent about a
+                                // thumbnail that shows the loading screen.
+                                if (await sheetWasStillLoading(page, logger)) {
+                                    logger.warn(
+                                        stillLoadingWarning(
+                                            'QSEOW APP',
+                                            iSheetNum,
+                                            sheet?.qMeta?.title,
+                                            options.pagewait
+                                        )
+                                    );
+                                }
+
                                 await sheetMainPart.screenshot({
                                     path: fileName,
                                 });

--- a/src/lib/util/__tests__/sheet-loading.test.js
+++ b/src/lib/util/__tests__/sheet-loading.test.js
@@ -1,0 +1,88 @@
+import { describe, test, expect, jest } from '@jest/globals';
+
+import {
+    sheetWasStillLoading,
+    stillLoadingWarning,
+    SENSE_LOADING_CLASS_FRAGMENTS,
+} from '../sheet-loading.js';
+
+describe('sheetWasStillLoading', () => {
+    test('reports the loading screen when the page finds a visible loader', async () => {
+        const page = { evaluate: jest.fn().mockResolvedValue(true) };
+
+        await expect(sheetWasStillLoading(page)).resolves.toBe(true);
+    });
+
+    test('reports nothing when the page finds none', async () => {
+        const page = { evaluate: jest.fn().mockResolvedValue(false) };
+
+        await expect(sheetWasStillLoading(page)).resolves.toBe(false);
+    });
+
+    test('hands the page the observed Sense loader class fragments', async () => {
+        const page = { evaluate: jest.fn().mockResolvedValue(false) };
+
+        await sheetWasStillLoading(page);
+
+        const [, fragments] = page.evaluate.mock.calls[0];
+        expect(fragments).toEqual([...SENSE_LOADING_CLASS_FRAGMENTS]);
+        expect(fragments).toContain('qv-loader-container');
+    });
+
+    test('does not treat senseloader-block-ui as a loading indicator', async () => {
+        // It looks like one - it is visible on every mid-load sample - but it is visible on a
+        // fully rendered sheet too, indefinitely: measured against a live Qlik Sense client,
+        // still visible 20 seconds after the charts had drawn and the real loader elements had
+        // gone. Including it reported every sheet of every run as still loading.
+        expect([...SENSE_LOADING_CLASS_FRAGMENTS]).not.toContain('senseloader-block-ui');
+    });
+
+    test('a failed check never costs the run its thumbnail', async () => {
+        // This runs on the capture path of a working run. The screenshot is the product; a
+        // detector that throws must not take it down, so the caller is told "not loading"
+        // and the run proceeds exactly as it did before this check existed.
+        const page = {
+            evaluate: jest.fn().mockRejectedValue(new Error('Execution context destroyed')),
+        };
+        const logger = { debug: jest.fn() };
+
+        await expect(sheetWasStillLoading(page, logger)).resolves.toBe(false);
+        expect(logger.debug).toHaveBeenCalled();
+    });
+
+    test('survives a page that cannot evaluate at all', async () => {
+        // Older callers, and every test double that predates this check, hand over a page
+        // object with no evaluate() on it.
+        await expect(sheetWasStillLoading({})).resolves.toBe(false);
+    });
+
+    test('matches loader classes as substrings, because Sense mixes animation classes in', async () => {
+        // The live client showed `qv-loader-container qs-pong-loader-logo qv-fade-in
+        // qv-loader-huge` on one frame and `... ng-animate qv-loader-huge-add-active` on the
+        // next. An exact class-name match would see the first and miss the second.
+        const page = {
+            evaluate: jest.fn(async (fn, fragments) => {
+                const html = [
+                    '<div class="qv-animate qv-loader-container qs-pong-loader-logo qv-fade-in"></div>',
+                ].join('');
+                return fragments.some((fragment) => html.includes(fragment));
+            }),
+        };
+
+        await expect(sheetWasStillLoading(page)).resolves.toBe(true);
+    });
+});
+
+describe('stillLoadingWarning', () => {
+    test('names the sheet, what the image really shows, and the option that fixes it', () => {
+        const warning = stillLoadingWarning('QSEOW APP', 4, 'Regional sales', 1);
+
+        expect(warning).toContain('Sheet 4');
+        expect(warning).toContain('Regional sales');
+        expect(warning).toContain('loading screen');
+        // Without the current value the reader cannot tell what to raise it from.
+        expect(warning).toContain('--pagewait (currently 1)');
+        // The thumbnail is not withheld, and saying so stops a reader hunting for a failure.
+        expect(warning).toContain('uploaded and assigned anyway');
+    });
+});

--- a/src/lib/util/sheet-loading.js
+++ b/src/lib/util/sheet-loading.js
@@ -1,0 +1,95 @@
+/**
+ * Detection of the Qlik Sense "still opening the sheet" overlay.
+ *
+ * A thumbnail is a screenshot of a sheet, taken `--pagewait` seconds after navigating to it.
+ * The wait is a fixed sleep, not a readiness check: `page.waitForSelector()` before the
+ * screenshot only proves the sheet-part *container* exists, and Qlik Sense renders its loading
+ * screen inside that container. So on a short wait the screenshot can catch the loading screen,
+ * and that image is then uploaded and pointed at from the sheet exactly as a real thumbnail
+ * would be. Nothing in the run distinguishes the two - the run card counts the sheet as
+ * captured and exits 0 (issue #1119).
+ *
+ * This does not change what is captured. It reports what was on screen when the shutter fell,
+ * so a wrong thumbnail stops being silent.
+ */
+
+/**
+ * Class fragments Qlik Sense puts on the elements that make up its sheet loading screen.
+ *
+ * Taken from a live client-managed Qlik Sense 12.2759.8 client, sampled from navigation until
+ * well after the sheet had rendered. Both of these are visible on arrival and gone within about
+ * half a second of the sheet being drawn.
+ *
+ * `senseloader-block-ui` looked like a third candidate - it is visible on every mid-load sample -
+ * but it is **not** a loading indicator: it stays visible indefinitely on a fully rendered sheet
+ * (still present 20 seconds in, with the sheet's charts drawn and the other two gone). Including
+ * it made the check report every sheet of every run as still loading. It is listed here only so
+ * the next person does not rediscover it and add it back.
+ *
+ * Matched as substrings of the class attribute rather than as exact class names, because the
+ * animation classes around them change between frames (`qv-fade-in`, `ng-animate`,
+ * `qv-loader-huge-add-active`) and between Sense versions.
+ *
+ * @type {readonly string[]}
+ */
+export const SENSE_LOADING_CLASS_FRAGMENTS = Object.freeze([
+    'qv-loader-container',
+    'qv-loader-text',
+]);
+
+/**
+ * Reports whether Qlik Sense's loading screen was visible on the page.
+ *
+ * Visibility, not presence: the loader elements stay in the DOM after the sheet has rendered,
+ * so `document.querySelector()` finding one says nothing. Only an element with a non-zero box
+ * is actually covering the sheet.
+ *
+ * Never throws. This runs on the capture path of a working run, and a thumbnail that was
+ * produced correctly must not be lost to a failure in the code that checks it - the caller
+ * gets `false` and the run proceeds exactly as it did before this existed.
+ *
+ * @param {object} page - Puppeteer page positioned on the sheet.
+ * @param {object} [logger] - Logger, used only to record why detection was skipped.
+ *
+ * @returns {Promise<boolean>} `true` when the loading screen was covering the sheet.
+ */
+export const sheetWasStillLoading = async (page, logger) => {
+    try {
+        return await page.evaluate(
+            (fragments) => {
+                const isVisible = (element) => element.offsetWidth > 0 && element.offsetHeight > 0;
+
+                // `globalThis.document`, not a bare `document`: this callback is serialised
+                // and run inside the page, where a document exists, but it is linted as Node
+                // source, where it does not. Qualifying it keeps the file honest about that
+                // without suppressing the rule or adding browser globals project-wide.
+                return fragments.some((fragment) =>
+                    [...globalThis.document.querySelectorAll(`[class*="${fragment}"]`)].some(
+                        isVisible
+                    )
+                );
+            },
+            [...SENSE_LOADING_CLASS_FRAGMENTS]
+        );
+    } catch (err) {
+        logger?.debug?.(`Could not check whether the sheet was still loading: ${err}`);
+        return false;
+    }
+};
+
+/**
+ * The warning text for a thumbnail captured mid-load.
+ *
+ * One place so both platforms say the same thing, and so the advice stays attached to the
+ * observation: the reader needs to know which sheet, what the image actually shows, and the
+ * one option that changes it.
+ *
+ * @param {string} logPrefix - Platform log prefix, e.g. `QSEOW APP`.
+ * @param {number} iSheetNum - Sheet number within the run.
+ * @param {string} sheetTitle - Sheet title, for an operator who does not count sheets.
+ * @param {number|string} pagewait - The `--pagewait` value in force.
+ *
+ * @returns {string} The warning line.
+ */
+export const stillLoadingWarning = (logPrefix, iSheetNum, sheetTitle, pagewait) =>
+    `${logPrefix}: Sheet ${iSheetNum} ('${sheetTitle}') was still opening when its thumbnail was captured, so the image shows Qlik Sense's loading screen rather than the sheet. It was uploaded and assigned anyway. Raise --pagewait (currently ${pagewait}) and run again.`;


### PR DESCRIPTION
A thumbnail is a screenshot of a sheet taken `--pagewait` seconds after navigating to it. That wait is a **fixed sleep, not a readiness check** — the `page.waitForSelector()` before the shutter only proves the sheet-part *container* exists, and Qlik Sense draws its loading screen inside that container. So on a short wait the screenshot can catch "Opening the sheet", and that image is uploaded to the content library and pointed at from the sheet exactly as a real thumbnail would be.

The run then reported complete success: `8 captured`, `updated 8 of 9 sheet(s)`, exit 0. Nothing distinguished a sheet miniature from a photograph of a spinner. This makes that impossible.

Closes #1119.

## What it does, and deliberately does not do

It warns:

```
Sheet 4 ('Regional sales') was still opening when its thumbnail was captured, so the image
shows Qlik Sense's loading screen rather than the sheet. It was uploaded and assigned anyway.
Raise --pagewait (currently 1) and run again.
```

Nothing is skipped, withheld, or captured differently, and no run outcome changes. A detector that throws returns "not loading", so a thumbnail that was produced correctly can never be lost to the code inspecting it. Silently dropping the sheet instead would trade one invisible outcome for another.

## The signal, and the one that looked right and wasn't

Detection keys off Qlik's loader elements being **visible**, not present — they stay in the DOM after the sheet renders, so `querySelector` finding one says nothing.

`senseloader-block-ui` is deliberately excluded. It looks like the strongest of the three candidates, because it is visible on every mid-load sample. Sampling a live client from navigation onwards showed it **still visible 20 seconds after the charts had drawn** and the genuine loader elements had gone. Including it reported every sheet of every run as still loading. It is named in the source and pinned by a test so it does not get re-added on the same reasoning that first put it there.

That is also why this reports rather than waits: under a wait-for-ready design, the same wrong selector would have stalled every sheet to its timeout instead of merely being noisy.

## Verification

Against a live client-managed Qlik Sense server, both directions:

| Run | Warnings | Outcome |
| --- | --- | --- |
| `--pagewait 0` | 8 of 8 sheets | `RESULT ok`, 8 captured, exit 0 |
| `--pagewait 5` | none | `RESULT ok`, 8 captured, exit 0 |

The warnings are true positives, not merely present: the same sheet's thumbnail is the literal "Opening the sheet" screen in the first run and a proper miniature in the second.

3266 unit tests pass, lint clean. Both twins' wiring is mutation-tested — the tests were confirmed to fail against code that never warns.

Note on test placement: the Cloud tests live in `sheet_screenshot.test.js`, not the Cloud process-app suite, because `sheet-screenshot.js` is mocked there and tests placed in it would pass while exercising nothing.

## Related, not fixed here

A failed run leaks its web-UI session — `qseowLogout` sits after the sheet loop, so a sheet-level failure throws past it and only the browser is closed, leaving the proxy session alive until timeout. Failures therefore make the next run likelier to fail. Worth its own change (moving the logout into a `finally`); it is what turned a run of verification attempts into a Qlik Sense parallel-session exhaustion that needed the Engine and Proxy services restarted by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
