### PR TITLE
Archive the five drafts published to the doc site

### DIFF
--- a/docs/to-doc-site/done/done_overview-before-and-after-screenshots.md
+++ b/docs/to-doc-site/done/done_overview-before-and-after-screenshots.md
@@ -1,3 +1,22 @@
+<!--
+PUBLISHED to `next` on 2026-08-19, butler-sheet-icons-docs PR #112. Version gate 5.0.0, read
+from release-please PR #974 at publish time. Publishing this completed the doc half of #735.
+
+Published as a NEW Core Concepts page, `/guide/concepts/app-overview-screenshots`, with a
+sidebar entry. The draft hedged between "new page or a section on run output"; a page won
+because the material is a concept (what the pair is for) rather than an option reference, and
+the reference tables carry the option itself.
+
+DROPPED CLAIM. This draft costs the second sign-in as "one extra browser launch and one extra
+web UI login, roughly ten seconds". The ten seconds was an estimate, never measured - a real
+run's second sign-in was never timed in isolation. The published page states the extra launch
+and login and says nothing about duration. Do not reinstate the figure without measuring it.
+
+ADDED AT PUBLICATION. A `See also` section, and the note that the wizard asks about the option
+under Advanced. The login-screenshot warning was reworded to say the `loginpage-after-*` files
+exist only when the after-capture actually runs.
+-->
+
 # Before/after app overview screenshots on every thumbnail run
 
 **Status:** pending publication

--- a/docs/to-doc-site/done/done_remove-sheet-icons-dry-run-summary-counts.md
+++ b/docs/to-doc-site/done/done_remove-sheet-icons-dry-run-summary-counts.md
@@ -1,3 +1,25 @@
+<!--
+PUBLISHED to `next` on 2026-08-19, butler-sheet-icons-docs PR #113. No version gate of its own:
+it is an addition to `/guide/concepts/dry-run`, which already carries the 5.0.0 gate.
+
+NOT published as a page, exactly as this draft's own publisher notes proposed - it went into
+the `remove-sheet-icons` paragraph on `/guide/concepts/dry-run`.
+
+The notes also asked whether `/reference/qseow` or `/reference/qscloud` show a removal dry-run
+transcript that would need the same correction. Checked: neither page contains one, so there
+was nothing to fix there.
+
+TRANSCRIPT SOURCE. The published sample was taken from `demo/snapshots/
+qseow-remove-sheet-icons-dry-run.txt`, which is generated from a real run against a lab server,
+rather than from this draft. They matched exactly, and the conditional `with no icon` clause was
+confirmed against `renderDryRunReport` in `src/lib/util/run-report.js` - but a generated snapshot
+is the better thing to copy from, and stays the better thing next time.
+
+STILL TRUE at publication: the warning in note 3 below. `done/done_qseow-remove-sheet-icons.md`
+in this folder holds a transcript with the old, wrong summary line, and already carries its own
+OUTDATED TRANSCRIPT note saying so.
+-->
+
 # The removal dry run's summary now counts sheets the way the real run does
 
 > **Publisher notes (not for the site):**

--- a/docs/to-doc-site/done/done_run-output-live-view.md
+++ b/docs/to-doc-site/done/done_run-output-live-view.md
@@ -1,3 +1,29 @@
+<!--
+PUBLISHED to `next` on 2026-08-19, butler-sheet-icons-docs PR #113, as
+`/guide/concepts/live-view` with a sidebar entry beside the contact sheet. The version gate
+resolved to 5.0.0, read from release-please PR #974 at publish time as this draft instructed.
+
+CORRECTED BEFORE PUBLISHING. The draft said "`qscloud remove-sheet-icons` keeps the contact
+sheet". It was written before `qseow remove-sheet-icons` existed, so it named the only removal
+command there was. Both keep the contact sheet - only the two `create-sheet-thumbnails` workers
+call `startLiveRunView` - and the published page says so.
+
+VERIFIED STILL TRUE, not assumed. The Ctrl-C caveat: there is no `SIGINT` or `SIGTERM` handler
+anywhere in `src/lib`, so an interrupted run can still leave the cursor hidden, while completion,
+failure and crash all restore the terminal through `restoreLiveTerminal`. This is the claim most
+likely to rot - it describes something *missing*, so it silently becomes wrong the day graceful
+interrupt handling lands. Re-check it rather than trusting the page.
+
+The gate list ("when you get it - and when you deliberately do not") was checked line by line
+against `selectRung` in `src/lib/util/select-rung.js` and matches, including the 80x24 minimum,
+the `TERM=dumb` gate being independent of colour, and `BSI_OUTPUT=live` being a permission rather
+than a force.
+
+FIXED IN THE SAME PR. Publishing this made the contact-sheet page self-contradictory: its
+`BSI_OUTPUT` table still described `live` as "reserved for a future live view; today it behaves
+like automatic selection". That row was corrected alongside.
+-->
+
 # Live run view: watching a thumbnail run as it happens
 
 > **Publisher note:** new page — it needs a sidebar entry in

--- a/docs/to-doc-site/done/done_thumbnail-captured-while-sheet-loading.md
+++ b/docs/to-doc-site/done/done_thumbnail-captured-while-sheet-loading.md
@@ -1,3 +1,23 @@
+<!--
+PUBLISHED to `next` on 2026-08-19, butler-sheet-icons-docs PR #112. Version gate 5.0.0, read
+from release-please PR #974 at publish time. Publishing this completed the doc half of #1119.
+
+NOT published as a page. The doc site has a single `/guide/troubleshooting` page rather than a
+troubleshooting folder, so this became a section in it,
+`#thumbnail-shows-loading-screen`, placed at the end of the run-failure material and before
+`## Authentication Issues`.
+
+DROPPED SECTION. "Why Butler Sheet Icons does not simply wait longer by itself" was left out.
+It explains an implementation choice - that a readiness signal differs across Sense versions
+and platforms - which reads as a design note rather than troubleshooting, and the section is
+already long. The reasoning is preserved in the #1119 pull request if it is ever wanted.
+
+FIXED BEFORE PUBLICATION. The draft's "Checking the result" section linked the after-run
+overview screenshot as a placeholder `(#)`, which would have failed the doc-site build. It now
+names `--capture-overview-after` in prose, and the published section links
+`/guide/concepts/app-overview-screenshots` instead.
+-->
+
 # When a thumbnail shows the loading screen instead of the sheet
 
 **Status:** pending publication

--- a/docs/to-doc-site/done/done_too-many-sessions-active-in-parallel.md
+++ b/docs/to-doc-site/done/done_too-many-sessions-active-in-parallel.md
@@ -1,3 +1,23 @@
+<!--
+PUBLISHED to `next` on 2026-08-19, butler-sheet-icons-docs PR #112. Version gate 5.0.0, read
+from release-please PR #974 at publish time. Publishing this completed the doc half of #1122.
+
+NOT published as a page. Became a section of `/guide/troubleshooting`,
+`#too-many-sessions-active-in-parallel`, placed at the top of `## Authentication Issues` -
+it is an access failure, and that is where a reader looks for one.
+
+RESHAPED AT PUBLICATION. The draft's "Let runs log out" bullet was dropped from the advice
+list, because it told the reader to do something that is no longer theirs to do: 5.0.0 logs
+out on both paths by itself. It became a `Fixed in 5.0.0` tip container explaining what the
+old behaviour was and why it made the problem self-reinforcing, which is the part a reader on
+an older version still needs.
+
+WORTH KNOWING. Everything in the symptom section was observed rather than reasoned: the
+selector-timeout wording, the Qlik dialog text, and the fact that QRS and the hub keep
+answering while the web client is unusable all came from hitting this on the lab server on
+2026-08-18. See the `qseow-lab-server` memory note for the full signature.
+-->
+
 # "Too many sessions active in parallel"
 
 **Status:** pending publication


### PR DESCRIPTION
Archives all five drafts published to the doc site today, in one pass. `docs/to-doc-site/` now holds only its README — nothing is pending.

| Draft | Published as | Doc PR |
| --- | --- | --- |
| `overview-before-and-after-screenshots` | New page, `/guide/concepts/app-overview-screenshots` | [#112](https://github.com/ptarmiganlabs/butler-sheet-icons-docs/pull/112) |
| `thumbnail-captured-while-sheet-loading` | Section of `/guide/troubleshooting` | [#112](https://github.com/ptarmiganlabs/butler-sheet-icons-docs/pull/112) |
| `too-many-sessions-active-in-parallel` | Section of `/guide/troubleshooting` | [#112](https://github.com/ptarmiganlabs/butler-sheet-icons-docs/pull/112) |
| `remove-sheet-icons-dry-run-summary-counts` | Addition to `/guide/concepts/dry-run` | [#113](https://github.com/ptarmiganlabs/butler-sheet-icons-docs/pull/113) |
| `run-output-live-view` | New page, `/guide/concepts/live-view` | [#113](https://github.com/ptarmiganlabs/butler-sheet-icons-docs/pull/113) |

Only two of the five became pages of their own. The site has a single `/guide/troubleshooting` page rather than a folder, so both troubleshooting drafts became sections of it — worth recording, because the drafts' own "suggested target pages" implied otherwise and the next person reading them should not expect to find them standalone.

Each archive note records what changed between the draft and what shipped. Four are worth surfacing here:

- **A claim that was dropped rather than published.** The overview-screenshots draft costed the second sign-in at "roughly ten seconds". That was an estimate and was never measured — whole runs were timed, the second sign-in never was. The published page states the extra launch and login with no duration, and the note says not to reinstate the figure without measuring it.
- **A claim that had gone stale.** The live-view draft said `qscloud remove-sheet-icons` keeps the contact sheet. It predated `qseow remove-sheet-icons` existing, so it named the only removal command there was. Corrected before publishing.
- **Advice that stopped being the reader's job.** The session-exhaustion draft told the reader to "let runs log out". As of 5.0.0 the run does that itself, so it became a "Fixed in 5.0.0" note explaining the old behaviour — which is what a reader on an older version still needs.
- **A claim re-verified rather than assumed.** The live-view draft's Ctrl-C caveat still holds: there is no `SIGINT` or `SIGTERM` handler in `src/lib`. Its note flags this as the page's most rot-prone statement, because it describes something *missing* and so becomes wrong the day graceful interrupt handling lands.

Each draft's body is preserved byte-identical to what was staged; only the note is prepended. Prettier would have reflowed some emphasis markers in the live-view draft, and that was deliberately not applied — an archive that has been reformatted no longer shows what was actually staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
