### PR TITLE
Release the Qlik Sense session when a run fails, not only when it succeeds

### DIFF
--- a/docs/to-doc-site/too-many-sessions-active-in-parallel.md
+++ b/docs/to-doc-site/too-many-sessions-active-in-parallel.md
@@ -1,0 +1,36 @@
+# "Too many sessions active in parallel"
+
+**Status:** pending publication
+**Suggested target pages:** `/guide/troubleshooting`
+**Version gate:** not released yet — read the open release-please PR title for the version before publishing. Do not copy a version number from this draft.
+
+---
+
+## What changed, in one paragraph
+
+Butler Sheet Icons now logs out of the Qlik Sense web UI even when a run fails partway through. Previously the logout only ran on the success path, so a failed run left its session alive on the server until Qlik Sense timed it out. Because each stranded session counts against the logon user's parallel-session limit, one failed run made the next one more likely to fail — a spiral that ends with Qlik Sense refusing to open apps at all.
+
+## The symptom this prevents
+
+On client-managed Qlik Sense, a run that has exhausted the limit fails like this:
+
+```
+error: QSEOW: qseowProcessApp: Waiting for selector `#grid-wrap` failed
+       [caused by: Waiting failed: 90000ms exceeded]
+error: QSEOW PROCESS APP: Failed to process app <app id>: Waiting for selector `#grid-wrap` failed
+```
+
+That message names a selector and says nothing about sessions, which sends most people looking at the wrong thing. Two facts identify it quickly:
+
+- **The run's own screenshots show the real error.** Open `loginpage-1.png` or `overview-before.png` in the image directory. When this is the cause, the page shows a Qlik Sense dialog reading _"You cannot access Qlik Sense because you have too many sessions active in parallel."_
+- **The APIs stay healthy.** The repository API and the hub keep answering normally while the web client is unusable, so "Qlik Sense is up" does not rule this out. Only the browser-driven part of a run is affected — a `--dry-run`, which opens no browser, still works.
+
+## If you are already in this state
+
+Sessions are released when they time out, which is governed by the Qlik Sense proxy's session-inactivity setting. If you cannot wait, restarting the Qlik Sense Engine and Proxy services clears them. Note that a low current session count does not always mean the limit has stopped being enforced.
+
+## Reducing the pressure
+
+- **Let runs log out.** This happens automatically now, on both the success and failure paths. If a logout itself fails, Butler Sheet Icons says so and names the consequence rather than passing over it.
+- **Watch the per-app cost.** A thumbnail run signs in once per app, plus a second time per app if `--capture-overview-after` is on (its default). Over a large tag or collection that is a lot of sessions in a short window; `--capture-overview-after false` halves it.
+- **Give the runs their own account.** A dedicated service account for `--logonuserid` keeps a failed run from locking a human out of Qlik Sense, and makes the session count attributable.

--- a/src/lib/qseow/__tests__/qseow_logout.test.js
+++ b/src/lib/qseow/__tests__/qseow_logout.test.js
@@ -5,13 +5,18 @@ const logger = {
     error: jest.fn(),
     info: jest.fn(),
     verbose: jest.fn(),
+    warn: jest.fn(),
 };
 const sleep = jest.fn().mockResolvedValue(undefined);
 
 jest.unstable_mockModule('../../../globals.js', () => ({ logger, sleep }));
 
-const { QSEOW_LOGOUT_API_TIMEOUT_MS, QSEOW_LOGOUT_BUTTON_SELECTOR, qseowLogout } =
-    await import('../qseow-logout.js');
+const {
+    QSEOW_LOGOUT_API_TIMEOUT_MS,
+    QSEOW_LOGOUT_BUTTON_SELECTOR,
+    qseowLogout,
+    qseowLogoutQuietly,
+} = await import('../qseow-logout.js');
 
 /**
  * Builds a page mock for the API and hub logout paths.
@@ -186,5 +191,48 @@ describe('qseowLogout', () => {
         expect(loggedErrors).toContain('--sense-version 2026-May');
         expect(loggedErrors).toContain('support@ptarmiganlabs.com');
         expect(logger.debug).toHaveBeenCalled();
+    });
+});
+
+describe('qseowLogoutQuietly', () => {
+    test('does nothing when the run never signed in', async () => {
+        // Called from a finally that also runs when the sign-in itself failed. There is no
+        // session to release then, and warning about it would be noise on top of the real
+        // error the run is already reporting.
+        await expect(
+            qseowLogoutQuietly(undefined, logoutOptions, hubUserPageButton)
+        ).resolves.toBeUndefined();
+        expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    test('releases the session when there is a page to release it from', async () => {
+        const page = buildPage();
+
+        await qseowLogoutQuietly(page, logoutOptions, hubUserPageButton);
+
+        expect(page.evaluate).toHaveBeenCalled();
+    });
+
+    test('returns quietly when logout fails, rather than failing the caller', async () => {
+        // The caller is a finally. Whatever happens here must not replace the error the block
+        // is already unwinding with.
+        const page = buildPage();
+        page.evaluate.mockRejectedValue(new Error('QPS unavailable'));
+        page.goto.mockRejectedValue(new Error('hub unavailable'));
+
+        await expect(
+            qseowLogoutQuietly(page, logoutOptions, hubUserPageButton)
+        ).resolves.toBeUndefined();
+    });
+
+    test('qseowLogout reports failure by returning false, never by throwing', async () => {
+        // The reason the wrapper's catch is a contract guard rather than a live bug fix.
+        // If this ever starts throwing, the catch stops being theoretical - which is exactly
+        // why it is there.
+        const page = buildPage();
+        page.evaluate.mockRejectedValue(new Error('QPS unavailable'));
+        page.goto.mockRejectedValue(new Error('hub unavailable'));
+
+        await expect(qseowLogout(page, logoutOptions, hubUserPageButton)).resolves.toBe(false);
     });
 });

--- a/src/lib/qseow/__tests__/qseow_process_app.test.js
+++ b/src/lib/qseow/__tests__/qseow_process_app.test.js
@@ -79,6 +79,7 @@ const mockQseowUpdateSheets = jest.unstable_mockModule('../qseow-updatesheets.js
 
 const mockQseowLogout = jest.unstable_mockModule('../qseow-logout.js', () => ({
     qseowLogout: jest.fn().mockResolvedValue(true),
+    qseowLogoutQuietly: jest.fn().mockResolvedValue(undefined),
 }));
 
 const mockQseowQrs = jest.unstable_mockModule('../qseow-qrs.js', () => ({
@@ -118,6 +119,7 @@ let Jimp;
 let qseowUploadToContentLibrary;
 let qseowUpdateSheetThumbnails;
 let qseowLogout;
+let qseowLogoutQuietly;
 
 beforeAll(async () => {
     await Promise.all([
@@ -148,7 +150,7 @@ beforeAll(async () => {
     ({ Jimp } = await import('jimp'));
     ({ qseowUploadToContentLibrary } = await import('../qseow-upload.js'));
     ({ qseowUpdateSheetThumbnails } = await import('../qseow-updatesheets.js'));
-    ({ qseowLogout } = await import('../qseow-logout.js'));
+    ({ qseowLogout, qseowLogoutQuietly } = await import('../qseow-logout.js'));
     fs = (await import('fs')).default;
     ({ qseowProcessApp } = await import('../qseow-process-app.js'));
 });
@@ -772,7 +774,7 @@ describe('qseow-process-app.js — puppeteer launch and click options', () => {
                 senseVersion: '2026-May',
             });
 
-            expect(qseowLogout).toHaveBeenCalledWith(
+            expect(qseowLogoutQuietly).toHaveBeenCalledWith(
                 browser._page,
                 expect.objectContaining({
                     prefix: 'form',
@@ -786,12 +788,43 @@ describe('qseow-process-app.js — puppeteer launch and click options', () => {
 
         test('continues uploading and updating when logout cannot be completed', async () => {
             setupHappyPath();
-            qseowLogout.mockResolvedValueOnce(false);
+            qseowLogoutQuietly.mockResolvedValueOnce(undefined);
 
             await qseowProcessApp('test-app-id', defaultOptions);
 
             expect(qseowUploadToContentLibrary).toHaveBeenCalledTimes(1);
             expect(qseowUpdateSheetThumbnails).toHaveBeenCalledTimes(1);
+        });
+
+        test('logs out even when the sheet loop fails (#1119 follow-up)', async () => {
+            // Logging out is what releases the Qlik Sense proxy session; closing the browser
+            // does not. The logout used to sit at the end of the try, so any failure here
+            // skipped it and stranded the session until it timed out - and because stranded
+            // sessions count against the user's parallel-session limit, one failed run made
+            // the next likelier to fail, until Qlik Sense refused to open apps at all.
+            const browser = setupHappyPath();
+            browser._page.waitForSelector.mockRejectedValue(new Error('#grid-wrap timed out'));
+
+            await expect(qseowProcessApp('test-app-id', defaultOptions)).rejects.toThrow();
+
+            expect(qseowLogoutQuietly).toHaveBeenCalled();
+            expect(browser.close).toHaveBeenCalled();
+        });
+
+        test('does not attempt a logout when the run never signed in', async () => {
+            // No page means no session was ever established, so there is nothing to release
+            // and nothing to warn about.
+            const browser = setupHappyPath();
+            browser.newPage.mockRejectedValue(new Error('browser died on arrival'));
+
+            await expect(qseowProcessApp('test-app-id', defaultOptions)).rejects.toThrow();
+
+            expect(qseowLogoutQuietly).toHaveBeenCalledWith(
+                undefined,
+                expect.anything(),
+                expect.anything(),
+                expect.anything()
+            );
         });
     });
 
@@ -948,6 +981,8 @@ describe('qseow-process-app.js — puppeteer launch and click options', () => {
             puppeteer.launch.mockReset();
             qseowLogout.mockReset();
             qseowLogout.mockResolvedValue(true);
+            qseowLogoutQuietly.mockReset();
+            qseowLogoutQuietly.mockResolvedValue(undefined);
         });
 
         /**
@@ -1048,23 +1083,19 @@ describe('qseow-process-app.js — puppeteer launch and click options', () => {
             });
         });
 
-        test('a logout failure is not reported as a failed capture', async () => {
+        test('logs the after-capture session out once the screenshot is on disk', async () => {
             const browser = setupHappyPath();
-            qseowLogout.mockResolvedValueOnce(true);
-            qseowLogout.mockRejectedValueOnce(new Error('QPS DELETE refused'));
 
-            await expect(
-                qseowProcessApp('test-app-id', { ...defaultOptions, captureOverviewAfter: true })
-            ).resolves.not.toThrow();
+            await qseowProcessApp('test-app-id', {
+                ...defaultOptions,
+                captureOverviewAfter: true,
+            });
 
-            const warnings = logger.warn.mock.calls.map((call) => String(call[0])).join('\n');
-
-            // The screenshot is written before the logout is attempted, so the file exists.
-            // Saying it could not be captured would send an operator looking for a file that
-            // is sitting in the image directory.
+            // Both sessions are released. Whether a logout that fails can take the capture
+            // down with it is settled in qseow_logout.test.js, which owns the wrapper that
+            // swallows it - here it is enough that the second session is logged out at all.
             expect(shotPaths(browser)).toContain('./img/qseow/test-app-id/overview-after.png');
-            expect(warnings).toContain('could not log the second session out');
-            expect(warnings).not.toContain('Could not capture the app overview');
+            expect(qseowLogoutQuietly).toHaveBeenCalledTimes(2);
         });
 
         test('survives a rejection that carries no message', async () => {

--- a/src/lib/qseow/qseow-app-session.js
+++ b/src/lib/qseow/qseow-app-session.js
@@ -2,9 +2,8 @@ import { logger, sleep } from '../../globals.js';
 import { launchBrowserForApp, closeBrowserQuietly } from '../browser/browser-launch.js';
 import { QseowError } from '../util/errors.js';
 import { normalizeVirtualProxyPrefix } from './qseow-prefix.js';
-import { qseowLogout } from './qseow-logout.js';
+import { qseowLogoutQuietly } from './qseow-logout.js';
 import { removeStaleImage } from '../util/image-dir.js';
-import { describeWithCauses } from '../util/log-error.js';
 
 const selectorLoginPageUserName = '#username-input';
 const selectorLoginPageUserPwd = '#password-input';
@@ -172,6 +171,9 @@ export const captureQseowOverviewAfter = async (
         ErrorClass: QseowError,
     });
 
+    let signedInPage;
+    let signedInHubUrl;
+
     try {
         const { page, hubUrl } = await openQseowAppOverviewPage(browser, options, appId, {
             imgDir,
@@ -179,32 +181,27 @@ export const captureQseowOverviewAfter = async (
             loginPagePrefix: 'loginpage-after',
         });
 
-        await page.screenshot({ path: imagePath });
+        signedInPage = page;
+        signedInHubUrl = hubUrl;
 
-        // The screenshot is this function's product and it is now on disk. Logging out is
-        // cleanup, so its failure is reported on its own terms rather than propagating into
-        // the caller's "could not capture the app overview" warning - which would claim the
-        // file is missing while it sits in the image directory. The session is closed from
-        // the client side by the finally below either way.
-        try {
-            await qseowLogout(
-                page,
-                {
-                    prefix: options.prefix,
-                    hubUrl,
-                    pageTimeout,
-                    pagewait: options.pagewait,
-                    senseVersion: options.senseVersion,
-                },
-                userMenuButton,
-                legacyLogoutButton
-            );
-        } catch (err) {
-            logger.warn(
-                `QSEOW: Captured the after-update app overview, but could not log the second session out cleanly. ${describeWithCauses(err)}`
-            );
-        }
+        await page.screenshot({ path: imagePath });
     } finally {
+        // Same reasoning as the main session: this session has to be released however the
+        // block ends, and a logout failure must not surface as "could not capture the app
+        // overview" when the screenshot is already on disk.
+        await qseowLogoutQuietly(
+            signedInPage,
+            {
+                prefix: options.prefix,
+                hubUrl: signedInHubUrl,
+                pageTimeout,
+                pagewait: options.pagewait,
+                senseVersion: options.senseVersion,
+            },
+            userMenuButton,
+            legacyLogoutButton
+        );
+
         await closeBrowserQuietly(browser, 'QSEOW');
     }
 

--- a/src/lib/qseow/qseow-logout.js
+++ b/src/lib/qseow/qseow-logout.js
@@ -1,6 +1,7 @@
 import crypto from 'node:crypto';
 
 import { logger, sleep } from '../../globals.js';
+import { describeWithCauses } from '../util/log-error.js';
 import { normalizeVirtualProxyPrefix } from './qseow-prefix.js';
 
 /** The stable selector for the Qlik Sense hub logout item. */
@@ -187,5 +188,53 @@ export const qseowLogout = async (page, options, xpathHubUserPageButton, legacyL
             `QSEOW: Please report this to support@ptarmiganlabs.com or https://github.com/ptarmiganlabs/butler-sheet-icons/issues/new, including the Qlik Sense version and --sense-version value.`
         );
         return false;
+    }
+};
+
+/**
+ * Logs out without letting the attempt fail the caller.
+ *
+ * Mirrors `closeBrowserQuietly`. Two jobs, only one of which is load-bearing today.
+ *
+ * The load-bearing one is the `!page` guard: this is called from a `finally` that also runs
+ * when the sign-in itself failed, and there is then no session to release.
+ *
+ * The `catch` is a guard on a contract, not a live bug. `qseowLogout` above reports both of
+ * its failure paths and returns `false` rather than throwing, so today nothing reaches it.
+ * It stays because this runs in a `finally`, where anything thrown replaces whatever the
+ * block was already failing with - a logout error would bury the sheet-render error that
+ * actually explains the run - and because that contract is a property of the function below,
+ * not of the language.
+ *
+ * Logging out is what releases the Qlik Sense proxy session; closing the browser does not.
+ * A session that is not released stays alive until it times out, and every stranded session
+ * brings the user closer to their parallel-session limit, at which point Qlik Sense refuses
+ * to open apps at all. That makes leaked sessions self-reinforcing: one failed run makes the
+ * next one likelier to fail, and on a busy server it takes a service restart to clear.
+ *
+ * @param {object|undefined} page - Puppeteer page holding the session, if one was ever opened.
+ * @param {object} logoutOptions - Options forwarded to `qseowLogout`.
+ * @param {string} xpathHubUserPageButton - Hub user-menu selector for the fallback path.
+ * @param {string} legacyLogoutButton - Legacy logout selector for the fallback path.
+ *
+ * @returns {Promise<void>} Always resolves.
+ */
+export const qseowLogoutQuietly = async (
+    page,
+    logoutOptions,
+    xpathHubUserPageButton,
+    legacyLogoutButton
+) => {
+    // No page means the run never got as far as signing in, so there is no session to release.
+    if (!page) {
+        return;
+    }
+
+    try {
+        await qseowLogout(page, logoutOptions, xpathHubUserPageButton, legacyLogoutButton);
+    } catch (err) {
+        logger.warn(
+            `QSEOW: Could not log the browser session out. It will stay active on the server until Qlik Sense times it out, which counts against the parallel-session limit for this user. ${describeWithCauses(err)}`
+        );
     }
 };

--- a/src/lib/qseow/qseow-process-app.js
+++ b/src/lib/qseow/qseow-process-app.js
@@ -20,7 +20,7 @@ import { activeLiveView } from '../util/run-live.js';
 import { addAppToReport, recordPlannedSheet, recordAppOutcome } from '../util/run-report.js';
 import { appProgressLine, sheetProgressLine } from '../util/run-report-render.js';
 import { QSEOW_SHEET_PART_SELECTORS } from './sheet-parts.js';
-import { qseowLogout } from './qseow-logout.js';
+import { qseowLogoutQuietly } from './qseow-logout.js';
 import { getQseowHubSelectors } from './qseow-selectors.js';
 import { logError, describeWithCauses } from '../util/log-error.js';
 import { openQseowAppOverviewPage, captureQseowOverviewAfter } from './qseow-app-session.js';
@@ -147,6 +147,11 @@ export const qseowProcessApp = async (appId, options, report = null) => {
                         ErrorClass: QseowError,
                     });
 
+                    // Declared outside the try so the `finally` can reach them even when the
+                    // sign-in itself is what failed.
+                    let signedInPage;
+                    let signedInHubUrl;
+
                     try {
                         // The live `signed in` row (issue #1075) is bound to
                         // the real login below: it begins here and resolves
@@ -164,6 +169,11 @@ export const qseowProcessApp = async (appId, options, report = null) => {
                             appId,
                             { imgDir, pageTimeout, loginPagePrefix: 'loginpage' }
                         );
+
+                        // Held for the `finally` below, which has to log this session out
+                        // however this block ends.
+                        signedInPage = page;
+                        signedInHubUrl = hubUrl;
 
                         // Only now is the session real: the login click has
                         // navigated and the page has settled.
@@ -387,15 +397,23 @@ export const qseowProcessApp = async (appId, options, report = null) => {
                         }
 
                         logger.verbose(`QSEoW APP: Done creating thumbnails`);
-
+                    } finally {
+                        // In the `finally`, not at the end of the try: a failure anywhere in
+                        // the sheet loop used to skip the logout entirely and strand the Qlik
+                        // Sense session until it timed out. Closing the browser does not
+                        // release it. Since a stranded session counts against the user's
+                        // parallel-session limit, one failed run made the next likelier to
+                        // fail, and a run of failures could take the server to the point where
+                        // it refuses to open apps at all.
+                        //
                         // The API path avoids a version- and privilege-dependent hub menu. The
-                        // fallback remains available for virtual proxies or authentication modes
-                        // that do not accept the browser-side QPS DELETE.
-                        await qseowLogout(
-                            page,
+                        // fallback remains available for virtual proxies or authentication
+                        // modes that do not accept the browser-side QPS DELETE.
+                        await qseowLogoutQuietly(
+                            signedInPage,
                             {
                                 prefix: options.prefix,
-                                hubUrl,
+                                hubUrl: signedInHubUrl,
                                 pageTimeout,
                                 pagewait: options.pagewait,
                                 senseVersion: options.senseVersion,
@@ -403,7 +421,7 @@ export const qseowProcessApp = async (appId, options, report = null) => {
                             xpathHubUserPageButton,
                             legacyLogoutButton
                         );
-                    } finally {
+
                         await closeBrowserQuietly(browser, 'QSEOW');
                     }
                 }


### PR DESCRIPTION
The logout sat at the end of the browser block's `try`, so any failure in the sheet loop threw straight past it and only `closeBrowserQuietly` ran. **Closing the browser does not release the Qlik Sense proxy session — only the logout does.** Every failed run therefore stranded a session until the server timed it out.

That is self-reinforcing rather than merely untidy. Stranded sessions count against the logon user's parallel-session limit, so one failure makes the next run likelier to fail, and a run of failures takes Qlik Sense to the point where it refuses to open apps at all. The run then fails with `Waiting for selector #grid-wrap failed`, which names a selector and says nothing about sessions; clearing it can need an Engine and Proxy service restart.

This is not hypothetical. It happened twice yesterday: it took the lab server down mid-verification, and it turned the `main` build red after #735 merged, because CI's QSEoW integration job and local verification runs were competing for the same session budget at the same minute. Both were misdiagnosed as code failures until the run's own `overview-before.png` turned out to show Qlik's *"you have too many sessions active in parallel"* dialog.

Both QSEoW browser sessions now log out from a `finally` — the main thumbnail session and the after-capture session added in #735.

## About the wrapper

`qseowLogoutQuietly` mirrors `closeBrowserQuietly`. Worth being precise about which half earns its keep:

- The **`!page` guard is load-bearing.** The `finally` also runs when the sign-in itself failed, and there is then no session to release and nothing to warn about.
- The **`catch` is a contract guard, not a live bug fix.** `qseowLogout` reports both of its failure paths by returning `false` and does not throw — now pinned by a test — so nothing reaches that catch today. It stays because a `finally` that can throw would replace the error the block is already unwinding with, and because not-throwing is a property of that function rather than of the language.

I'm calling that out because I originally reported the opposite during the #735 review: I claimed a logout failure would propagate and be reported as a failed capture. That finding was wrong. I read the call-site structure and did not check the callee's failure semantics, and the test I wrote for it passed only because the *mock* rejected — something the real module cannot do. The defensive wrapping I added then was harmless but unnecessary; this PR replaces it with an accurate account.

## Verification

The regression test drives the sheet loop into a failure and asserts the logout still happens. It was mutation-tested: moving the logout back to the end of the `try` — the original bug — fails it.

3272 unit tests pass, lint clean. Behaviour on the success path is unchanged; the only new behaviour is that a failing run now also releases its session.

## Also

A staged troubleshooting page for the symptom, since the error message points at the wrong thing. It leads with the two facts that identify it quickly: the run's own login/overview screenshots show the real Qlik dialog, and the repository API and hub keep answering normally while the web client is unusable — so "Qlik Sense is up" does not rule it out.

Not addressed here: Qlik Sense Cloud has no logout step at all, so the same reasoning does not apply to that twin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
