### PR TITLE
Let the Cloud round-trip test repair the tenant state it needs

### DIFF
--- a/src/lib/cloud/__tests__/qscloudRemoveSheetIcons_roundtrip.integration.test.js
+++ b/src/lib/cloud/__tests__/qscloudRemoveSheetIcons_roundtrip.integration.test.js
@@ -187,24 +187,41 @@ test(
         // than an unconditional create.
         // ---------------------------------------------------------------------------------
         let iconsBefore = await readIconState(appIds);
+        let mediaBefore = await readThumbnailMediaCounts(saasInstance, appIds);
         const anyIcon = (state) =>
             Object.values(state).some((sheets) => sheetIdsWithIcon(sheets).length > 0);
 
-        if (!anyIcon(iconsBefore)) {
+        // An app whose sheets carry icons but whose media library holds none of the files
+        // behind them is arranged, not asserted against. That state is reachable without
+        // anything being broken: creating thumbnails on Cloud deletes the old media before
+        // uploading the new, so a create run that failed in between leaves sheets pointing at
+        // files that no longer exist. This test used to assert the pairing here and fail on
+        // it, which made it depend on the tenant's history and on which test had run before
+        // it - it failed on exactly this the first time it ran in CI, and the create-thumbnails
+        // test later in the same job repaired the tenant behind it. Creating thumbnails
+        // restores both halves, so arranging covers this case as naturally as the no-icons one.
+        const iconsWithoutMedia = appIds.filter(
+            (appId) => sheetIdsWithIcon(iconsBefore[appId]).length > 0 && mediaBefore[appId] === 0
+        );
+
+        if (!anyIcon(iconsBefore) || iconsWithoutMedia.length > 0) {
             console.log(
-                'No sheet in the selected app(s) carries an icon. Creating thumbnails first, so the removal has something to remove.'
+                iconsWithoutMedia.length > 0
+                    ? `Sheet icons in app(s) ${iconsWithoutMedia.join(', ')} have no thumbnail media behind them. Creating thumbnails first, so both halves of the removal have something to remove.`
+                    : 'No sheet in the selected app(s) carries an icon. Creating thumbnails first, so the removal has something to remove.'
             );
             expect(await qscloudCreateThumbnails(options)).toBe(true);
             iconsBefore = await readIconState(appIds);
+            mediaBefore = await readThumbnailMediaCounts(saasInstance, appIds);
         }
 
         expect(anyIcon(iconsBefore)).toBe(true);
 
-        const mediaBefore = await readThumbnailMediaCounts(saasInstance, appIds);
         const datesBefore = await readAppModifiedDates(saasInstance, appIds);
 
-        // Every app that has icons must also have the media files behind them, or the media half
-        // of the assertion below would be testing nothing.
+        // Now a statement about what arranging produced rather than about the tenant's past:
+        // every app that has icons has the media files behind them, or the media half of the
+        // assertion below would be testing nothing.
         for (const appId of appIds) {
             if (sheetIdsWithIcon(iconsBefore[appId]).length > 0) {
                 expect(mediaBefore[appId]).toBeGreaterThan(0);

--- a/src/lib/cloud/__tests__/qscloudRemoveSheetIcons_roundtrip.integration.test.js
+++ b/src/lib/cloud/__tests__/qscloudRemoveSheetIcons_roundtrip.integration.test.js
@@ -205,12 +205,22 @@ test(
         );
 
         if (!anyIcon(iconsBefore) || iconsWithoutMedia.length > 0) {
+            // Repairing missing media is scoped to the apps that are actually missing it.
+            // The whole selection would be correct but wasteful: a create pass costs minutes
+            // per app, the test already pays for one at the end to restore what it removed,
+            // and a second full pass took the round trip past its timeout with every
+            // assertion still passing - a slower test failing for the clock, not the code.
+            const arrangeOptions =
+                iconsWithoutMedia.length > 0 && anyIcon(iconsBefore)
+                    ? { ...options, appid: iconsWithoutMedia, collectionid: '' }
+                    : options;
+
             console.log(
                 iconsWithoutMedia.length > 0
-                    ? `Sheet icons in app(s) ${iconsWithoutMedia.join(', ')} have no thumbnail media behind them. Creating thumbnails first, so both halves of the removal have something to remove.`
+                    ? `Sheet icons in app(s) ${iconsWithoutMedia.join(', ')} have no thumbnail media behind them. Creating thumbnails for those app(s) first, so both halves of the removal have something to remove.`
                     : 'No sheet in the selected app(s) carries an icon. Creating thumbnails first, so the removal has something to remove.'
             );
-            expect(await qscloudCreateThumbnails(options)).toBe(true);
+            expect(await qscloudCreateThumbnails(arrangeOptions)).toBe(true);
             iconsBefore = await readIconState(appIds);
             mediaBefore = await readThumbnailMediaCounts(saasInstance, appIds);
         }


### PR DESCRIPTION
The Cloud round-trip test failed the first time it ran, which was **after** merge — `ci.yaml` only triggers integration jobs on push to `main`, so #1118 could never have run it. This makes it establish its preconditions instead of asserting them.

## What was wrong

The test asserted that any app whose sheets carry icons also has the thumbnail media files behind them. That is not an invariant of the tenant; it is an invariant of a *clean history*. Creating thumbnails on Qlik Sense Cloud **deletes the old media before uploading the new**, so a create run that fails in between leaves sheets pointing at files that no longer exist — and the test then failed on a state it could simply have repaired.

Its arrange step already knew how to produce what it needs: it runs create-thumbnails when no icons exist at all. This widens that trigger to cover icons-without-media, which the same call fixes.

Worth noting how it went green again without anyone touching it: the create-thumbnails test later in the same job recreated the media, repairing the tenant behind it, and a re-run of the failed job passed with no code change. Green by luck. It would have failed again the next time the tenant was in that state.

## Two commits, because the first fix was too slow to use

The first version repaired the whole selection whenever any app was missing media. Correct, and unusable: a create pass costs minutes per app, the test already pays for one at the end to restore what it removed, and a second full pass pushed the round trip past its 900 s timeout — **failing on the clock with every assertion passing**. That would have converted a rare honest failure into a reliable timeout.

Scoped to the apps actually missing media, the repair costs one app's worth of work.

## Verification

Not run against a healthy tenant and called verified — that path never enters the new branch and would have proven nothing. The broken state was reproduced deliberately: one app left holding sheet icons whose media files had been deleted.

| | Result |
| --- | --- |
| Before the fix | fails at the precondition, 7 s |
| Unscoped repair | all assertions pass, **times out at 900 s** |
| Scoped repair | **passes in 602 s** |

The arrange log names only the affected app, and the tenant is left healthy — 8 media files and 4 icon-bearing sheets per app, confirmed after the run.

Cloud only. QSEoW removal leaves content-library files alone, so its twin has no media assertions to get wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
