### PR TITLE
Stop cleanly on Ctrl-C and report which apps were already updated

### DIFF
--- a/docs/to-doc-site/done/done_run-output-live-view.md
+++ b/docs/to-doc-site/done/done_run-output-live-view.md
@@ -14,6 +14,13 @@ failure and crash all restore the terminal through `restoreLiveTerminal`. This i
 likely to rot - it describes something *missing*, so it silently becomes wrong the day graceful
 interrupt handling lands. Re-check it rather than trusting the page.
 
+NOW WRONG, as predicted above. Issue #1107 landed graceful signal handling: an interrupted run
+collapses the live view and restores the terminal through the same `restoreLiveTerminal` hook,
+and the signal handler writes a show-cursor sequence besides. The published page's Ctrl-C
+paragraph must be corrected - `interrupting-a-run.md` in the staging folder carries that
+instruction and the replacement wording. Recorded here so a later reader of `done/` does not
+trust the caveat above.
+
 The gate list ("when you get it - and when you deliberately do not") was checked line by line
 against `selectRung` in `src/lib/util/select-rung.js` and matches, including the 80x24 minimum,
 the `TERM=dumb` gate being independent of colour, and `BSI_OUTPUT=live` being a permission rather

--- a/docs/to-doc-site/interrupting-a-run.md
+++ b/docs/to-doc-site/interrupting-a-run.md
@@ -1,0 +1,181 @@
+<!--
+DRAFT — not yet published.
+
+Covers issue #1107: Butler Sheet Icons now handles SIGINT and SIGTERM instead of being
+killed outright.
+
+PUBLISHER NOTES — three things, in this order:
+
+1. NEW PAGE, suggested at `/guide/concepts/interrupting-a-run`, with a sidebar entry in
+   `docs/.vitepress/config.js` next to the live view page (`/guide/concepts/live-view`),
+   which it cross-links.
+
+2. CORRECT AN ALREADY-PUBLISHED PAGE. `/guide/concepts/live-view` carries a Ctrl-C caveat
+   saying an interrupted run can leave the cursor hidden, because there was no signal
+   handler. That is now wrong — it was flagged as the claim most likely to rot in
+   `done/done_run-output-live-view.md`, and this change is what rots it. Replace that
+   paragraph with a sentence saying an interrupted run collapses the live view and restores
+   the terminal like any other ending, and link here. Publish that correction in the SAME
+   PR as this page, or the site contradicts itself.
+
+3. EXIT CODES. If a general exit-code reference page exists by publication time, add 130 and
+   143 to its table rather than leaving them stated only here. Issue #1090 is building that
+   table; if it has not landed, this page is the only home for them and that is fine.
+
+VERSION GATE: read the open release-please PR title at publish time. It said
+`chore(main): release butler-sheet-icons 5.0.0` when this draft was written — do not trust
+that number, re-read it.
+
+EVERY log line, exit code and timing below was taken from real interrupted runs against the
+QSEoW lab server, not from reading the source. The 130/143/129 codes and the eight-second
+shutdown bound were measured.
+
+CORRECTED IN DRAFT, before publication. An earlier version of this page said the QSEoW web
+session is signed out on the way past. It is not, and cannot be: stopping the run closes the
+browser the logout needs. The "What is cleaned up" section now says the session stays until
+Qlik Sense times it out, and quotes the line the run actually prints. That claim had been
+written from intent rather than from a run — exactly what README step 3 warns about.
+-->
+
+# Stopping a run part-way through
+
+::: warning Requires BSI 5.0.0 or later
+In earlier versions there was no signal handling at all. Pressing Ctrl-C, or stopping a
+container, killed Butler Sheet Icons on the spot: no summary, no record of which apps had
+already been changed.
+:::
+
+A thumbnail run can take a long time. Fifty apps, a handful of sheets each, several seconds
+per sheet to let it render — that is a job you start and walk away from. Sometimes you come
+back and need to stop it: you pointed it at the wrong tag, someone needs the Sense server
+left alone, or a scheduled job has to make way.
+
+Stopping it is safe, and Butler Sheet Icons tells you where it got to.
+
+## What happens when you press Ctrl-C
+
+The run stops as soon as it can and then prints its normal end-of-run summary, covering the
+apps it had already finished:
+
+```
+warn: SIGINT received. Stopping the run and reporting what has already been done - press Ctrl-C again to exit immediately.
+info: Interrupted while processing app ded8d27d-53b1-4d46-8d4e-44f552aeb8bc - it was abandoned: The operation was aborted
+info: Interrupted: stopping here. 12 of 15 app(s) were not started.
+
+RESULT  INTERRUPTED
+  apps          2 ok, 1 interrupted, 12 not started
+  sheets        6 seen, 6 captured, 0 excluded
+  thumbnails    6 sheet(s) given new thumbnails in content library "Sheet thumbnails"
+```
+
+`The operation was aborted` on that middle line is not a problem — it is how stopping works
+under the bonnet, and it is reported at `info` rather than as an error for exactly that
+reason. Nothing failed.
+
+That summary is the reason this behaviour exists. Thumbnails are written to Qlik Sense as the
+run proceeds, app by app, and **there is no undo**. Before, an interrupted run left you
+guessing which apps had new thumbnails and which still had their old ones. Now the run tells
+you, and the three counts say exactly what you are looking at:
+
+| Count         | Meaning                                                                           |
+| ------------- | --------------------------------------------------------------------------------- |
+| `ok`          | Finished completely. New thumbnails are in Qlik Sense.                            |
+| `interrupted` | Was being worked on when you stopped it. See below — usually nothing was changed. |
+| `not started` | Never touched. Exactly as they were.                                              |
+
+The same three counts appear whichever output style you get. On a normal terminal Butler Sheet
+Icons draws the summary as a card, where the line reads `INTERRUPTED after 3m 12s · 2 app(s) ok
+· 1 interrupted · 12 not started`; piped to a file or a log collector it is the plainer block
+shown above. The words and the numbers match.
+
+## What happens to the app it was in the middle of
+
+For `create-sheet-thumbnails` on both Qlik Sense Cloud and Qlik Sense Enterprise on Windows:
+**nothing is changed in that app.**
+
+That is not luck, it is the order of the work. Butler Sheet Icons captures every sheet in an
+app first, and only then uploads the images and points the sheets at them. Stopping during
+the capture means it never reaches the part that writes, so the app keeps the thumbnails it
+already had.
+
+::: warning `remove-sheet-icons` is different
+The removal commands clear icons **one sheet at a time**, so an app that was being processed
+when you stopped the run can be left part-way: some sheets cleared, the rest still with their
+icons. The summary's `cleared` count tells you how many were done. Re-run the command on that
+app to finish the job — clearing an icon that is already gone is harmless.
+:::
+
+## How long it takes
+
+Well under a second in normal use — it does not sit and wait for the sheet it was capturing.
+
+This matters most in a container. `docker stop` sends the stop signal and then kills the
+container about ten seconds later whatever is happening, so a slow shutdown would lose you the
+very summary you need. Butler Sheet Icons is designed around that deadline, and it does not
+grow with your settings: a run using `--pagewait 45` stops just as quickly as one using the
+default.
+
+If shutdown somehow cannot finish, two things end it anyway:
+
+- **Press Ctrl-C a second time.** It exits immediately.
+- **It gives up on its own after eight seconds**, prints whatever the summary holds by then,
+  and exits — so an unattended container job is never left hanging.
+
+## Exit codes
+
+Butler Sheet Icons follows the standard shell convention, so a scheduler or CI job can tell an
+interrupted run apart from a failed one:
+
+| How the run ended                     | Exit code |
+| ------------------------------------- | --------- |
+| Finished, everything worked           | `0`       |
+| Finished, something failed            | `1`       |
+| Stopped with Ctrl-C (SIGINT)          | `130`     |
+| Stopped with SIGTERM                  | `143`     |
+| Terminal closed or connection dropped | `129`     |
+
+`129` is the one to expect when a terminal window is closed or an SSH session drops mid-run.
+Butler Sheet Icons treats that like any other stop: it shuts the browser down and reports what
+it had done.
+
+`143` is the one to watch for in a container or an orchestrator: `docker stop`,
+`kubectl delete pod` and a Kubernetes rolling update all send `SIGTERM`. A job that reports
+`143` was **stopped**, not broken — no Qlik Sense server to investigate, no credentials to
+check. Re-run it and it will pick the work up from scratch.
+
+An interrupted run never exits `0`, even when nothing went wrong before you stopped it. It did
+not do the job you asked for, and a scheduler must not be told otherwise.
+
+## What is cleaned up
+
+Whatever it was doing, Butler Sheet Icons closes the browser it was driving and releases its
+engine session.
+
+On Qlik Sense Enterprise on Windows there is one loose end it cannot tidy. Signing the web
+session out needs the browser, and stopping the run is what closes the browser — so an
+interrupted run leaves that session on the server until Qlik Sense times it out. The run says
+so, once, at the end:
+
+```
+info: The run was interrupted before the browser session could be logged out. Qlik Sense will release it when it times out.
+```
+
+It is worth knowing because Qlik Sense limits how many sessions one user may hold at a time.
+Stopping a run repeatedly in quick succession can leave enough sessions behind to make the next
+run fail to sign in. They clear themselves; if you need them gone sooner, an administrator can
+end them from the QMC.
+
+If you are watching the [live run view](/guide/concepts/live-view), the progress display
+collapses and your terminal is handed back with the cursor where it belongs — the same as
+when a run finishes normally.
+
+## What it does not do
+
+Stopping a run does not undo anything. Apps reported as `ok` keep their new thumbnails; there
+is no rollback, and none is planned. If you stopped a run because it was pointed at the wrong
+apps, you will need to put those apps' thumbnails back yourself.
+
+Nor is there anything to resume. Butler Sheet Icons does not remember where it got to between
+runs. To finish the job, run the same command again — apps that already have their new
+thumbnails are simply done again, harmlessly. To do only what is left, name the remaining apps
+with `--appid`.

--- a/src/__tests__/globals.test.js
+++ b/src/__tests__/globals.test.js
@@ -1,9 +1,12 @@
-import { describe, test, expect, beforeAll, afterAll } from '@jest/globals';
+import { describe, test, expect, beforeAll, afterAll, afterEach } from '@jest/globals';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 let logger;
+let sleep;
+let markInterrupted;
+let resetInterruptState;
 let originalWarningListeners;
 let originalNoProcessWarnings;
 
@@ -12,7 +15,8 @@ beforeAll(async () => {
     originalNoProcessWarnings = process.noProcessWarnings;
     process.removeAllListeners('warning');
 
-    ({ logger } = await import('../globals.js'));
+    ({ logger, sleep } = await import('../globals.js'));
+    ({ markInterrupted, resetInterruptState } = await import('../lib/util/interrupt.js'));
 });
 
 afterAll(() => {
@@ -180,5 +184,57 @@ describe('library code does not read .env off disk (issue #1014)', () => {
 
         expect(dotenvAt).toBeGreaterThanOrEqual(0);
         expect(dotenvAt).toBeLessThan(firstOther);
+    });
+});
+
+describe('sleep aborts when the run is interrupted (issue #1107)', () => {
+    afterEach(() => {
+        resetInterruptState();
+    });
+
+    test('resolves normally when nothing interrupts it', async () => {
+        await expect(sleep(1)).resolves.toBeUndefined();
+    });
+
+    test('a pending sleep rejects the moment the signal arrives', async () => {
+        // Closing the browser unblocks every in-flight Puppeteer call, but not
+        // a sleep. Without this a shutdown waits out --pagewait, which
+        // operators are told to set high enough for the slowest sheet - past
+        // `docker stop`'s ten-second grace period.
+        const started = Date.now();
+        const pending = sleep(60_000);
+
+        markInterrupted('SIGINT');
+
+        await expect(pending).rejects.toThrow();
+        expect(Date.now() - started).toBeLessThan(1000);
+    });
+
+    test('rejects rather than resolving early', async () => {
+        // Resolving would let the caller carry on into work the operator has
+        // just asked it to stop doing. Rejecting propagates through the
+        // caller's existing error path, exactly as the browser close does.
+        const pending = sleep(60_000);
+        markInterrupted('SIGINT');
+
+        await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    });
+
+    test('a sleep started after the interrupt rejects immediately', async () => {
+        markInterrupted('SIGINT');
+
+        await expect(sleep(60_000)).rejects.toThrow();
+    });
+
+    test('reads the abort signal per call, so a reset restores normal sleeping', async () => {
+        markInterrupted('SIGINT');
+        await expect(sleep(1)).rejects.toThrow();
+
+        resetInterruptState();
+
+        // A module that captured the signal at import time would hold the
+        // aborted one, and every sleep for the rest of the process would
+        // reject.
+        await expect(sleep(1)).resolves.toBeUndefined();
     });
 });

--- a/src/__tests__/signal-shutdown.integration.test.js
+++ b/src/__tests__/signal-shutdown.integration.test.js
@@ -1,0 +1,231 @@
+import { describe, test, expect } from '@jest/globals';
+import childProcess from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+/**
+ * End-to-end signal tests, in real child processes taking real signals.
+ *
+ * Every other test in this area installs the handlers onto a throwaway
+ * `EventEmitter` with an injected `exit` spy — necessary, because a suite
+ * cannot register listeners on the Jest worker's own `process` or actually
+ * terminate it. The cost is that nothing proves the wiring: mutation testing
+ * showed that deleting BOTH `installSignalHandlers()` and the outermost
+ * `process.exit` block from the entry point left all 3371 unit tests green,
+ * with Ctrl-C doing nothing at all. These close that gap (issue #1107).
+ *
+ * `.integration.test.js` because they spawn processes and are timing-bound.
+ * They need no network, credentials or browser, so they are safe anywhere.
+ */
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const signalHandlersUrl = pathToFileURL(
+    path.resolve(HERE, '..', 'lib', 'util', 'signal-handlers.js')
+).href;
+const interruptUrl = pathToFileURL(path.resolve(HERE, '..', 'lib', 'util', 'interrupt.js')).href;
+const flushExitUrl = pathToFileURL(path.resolve(HERE, '..', 'lib', 'util', 'flush-exit.js')).href;
+
+const READY = '__BSI_READY__';
+
+/**
+ * Spawns a child that installs the real handlers, signals it, and reports how
+ * it died.
+ *
+ * @param {object} spec - The scenario.
+ * @param {string} spec.signal - Signal to send, e.g. `'SIGINT'`.
+ * @param {string} [spec.body] - Extra module source run before READY is printed.
+ *
+ * @returns {Promise<{code: number|null, signal: string|null, stdout: string}>} How it ended.
+ */
+const runSignalled = ({ signal, body = '' }) =>
+    new Promise((resolve, reject) => {
+        const source = [
+            `import { installSignalHandlers } from ${JSON.stringify(signalHandlersUrl)};`,
+            `import { beginInterruptibleRun, isInterrupted, interruptExitCode } from ${JSON.stringify(interruptUrl)};`,
+            `import { flushAndExit } from ${JSON.stringify(flushExitUrl)};`,
+            'installSignalHandlers();',
+            body,
+            // Mirrors the entry point's own tail.
+            'const idle = setInterval(() => {}, 1000);',
+            `console.log(${JSON.stringify(READY)});`,
+            'setTimeout(() => { clearInterval(idle); }, 25000);',
+        ].join('\n');
+
+        const child = childProcess.spawn('node', ['--input-type=module', '-e', source], {
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+
+        let stdout = '';
+        let signalled = false;
+        child.stdout.on('data', (chunk) => {
+            stdout += chunk;
+            if (!signalled && stdout.includes(READY)) {
+                signalled = true;
+                child.kill(signal);
+            }
+        });
+
+        child.on('error', reject);
+        child.on('close', (code, closeSignal) => resolve({ code, signal: closeSignal, stdout }));
+    });
+
+describe('the real entry-point wiring (issue #1107)', () => {
+    test('SIGINT outside a run exits 130, not killed by the signal', async () => {
+        const result = await runSignalled({ signal: 'SIGINT' });
+
+        // `signal: null` is the assertion that matters: with no handler the
+        // process would be KILLED by SIGINT and report signal 'SIGINT' with a
+        // null code. A real exit code means a listener ran.
+        expect(result.signal).toBeNull();
+        expect(result.code).toBe(130);
+    }, 30000);
+
+    test('SIGTERM exits 143', async () => {
+        const result = await runSignalled({ signal: 'SIGTERM' });
+
+        expect(result.signal).toBeNull();
+        expect(result.code).toBe(143);
+    }, 30000);
+
+    test('SIGHUP exits 129 rather than dying on the OS default', async () => {
+        // Node's default disposition for SIGHUP terminates WITHOUT running
+        // `process.on('exit')`, which is the hook Puppeteer relies on to kill
+        // Chromium — and its own SIGHUP handler is switched off at launch.
+        const result = await runSignalled({ signal: 'SIGHUP' });
+
+        expect(result.signal).toBeNull();
+        expect(result.code).toBe(129);
+    }, 30000);
+
+    test('a signal during a run still exits, and reports the run first', async () => {
+        const result = await runSignalled({
+            signal: 'SIGINT',
+            body: [
+                'beginInterruptibleRun();',
+                // Stands in for the app loop: something that only ends because
+                // the interrupt tells it to.
+                'const loop = setInterval(() => {',
+                '  if (isInterrupted()) {',
+                '    clearInterval(loop);',
+                "    console.log('RESULT  INTERRUPTED');",
+                '    flushAndExit(interruptExitCode());',
+                '  }',
+                '}, 10);',
+            ].join('\n'),
+        });
+
+        expect(result.stdout).toContain('RESULT  INTERRUPTED');
+        expect(result.signal).toBeNull();
+        expect(result.code).toBe(130);
+    }, 30000);
+
+    test('the report survives the exit even when stdout is a pipe', async () => {
+        // The regression this guards: `process.exit()` discards a pipe's
+        // buffered writes. Measured before the fix at 333 of 400 lines
+        // delivered, with the verdict block lost — invisible on a TTY, which
+        // is why it survived manual testing.
+        const result = await runSignalled({
+            signal: 'SIGINT',
+            body: [
+                'beginInterruptibleRun();',
+                'const loop = setInterval(() => {',
+                '  if (isInterrupted()) {',
+                '    clearInterval(loop);',
+                "    for (let i = 0; i < 400; i += 1) console.log('pad ' + i + ' ' + 'x'.repeat(180));",
+                "    console.log('RESULT  INTERRUPTED');",
+                '    flushAndExit(interruptExitCode());',
+                '  }',
+                '}, 10);',
+            ].join('\n'),
+        });
+
+        expect(result.stdout).toContain('RESULT  INTERRUPTED');
+        expect(result.stdout.split('\n').filter((l) => l.startsWith('pad '))).toHaveLength(400);
+        expect(result.code).toBe(130);
+    }, 30000);
+});
+
+describe('the real CLI binary, end to end', () => {
+    /**
+     * A syntactically valid throwaway certificate pair. QSEoW options are
+     * mandatory and the PEM is parsed before any connection is attempted, so
+     * without one the command exits before a signal can reach it. Generated
+     * offline; it is never presented to anything.
+     *
+     * @returns {{dir: string, cert: string, key: string}|null} Paths, or null
+     *     if openssl is unavailable on this machine.
+     */
+    const makeCertPair = () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bsi-signal-'));
+        const cert = path.join(dir, 'c.pem');
+        const key = path.join(dir, 'k.pem');
+        const result = childProcess.spawnSync(
+            'openssl',
+            // prettier-ignore
+            ['req', '-x509', '-newkey', 'rsa:2048', '-nodes',
+             '-keyout', key, '-out', cert, '-days', '1', '-subj', '/CN=bsi-test'],
+            { encoding: 'utf-8', timeout: 30000 }
+        );
+
+        if (result.status !== 0 || !fs.existsSync(cert)) {
+            fs.rmSync(dir, { recursive: true, force: true });
+            return null;
+        }
+
+        return { dir, cert, key };
+    };
+
+    test('Ctrl-C on a real run exits 130, not killed by the signal', async () => {
+        const certs = makeCertPair();
+
+        if (!certs) {
+            // No openssl: the module-level tests above still cover the
+            // handlers; only the entry-point wiring goes unchecked here.
+            return;
+        }
+
+        try {
+            const entry = path.resolve(HERE, '..', 'butler-sheet-icons.js');
+            // TEST-NET-1 (RFC 5737) is guaranteed unroutable, so the first QRS
+            // call blocks and the process is alive and busy when the signal
+            // lands. No traffic leaves the machine.
+            const child = childProcess.spawn(
+                'node',
+                // prettier-ignore
+                [entry, 'qseow', 'create-sheet-thumbnails',
+                 '--host', '192.0.2.1', '--appid', 'deadbeef',
+                 '--apiuserdir', 'X', '--apiuserid', 'Y',
+                 '--logonuserdir', 'X', '--logonuserid', 'Y', '--logonpwd', 'Z',
+                 '--contentlibrary', 'L',
+                 '--certfile', certs.cert, '--certkeyfile', certs.key],
+                { stdio: ['ignore', 'pipe', 'pipe'] }
+            );
+
+            let stdout = '';
+            let signalled = false;
+            child.stdout.on('data', (chunk) => {
+                stdout += chunk;
+                if (!signalled && stdout.includes('Starting creation of thumbnails')) {
+                    signalled = true;
+                    child.kill('SIGINT');
+                }
+            });
+
+            const ended = await new Promise((resolve) => {
+                child.on('close', (code, signal) => resolve({ code, signal }));
+            });
+
+            // This is the assertion the unit tests structurally cannot make.
+            // Deleting `installSignalHandlers()` from the entry point left all
+            // 3371 of them green while Ctrl-C did nothing; here the process
+            // would come back as KILLED by SIGINT (signal set, code null)
+            // instead of exiting 130.
+            expect(ended.signal).toBeNull();
+            expect(ended.code).toBe(130);
+        } finally {
+            fs.rmSync(certs.dir, { recursive: true, force: true });
+        }
+    }, 60000);
+});

--- a/src/butler-sheet-icons.js
+++ b/src/butler-sheet-icons.js
@@ -5,6 +5,9 @@ import 'dotenv/config';
 import { Command } from 'commander';
 import { appVersion } from './globals.js';
 import { installFatalHandlers } from './lib/util/fatal-handlers.js';
+import { installSignalHandlers } from './lib/util/signal-handlers.js';
+import { isInterrupted, interruptExitCode } from './lib/util/interrupt.js';
+import { flushAndExit } from './lib/util/flush-exit.js';
 import { buildQseowCommand } from './lib/commands/qseow/index.js';
 import { buildQscloudCommand } from './lib/commands/qscloud/index.js';
 import { buildBrowserCommand } from './lib/commands/browser/index.js';
@@ -16,6 +19,12 @@ import { relaxMandatoryOptionsIfInteractive } from './lib/interactive/mandatory-
 // write a crash dump, and exit with code 1. Installed before anything else so
 // the net is in place before there is anything to fall out of it.
 installFatalHandlers();
+
+// Ctrl-C, `docker stop` and a CI timeout all arrive here (issue #1107). Beside
+// the crash net rather than inside it: a signal is not a crash, writes no dump,
+// and shuts the run down through the ordinary teardown so the operator is told
+// which apps were already updated.
+installSignalHandlers();
 
 const program = new Command();
 
@@ -44,4 +53,24 @@ const program = new Command();
     relaxMandatoryOptionsIfInteractive(program, process.argv);
 
     await program.parseAsync(process.argv);
+
+    // The one place the interrupted run is allowed to end the process, and the
+    // second considered exception to the codebase's "set `process.exitCode`,
+    // never call `process.exit()`" rule - the first being the injected `exit`
+    // in `fatal-handlers.js`.
+    //
+    // It has to be here rather than inside the run: `runCommand` has already
+    // set the code, but a shutdown leaves Puppeteer and enigma handles behind
+    // that can hold the event loop open indefinitely, so waiting for a natural
+    // drain would hang the very shutdown this exists to make prompt. By this
+    // point the command has returned and the report has been rendered, so
+    // nothing is lost by exiting outright.
+    if (isInterrupted()) {
+        // Drains stdout before exiting rather than calling `process.exit()`
+        // outright. The verdict has just been rendered, and on a pipe -
+        // `docker logs`, a CI collector, `| tee` - it is still buffered; a
+        // hard exit here discards the report the interrupt existed to
+        // produce. `flush-exit.js` carries the measurements and the bound.
+        flushAndExit(process.exitCode ?? interruptExitCode());
+    }
 })();

--- a/src/globals.js
+++ b/src/globals.js
@@ -3,6 +3,7 @@ import { createRequire } from 'node:module';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
 // `dotenv/config` is deliberately NOT imported here. Importing this module used to read `.env`
 // off disk as a side effect, and almost every unit test imports it transitively - so unit runs
 // executed against whatever Qlik Sense settings the developer happened to have. Because option
@@ -13,6 +14,7 @@ import path from 'node:path';
 import { redactSensitivePatterns, redactValue } from './lib/util/redact-secrets.js';
 import { isColourEnabled } from './lib/util/colour.js';
 import { isTimestampEnabled } from './lib/util/log-timestamps.js';
+import { interruptAbortSignal } from './lib/util/interrupt.js';
 
 const require = createRequire(import.meta.url);
 const LEVEL = Symbol.for('level');
@@ -332,14 +334,37 @@ const isSea = sea.isSea();
 const bsiExecutablePath = isSea ? path.dirname(process.execPath) : process.cwd();
 
 /**
- * Resolves after the given number of milliseconds.
+ * Resolves after the given number of milliseconds, or rejects at once if the run
+ * is interrupted.
+ *
+ * The abort is what makes Ctrl-C feel immediate (issue #1107). Closing the
+ * browser unblocks every in-flight Puppeteer call, but not a sleep: a pending
+ * `--pagewait` would run out its clock first, and operators are told to set
+ * that high enough for the slowest sheet to render. At the values seen in the
+ * field that is the difference between shutting down inside `docker stop`'s
+ * ten-second grace period and being SIGKILLed before the report is written.
+ *
+ * Rejecting rather than resolving early is deliberate, and is the same
+ * mechanism the browser close uses: the rejection propagates through the
+ * caller's existing error path, the app unwinds, and the loop stops at its
+ * next boundary. Resolving early would let the caller carry on into work the
+ * operator has just asked it to stop doing.
+ *
+ * Every current caller is work that should stop when the run does - the two
+ * per-sheet page waits, the logout waits, and `browser-install`'s retry delay.
  *
  * @param {number} ms - Number of milliseconds to wait before resolving.
  *
  * @returns {Promise<void>} A promise that resolves after `ms` milliseconds.
+ *
+ * @throws {Error} An `AbortError` if the run is interrupted while waiting, or
+ *     was already interrupted when the call was made.
  */
 function sleep(ms) {
-    return new Promise((resolve) => setTimeout(resolve, ms));
+    // Read per call, never captured at module load: the signal is replaced
+    // when the interrupt state is reset, and a captured one would be the
+    // previous run's - already aborted, so every sleep would reject.
+    return delay(ms, undefined, { signal: interruptAbortSignal() });
 }
 
 // Export all the variables and functions

--- a/src/lib/browser/__tests__/browser_launch.test.js
+++ b/src/lib/browser/__tests__/browser_launch.test.js
@@ -81,6 +81,8 @@ const {
     BROWSER_LAUNCH_TIMEOUT_MS,
     BROWSER_PROTOCOL_TIMEOUT_MS,
 } = await import('../browser-launch.js');
+const { markInterrupted, runInterruptActions, resetInterruptState } =
+    await import('../../util/interrupt.js');
 
 /** Stand-in typed error, matching the (message, { cause }) shape of the real ones. */
 class TestError extends Error {
@@ -732,5 +734,85 @@ describe('launchBrowserForApp — slow launch reporting (issue #870)', () => {
         expect(errorOutput()).toContain('Could not launch virtual browser');
         expect(errorOutput()).not.toContain('did not become ready within');
         expect(logger.warn).not.toHaveBeenCalled();
+    });
+});
+
+describe('a launched browser is closed when the run is interrupted (issue #1107)', () => {
+    beforeEach(() => {
+        resetInterruptState();
+    });
+
+    afterEach(() => {
+        resetInterruptState();
+    });
+
+    test("puppeteer's own signal handlers are off, or it exits before the report", async () => {
+        puppeteer.launch.mockResolvedValue(fakeBrowser());
+
+        await launchBrowserForApp(OPTIONS, CONTEXT);
+
+        // @puppeteer/browsers defaults these to true, and its SIGINT handler
+        // is `this.kill(); process.exit(130)` - unconditional and immediate.
+        // Left on, the run never unwinds and the report naming the apps
+        // already written is never printed. It exits 130, the same code BSI
+        // uses, so the shell cannot tell the difference.
+        expect(puppeteer.launch).toHaveBeenCalledWith(
+            expect.objectContaining({
+                handleSIGINT: false,
+                handleSIGTERM: false,
+                handleSIGHUP: false,
+            })
+        );
+    });
+
+    test('the signal handler can close a browser that lives inside a processor', async () => {
+        const browser = fakeBrowser();
+        puppeteer.launch.mockResolvedValue(browser);
+
+        await launchBrowserForApp(OPTIONS, CONTEXT);
+
+        // This is what makes every in-flight Puppeteer await reject, which is
+        // the only thing that unwinds a run parked on a page navigation.
+        expect(runInterruptActions()).toBe(1);
+        await new Promise((resolve) => setImmediate(resolve));
+        expect(browser.close).toHaveBeenCalledTimes(1);
+    });
+
+    test('a browser already closed on the way out is not closed again', async () => {
+        const browser = fakeBrowser();
+        puppeteer.launch.mockResolvedValue(browser);
+
+        await launchBrowserForApp(OPTIONS, CONTEXT);
+        await closeBrowserQuietly(browser, 'TEST');
+
+        expect(browser.close).toHaveBeenCalledTimes(1);
+        // Whoever closes it first wins; the other must find nothing to do.
+        expect(runInterruptActions()).toBe(0);
+        expect(browser.close).toHaveBeenCalledTimes(1);
+    });
+
+    test('a browser that could not be driven leaves no stale registration', async () => {
+        const browser = fakeBrowser({
+            version: jest.fn().mockRejectedValue(new Error('Session closed')),
+        });
+        puppeteer.launch.mockResolvedValue(browser);
+
+        await expect(launchBrowserForApp(OPTIONS, CONTEXT)).rejects.toThrow(TestError);
+
+        // It is closed on that failure path already; a registration pointing
+        // at it would be an action with nothing to do.
+        expect(runInterruptActions()).toBe(0);
+    });
+
+    test('a browser launched after the signal is closed immediately', async () => {
+        const browser = fakeBrowser();
+        puppeteer.launch.mockResolvedValue(browser);
+        markInterrupted('SIGINT');
+
+        await launchBrowserForApp(OPTIONS, CONTEXT);
+        await new Promise((resolve) => setImmediate(resolve));
+
+        // Otherwise it is stranded with nothing left to close it.
+        expect(browser.close).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/lib/browser/browser-launch.js
+++ b/src/lib/browser/browser-launch.js
@@ -19,6 +19,7 @@ import { parseHeadlessOption } from '../util/headless-option.js';
 import { activeLiveView } from '../util/run-live.js';
 import { markReported } from '../util/reported-error.js';
 import { logError } from '../util/log-error.js';
+import { registerInterruptAction, interruptAbortSignal } from '../util/interrupt.js';
 
 /**
  * Chromium flags used for every Butler Sheet Icons browser launch.
@@ -447,6 +448,39 @@ export const launchBrowserForApp = async (options, { appId, logPrefix, appLabel,
             // The name is not interchangeable: grep the installed puppeteer-core for
             // `ignoreHTTPSErrors` and there are zero hits, in the code and in the type definitions.
             acceptInsecureCerts: true,
+            // Butler Sheet Icons owns signal handling now (issue #1107), and
+            // these three must be off or it does not.
+            //
+            // Puppeteer's defaults are all `true`, and its handler in
+            // `@puppeteer/browsers` is `case 'SIGINT': this.kill();
+            // process.exit(130)`. That exit is unconditional and immediate: it
+            // runs the moment Ctrl-C arrives, so the run never unwinds, the app
+            // loop never reaches its next boundary, and the report saying which
+            // apps were already written is never printed. The whole feature is
+            // silently defeated by a library default.
+            //
+            // It hid well, which is why this comment is long. Puppeteer exits
+            // 130 - exactly the code BSI uses for SIGINT - so an interrupted run
+            // still looked completely correct from the shell. Only the missing
+            // report gave it away, on a live run against a real server.
+            //
+            // Nothing is lost by turning them off. The browser is closed on
+            // interrupt through the teardown registered below, which is the
+            // same `closeBrowserQuietly` every other path uses, and unlike
+            // Puppeteer's version it lets the run finish reporting first.
+            handleSIGINT: false,
+            handleSIGTERM: false,
+            handleSIGHUP: false,
+            // Covers the launch itself, which the teardown registry cannot:
+            // the browser is only registered once `version()` has answered,
+            // and `launch()` may sit here for BROWSER_LAUNCH_TIMEOUT_MS on a
+            // cold cache or with security software holding startup. Without
+            // this, a Ctrl-C in that window reached nothing at all - the
+            // registry was empty and Puppeteer's own handlers are off - and
+            // shutdown stalled the full watchdog before hard-exiting, on the
+            // one path where BSI has nothing useful to report anyway.
+            // Puppeteer closes the browser when this aborts.
+            signal: interruptAbortSignal(),
             executablePath,
             headless,
             args: browserArgs,
@@ -488,6 +522,18 @@ export const launchBrowserForApp = async (options, { appId, logPrefix, appLabel,
         const version = await browser.version();
         logger.verbose(`Browser responded to version query: ${version}`);
 
+        // Registered here, and here only, so both platform twins are wired
+        // identically by construction - the same argument as the live-view
+        // call above. This is how a Ctrl-C reaches a browser that otherwise
+        // lives in a local variable inside a processor: closing it makes every
+        // in-flight Puppeteer await reject, which unwinds the run through the
+        // error paths that already exist (issue #1107).
+        //
+        // After the version query, not after `launch()`: a browser that cannot
+        // answer a protocol call is closed on the failure path below, and
+        // registering earlier would leave a stale action pointing at it.
+        registerBrowserForInterrupt(browser, logPrefix);
+
         // Resolved only now: the browser is not just found and started but
         // has answered a protocol call - the same bar the launch itself sets.
         const live = activeLiveView();
@@ -514,6 +560,52 @@ export const launchBrowserForApp = async (options, { appId, logPrefix, appLabel,
 };
 
 /**
+ * Unregister thunks for browsers currently registered as interrupt teardown.
+ *
+ * Keyed by the browser handle so `closeBrowserQuietly` can drop exactly the
+ * one it is closing. Normally holds at most one entry - BSI processes apps
+ * sequentially - but a map rather than a single slot, because a second browser
+ * appearing would otherwise silently overwrite the first and strand it.
+ *
+ * A `WeakMap` so a browser that is closed without going through
+ * `closeBrowserQuietly` cannot be kept alive by this bookkeeping.
+ *
+ * @type {WeakMap<object, () => void>}
+ */
+const interruptUnregister = new WeakMap();
+
+/**
+ * Registers a launched browser to be closed if the run is interrupted.
+ *
+ * @param {object} browser - Puppeteer browser handle.
+ * @param {string} logPrefix - Prefix for the error line, e.g. `'QSEOW'`.
+ *
+ * @returns {void}
+ */
+const registerBrowserForInterrupt = (browser, logPrefix) => {
+    interruptUnregister.set(
+        browser,
+        registerInterruptAction(() => closeBrowserQuietly(browser, logPrefix))
+    );
+};
+
+/**
+ * Drops a browser's interrupt registration.
+ *
+ * @param {object} browser - Puppeteer browser handle.
+ *
+ * @returns {void}
+ */
+const unregisterBrowserForInterrupt = (browser) => {
+    const unregister = interruptUnregister.get(browser);
+
+    if (unregister) {
+        interruptUnregister.delete(browser);
+        unregister();
+    }
+};
+
+/**
  * Closes a virtual browser, swallowing and logging any failure.
  *
  * Belongs in a `finally`. Both screenshot paths launched the browser and closed it ~290 lines
@@ -535,6 +627,12 @@ export const closeBrowserQuietly = async (browser, logPrefix) => {
     if (!browser) {
         return;
     }
+
+    // Whoever closes it first wins: an ordinary `finally` on the way out of an
+    // app, or the signal handler on the way out of the run. Dropping the
+    // registration here means the second one finds nothing to do rather than
+    // closing a browser that has already gone (issue #1107).
+    unregisterBrowserForInterrupt(browser);
 
     // Recorded before the close so the `disconnected` handler installed at launch stays quiet:
     // every successful run ends with a disconnect, and reporting those as "the build cannot be

--- a/src/lib/cloud/__tests__/process_cloud_app.test.js
+++ b/src/lib/cloud/__tests__/process_cloud_app.test.js
@@ -96,6 +96,8 @@ const mockSheetScreenshot = jest.unstable_mockModule('../sheet-screenshot.js', (
 
 let fs;
 let processCloudApp;
+let markInterrupted;
+let resetInterruptState;
 let puppeteer;
 let enigma;
 let logger;
@@ -132,6 +134,7 @@ beforeAll(async () => {
     ({ qscloudUploadToApp } = await import('../cloud-upload.js'));
     ({ qscloudUpdateSheetThumbnails } = await import('../cloud-updatesheets.js'));
     ({ processCloudApp } = await import('../process-cloud-app.js'));
+    ({ markInterrupted, resetInterruptState } = await import('../../util/interrupt.js'));
 });
 
 describe('process-cloud-app.js — puppeteer launch and click options', () => {
@@ -800,6 +803,54 @@ describe('process-cloud-app.js — puppeteer launch and click options', () => {
 
             const warnings = logger.warn.mock.calls.map((call) => String(call[0])).join('\n');
             expect(warnings).toContain('Could not capture the app overview after the update');
+            expect(qscloudUpdateSheetThumbnails).toHaveBeenCalled();
+        });
+    });
+
+    describe('the sheet loop stops when the run is interrupted (#1107)', () => {
+        afterEach(() => {
+            resetInterruptState();
+        });
+
+        test('abandons the app rather than failing every remaining sheet', async () => {
+            const browser = setupHappyPath();
+            markInterrupted('SIGINT');
+
+            await expect(
+                processCloudApp('test-app-id', defaultSaasInstance, {
+                    ...defaultOptions,
+                    pagewait: 0,
+                })
+            ).rejects.toThrow(/abandoned when the run was interrupted/);
+
+            // No sheet was captured, so nothing was uploaded and no sheet was
+            // repointed - the app is left exactly as it was.
+            expect(qscloudUploadToApp).not.toHaveBeenCalled();
+            expect(qscloudUpdateSheetThumbnails).not.toHaveBeenCalled();
+            expect(browser.close).toHaveBeenCalled();
+        });
+
+        test('does not report a lost engine session for a browser the shutdown closed', async () => {
+            setupHappyPath();
+            markInterrupted('SIGINT');
+
+            await processCloudApp('test-app-id', defaultSaasInstance, {
+                ...defaultOptions,
+                pagewait: 0,
+            }).catch(() => {});
+
+            const errors = logger.error.mock.calls.map(([line]) => String(line)).join('\n');
+            expect(errors).not.toContain('Lost the engine session');
+        });
+
+        test('an uninterrupted run is unaffected', async () => {
+            setupHappyPath();
+
+            await processCloudApp('test-app-id', defaultSaasInstance, {
+                ...defaultOptions,
+                pagewait: 0,
+            });
+
             expect(qscloudUpdateSheetThumbnails).toHaveBeenCalled();
         });
     });

--- a/src/lib/cloud/cloud-remove-sheet-icons.js
+++ b/src/lib/cloud/cloud-remove-sheet-icons.js
@@ -136,6 +136,26 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options, report = n
             `Closed session after removing sheet icons in QS Cloud app ${appId} on tenant ${options.tenanturl}`
         );
 
+        // Before the media deletion below, and this is the whole reason it is
+        // here (issue #1107). An interrupted removal has cleared *some* of the
+        // sheets and saved them; the rest still reference their thumbnail
+        // files. Falling through would delete every file in the folder,
+        // including the ones those untouched sheets point at - which is the
+        // failure mode the comment below describes, arrived at from the other
+        // direction. The result is irreversible: sheets showing a broken image
+        // where they previously had a working icon.
+        //
+        // Only for the interrupt. A genuine per-sheet failure still falls
+        // through, deliberately - see `assertAllProcessed()` at the end of this
+        // function, which is deferred precisely so the sheets that did work are
+        // finished off first.
+        //
+        // The `processCloudApp` twin got this guard and this one did not, which
+        // is the repo's standing failure shape.
+        if (sheetRun?.interrupted) {
+            sheetRun.assertAllProcessed();
+        }
+
         // Deleted only after the sheets have been repointed and the app saved. Doing it
         // first meant a failed save left every sheet pointing at images that no longer
         // existed - broken icons on every sheet, where the old behaviour of saving per

--- a/src/lib/cloud/cloud-updatesheets.js
+++ b/src/lib/cloud/cloud-updatesheets.js
@@ -152,7 +152,22 @@ export const qscloudUpdateSheetThumbnails = async (createdFiles, appId, options)
     // about them even as the app is counted failed.
     const changed = logUpdatedSheetSummary(sheetRun);
 
-    sheetRun?.assertAllProcessed();
+    try {
+        sheetRun?.assertAllProcessed();
+    } catch (err) {
+        // The count rides out on the error for the same reason the summary is
+        // logged before the assert: these sheets were repointed and saved, and
+        // throwing loses the return value that would otherwise have told the
+        // report so (issue #1107).
+        //
+        // It matters most on the interrupt path. Each sheet is written as the
+        // loop reaches it, so a signal here leaves real, irreversible changes
+        // in Sense - and without this the verdict says `0 thumbnails uploaded`
+        // for an app whose thumbnails are live, which is the one thing the
+        // run report must never get wrong.
+        err.sheetsUpdated = changed;
+        throw err;
+    }
 
     return changed;
 };

--- a/src/lib/cloud/process-cloud-app.js
+++ b/src/lib/cloud/process-cloud-app.js
@@ -14,6 +14,8 @@ import {
     SHEET_LIST_FIELDS_WITH_SHOW_CONDITION,
 } from '../util/sheet-list.js';
 import { withEngineSession } from '../util/engine-session.js';
+import { isInterrupted } from '../util/interrupt.js';
+import { isAbortArtifact } from '../util/abort-artifact.js';
 import { createAppImageDir } from '../util/image-dir.js';
 import { activeLiveView } from '../util/run-live.js';
 import { determineSheetExcludeStatus } from './determine-sheet-exclude-status.js';
@@ -301,11 +303,44 @@ export const processCloudApp = async (appId, saasInstance, options, report = nul
             `Closed session after generating sheet thumbnail images for all sheets in QS Cloud app ${appId} on tenant ${options.tenanturl}`
         );
 
+        // Symmetry with the QSEoW twin, which abandons the app from inside its
+        // bare sheet loop (issue #1107). Only for the interrupt: a genuine
+        // partial failure still falls through to the upload and update below,
+        // deliberately, so the sheets that did work are applied - that is what
+        // the `assertAllProcessed()` at the very end of this function is for.
+        //
+        // An interrupt is different in both directions. The steps below are two
+        // more round trips to the tenant during a shutdown that has to finish
+        // inside `docker stop`'s ten seconds; and applying a partial set of
+        // thumbnails would make the report's account of an abandoned app -
+        // left exactly as it was - untrue on this platform and true on the
+        // other.
+        if (sheetRun?.interrupted) {
+            sheetRun.assertAllProcessed();
+        }
+
         // Upload to QS Cloud app
         await qscloudUploadToApp(createdFiles, appId, options);
 
         // Update sheets in app
-        const sheetsUpdated = await qscloudUpdateSheetThumbnails(createdFiles, appId, options);
+        let sheetsUpdated;
+        // Wrapped so the interrupt path still records what landed (issue
+        // #1107). The update writes and saves each sheet as it goes, so a
+        // signal part-way through leaves real thumbnails in Sense; the throw
+        // that follows would otherwise skip `recordAppOutcome` below and the
+        // verdict would report zero for work that was done.
+        try {
+            sheetsUpdated = await qscloudUpdateSheetThumbnails(createdFiles, appId, options);
+        } catch (err) {
+            recordAppOutcome(appEntry, {
+                sheetsUpdated: err?.sheetsUpdated ?? 0,
+                imagesDir: `${imgDir}/cloud/${appId}`,
+                imageFileNames: createdFiles.flatMap((file) =>
+                    [file.fileNameShort, file.fileNameShortBlurred].filter(Boolean)
+                ),
+            });
+            throw err;
+        }
 
         // The sheets now point at their new thumbnails, which is the first moment an
         // overview screenshot can show the result rather than the starting state. The
@@ -346,7 +381,21 @@ export const processCloudApp = async (appId, saasInstance, options, report = nul
         // anyone debugging at verbose.
         logger.verbose(`Done processing app ${appId}`);
     } catch (err) {
-        logError('CLOUD APP', err);
+        // An interrupted app is not a failed one, and this line is the
+        // only thing on the shutdown path that says otherwise: the abort
+        // that unwound the run arrives here as an ordinary error, and
+        // `logError` prints it at error level with its cause chain. The app
+        // loop already reports the abandonment at info, so this would be a
+        // second, louder account of a Ctrl-C the operator asked for
+        // (issue #1107).
+        //
+        // Narrowed to errors the teardown itself produced. Keyed on the flag
+        // alone, a genuine failure that happened to be unwinding when the
+        // signal landed lost its error line AND its cause chain - the run
+        // could end with a real defect and no record of it anywhere.
+        if (!isInterrupted() || !isAbortArtifact(err)) {
+            logError('CLOUD APP', err);
+        }
         // Rethrow so the app loop can count this app as failed. Logging and returning
         // normally made a run in which every app failed look exactly like a clean run.
         throw err;

--- a/src/lib/commands/__tests__/run-command.test.js
+++ b/src/lib/commands/__tests__/run-command.test.js
@@ -1,0 +1,113 @@
+import { jest, describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+
+jest.unstable_mockModule('../../../globals.js', () => ({
+    logger: {
+        info: jest.fn(),
+        verbose: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+    },
+}));
+
+jest.unstable_mockModule('../../util/log-error.js', () => ({ logError: jest.fn() }));
+
+const restoreLiveTerminal = jest.fn();
+jest.unstable_mockModule('../../util/run-live.js', () => ({ restoreLiveTerminal }));
+
+const { runCommand } = await import('../run-command.js');
+const { markInterrupted, resetInterruptState } = await import('../../util/interrupt.js');
+
+/**
+ * The exit code the process had before this suite ran, so a test that sets it
+ * cannot make the Jest worker itself exit non-zero.
+ */
+let originalExitCode;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    resetInterruptState();
+    originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+});
+
+afterEach(() => {
+    resetInterruptState();
+    process.exitCode = originalExitCode;
+});
+
+describe('runCommand exit codes', () => {
+    test('a successful command leaves the exit code alone', async () => {
+        await runCommand('TEST', async () => true);
+
+        expect(process.exitCode).toBeUndefined();
+    });
+
+    test('a command reporting failure exits 1', async () => {
+        await runCommand('TEST', async () => false);
+
+        expect(process.exitCode).toBe(1);
+    });
+
+    test('a throwing command exits 1 without rethrowing', async () => {
+        await expect(
+            runCommand('TEST', async () => {
+                throw new Error('server unreachable');
+            })
+        ).resolves.toBe(false);
+
+        expect(process.exitCode).toBe(1);
+    });
+});
+
+describe('runCommand when the run is interrupted (issue #1107)', () => {
+    test('SIGINT exits 130 even though nothing failed', async () => {
+        // The app loop stops at a boundary, so an interrupted run can report
+        // success. Exiting 0 there would tell a scheduler the run did its job
+        // when the operator had just stopped it.
+        await runCommand('TEST', async () => {
+            markInterrupted('SIGINT');
+            return true;
+        });
+
+        expect(process.exitCode).toBe(130);
+    });
+
+    test('SIGTERM exits 143', async () => {
+        await runCommand('TEST', async () => {
+            markInterrupted('SIGTERM');
+            return true;
+        });
+
+        expect(process.exitCode).toBe(143);
+    });
+
+    test('the signal code wins over the ordinary failure code', async () => {
+        await runCommand('TEST', async () => {
+            markInterrupted('SIGINT');
+            return false;
+        });
+
+        // "A person stopped this" is the more useful thing to tell a
+        // scheduler than "something went wrong".
+        expect(process.exitCode).toBe(130);
+    });
+
+    test('the signal code wins even when the command threw on the way out', async () => {
+        await runCommand('TEST', async () => {
+            markInterrupted('SIGINT');
+            throw new Error('Protocol error: Target closed');
+        });
+
+        expect(process.exitCode).toBe(130);
+    });
+
+    test('the terminal is still restored on the interrupt path', async () => {
+        await runCommand('TEST', async () => {
+            markInterrupted('SIGINT');
+            return true;
+        });
+
+        expect(restoreLiveTerminal).toHaveBeenCalled();
+    });
+});

--- a/src/lib/commands/run-command.js
+++ b/src/lib/commands/run-command.js
@@ -1,6 +1,7 @@
 import { logger } from '../../globals.js';
 import { logError } from '../util/log-error.js';
 import { restoreLiveTerminal } from '../util/run-live.js';
+import { isInterrupted, interruptExitCode } from '../util/interrupt.js';
 
 /**
  * Runs a command implementation on behalf of a Commander action handler, and makes its
@@ -55,5 +56,14 @@ export const runCommand = async (logPrefix, run, onError) => {
         // shell. A no-op for every command that never started a live view;
         // the crash half lives in installFatalHandlers.
         restoreLiveTerminal();
+
+        // In the `finally`, and last, so it wins over both branches above
+        // (issue #1107). An interrupted run can legitimately report success -
+        // the app loop stops at a boundary, so nothing need have failed - and
+        // exiting 0 there would tell a scheduler the run did its job when the
+        // operator had just stopped it. 130 for SIGINT, 143 for SIGTERM.
+        if (isInterrupted()) {
+            process.exitCode = interruptExitCode();
+        }
     }
 };

--- a/src/lib/interactive/index.js
+++ b/src/lib/interactive/index.js
@@ -6,6 +6,7 @@ import { askQuestions } from './ask-questions.js';
 import { answersToOptions } from './to-cli-options.js';
 import { formatCommandLine, formatSecretEnvVars } from './render-command-line.js';
 import { defaultRuntime } from './prompt-runtime.js';
+import { isInterrupted } from '../util/interrupt.js';
 import { buildTheme } from './theme.js';
 import { getSymbols } from './symbols.js';
 import { loadWizard } from './registry.js';
@@ -386,9 +387,21 @@ export const runInteractive = async ({
         const result = await wizard.run(options);
         const ok = result !== false;
 
-        runtime.write(
-            `\n${ok ? `${symbols.done} Done` : `${symbols.failed} The run reported a failure - the log above says which apps and why`}\n`
-        );
+        // An interrupted run returns false so the exit code is right, but it
+        // did not fail (issue #1107). Saying so here would sit directly under
+        // a verdict that just went out of its way to print INTERRUPTED rather
+        // than FAILED, and send the operator hunting for broken apps that do
+        // not exist.
+        let line;
+        if (isInterrupted()) {
+            line = `${symbols.warning} Stopped - the run card above says which apps were already updated`;
+        } else if (ok) {
+            line = `${symbols.done} Done`;
+        } else {
+            line = `${symbols.failed} The run reported a failure - the log above says which apps and why`;
+        }
+
+        runtime.write(`\n${line}\n`);
 
         return ok;
     }

--- a/src/lib/qseow/__tests__/qseow_process_app.test.js
+++ b/src/lib/qseow/__tests__/qseow_process_app.test.js
@@ -108,6 +108,8 @@ const mockDetermineSheetExcludeStatus = jest.unstable_mockModule(
 
 let fs;
 let qseowProcessApp;
+let markInterrupted;
+let resetInterruptState;
 let puppeteer;
 let enigma;
 let qrsInteract;
@@ -153,6 +155,7 @@ beforeAll(async () => {
     ({ qseowLogout, qseowLogoutQuietly } = await import('../qseow-logout.js'));
     fs = (await import('fs')).default;
     ({ qseowProcessApp } = await import('../qseow-process-app.js'));
+    ({ markInterrupted, resetInterruptState } = await import('../../util/interrupt.js'));
 });
 
 describe('qseow-process-app.js — puppeteer launch and click options', () => {
@@ -1130,6 +1133,48 @@ describe('qseow-process-app.js — puppeteer launch and click options', () => {
             expect(warnings).toContain('Could not capture the app overview after the update');
 
             // The thumbnails were applied before the capture was attempted, so the run stands.
+            expect(qseowUpdateSheetThumbnails).toHaveBeenCalled();
+        });
+    });
+
+    describe('qseow-process-app.js — the sheet loop stops when the run is interrupted (#1107)', () => {
+        afterEach(() => {
+            resetInterruptState();
+        });
+
+        test('abandons the app rather than working through the remaining sheets', async () => {
+            const browser = setupHappyPath();
+            markInterrupted('SIGINT');
+
+            await expect(
+                qseowProcessApp('test-app-id', { ...defaultOptions, pagewait: 0 })
+            ).rejects.toThrow(/abandoned when the run was interrupted/);
+
+            // No sheet was captured, so no thumbnail was uploaded and no sheet was
+            // repointed - the app is left exactly as it was.
+            expect(qseowUploadToContentLibrary).not.toHaveBeenCalled();
+            expect(qseowUpdateSheetThumbnails).not.toHaveBeenCalled();
+            expect(browser.close).toHaveBeenCalled();
+        });
+
+        test('the QSEoW session is still logged out on the way past', async () => {
+            setupHappyPath();
+            markInterrupted('SIGINT');
+
+            await qseowProcessApp('test-app-id', { ...defaultOptions, pagewait: 0 }).catch(
+                () => {}
+            );
+
+            // A stranded Sense session counts against the parallel-session limit,
+            // so an interrupted run must not leave one behind either.
+            expect(qseowLogoutQuietly).toHaveBeenCalled();
+        });
+
+        test('an uninterrupted run is unaffected', async () => {
+            setupHappyPath();
+
+            await qseowProcessApp('test-app-id', { ...defaultOptions, pagewait: 0 });
+
             expect(qseowUpdateSheetThumbnails).toHaveBeenCalled();
         });
     });

--- a/src/lib/qseow/qseow-logout.js
+++ b/src/lib/qseow/qseow-logout.js
@@ -1,6 +1,7 @@
 import crypto from 'node:crypto';
 
 import { logger, sleep } from '../../globals.js';
+import { isInterrupted } from '../util/interrupt.js';
 import { describeWithCauses } from '../util/log-error.js';
 import { normalizeVirtualProxyPrefix } from './qseow-prefix.js';
 
@@ -175,6 +176,25 @@ export const qseowLogout = async (page, options, xpathHubUserPageButton, legacyL
     } catch (hubError) {
         logger.info(`QSEOW: Legacy hub logout fallback failed: ${hubError?.message ?? hubError}`);
         logger.debug(`QSEOW: Legacy hub logout fallback failure: ${hubError?.stack ?? hubError}`);
+
+        // On an interrupted run both paths were always going to fail, and none
+        // of the advice below applies (issue #1107). Shutdown closes the
+        // browser to unblock the run, and this runs from the `finally` just
+        // after - so `page.evaluate` and `page.goto` are driving a browser that
+        // is already gone, and the page waits reject as well. Saying the Sense
+        // web client has changed, and asking the operator to open a support
+        // ticket, is wrong on every count for a Ctrl-C they pressed
+        // deliberately.
+        //
+        // The session is genuinely left behind, which is worth one line rather
+        // than five: it is released when Qlik Sense times it out.
+        if (isInterrupted()) {
+            logger.info(
+                `QSEOW: The run was interrupted before the browser session could be logged out. Qlik Sense will release it when it times out.`
+            );
+            return false;
+        }
+
         logger.error(
             `QSEOW: Could not log out of Qlik Sense - both the proxy session API and the hub's user menu failed.`
         );
@@ -233,6 +253,17 @@ export const qseowLogoutQuietly = async (
     try {
         await qseowLogout(page, logoutOptions, xpathHubUserPageButton, legacyLogoutButton);
     } catch (err) {
+        // Same reasoning as the block above: on an interrupted run this is the
+        // expected outcome, not a fault, and `qseowLogout` has already said so
+        // at `info`. Warning about the parallel-session limit here would put a
+        // second, more alarming account of one Ctrl-C on the operator's screen.
+        if (isInterrupted()) {
+            logger.verbose(
+                `QSEOW: Logout skipped because the run was interrupted: ${describeWithCauses(err)}`
+            );
+            return;
+        }
+
         logger.warn(
             `QSEOW: Could not log the browser session out. It will stay active on the server until Qlik Sense times it out, which counts against the parallel-session limit for this user. ${describeWithCauses(err)}`
         );

--- a/src/lib/qseow/qseow-process-app.js
+++ b/src/lib/qseow/qseow-process-app.js
@@ -15,6 +15,8 @@ import {
     SHEET_LIST_FIELDS_WITH_SHOW_CONDITION,
 } from '../util/sheet-list.js';
 import { withEngineSession } from '../util/engine-session.js';
+import { isInterrupted } from '../util/interrupt.js';
+import { isAbortArtifact } from '../util/abort-artifact.js';
 import { createAppImageDir } from '../util/image-dir.js';
 import { activeLiveView } from '../util/run-live.js';
 import { addAppToReport, recordPlannedSheet, recordAppOutcome } from '../util/run-report.js';
@@ -193,6 +195,19 @@ export const qseowProcessApp = async (appId, options, report = null) => {
 
                         // Loop over all sheets in app, processing each one unless excluded
                         for (const sheet of sheets) {
+                            // The sheet boundary an interrupted run stops at,
+                            // mirroring the `runOverSheets` check the Cloud
+                            // twin gets for free (issue #1107). A capture
+                            // failure already throws straight out of this bare
+                            // loop, but a blur failure is caught per sheet and
+                            // continues - so without this, shutdown would work
+                            // through every remaining sheet failing each one.
+                            if (isInterrupted()) {
+                                throw new QseowError(
+                                    `App ${appId} was abandoned when the run was interrupted, at sheet ${iSheetNum} of ${sheets.length}`
+                                );
+                            }
+
                             // Get repository db sheet id from mapRepoEngineSheetId, using sheet.qInfo.qId as key
                             const repoDbSheetId = mapRepoEngineSheetId.get(sheet.qInfo.qId);
                             const engineSheetId = sheet.qInfo.qId;
@@ -438,12 +453,27 @@ export const qseowProcessApp = async (appId, options, report = null) => {
         // The blur-tag metadata is passed, never the exclude-tag metadata: they are queried on
         // different options, and handing the exclude set to the blur rule would blur sheets
         // carrying the *exclude* tag. See issue #840.
-        const sheetsUpdated = await qseowUpdateSheetThumbnails(
-            createdFiles,
-            appId,
-            options,
-            blurTagSheetAppMetadata
-        );
+        let sheetsUpdated;
+        // Wrapped so the interrupt path still records what landed (issue
+        // #1107). The update writes and saves each sheet as it goes, so a
+        // signal part-way through leaves real thumbnails in Sense; the throw
+        // that follows would otherwise skip `recordAppOutcome` below and the
+        // verdict would report zero for work that was done.
+        try {
+            sheetsUpdated = await qseowUpdateSheetThumbnails(
+                createdFiles,
+                appId,
+                options,
+                blurTagSheetAppMetadata
+            );
+        } catch (err) {
+            recordAppOutcome(appEntry, {
+                sheetsUpdated: err?.sheetsUpdated ?? 0,
+                imagesDir: `${imgDir}/qseow/${appId}`,
+                imageFileNames: createdFiles.map((file) => file.fileNameShort),
+            });
+            throw err;
+        }
 
         // The sheets now point at their new thumbnails, which is the first moment an
         // overview screenshot can show the result rather than the starting state. The
@@ -484,7 +514,21 @@ export const qseowProcessApp = async (appId, options, report = null) => {
         // anyone debugging at verbose.
         logger.verbose(`Done processing app ${appId}`);
     } catch (err) {
-        logError('QSEOW: qseowProcessApp', err);
+        // An interrupted app is not a failed one, and this line is the
+        // only thing on the shutdown path that says otherwise: the abort
+        // that unwound the run arrives here as an ordinary error, and
+        // `logError` prints it at error level with its cause chain. The app
+        // loop already reports the abandonment at info, so this would be a
+        // second, louder account of a Ctrl-C the operator asked for
+        // (issue #1107).
+        //
+        // Narrowed to errors the teardown itself produced. Keyed on the flag
+        // alone, a genuine failure that happened to be unwinding when the
+        // signal landed lost its error line AND its cause chain - the run
+        // could end with a real defect and no record of it anywhere.
+        if (!isInterrupted() || !isAbortArtifact(err)) {
+            logError('QSEOW: qseowProcessApp', err);
+        }
         // Rethrow so the app loop can count this app as failed. Logging and returning
         // normally made a run in which every app failed look exactly like a clean run.
         throw err;

--- a/src/lib/qseow/qseow-updatesheets.js
+++ b/src/lib/qseow/qseow-updatesheets.js
@@ -158,7 +158,22 @@ export const qseowUpdateSheetThumbnails = async (
     // about them even as the app is counted failed.
     const changed = logUpdatedSheetSummary(sheetRun);
 
-    sheetRun?.assertAllProcessed();
+    try {
+        sheetRun?.assertAllProcessed();
+    } catch (err) {
+        // The count rides out on the error for the same reason the summary is
+        // logged before the assert: these sheets were repointed and saved, and
+        // throwing loses the return value that would otherwise have told the
+        // report so (issue #1107).
+        //
+        // It matters most on the interrupt path. Each sheet is written as the
+        // loop reaches it, so a signal here leaves real, irreversible changes
+        // in Sense - and without this the verdict says `0 thumbnails uploaded`
+        // for an app whose thumbnails are live, which is the one thing the
+        // run report must never get wrong.
+        err.sheetsUpdated = changed;
+        throw err;
+    }
 
     return changed;
 };

--- a/src/lib/util/__tests__/abort-artifact.test.js
+++ b/src/lib/util/__tests__/abort-artifact.test.js
@@ -1,0 +1,50 @@
+import { describe, test, expect } from '@jest/globals';
+import { isAbortArtifact } from '../abort-artifact.js';
+
+describe('isAbortArtifact', () => {
+    test('recognises what sleep() rejects with once the run is interrupted', () => {
+        const err = new Error('The operation was aborted');
+        err.name = 'AbortError';
+
+        expect(isAbortArtifact(err)).toBe(true);
+    });
+
+    test('recognises the AbortError code as well as the name', () => {
+        const err = new Error('aborted');
+        err.code = 'ABORT_ERR';
+
+        expect(isAbortArtifact(err)).toBe(true);
+    });
+
+    test.each([
+        'Protocol error (Page.navigate): Target closed',
+        'Session closed. Most likely the page has been closed.',
+        'Navigation failed because browser has disconnected!',
+    ])('recognises what closing the browser produces: %s', (message) => {
+        expect(isAbortArtifact(new Error(message))).toBe(true);
+    });
+
+    test('looks down the cause chain, because processors rethrow wrapped', () => {
+        const cause = new Error('Protocol error: Target closed');
+        const wrapped = new Error('Failed to process QSEoW app abc', { cause });
+
+        expect(isAbortArtifact(wrapped)).toBe(true);
+    });
+
+    test.each([
+        'Request failed with status code 500',
+        'getaddrinfo ENOTFOUND sense.example.com',
+        'Sheet 3 could not be read',
+    ])('does NOT claim a genuine failure: %s', (message) => {
+        // This is the direction that matters. Keyed on the interrupt flag
+        // alone, an app failing on a real server error at the moment docker
+        // stop arrived was filed as abandoned and dropped out of the verdict's
+        // failure count entirely.
+        expect(isAbortArtifact(new Error(message))).toBe(false);
+    });
+
+    test('survives a non-Error and a nullish value', () => {
+        expect(isAbortArtifact(undefined)).toBe(false);
+        expect(isAbortArtifact('just a string')).toBe(false);
+    });
+});

--- a/src/lib/util/__tests__/flush-exit.test.js
+++ b/src/lib/util/__tests__/flush-exit.test.js
@@ -1,0 +1,132 @@
+import { jest, describe, test, expect } from '@jest/globals';
+import { flushAndExit, FLUSH_TIMEOUT_MS } from '../flush-exit.js';
+
+/**
+ * A stand-in Writable that reports a non-empty buffer and only invokes the
+ * drain callback when the test says so — the shape of a pipe whose reader is
+ * behind.
+ *
+ * @param {object} [options] - Stream shape.
+ * @param {number} [options.writableLength] - Bytes reported as still queued.
+ * @param {boolean} [options.writableEnded] - Whether the stream is already ended.
+ * @param {boolean} [options.throws] - Make `write` throw, as a dead stream does.
+ *
+ * @returns {object} The fake stream, with `release()` to drain it.
+ */
+const fakeStream = ({ writableLength = 100, writableEnded = false, throws = false } = {}) => {
+    let cb = null;
+
+    return {
+        writableLength,
+        writableEnded,
+        /**
+         * Records the drain callback instead of calling it.
+         *
+         * @param {string} _chunk - Ignored.
+         * @param {Function} callback - Drain callback.
+         *
+         * @returns {void}
+         */
+        write(_chunk, callback) {
+            if (throws) throw new Error('EPIPE');
+            cb = callback;
+        },
+        /**
+         * Fires the recorded drain callback.
+         *
+         * @returns {void}
+         */
+        release() {
+            cb?.();
+        },
+    };
+};
+
+/**
+ * Lets queued `setImmediate` callbacks run.
+ *
+ * @returns {Promise<void>} Resolves on the next macrotask turn.
+ */
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+describe('flushAndExit', () => {
+    test('waits for a lagging stream before exiting', async () => {
+        const exit = jest.fn();
+        const stream = fakeStream();
+
+        flushAndExit(130, { streams: [stream], exit });
+        await tick();
+
+        // The whole point: a bare process.exit() here discards the report.
+        // Measured at 333 of 400 lines delivered, verdict block among them.
+        expect(exit).not.toHaveBeenCalled();
+
+        stream.release();
+        expect(exit).toHaveBeenCalledWith(130);
+    });
+
+    test('exits without waiting when nothing is buffered', async () => {
+        const exit = jest.fn();
+
+        flushAndExit(143, { streams: [fakeStream({ writableLength: 0 })], exit });
+        await tick();
+
+        // The TTY case: writes already completed synchronously, so Ctrl-C
+        // must stay instant rather than paying the drain.
+        expect(exit).toHaveBeenCalledWith(143);
+    });
+
+    test('exits anyway when the reader never drains', async () => {
+        jest.useFakeTimers();
+        const exit = jest.fn();
+
+        flushAndExit(130, { streams: [fakeStream()], exit, timeoutMs: 50 });
+        jest.advanceTimersByTime(0);
+        await Promise.resolve();
+        jest.advanceTimersByTime(50);
+
+        // A reader that has gone away never calls the callback; the timer is
+        // the only route out, and a shutdown that hangs is worse than one
+        // that truncates.
+        expect(exit).toHaveBeenCalledWith(130);
+        jest.useRealTimers();
+    });
+
+    test('exits once, not twice, when the drain and the timer race', async () => {
+        jest.useFakeTimers();
+        const exit = jest.fn();
+        const stream = fakeStream();
+
+        flushAndExit(130, { streams: [stream], exit, timeoutMs: 50 });
+        jest.advanceTimersByTime(0);
+        await Promise.resolve();
+        stream.release();
+        jest.advanceTimersByTime(500);
+
+        expect(exit).toHaveBeenCalledTimes(1);
+        jest.useRealTimers();
+    });
+
+    test('sets process.exitCode as well, so a missed exit still ends correctly', async () => {
+        const original = process.exitCode;
+        try {
+            flushAndExit(143, { streams: [fakeStream({ writableLength: 0 })], exit: jest.fn() });
+            expect(process.exitCode).toBe(143);
+        } finally {
+            process.exitCode = original;
+        }
+    });
+
+    test('a stream that cannot be written does not hold up the exit', async () => {
+        const exit = jest.fn();
+
+        flushAndExit(130, { streams: [fakeStream({ throws: true })], exit });
+        await tick();
+
+        expect(exit).toHaveBeenCalledWith(130);
+    });
+
+    test('the default deadline stays inside docker stop’s grace period', () => {
+        expect(FLUSH_TIMEOUT_MS).toBeLessThan(10_000);
+    });
+});

--- a/src/lib/util/__tests__/interrupt.test.js
+++ b/src/lib/util/__tests__/interrupt.test.js
@@ -1,0 +1,180 @@
+import { describe, test, expect, beforeEach, afterEach, jest } from '@jest/globals';
+
+import {
+    INTERRUPT_EXIT_CODES,
+    markInterrupted,
+    isInterrupted,
+    interruptSignal,
+    interruptExitCode,
+    interruptAbortSignal,
+    registerInterruptAction,
+    runInterruptActions,
+    beginInterruptibleRun,
+    endInterruptibleRun,
+    hasInterruptibleWork,
+    resetInterruptState,
+} from '../interrupt.js';
+
+beforeEach(() => {
+    resetInterruptState();
+});
+
+afterEach(() => {
+    resetInterruptState();
+});
+
+describe('interrupt state', () => {
+    test('starts clean', () => {
+        expect(isInterrupted()).toBe(false);
+        expect(interruptSignal()).toBeNull();
+        expect(hasInterruptibleWork()).toBe(false);
+        expect(interruptAbortSignal().aborted).toBe(false);
+    });
+
+    test('records the signal and aborts the shared controller', () => {
+        const signal = interruptAbortSignal();
+
+        expect(markInterrupted('SIGINT')).toBe(true);
+
+        expect(isInterrupted()).toBe(true);
+        expect(interruptSignal()).toBe('SIGINT');
+        expect(signal.aborted).toBe(true);
+    });
+
+    test('the first signal wins - a second cannot overwrite which one is reported', () => {
+        markInterrupted('SIGINT');
+
+        expect(markInterrupted('SIGTERM')).toBe(false);
+        expect(interruptSignal()).toBe('SIGINT');
+    });
+
+    test('exit code follows the signal convention', () => {
+        expect(INTERRUPT_EXIT_CODES.SIGINT).toBe(130);
+        expect(INTERRUPT_EXIT_CODES.SIGTERM).toBe(143);
+        expect(INTERRUPT_EXIT_CODES.SIGHUP).toBe(129);
+
+        markInterrupted('SIGTERM');
+        expect(interruptExitCode()).toBe(143);
+    });
+
+    test('SIGHUP exits 129, so a dropped session is not read as a failure', () => {
+        markInterrupted('SIGHUP');
+        expect(interruptExitCode()).toBe(129);
+    });
+
+    test('an unknown signal still gets a usable exit code', () => {
+        markInterrupted('SIGUSR2');
+        expect(interruptExitCode()).toBe(130);
+    });
+
+    test('the abort signal is re-read after a reset, never captured once', () => {
+        markInterrupted('SIGINT');
+        expect(interruptAbortSignal().aborted).toBe(true);
+
+        resetInterruptState();
+
+        // A module that captured the signal at import time would still hold
+        // the aborted one, and every sleep would reject for the rest of the
+        // process.
+        expect(interruptAbortSignal().aborted).toBe(false);
+    });
+});
+
+describe('teardown actions', () => {
+    test('run on interrupt, and the registry is emptied', () => {
+        const close = jest.fn();
+        registerInterruptAction(close);
+
+        expect(runInterruptActions()).toBe(1);
+        expect(close).toHaveBeenCalledTimes(1);
+
+        // A second pass must not close a browser that has already gone.
+        expect(runInterruptActions()).toBe(0);
+        expect(close).toHaveBeenCalledTimes(1);
+    });
+
+    test('an unregistered action does not run', () => {
+        const close = jest.fn();
+        const unregister = registerInterruptAction(close);
+
+        unregister();
+        runInterruptActions();
+
+        expect(close).not.toHaveBeenCalled();
+    });
+
+    test('unregistering twice is safe', () => {
+        const unregister = registerInterruptAction(jest.fn());
+
+        unregister();
+        expect(() => unregister()).not.toThrow();
+    });
+
+    test('one action throwing does not stop the others', () => {
+        const first = jest.fn(() => {
+            throw new Error('browser handle already gone');
+        });
+        const second = jest.fn();
+
+        registerInterruptAction(first);
+        registerInterruptAction(second);
+
+        expect(() => runInterruptActions()).not.toThrow();
+        expect(second).toHaveBeenCalledTimes(1);
+    });
+
+    test('a rejecting action is swallowed rather than becoming an unhandled rejection', async () => {
+        // Left unhandled, this would reach the `unhandledRejection` handler and
+        // write a crash dump for a browser that failed to close during a
+        // shutdown the operator asked for.
+        registerInterruptAction(async () => {
+            throw new Error('close timed out');
+        });
+
+        expect(() => runInterruptActions()).not.toThrow();
+
+        await new Promise((resolve) => setImmediate(resolve));
+    });
+
+    test('registering after the interrupt runs the action immediately', () => {
+        markInterrupted('SIGINT');
+
+        const close = jest.fn();
+        registerInterruptAction(close);
+
+        // A browser launched during shutdown would otherwise be stranded with
+        // nothing left to close it.
+        expect(close).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('interruptible run regions', () => {
+    test('open and close', () => {
+        beginInterruptibleRun();
+        expect(hasInterruptibleWork()).toBe(true);
+
+        endInterruptibleRun();
+        expect(hasInterruptibleWork()).toBe(false);
+    });
+
+    test('nest', () => {
+        beginInterruptibleRun();
+        beginInterruptibleRun();
+        endInterruptibleRun();
+
+        expect(hasInterruptibleWork()).toBe(true);
+
+        endInterruptibleRun();
+        expect(hasInterruptibleWork()).toBe(false);
+    });
+
+    test('an unbalanced close cannot drive the depth negative', () => {
+        endInterruptibleRun();
+        endInterruptibleRun();
+        beginInterruptibleRun();
+
+        // A negative counter would swallow the next real region, and the
+        // signal handler would exit immediately in the middle of a run.
+        expect(hasInterruptibleWork()).toBe(true);
+    });
+});

--- a/src/lib/util/__tests__/run-board.test.js
+++ b/src/lib/util/__tests__/run-board.test.js
@@ -612,3 +612,121 @@ describe('the verdict block', () => {
         expect(verdict).not.toContain('thumbnails uploaded');
     });
 });
+
+describe('the board on an interrupted run (issue #1107)', () => {
+    /**
+     * A report stopped mid-run: one app done, one abandoned in flight, two
+     * never started.
+     *
+     * @returns {object} The report.
+     */
+    const interruptedReport = () => ({
+        command: 'qseow create-sheet-thumbnails',
+        startedAt: 1000,
+        finishedAt: 5000,
+        succeeded: false,
+        interrupted: { signal: 'SIGINT' },
+        appsNotStarted: 2,
+        selection: { total: 4 },
+        apps: [
+            {
+                id: 'app-1',
+                name: 'Done',
+                sheetCount: 2,
+                failed: false,
+                interrupted: false,
+                sheetsUpdated: 2,
+                sheets: [
+                    { n: 1, title: 'One', action: 'update', reason: null },
+                    { n: 2, title: 'Two', action: 'update', reason: null },
+                ],
+            },
+            {
+                id: 'app-2',
+                name: 'Abandoned',
+                sheetCount: 3,
+                failed: false,
+                interrupted: true,
+                sheets: [{ n: 1, title: 'One', action: 'update', reason: null }],
+            },
+        ],
+    });
+
+    test('says INTERRUPTED rather than FAILED', () => {
+        const out = stripAnsi(renderBoardVerdict(interruptedReport(), uniCtx()));
+
+        expect(out).toContain('INTERRUPTED');
+        expect(out).not.toContain('FAILED');
+    });
+
+    test('states what was abandoned and what was never started', () => {
+        const out = stripAnsi(renderBoardVerdict(interruptedReport(), uniCtx()));
+
+        expect(out).toContain('1 app(s) ok');
+        expect(out).toContain('1 interrupted');
+        expect(out).toContain('2 not started');
+    });
+
+    test('the interrupt is yellow, not red - stopped is not broken', () => {
+        const out = renderBoardVerdict(interruptedReport(), uniCtx(true));
+
+        expect(out).toMatch(ANSI);
+        // 33 is yellow, 31 red. A red INTERRUPTED would send the operator
+        // looking for a fault they caused deliberately.
+        expect(out).toContain(`${ESC}[33mINTERRUPTED`);
+    });
+
+    test('the marker keeps its column width in the ASCII set', () => {
+        const [done, abandoned] = interruptedReport().apps;
+
+        const okRow = stripAnsi(
+            renderBoardAppRow(done, { n: 1, total: 4, removal: false }, asciiCtx())
+        );
+        const warnRow = stripAnsi(
+            renderBoardAppRow(abandoned, { n: 2, total: 4, removal: false }, asciiCtx())
+        );
+
+        // symbols.warning is '!' in BOTH sets while the ASCII markers are
+        // '[ok]' and '[!!]'. Unpadded, the abandoned row shifted three columns
+        // left of every other row on Windows conhost and any runner without
+        // unicode - which is exactly where docker stop and SIGTERM are the
+        // normal way a run ends.
+        expect(warnRow.indexOf('2/4')).toBe(okRow.indexOf('1/4'));
+    });
+
+    test('an abandoned app row is marked with the warning symbol, not a tick or a cross', () => {
+        const [, abandoned] = interruptedReport().apps;
+
+        const uni = stripAnsi(
+            renderBoardAppRow(abandoned, { n: 2, total: 4, removal: false }, uniCtx())
+        );
+        const ascii = stripAnsi(
+            renderBoardAppRow(abandoned, { n: 2, total: 4, removal: false }, asciiCtx())
+        );
+
+        expect(uni).toContain(UNICODE_SYMBOLS.warning);
+        expect(uni).not.toContain(UNICODE_SYMBOLS.done);
+        expect(uni).not.toContain(UNICODE_SYMBOLS.failed);
+        expect(ascii).toContain(ASCII_SYMBOLS.warning);
+    });
+
+    test('a completed app row still gets its tick', () => {
+        const [done] = interruptedReport().apps;
+
+        const out = stripAnsi(
+            renderBoardAppRow(done, { n: 1, total: 4, removal: false }, uniCtx())
+        );
+
+        expect(out).toContain(UNICODE_SYMBOLS.done);
+    });
+
+    test('the abandoned app has no failed cells painted for sheets it never reached', () => {
+        const [, abandoned] = interruptedReport().apps;
+
+        // recordPlannedSheet only runs after a capture succeeds, so the
+        // unreached tail is simply absent rather than shown as failed.
+        const cells = stripForApp(abandoned, UNICODE_SYMBOLS);
+
+        expect(cells.filter((cell) => cell.kind === 'failed')).toHaveLength(0);
+    });
+});

--- a/src/lib/util/__tests__/run-over-apps.test.js
+++ b/src/lib/util/__tests__/run-over-apps.test.js
@@ -1,4 +1,4 @@
-import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+import { jest, describe, test, expect, beforeEach, afterEach } from '@jest/globals';
 
 jest.unstable_mockModule('../../../globals.js', () => ({
     logger: {
@@ -12,6 +12,7 @@ jest.unstable_mockModule('../../../globals.js', () => ({
 
 const { logger } = await import('../../../globals.js');
 const { runOverApps } = await import('../run-over-apps.js');
+const { markInterrupted, resetInterruptState } = await import('../interrupt.js');
 
 const CTX = { logPrefix: 'TEST PREFIX' };
 
@@ -22,8 +23,20 @@ const CTX = { logPrefix: 'TEST PREFIX' };
  */
 const errorLog = () => logger.error.mock.calls.map((call) => String(call[0])).join('\n');
 
+/**
+ * Joins everything logged at info level, for substring assertions.
+ *
+ * @returns {string} All info lines, newline separated.
+ */
+const infoLog = () => logger.info.mock.calls.map((call) => String(call[0])).join('\n');
+
 beforeEach(() => {
     jest.clearAllMocks();
+    resetInterruptState();
+});
+
+afterEach(() => {
+    resetInterruptState();
 });
 
 describe('runOverApps', () => {
@@ -188,5 +201,85 @@ describe('runOverApps', () => {
 
         expect(result).toBe(false);
         expect(errorLog()).toContain('just a string');
+    });
+});
+
+describe('runOverApps when the run is interrupted (issue #1107)', () => {
+    test('stops starting new apps at the app boundary', async () => {
+        const worker = jest.fn(async (appId) => {
+            if (appId === 'b') markInterrupted('SIGINT');
+        });
+
+        await runOverApps(['a', 'b', 'c', 'd'], CTX, worker);
+
+        // Every app past the boundary is one the operator can be told was
+        // left exactly as it was - which is the whole point of the report.
+        expect(worker.mock.calls.map((call) => call[0])).toEqual(['a', 'b']);
+    });
+
+    test('says how many apps were not started', async () => {
+        const worker = jest.fn(async (appId) => {
+            if (appId === 'a') markInterrupted('SIGINT');
+        });
+
+        await runOverApps(['a', 'b', 'c'], CTX, worker);
+
+        expect(infoLog()).toContain('2 of 3 app(s) were not started');
+    });
+
+    test('never announces an app it did not start', async () => {
+        const worker = jest.fn(async () => markInterrupted('SIGINT'));
+
+        await runOverApps(['first', 'second'], CTX, worker);
+
+        expect(infoLog()).not.toContain('second');
+    });
+
+    test('an abandoned app is not counted as a failed one', async () => {
+        const worker = jest.fn(async () => {
+            markInterrupted('SIGINT');
+            // Shutdown closes the browser, so the in-flight await rejects
+            // exactly like a real failure would.
+            throw new Error('Protocol error: Target closed');
+        });
+
+        await runOverApps(['a', 'b'], CTX, worker);
+
+        // An operator who pressed Ctrl-C and reads "1 failed" goes looking for
+        // a broken app that does not exist.
+        expect(errorLog()).not.toContain('Failed to process');
+        expect(infoLog()).toContain('it was abandoned');
+    });
+
+    test('the cause of the abandonment is still available, just not as an error', async () => {
+        const worker = jest.fn(async () => {
+            markInterrupted('SIGTERM');
+            throw new Error('Protocol error: Target closed');
+        });
+
+        await runOverApps(['a'], CTX, worker);
+
+        expect(infoLog()).toContain('Target closed');
+    });
+
+    test('a genuine failure before the signal is still reported as a failure', async () => {
+        const worker = jest.fn(async (appId) => {
+            if (appId === 'a') throw new Error('server unreachable');
+            markInterrupted('SIGINT');
+        });
+
+        const result = await runOverApps(['a', 'b', 'c'], CTX, worker);
+
+        expect(result).toBe(false);
+        expect(errorLog()).toContain('Failed to process app a');
+    });
+
+    test('an interrupted run with nothing failing still returns true here', async () => {
+        // runOverAppsWithReport overrides this - the verdict a stopped run
+        // reports is not this loop's job. Pinned so a future change to either
+        // side has to look at the other.
+        const worker = jest.fn(async () => markInterrupted('SIGINT'));
+
+        await expect(runOverApps(['a', 'b'], CTX, worker)).resolves.toBe(true);
     });
 });

--- a/src/lib/util/__tests__/run-report-flow.test.js
+++ b/src/lib/util/__tests__/run-report-flow.test.js
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, jest } from '@jest/globals';
+import { describe, test, expect, beforeEach, afterEach, jest } from '@jest/globals';
 
 /**
  * Flow tests for `runOverAppsWithReport` as extended by issue #1073: the plan
@@ -27,6 +27,9 @@ jest.unstable_mockModule('../../../globals.js', () => ({
 
 const { runOverAppsWithReport } = await import('../run-report.js');
 const { getLoggingLevel, setLoggingLevel } = await import('../../../globals.js');
+const { emitRunVerdictOnce } = await import('../run-report.js');
+const { markInterrupted, resetInterruptState, hasInterruptibleWork } =
+    await import('../interrupt.js');
 
 /**
  * A minimal but complete run argument bag.
@@ -70,6 +73,11 @@ beforeEach(() => {
     // rung the loop selects and route the blocks away from the logger these
     // assertions read. The board rung has its own flow test.
     delete process.env.BSI_OUTPUT;
+    resetInterruptState();
+});
+
+afterEach(() => {
+    resetInterruptState();
 });
 
 describe('runOverAppsWithReport - the plan renders before the first write', () => {
@@ -203,5 +211,102 @@ describe('runOverAppsWithReport - countable app lines', () => {
         await runOverAppsWithReport(runArgs({ dryRun: true }));
 
         expect(timeline).toContain('LOG plan app 1/2  app-1');
+    });
+});
+
+describe('runOverAppsWithReport - an interrupted run (issue #1107)', () => {
+    /**
+     * Everything the logger was given, joined.
+     *
+     * @returns {string} All log lines, newline separated.
+     */
+    const logged = () => timeline.filter((entry) => entry.startsWith('LOG ')).join('\n');
+
+    test('emits a verdict covering the apps already completed', async () => {
+        const processApp = jest.fn(async (appId) => {
+            timeline.push(`PROCESS ${appId}`);
+            if (appId === 'app-1') markInterrupted('SIGINT');
+        });
+
+        await runOverAppsWithReport(runArgs({ appIds: ['app-1', 'app-2', 'app-3'], processApp }));
+
+        // The one thing an operator needs after a Ctrl-C: which apps were
+        // already written, and how much is left to re-run.
+        expect(logged()).toContain('RESULT  INTERRUPTED');
+        expect(logged()).toContain('1 ok');
+        expect(logged()).toContain('2 not started');
+    });
+
+    test('reports failure, whatever the app loop counted', async () => {
+        // The loop can legitimately count zero failures - it stopped at a
+        // boundary - and exiting 0 there would tell a scheduler the run did
+        // its job.
+        const processApp = jest.fn(async () => markInterrupted('SIGINT'));
+
+        await expect(
+            runOverAppsWithReport(runArgs({ appIds: ['app-1', 'app-2'], processApp }))
+        ).resolves.toBe(false);
+    });
+
+    test('the app in flight is recorded as interrupted, not failed', async () => {
+        const processApp = jest.fn(async () => {
+            markInterrupted('SIGINT');
+            throw new Error('Protocol error: Target closed');
+        });
+
+        await runOverAppsWithReport(runArgs({ appIds: ['app-1', 'app-2'], processApp }));
+
+        expect(logged()).toContain('1 interrupted');
+        expect(logged()).not.toContain('1 failed');
+    });
+
+    test('a genuine failure is still a failure when a later signal arrives', async () => {
+        const processApp = jest.fn(async (appId) => {
+            if (appId === 'app-1') throw new Error('server unreachable');
+            markInterrupted('SIGINT');
+        });
+
+        await runOverAppsWithReport(runArgs({ appIds: ['app-1', 'app-2', 'app-3'], processApp }));
+
+        expect(logged()).toContain('1 failed');
+    });
+
+    test('the verdict is emitted exactly once, whichever path reaches it first', async () => {
+        const processApp = jest.fn(async () => markInterrupted('SIGINT'));
+
+        await runOverAppsWithReport(runArgs({ appIds: ['app-1', 'app-2'], processApp }));
+
+        const verdicts = timeline.filter((entry) => entry.includes('RESULT')).length;
+        expect(verdicts).toBe(1);
+
+        // The signal handler's second-signal and watchdog paths both call
+        // this. Neither may print a second verdict.
+        expect(emitRunVerdictOnce()).toBe(false);
+        expect(timeline.filter((entry) => entry.includes('RESULT')).length).toBe(1);
+    });
+
+    test('the interruptible region is closed even when the loop throws', async () => {
+        const planApp = jest.fn(async () => {
+            throw new Error('planner exploded');
+        });
+
+        await runOverAppsWithReport(runArgs({ dryRun: true, planApp })).catch(() => {});
+
+        // Left open, every later signal would wait eight seconds for a run
+        // that had already finished.
+        expect(hasInterruptibleWork()).toBe(false);
+    });
+
+    test('a dry run discards the pending verdict rather than printing two reports', async () => {
+        await runOverAppsWithReport(runArgs({ dryRun: true }));
+
+        expect(emitRunVerdictOnce()).toBe(false);
+    });
+
+    test('an uninterrupted run still says ok', async () => {
+        await runOverAppsWithReport(runArgs());
+
+        expect(logged()).toContain('RESULT  ok');
+        expect(logged()).not.toContain('not started');
     });
 });

--- a/src/lib/util/__tests__/run-report-render.test.js
+++ b/src/lib/util/__tests__/run-report-render.test.js
@@ -10,6 +10,8 @@ import {
     formatElapsed,
     formatBytes,
     isOptionEnabled,
+    verdictFacts,
+    appCountSummary,
 } from '../run-report-render.js';
 import {
     createRunReport,
@@ -527,5 +529,92 @@ describe('formatters', () => {
         expect(isOptionEnabled('true')).toBe(true);
         expect(isOptionEnabled(false)).toBe(false);
         expect(isOptionEnabled('false')).toBe(false);
+    });
+});
+
+describe('the verdict of an interrupted run (issue #1107)', () => {
+    /**
+     * A report stopped mid-run: one app done, one abandoned in flight, two
+     * never started.
+     *
+     * @returns {object} The report.
+     */
+    const interruptedReport = () => {
+        const report = qseowReport();
+
+        report.apps = [];
+        addAppToReport(report, { id: 'app-1', name: 'Done', sheetCount: 2 }).sheetsUpdated = 2;
+        addAppToReport(report, { id: 'app-2', name: 'Abandoned', sheetCount: 3 }).interrupted =
+            true;
+
+        report.interrupted = { signal: 'SIGINT' };
+        report.appsNotStarted = 2;
+        report.succeeded = false;
+        report.finishedAt = report.startedAt + 4000;
+
+        return report;
+    };
+
+    test('an abandoned app counts as neither ok nor failed', () => {
+        const facts = verdictFacts(interruptedReport());
+
+        expect(facts).toMatchObject({
+            okApps: 1,
+            failedApps: 0,
+            interruptedApps: 1,
+            notStartedApps: 2,
+            interrupted: true,
+        });
+    });
+
+    test('says INTERRUPTED, not FAILED', () => {
+        const lines = renderRunVerdictLines(interruptedReport()).join('\n');
+
+        // The two call for different responses: a failed run is something to
+        // investigate, an interrupted one is something to re-run.
+        expect(lines).toContain('RESULT  INTERRUPTED');
+        expect(lines).not.toContain('FAILED');
+    });
+
+    test('states what is left to re-run', () => {
+        const lines = renderRunVerdictLines(interruptedReport()).join('\n');
+
+        expect(lines).toContain('1 ok, 1 interrupted, 2 not started');
+    });
+
+    test('stays pure ASCII, like every other renderer output', () => {
+        const lines = renderRunVerdictLines(interruptedReport()).join('\n');
+
+        expect(lines).toMatch(PURE_ASCII);
+    });
+
+    test('an ordinary run keeps its 0 failed, which operators grep for', () => {
+        expect(
+            appCountSummary({ okApps: 3, failedApps: 0, interruptedApps: 0, notStartedApps: 0 })
+        ).toBe('3 ok, 0 failed');
+    });
+
+    test('a failed app is still reported alongside an interrupt', () => {
+        expect(
+            appCountSummary({
+                okApps: 1,
+                failedApps: 2,
+                interruptedApps: 1,
+                notStartedApps: 5,
+                interrupted: true,
+            })
+        ).toBe('1 ok, 2 failed, 1 interrupted, 5 not started');
+    });
+
+    test('an uninterrupted report is unchanged', () => {
+        const report = qseowReport();
+        report.succeeded = true;
+
+        const facts = verdictFacts(report);
+
+        expect(facts.interrupted).toBe(false);
+        expect(facts.interruptedApps).toBe(0);
+        expect(facts.notStartedApps).toBe(0);
+        expect(renderRunVerdictLines(report).join('\n')).toContain('RESULT  ok');
     });
 });

--- a/src/lib/util/__tests__/sheet-list.test.js
+++ b/src/lib/util/__tests__/sheet-list.test.js
@@ -1,4 +1,4 @@
-import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+import { jest, describe, test, expect, beforeEach, afterEach } from '@jest/globals';
 
 jest.unstable_mockModule('../../../globals.js', () => ({
     logger: {
@@ -22,6 +22,7 @@ const {
     SHEET_LIST_FIELDS,
     SHEET_LIST_FIELDS_EXTENDED,
 } = await import('../sheet-list.js');
+const { markInterrupted, resetInterruptState } = await import('../interrupt.js');
 
 /**
  * Joins everything logged at error level, for substring assertions.
@@ -30,8 +31,20 @@ const {
  */
 const errorLog = () => logger.error.mock.calls.map((call) => String(call[0])).join('\n');
 
+/**
+ * Joins everything logged at info level, for substring assertions.
+ *
+ * @returns {string} All info lines, newline separated.
+ */
+const infoLog = () => logger.info.mock.calls.map((call) => String(call[0])).join('\n');
+
 beforeEach(() => {
     jest.clearAllMocks();
+    resetInterruptState();
+});
+
+afterEach(() => {
+    resetInterruptState();
 });
 
 /**
@@ -623,5 +636,119 @@ describe('getSheetList', () => {
 
     test('an app with no sheets yields an empty list, not a throw', async () => {
         await expect(getSheetList(appReturning([]))).resolves.toEqual([]);
+    });
+});
+
+describe('runOverSheets when the run is interrupted (issue #1107)', () => {
+    const CTX = {
+        logPrefix: 'TEST PREFIX',
+        appId: 'app-1',
+        action: 'remove icons for',
+        ErrorClass: class TestError extends Error {},
+    };
+
+    test('stops at the sheet boundary rather than writing to more sheets', async () => {
+        // remove-sheet-icons is the one path that writes per sheet, so this
+        // boundary is what keeps the cleared count true.
+        const worker = jest.fn(async (s, n) => {
+            if (n === 2) markInterrupted('SIGINT');
+        });
+
+        const result = await runOverSheets(
+            [sheet('a'), sheet('b'), sheet('c'), sheet('d')],
+            CTX,
+            worker
+        );
+
+        expect(worker).toHaveBeenCalledTimes(2);
+        expect(result.interrupted).toBe(true);
+        expect(result.changed).toBe(2);
+    });
+
+    test('the abandoned sheet is not counted as failed', async () => {
+        const worker = jest.fn(async (s, n) => {
+            if (n !== 2) return undefined;
+            markInterrupted('SIGINT');
+            throw new Error('Protocol error: Target closed');
+        });
+
+        const result = await runOverSheets([sheet('a'), sheet('b'), sheet('c')], CTX, worker);
+
+        expect(result.failed).toBe(0);
+        expect(result.interrupted).toBe(true);
+        expect(errorLog()).toBe('');
+    });
+
+    test('does not blame the engine for a browser the shutdown closed', async () => {
+        // `Target closed` matches isSessionLevelFailure, so without the
+        // interrupt check first this reads as a lost engine session - the
+        // wrong explanation, and the one the operator would act on.
+        const worker = jest.fn(async () => {
+            markInterrupted('SIGINT');
+            throw new Error('Protocol error: Target closed');
+        });
+
+        await runOverSheets([sheet('a'), sheet('b')], CTX, worker);
+
+        expect(errorLog()).not.toContain('Lost the engine session');
+        expect(infoLog()).toContain('abandoned when the run was interrupted');
+    });
+
+    test('assertAllProcessed throws so the app unwinds, saying it was abandoned', async () => {
+        const worker = jest.fn(async (s, n) => {
+            if (n === 2) markInterrupted('SIGINT');
+        });
+
+        const result = await runOverSheets([sheet('a'), sheet('b'), sheet('c')], CTX, worker);
+
+        expect(() => result.assertAllProcessed()).toThrow(/abandoned when the run was interrupted/);
+        // The count is the number the operator needs: how far the removal got.
+        expect(() => result.assertAllProcessed()).toThrow(/2 sheet\(s\) had been processed/);
+    });
+
+    test('a real sheet failure outranks the interrupt', async () => {
+        const worker = jest.fn(async (s, n) => {
+            if (n === 1) throw new Error('sheet is broken');
+            markInterrupted('SIGINT');
+        });
+
+        const result = await runOverSheets([sheet('a'), sheet('b'), sheet('c')], CTX, worker);
+
+        // Both are true, but only one of them is still true after a re-run.
+        // Reported the other way round, an interrupt at sheet 5 erased four
+        // genuine failures at sheets 1-4: the app came back as merely
+        // abandoned, `failedApps` was 0, and the operator re-ran without ever
+        // learning those sheets were broken.
+        expect(result.failed).toBe(1);
+        expect(result.interrupted).toBe(true);
+        expect(() => result.assertAllProcessed()).toThrow(/Failed to remove icons for 1 of/);
+    });
+
+    test('a lost engine session also outranks the interrupt', async () => {
+        const worker = jest.fn(async (s, n) => {
+            if (n === 1) throw new Error('Socket closed');
+            markInterrupted('SIGINT');
+        });
+
+        const result = await runOverSheets([sheet('a'), sheet('b')], CTX, worker);
+
+        expect(() => result.assertAllProcessed()).toThrow(/Socket closed/);
+    });
+
+    test('with nothing broken, the interrupt is what is reported', async () => {
+        const worker = jest.fn(async (s, n) => {
+            if (n === 2) markInterrupted('SIGINT');
+        });
+
+        const result = await runOverSheets([sheet('a'), sheet('b'), sheet('c')], CTX, worker);
+
+        expect(() => result.assertAllProcessed()).toThrow(/abandoned when the run was interrupted/);
+    });
+
+    test('an uninterrupted run is untouched', async () => {
+        const result = await runOverSheets([sheet('a'), sheet('b')], CTX, jest.fn());
+
+        expect(result.interrupted).toBe(false);
+        expect(() => result.assertAllProcessed()).not.toThrow();
     });
 });

--- a/src/lib/util/__tests__/signal-handlers.test.js
+++ b/src/lib/util/__tests__/signal-handlers.test.js
@@ -1,0 +1,434 @@
+import { jest, describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { EventEmitter } from 'node:events';
+
+const emitRunVerdictOnce = jest.fn();
+
+// Mocked so these tests are about the shutdown decisions, not about report
+// rendering - which `run-report.test.js` owns. Importing the real module here
+// would also pull winston in behind the logger this suite replaces.
+jest.unstable_mockModule('../run-report.js', () => ({ emitRunVerdictOnce }));
+
+const {
+    installSignalHandlers,
+    resetSignalHandlerState,
+    INTERRUPT_EXIT_WATCHDOG_MS,
+    HANDLED_SIGNALS,
+    SHOW_CURSOR,
+} = await import('../signal-handlers.js');
+
+const {
+    resetInterruptState,
+    isInterrupted,
+    interruptSignal,
+    interruptAbortSignal,
+    registerInterruptAction,
+    beginInterruptibleRun,
+    endInterruptibleRun,
+} = await import('../interrupt.js');
+
+/**
+ * Every test installs onto a throwaway emitter with an injected `exit` spy, so
+ * nothing here registers a listener on the real `process` or takes the Jest
+ * worker down with it.
+ */
+let target;
+let exit;
+let logger;
+let restoreTerminal;
+let stdout;
+let flushAndExit;
+
+beforeEach(() => {
+    resetSignalHandlerState();
+    resetInterruptState();
+    emitRunVerdictOnce.mockClear();
+
+    target = new EventEmitter();
+    exit = jest.fn();
+    logger = { warn: jest.fn(), info: jest.fn(), error: jest.fn() };
+    restoreTerminal = jest.fn();
+    stdout = { isTTY: true, write: jest.fn() };
+    // Synchronous stand-in for the real drain-then-exit helper, so these tests
+    // stay about the shutdown DECISIONS. The draining itself is deferred by a
+    // `setImmediate` and is covered by flush-exit.test.js.
+    flushAndExit = jest.fn((code, opts) => (opts?.exit ?? exit)(code));
+});
+
+afterEach(() => {
+    resetSignalHandlerState();
+    resetInterruptState();
+    jest.useRealTimers();
+});
+
+/**
+ * Installs the handlers with the shared test doubles.
+ *
+ * @param {object} [overrides] - Dependency overrides.
+ *
+ * @returns {void}
+ */
+const install = (overrides = {}) =>
+    installSignalHandlers({
+        logger,
+        exit,
+        target,
+        restoreTerminal,
+        stdout,
+        flushAndExit,
+        ...overrides,
+    });
+
+/**
+ * The lines the logger was given, joined, for substring assertions.
+ *
+ * @returns {string} All warn and info lines, newline separated.
+ */
+const loggedText = () =>
+    [...logger.warn.mock.calls, ...logger.info.mock.calls].map(([line]) => line).join('\n');
+
+describe('installation', () => {
+    test('listens for every handled signal', () => {
+        install();
+
+        for (const signal of HANDLED_SIGNALS) {
+            expect(target.listenerCount(signal)).toBe(1);
+        }
+    });
+
+    test('handles SIGHUP, or a dropped SSH session orphans the browser', () => {
+        // Node's default disposition for SIGHUP terminates without running
+        // `process.on('exit')` - measured - and that hook is the last thing
+        // that would close a Chromium spawned `detached` into its own process
+        // group. Puppeteer's own SIGHUP handler is switched off at launch, so
+        // this listener is the only remaining cover.
+        expect(HANDLED_SIGNALS).toContain('SIGHUP');
+    });
+
+    test('re-installing replaces rather than stacks listeners', () => {
+        install();
+        install();
+
+        // Two listeners would run the whole shutdown twice.
+        expect(target.listenerCount('SIGINT')).toBe(1);
+    });
+
+    test('a target that cannot take listeners does not throw', () => {
+        const hostile = {
+            /**
+             * Refuses every listener, like a stripped-down SEA environment.
+             *
+             * @returns {void}
+             */
+            on() {
+                throw new Error('no listeners here');
+            },
+        };
+
+        expect(() => install({ target: hostile })).not.toThrow();
+    });
+});
+
+describe('a signal outside a run', () => {
+    test('exits immediately with the signal exit code', () => {
+        install();
+
+        target.emit('SIGINT');
+
+        // Nothing to unwind, no report to wait for. Waiting would make Ctrl-C
+        // look ignored for eight seconds and exit with the same code anyway.
+        expect(exit).toHaveBeenCalledWith(130);
+    });
+
+    test('SIGTERM exits 143', () => {
+        install();
+
+        target.emit('SIGTERM');
+
+        expect(exit).toHaveBeenCalledWith(143);
+    });
+
+    test('restores the terminal before logging', () => {
+        install();
+
+        target.emit('SIGINT');
+
+        // Under the live view the console transport is silenced and the cursor
+        // hidden, so a line logged first would be invisible.
+        expect(restoreTerminal).toHaveBeenCalled();
+        expect(restoreTerminal.mock.invocationCallOrder[0]).toBeLessThan(
+            logger.warn.mock.invocationCallOrder[0]
+        );
+    });
+});
+
+describe('a signal during a run', () => {
+    beforeEach(() => {
+        beginInterruptibleRun();
+    });
+
+    afterEach(() => {
+        endInterruptibleRun();
+    });
+
+    test('does not exit - the run is left to unwind and report', () => {
+        install();
+
+        target.emit('SIGINT');
+
+        expect(exit).not.toHaveBeenCalled();
+    });
+
+    test('records the interrupt and aborts pending sleeps', () => {
+        const abort = interruptAbortSignal();
+        install();
+
+        target.emit('SIGINT');
+
+        expect(isInterrupted()).toBe(true);
+        expect(interruptSignal()).toBe('SIGINT');
+        expect(abort.aborted).toBe(true);
+    });
+
+    test('closes the browser through the teardown registry', () => {
+        const closeBrowser = jest.fn();
+        registerInterruptAction(closeBrowser);
+        install();
+
+        target.emit('SIGINT');
+
+        // Asserted, not assumed: this is the thing that makes every in-flight
+        // Puppeteer await reject, which is what unwinds the run at all.
+        expect(closeBrowser).toHaveBeenCalledTimes(1);
+    });
+
+    test('tells the operator a second Ctrl-C exits at once', () => {
+        install();
+
+        target.emit('SIGINT');
+
+        expect(loggedText()).toContain('press Ctrl-C again to exit immediately');
+    });
+
+    test('a second signal exits immediately, mid-shutdown', () => {
+        install();
+
+        target.emit('SIGINT');
+        expect(exit).not.toHaveBeenCalled();
+
+        target.emit('SIGINT');
+
+        expect(exit).toHaveBeenCalledWith(130);
+        expect(loggedText()).toContain('Second SIGINT');
+    });
+
+    test('a second signal of the other kind also exits, keeping the first code', () => {
+        install();
+
+        target.emit('SIGINT');
+        target.emit('SIGTERM');
+
+        // The first signal owns the shutdown, so it owns the exit code too.
+        expect(exit).toHaveBeenCalledWith(130);
+    });
+
+    test('a second signal emits the verdict before exiting', () => {
+        install();
+
+        target.emit('SIGINT');
+        target.emit('SIGINT');
+
+        expect(emitRunVerdictOnce).toHaveBeenCalled();
+    });
+
+    test('exits at most once however many signals arrive', () => {
+        install();
+
+        target.emit('SIGINT');
+        target.emit('SIGINT');
+        target.emit('SIGINT');
+        target.emit('SIGTERM');
+
+        expect(exit).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('the watchdog', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        beginInterruptibleRun();
+    });
+
+    afterEach(() => {
+        endInterruptibleRun();
+    });
+
+    test('exits if graceful shutdown stalls', () => {
+        install();
+
+        target.emit('SIGTERM');
+        expect(exit).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(INTERRUPT_EXIT_WATCHDOG_MS);
+
+        // `docker stop` sends one signal and nobody is there to send a second,
+        // so this is the only bound on shutdown in a container.
+        expect(exit).toHaveBeenCalledWith(143);
+    });
+
+    test('fires inside docker stop’s ten-second grace period', () => {
+        expect(INTERRUPT_EXIT_WATCHDOG_MS).toBeLessThan(10_000);
+    });
+
+    test('emits the verdict, so a stalled shutdown still reports', () => {
+        install();
+
+        target.emit('SIGINT');
+        jest.advanceTimersByTime(INTERRUPT_EXIT_WATCHDOG_MS);
+
+        expect(emitRunVerdictOnce).toHaveBeenCalled();
+        expect(loggedText()).toContain('Shutdown did not finish');
+    });
+
+    test('is cancelled by a second signal, so the exit happens once', () => {
+        install();
+
+        target.emit('SIGINT');
+        target.emit('SIGINT');
+
+        expect(exit).toHaveBeenCalledTimes(1);
+
+        jest.advanceTimersByTime(INTERRUPT_EXIT_WATCHDOG_MS * 2);
+
+        expect(exit).toHaveBeenCalledTimes(1);
+    });
+
+    test('is cleared on reset, so it cannot outlive the run that armed it', () => {
+        install();
+
+        target.emit('SIGINT');
+        expect(jest.getTimerCount()).toBe(1);
+
+        resetSignalHandlerState();
+
+        // A run that shuts down in two seconds must not sit here for six.
+        // In production the timer is `unref`'d for the same reason; this is
+        // the half of it that is observable in-process.
+        expect(jest.getTimerCount()).toBe(0);
+    });
+});
+
+describe('robustness', () => {
+    test('a logger that throws does not stop the exit', () => {
+        logger.warn.mockImplementation(() => {
+            throw new Error('transport gone');
+        });
+        install();
+
+        target.emit('SIGINT');
+
+        expect(exit).toHaveBeenCalledWith(130);
+    });
+
+    test('a terminal restore that throws does not stop the exit', () => {
+        restoreTerminal.mockImplementation(() => {
+            throw new Error('stdout is gone');
+        });
+        install();
+
+        target.emit('SIGINT');
+
+        expect(exit).toHaveBeenCalledWith(130);
+    });
+
+    test('a verdict that throws does not stop the exit', () => {
+        emitRunVerdictOnce.mockImplementation(() => {
+            throw new Error('renderer blew up');
+        });
+        beginInterruptibleRun();
+        install();
+
+        target.emit('SIGINT');
+        target.emit('SIGINT');
+
+        expect(exit).toHaveBeenCalledWith(130);
+        endInterruptibleRun();
+    });
+});
+
+describe('the terminal is not left worse than it was found', () => {
+    test('the cursor is shown again on the way out', () => {
+        install();
+
+        target.emit('SIGINT');
+
+        // The interactive wizard hides the cursor itself, and nothing in BSI
+        // used to put it back when a signal ended the process - measured on
+        // main. BSI owns that exit now.
+        expect(stdout.write).toHaveBeenCalledWith(SHOW_CURSOR);
+    });
+
+    test('nothing is written when stdout is not a terminal', () => {
+        stdout.isTTY = false;
+        install();
+
+        target.emit('SIGINT');
+
+        // Piped output must not gain an escape sequence.
+        expect(stdout.write).not.toHaveBeenCalled();
+    });
+
+    test('a stream that has gone away does not stop the exit', () => {
+        stdout.write.mockImplementation(() => {
+            throw new Error('EPIPE');
+        });
+        install();
+
+        target.emit('SIGINT');
+
+        expect(exit).toHaveBeenCalledWith(130);
+    });
+
+    test('the cursor is restored on the second-signal path too', () => {
+        beginInterruptibleRun();
+        install();
+
+        target.emit('SIGINT');
+        stdout.write.mockClear();
+        target.emit('SIGINT');
+
+        expect(stdout.write).toHaveBeenCalledWith(SHOW_CURSOR);
+        endInterruptibleRun();
+    });
+});
+
+describe('the exit is flushed, never bare (issue #1107)', () => {
+    test('every exit path goes through the drain helper', () => {
+        install();
+
+        target.emit('SIGINT');
+
+        // A bare `process.exit()` discards stdout's buffer on a pipe, which is
+        // where `docker logs` and CI collectors read from - measured at 333 of
+        // 400 lines delivered, with the verdict block among the losses.
+        expect(flushAndExit).toHaveBeenCalledWith(130, expect.objectContaining({ exit }));
+    });
+
+    test('SIGHUP exits 129 through the same route', () => {
+        install();
+
+        target.emit('SIGHUP');
+
+        expect(flushAndExit).toHaveBeenCalledWith(129, expect.objectContaining({ exit }));
+    });
+
+    test('the second-signal escape is flushed too', () => {
+        beginInterruptibleRun();
+        install();
+
+        target.emit('SIGINT');
+        target.emit('SIGINT');
+
+        expect(flushAndExit).toHaveBeenCalledTimes(1);
+        endInterruptibleRun();
+    });
+});

--- a/src/lib/util/abort-artifact.js
+++ b/src/lib/util/abort-artifact.js
@@ -1,0 +1,67 @@
+/**
+ * Tells an error the shutdown caused from one it merely interrupted.
+ *
+ * Shutdown works by breaking things on purpose: the browser is closed under
+ * the run and pending sleeps are aborted, so whatever the run was awaiting
+ * rejects. Those rejections arrive in the same `catch` blocks a genuine
+ * failure does, and for a while the code told them apart by asking only
+ * whether a signal had been received - which quietly meant "any error
+ * unwinding when the signal landed was the signal's doing".
+ *
+ * That is wrong in the case that matters. An app failing on a real server
+ * error at the moment `docker stop` arrives was filed as abandoned rather than
+ * failed, dropped out of the verdict's failure count, and lost its error line
+ * and cause chain - so a run could end with a real defect that left no trace
+ * anywhere in the output. Deciding per error rather than per run is what fixes
+ * it (issue #1107).
+ *
+ * Recognition is by shape, matching what the two teardown mechanisms actually
+ * produce. That is the same approach - and the same trade - as
+ * `isSessionLevelFailure` in `sheet-list.js`, which this deliberately mirrors
+ * rather than reinventing: a message can always be worded differently by a
+ * future dependency, and the failure mode of a miss is a shutdown that reports
+ * an abandoned app as failed. Noisy, but never silent, which is the direction
+ * to be wrong in.
+ */
+
+/**
+ * Message fragments produced by closing the browser out from under a page.
+ *
+ * Puppeteer rejects every pending protocol call when its connection goes, and
+ * these are the wordings it uses. Lower-cased before matching.
+ */
+const ABORT_MESSAGE_FRAGMENTS = [
+    'target closed',
+    'session closed',
+    'protocol error',
+    'browser has disconnected',
+    'connection closed',
+    'the operation was aborted',
+];
+
+/**
+ * Reports whether an error is one the shutdown itself produced.
+ *
+ * @param {Error|unknown} err - The error to classify.
+ *
+ * @returns {boolean} `true` when this error looks like teardown fallout rather
+ *     than a genuine failure.
+ */
+export const isAbortArtifact = (err) => {
+    // What `sleep()` rejects with once the interrupt controller fires. Exact,
+    // not a guess: this one is a real type, set by Node.
+    if (err?.name === 'AbortError' || err?.code === 'ABORT_ERR') {
+        return true;
+    }
+
+    const message = typeof err?.message === 'string' ? err.message.toLowerCase() : '';
+
+    if (ABORT_MESSAGE_FRAGMENTS.some((fragment) => message.includes(fragment))) {
+        return true;
+    }
+
+    // Errors are wrapped as they travel up - the processors rethrow through
+    // typed platform errors with the original attached - so the shape has to be
+    // looked for down the chain too, not only at the top.
+    return err?.cause ? isAbortArtifact(err.cause) : false;
+};

--- a/src/lib/util/flush-exit.js
+++ b/src/lib/util/flush-exit.js
@@ -1,0 +1,146 @@
+/**
+ * Exit the process without throwing away buffered output.
+ *
+ * `process.exit()` is immediate and unsentimental: it discards whatever is
+ * still sitting in a stream's internal buffer. On a TTY that is invisible,
+ * because writes to a terminal are synchronous - which is exactly why this is
+ * so easy to ship. On a **pipe** they are not, and a pipe is what
+ * `docker logs`, a CI log collector and `bsi ... | tee run.log` all are.
+ *
+ * Measured on Node 24 against a reader lagging one second: 400 lines followed
+ * by `process.exit(130)` delivered 333 of them and lost the final report
+ * block entirely; the identical program that let the process end naturally
+ * delivered all 400 plus the report. So on the one path where the report
+ * matters most - `docker stop` on a container - a bare exit throws away the
+ * thing the run was interrupted to produce.
+ *
+ * The codebase already knows this. `browser/check.js` and `doctor/check.js`
+ * both carry the rule: set `process.exitCode` "rather than calling
+ * `process.exit()`, so winston flushes the report that explains it. A hard
+ * exit would truncate it."
+ *
+ * The catch is that an interrupted run cannot simply return and let Node
+ * drain, which is what those two commands do: Puppeteer and enigma leave
+ * handles behind that can hold the event loop open indefinitely, and a
+ * shutdown that hangs is worse than one that truncates. So this does both -
+ * drain first, exit second, and never wait longer than
+ * {@link FLUSH_TIMEOUT_MS}.
+ *
+ * Imports nothing, so the signal path and the entry point can both use it
+ * without pulling the module graph in behind them.
+ */
+
+/**
+ * How long (ms) to wait for buffered output to reach the far end.
+ *
+ * Deliberately short. It is bounded by `docker stop`'s ten-second window,
+ * which the interrupt watchdog has already spent most of by the time this can
+ * run, and by the fact that a reader which has genuinely gone away will never
+ * call the drain callback at all - the timer is the only thing that ends that
+ * case.
+ */
+export const FLUSH_TIMEOUT_MS = 2000;
+
+/**
+ * Flush the given streams, then exit.
+ *
+ * A zero-length write is the documented way to ask a Node stream "call me when
+ * everything queued ahead of this has been handed to the OS". Streams with an
+ * empty buffer are skipped, so the common case - a TTY, where writes already
+ * completed synchronously - exits on the same tick and Ctrl-C stays instant.
+ *
+ * `setImmediate` first, because winston hands its lines to the stream from a
+ * stream callback of its own: without one turn of the event loop the last log
+ * line may not have reached `process.stdout` yet, and draining would then
+ * report success while the line the operator needs is still upstream.
+ *
+ * @param {number} code - Exit code.
+ * @param {object} [options] - Overrides, all optional; injectable for tests.
+ * @param {Array<import('node:stream').Writable>} [options.streams] - Streams to drain.
+ *     Defaults to `process.stdout` and `process.stderr`.
+ * @param {Function} [options.exit] - Exit function. Defaults to `process.exit`.
+ * @param {number} [options.timeoutMs] - Drain deadline. Defaults to {@link FLUSH_TIMEOUT_MS}.
+ *
+ * @returns {void}
+ */
+export const flushAndExit = (
+    code,
+    {
+        streams = [process.stdout, process.stderr],
+        /**
+         * Default exit function: terminate the process with the given code.
+         *
+         * @param {number} exitCode - Process exit code.
+         *
+         * @returns {void}
+         */
+        exit = (exitCode) => process.exit(exitCode),
+        timeoutMs = FLUSH_TIMEOUT_MS,
+    } = {}
+) => {
+    // Set as well as passed, so that if anything below fails badly enough to
+    // leave the process to end on its own, it still ends with the right code.
+    process.exitCode = code;
+
+    let finished = false;
+
+    /**
+     * Exit, at most once, however we got here.
+     *
+     * @returns {void}
+     */
+    const finish = () => {
+        if (finished) return;
+        finished = true;
+        exit(code);
+    };
+
+    let timer = null;
+    try {
+        // Armed before the drains, and `unref`'d so it can never by itself keep
+        // a process alive that is otherwise ready to go. A reader that has
+        // vanished never calls its callback; this is what ends that case.
+        timer = setTimeout(finish, timeoutMs);
+        if (typeof timer.unref === 'function') timer.unref();
+    } catch {
+        // Without a timer the drain callbacks are the only route out. They
+        // fire in every case except a dead reader.
+    }
+
+    setImmediate(() => {
+        let pending = 0;
+
+        /**
+         * One stream finished draining.
+         *
+         * @returns {void}
+         */
+        const drained = () => {
+            pending -= 1;
+            if (pending === 0) {
+                if (timer) clearTimeout(timer);
+                finish();
+            }
+        };
+
+        for (const stream of streams) {
+            try {
+                // Nothing queued means nothing to wait for - the TTY case.
+                if (!stream || stream.writableEnded || !(stream.writableLength > 0)) {
+                    continue;
+                }
+                pending += 1;
+                stream.write('', drained);
+            } catch {
+                // A stream that cannot take a write is one we cannot flush.
+                // Do not let it hold up the exit.
+                if (pending > 0) pending -= 1;
+            }
+        }
+
+        if (pending === 0) {
+            if (timer) clearTimeout(timer);
+            finish();
+        }
+    });
+};

--- a/src/lib/util/interrupt.js
+++ b/src/lib/util/interrupt.js
@@ -1,0 +1,295 @@
+/**
+ * Process-wide interrupt state for Butler Sheet Icons (issue #1107).
+ *
+ * A signal cannot be thrown into an in-flight promise. Ctrl-C arrives on a
+ * synchronous listener while the run is parked on a Puppeteer round trip or a
+ * `--pagewait` sleep somewhere twenty frames down, and there is no way to
+ * inject a rejection into that await from the outside. So the shutdown works
+ * the only way it can: the signal makes the things being awaited fail, and the
+ * run unwinds through the error paths that already exist.
+ *
+ * This module is the shared state that makes that possible. It holds three
+ * things and nothing else:
+ *
+ *   - **The flag.** Whether a signal has arrived, and which one. The two app
+ *     loops read it at their boundaries to stop starting new work, and the
+ *     report reads it to record an abandoned app as interrupted rather than
+ *     failed.
+ *   - **An `AbortController`.** `sleep()` in `globals.js` binds to its signal,
+ *     so a pending `--pagewait` rejects the moment the flag is set instead of
+ *     running out its clock. Without this, shutdown waits for whatever the
+ *     operator set `--pagewait` to - fine at the default 5s, past `docker
+ *     stop`'s ten-second grace period at the values operators are told to use.
+ *   - **A registry of teardown actions.** `launchBrowserForApp` registers a
+ *     browser close here, so the signal handler can reach a browser that lives
+ *     in a local variable inside a processor. This mirrors the active-view
+ *     registry in `run-live.js`, which exists for the same reason: a deep site
+ *     has to be reachable without threading a handle through every signature
+ *     between here and there.
+ *
+ * ## Why this is a leaf module
+ *
+ * It imports nothing - not even the logger. `globals.js` has to import it, for
+ * `sleep`, and the signal handler has to import `globals.js`, for the logger.
+ * Putting the state and the handler in one module would close that loop. The
+ * split keeps the dependency one-way: `interrupt.js` <- `globals.js`, and
+ * `interrupt.js` + `globals.js` <- `signal-handlers.js`.
+ *
+ * Everything user-visible - installing the listeners, the log lines, the
+ * watchdog, the exit - lives in `signal-handlers.js`.
+ */
+
+// ---------------------------------------------------------------------------
+// Exit codes
+// ---------------------------------------------------------------------------
+
+/**
+ * Exit code per signal: 128 + the signal number, the status a shell reports for
+ * any process killed by that signal.
+ *
+ * `SIGHUP` gets 129 on the same rule (128 + 1): a dropped SSH session or a
+ * closed terminal window ends the run, and a scheduler reading the code should
+ * see that it was stopped rather than that it failed.
+ *
+ * This follows the signal convention rather than the graded run-outcome table
+ * in issue #1090, and deliberately so: an interrupted run has no outcome to
+ * grade. It did not succeed, it did not fail, it was stopped - and a scheduler
+ * that sees 130 knows a human pressed Ctrl-C, which is the one thing the graded
+ * codes cannot express. `fatal-handlers.js` already sets the precedent with
+ * `BROKEN_PIPE_EXIT_CODE = 141` (128 + SIGPIPE).
+ *
+ * Exit codes are a versioned public interface under issue #1101, so these two
+ * numbers cannot change without a major release.
+ */
+export const INTERRUPT_EXIT_CODES = Object.freeze({
+    SIGINT: 130,
+    SIGTERM: 143,
+    SIGHUP: 129,
+});
+
+/** Used when the signal name is not one of the two above. */
+const DEFAULT_INTERRUPT_EXIT_CODE = 130;
+
+// ---------------------------------------------------------------------------
+// Module-level state
+// ---------------------------------------------------------------------------
+
+/** The signal that interrupted the run, or null while it has not been. */
+let interruptingSignal = null;
+
+/**
+ * Aborted when the first signal arrives. Recreated by `resetInterruptState()`
+ * so each test starts with a controller that has not already fired.
+ */
+let controller = new AbortController();
+
+/**
+ * Teardown actions to run on the way out, newest first when they fire.
+ *
+ * A `Set` rather than an array so an action removed by its own unregister thunk
+ * cannot be removed twice, and so registration order is preserved for the rare
+ * case where two browsers are open at once.
+ *
+ * @type {Set<Function>}
+ */
+const actions = new Set();
+
+/**
+ * Depth of open interruptible runs. A counter rather than a boolean because
+ * nesting is cheap to allow and impossible to reason about once it happens by
+ * accident.
+ */
+let openRuns = 0;
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+/**
+ * Records that a signal arrived, and aborts everything bound to the shared
+ * controller.
+ *
+ * Idempotent: the first signal owns the shutdown, and a second one must not
+ * re-abort or overwrite which signal is being reported. `signal-handlers.js`
+ * checks {@link isInterrupted} before calling this and takes the force-exit
+ * path instead, so the guard here is a backstop rather than the mechanism.
+ *
+ * @param {string} signal - The signal name, e.g. `'SIGINT'`.
+ *
+ * @returns {boolean} `true` if this call was the one that set the flag.
+ */
+export const markInterrupted = (signal) => {
+    if (interruptingSignal !== null) {
+        return false;
+    }
+
+    interruptingSignal = signal;
+
+    try {
+        controller.abort();
+    } catch {
+        // An AbortController that cannot abort leaves the flag set, which is
+        // what the loop boundaries read. Sleeps run out their clock; the
+        // watchdog still bounds the shutdown.
+    }
+
+    return true;
+};
+
+/**
+ * Whether a signal has arrived. Read at every loop boundary and by the report.
+ *
+ * @returns {boolean} `true` once the run has been interrupted.
+ */
+export const isInterrupted = () => interruptingSignal !== null;
+
+/**
+ * The signal that interrupted the run.
+ *
+ * @returns {string|null} The signal name, or null if the run was not interrupted.
+ */
+export const interruptSignal = () => interruptingSignal;
+
+/**
+ * The exit code for the signal that interrupted the run.
+ *
+ * @returns {number} 130 for SIGINT, 143 for SIGTERM, 130 for anything else.
+ */
+export const interruptExitCode = () =>
+    INTERRUPT_EXIT_CODES[interruptingSignal] ?? DEFAULT_INTERRUPT_EXIT_CODE;
+
+/**
+ * The `AbortSignal` that fires when the run is interrupted.
+ *
+ * Read fresh on every call rather than exported as a value: `resetInterruptState()`
+ * replaces the controller, and a module that captured the signal at import time
+ * would hold the previous test's aborted one forever.
+ *
+ * @returns {AbortSignal} The shared abort signal.
+ */
+export const interruptAbortSignal = () => controller.signal;
+
+// ---------------------------------------------------------------------------
+// Teardown actions
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs one teardown action, swallowing everything it does wrong.
+ *
+ * @param {Function} action - The action to run.
+ *
+ * @returns {void}
+ */
+const runOneAction = (action) => {
+    try {
+        // Not awaited, and a rejection is swallowed here rather than left to
+        // the `unhandledRejection` handler - which would write a crash dump for
+        // a browser that failed to close during a shutdown the operator asked
+        // for.
+        Promise.resolve(action()).catch(() => {});
+    } catch {
+        // A synchronous throw from a teardown action must not stop the
+        // remaining ones from running.
+    }
+};
+
+/**
+ * Registers a teardown action to run when a signal arrives.
+ *
+ * The action is what actually unblocks the run - closing the browser makes
+ * every in-flight Puppeteer await reject, which is the fastest route out and
+ * the one that reuses `closeBrowserQuietly`. It may return a promise; the
+ * signal handler does not await it, because the handler is synchronous and the
+ * unwinding it triggers is the thing that has to happen next.
+ *
+ * Registering after the interrupt has already been recorded runs the action
+ * immediately: a browser launched during shutdown would otherwise be stranded
+ * with nothing left to close it.
+ *
+ * @param {Function} action - Teardown to run on interrupt. Must not throw.
+ *
+ * @returns {() => void} Unregisters the action. Safe to call more than once.
+ */
+export const registerInterruptAction = (action) => {
+    if (isInterrupted()) {
+        runOneAction(action);
+        return () => {};
+    }
+
+    actions.add(action);
+
+    return () => {
+        actions.delete(action);
+    };
+};
+
+/**
+ * Runs every registered teardown action and clears the registry.
+ *
+ * @returns {number} How many actions were run.
+ */
+export const runInterruptActions = () => {
+    const pending = [...actions];
+    actions.clear();
+
+    for (const action of pending) {
+        runOneAction(action);
+    }
+
+    return pending.length;
+};
+
+// ---------------------------------------------------------------------------
+// Interruptible run regions
+// ---------------------------------------------------------------------------
+
+/**
+ * Opens an interruptible region: a stretch of work that can shut down
+ * gracefully and has a report to render on the way out.
+ *
+ * Only `runOverAppsWithReport` opens one, which is the point. A signal arriving
+ * anywhere else - the interactive wizard, `browser install`, `doctor` - has
+ * nothing to unwind and no report to wait for, so the handler exits at once
+ * instead of leaving the operator staring at a terminal that ignored their
+ * Ctrl-C until a watchdog fired.
+ *
+ * @returns {void}
+ */
+export const beginInterruptibleRun = () => {
+    openRuns += 1;
+};
+
+/**
+ * Closes an interruptible region. Belongs in a `finally`.
+ *
+ * @returns {void}
+ */
+export const endInterruptibleRun = () => {
+    openRuns = Math.max(0, openRuns - 1);
+};
+
+/**
+ * Whether any interruptible region is open.
+ *
+ * @returns {boolean} `true` when a graceful shutdown is worth waiting for.
+ */
+export const hasInterruptibleWork = () => openRuns > 0;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/**
+ * Clears every piece of state in this module.
+ *
+ * Exists for tests, which need a clean slate between cases. Production code
+ * never resets: by the time the flag is set, the process is on its way out.
+ *
+ * @returns {void}
+ */
+export const resetInterruptState = () => {
+    interruptingSignal = null;
+    controller = new AbortController();
+    actions.clear();
+    openRuns = 0;
+};

--- a/src/lib/util/run-board.js
+++ b/src/lib/util/run-board.js
@@ -567,11 +567,24 @@ export const stripForApp = (appEntry, symbols) => {
                 : capturedCell
             : (glyphFor[sheet.action] ?? failedCell);
 
-    const count = Math.max(
-        typeof appEntry.sheetCount === 'number' ? appEntry.sheetCount : 0,
-        appEntry.sheets.length,
-        ...appEntry.sheets.map(positionOf)
-    );
+    // The gap-fill length. Sheets are recorded only once their capture has
+    // succeeded, so any position up to `sheetCount` without a row is a sheet
+    // that was reached and did not work - painted failed, which is the point.
+    //
+    // An app abandoned mid-run is the one case where that reading is wrong
+    // (issue #1107): its remaining sheets were never attempted, and painting
+    // them failed would show a wall of failures for a run the operator
+    // stopped, and count them into the verdict legend's "not processed".
+    // Clipped at the last recorded sheet instead - the same rule
+    // `renderSheetStrip` applies to the live view's in-progress app, for
+    // exactly the same reason.
+    const count = appEntry.interrupted
+        ? Math.max(appEntry.sheets.length, 0, ...appEntry.sheets.map(positionOf))
+        : Math.max(
+              typeof appEntry.sheetCount === 'number' ? appEntry.sheetCount : 0,
+              appEntry.sheets.length,
+              ...appEntry.sheets.map(positionOf)
+          );
 
     const cells = Array.from({ length: count }, () => failedCell);
     appEntry.sheets.forEach((sheet, i) => {
@@ -644,7 +657,24 @@ export const renderSheetStrip = (appEntry, ctx, limit = Infinity) =>
 export const renderBoardAppRow = (appEntry, { n, total, removal }, ctx) => {
     const { palette, symbols } = ctx;
 
-    const marker = appEntry.failed ? palette.red(symbols.failed) : palette.green(symbols.done);
+    // Three states, not two (issue #1107): an app abandoned mid-run gets the
+    // warning marker, because a green tick would claim work that never
+    // happened and a red cross would report a failure that never occurred.
+    //
+    // Padded to the width of the done/failed pair before it is coloured.
+    // `symbols.warning` is contact-sheet furniture - `!` in BOTH sets - while
+    // the ASCII markers are `[ok]` and `[!!]`, four columns each; dropping it
+    // in raw shifted the whole row three columns left on Windows conhost and
+    // any runner without unicode, which is exactly where `docker stop` and
+    // SIGTERM are the normal way a run ends. Padded plain, coloured after,
+    // for the standing reason that ANSI codes count as width otherwise.
+    const markerWidth = Math.max(width(symbols.done), width(symbols.failed));
+    const pad = (glyph) => glyph + ' '.repeat(Math.max(0, markerWidth - width(glyph)));
+    const marker = appEntry.interrupted
+        ? palette.yellow(pad(symbols.warning))
+        : appEntry.failed
+          ? palette.red(pad(symbols.failed))
+          : palette.green(pad(symbols.done));
 
     const counter = padTo(`${n}/${total}`, width(`${total}/${total}`));
     const name = padTo(clip(appEntry.name ?? appEntry.id ?? '', NAME_WIDTH), NAME_WIDTH);
@@ -712,7 +742,13 @@ export const renderBoardVerdict = (report, ctx) => {
     const counts = verdictCounts(report);
 
     const parts = [];
-    if (report.succeeded) {
+    if (facts.interrupted) {
+        // Yellow, not red: the run was stopped, not broken, and the two ask
+        // the operator for completely different things (issue #1107).
+        parts.push(
+            palette.yellow('INTERRUPTED') + (elapsed ? ` ${palette.dim(`after ${elapsed}`)}` : '')
+        );
+    } else if (report.succeeded) {
         parts.push(palette.green(elapsed ? `done in ${elapsed}` : 'done'));
     } else {
         parts.push(palette.red('FAILED') + (elapsed ? ` ${palette.dim(`after ${elapsed}`)}` : ''));
@@ -720,6 +756,17 @@ export const renderBoardVerdict = (report, ctx) => {
     parts.push(`${facts.okApps} app(s) ok`);
     if (facts.failedApps > 0) {
         parts.push(palette.red(`${facts.failedApps} failed`));
+    }
+    if (facts.interruptedApps > 0) {
+        // The same word the plain verdict uses. They disagreed - `abandoned`
+        // here, `interrupted` there - which meant the count most operators
+        // actually see (board is the default rung on a real terminal) was not
+        // the one the docs and any log matcher were written against.
+        parts.push(palette.yellow(`${facts.interruptedApps} interrupted`));
+    }
+    if (facts.notStartedApps > 0) {
+        // The number to act on: this is what a re-run has left to do.
+        parts.push(palette.yellow(`${facts.notStartedApps} not started`));
     }
 
     if (removal) {

--- a/src/lib/util/run-over-apps.js
+++ b/src/lib/util/run-over-apps.js
@@ -1,4 +1,6 @@
 import { logger } from '../../globals.js';
+import { isInterrupted } from './interrupt.js';
+import { isAbortArtifact } from './abort-artifact.js';
 
 /**
  * Runs a per-app worker over a list of app IDs, isolating each app from the others and
@@ -40,6 +42,9 @@ import { logger } from '../../globals.js';
  *
  * @returns {Promise<boolean>} `true` only when at least one app was selected and every one
  *     of them was processed without error. An empty selection is a failure, not a no-op.
+ *     An interrupted run can still return `true` - nothing failed, the run simply stopped
+ *     early - so `runOverAppsWithReport` overrides the verdict for that case rather than
+ *     letting a stopped run exit 0.
  */
 export const runOverApps = async (
     appIds,
@@ -63,8 +68,23 @@ export const runOverApps = async (
 
     let failed = 0;
     let appNumber = 0;
+    let abandoned = 0;
 
     for (const appId of uniqueAppIds) {
+        // The app boundary is where an interrupted run stops (issue #1107).
+        // Checked before the banner line, so the log never announces an app
+        // that was never touched - and before any write, which is the whole
+        // point: every app past this line is one the operator can be told was
+        // left exactly as it was.
+        if (isInterrupted()) {
+            const notStarted = uniqueAppIds.length - appNumber;
+            logger.info('');
+            logger.info(
+                `Interrupted: stopping here. ${notStarted} of ${uniqueAppIds.length} app(s) were not started.`
+            );
+            break;
+        }
+
         appNumber += 1;
         try {
             // Countable, and printed before the worker runs, so a run that
@@ -80,6 +100,29 @@ export const runOverApps = async (
 
             logger.verbose(`Done processing app ${appId}`);
         } catch (err) {
+            // An app that was in flight when the signal arrived lands here
+            // too: shutdown closes the browser under it, so its next await
+            // rejects exactly like a real failure. It is not one, and must not
+            // be counted as one - an operator who pressed Ctrl-C and reads
+            // `1 failed` goes looking for a broken app that does not exist.
+            // Reported at `info` with the cause still attached, because the
+            // detail is occasionally worth having and never worth an error
+            // line.
+            //
+            // Both halves of the condition matter. The flag alone said "any
+            // error that happens to be unwinding when a signal lands is the
+            // signal's doing" - so an app failing on a real server error at the
+            // moment `docker stop` arrived was filed as abandoned, and its
+            // failure vanished from the verdict entirely. `isAbortArtifact`
+            // asks whether THIS error is one we caused.
+            if (isInterrupted() && isAbortArtifact(err)) {
+                abandoned += 1;
+                logger.info(
+                    `Interrupted while processing app ${appId} - it was abandoned: ${err?.message ?? err}`
+                );
+                continue;
+            }
+
             failed += 1;
             logger.error(`${logPrefix}: Failed to process app ${appId}: ${err?.message ?? err}`);
         }
@@ -87,6 +130,10 @@ export const runOverApps = async (
 
     if (failed > 0) {
         logger.error(`Failed to process ${failed} of ${uniqueAppIds.length} app(s)`);
+    }
+
+    if (abandoned > 0) {
+        logger.info(`Abandoned ${abandoned} app(s) that were being processed when the run stopped`);
     }
 
     return failed === 0;

--- a/src/lib/util/run-report-render.js
+++ b/src/lib/util/run-report-render.js
@@ -554,15 +554,61 @@ export const verdictCounts = (report) => {
 export const verdictFacts = (report) => {
     const failedApps = report.apps.filter((app) => app.failed).length;
 
+    // An app abandoned mid-run is neither ok nor failed (issue #1107). Counted
+    // out of `okApps` as well as out of `failedApps`, or an interrupted run
+    // would claim to have finished an app it stopped halfway through.
+    const interruptedApps = report.apps.filter((app) => app.interrupted).length;
+
     return {
-        okApps: report.apps.length - failedApps,
+        okApps: report.apps.length - failedApps - interruptedApps,
         failedApps,
+        interruptedApps,
+        interrupted: Boolean(report.interrupted),
+        notStartedApps: report.appsNotStarted ?? 0,
         emptySelection: (report.selection?.total ?? 0) === 0 && report.apps.length === 0,
         sheetsUpdated: sumAppField(report, 'sheetsUpdated'),
         imagesKeptFiles: sumAppField(report, 'imagesKeptFiles'),
         imagesKeptBytes: sumAppField(report, 'imagesKeptBytes'),
         mediaFilesDeleted: sumAppField(report, 'mediaFilesDeleted'),
     };
+};
+
+/**
+ * The `apps` line's counts, as one string.
+ *
+ * A shared builder for the same reason `verdictFacts` and `describeWrites`
+ * are: the plain verdict and the board verdict must never be able to disagree
+ * about how many apps were done. The two interrupt counts appear only when
+ * they are non-zero, so an ordinary run's line is unchanged.
+ *
+ * `not started` is the number that matters after a Ctrl-C - it is what is left
+ * to re-run - and it is deliberately distinct from `interrupted`, which is the
+ * single app that was in flight.
+ *
+ * @param {object} facts - From {@link verdictFacts}.
+ *
+ * @returns {string} e.g. `7 ok, 1 interrupted, 4 not started`.
+ */
+export const appCountSummary = (facts) => {
+    const parts = [`${facts.okApps} ok`];
+
+    if (facts.failedApps > 0) {
+        parts.push(`${facts.failedApps} failed`);
+    } else if (!facts.interrupted) {
+        // Kept unconditionally on an ordinary run: `0 failed` is the shape
+        // every existing run has printed, and operators grep for it.
+        parts.push('0 failed');
+    }
+
+    if (facts.interruptedApps > 0) {
+        parts.push(`${facts.interruptedApps} interrupted`);
+    }
+
+    if (facts.notStartedApps > 0) {
+        parts.push(`${facts.notStartedApps} not started`);
+    }
+
+    return parts.join(', ');
 };
 
 /**
@@ -579,9 +625,14 @@ export const verdictFacts = (report) => {
  * @returns {string[]} The block's lines.
  */
 export const renderRunVerdictLines = (report) => {
-    const lines = ['', `RESULT  ${report.succeeded ? 'ok' : 'FAILED'}`];
-
     const facts = verdictFacts(report);
+
+    // INTERRUPTED rather than FAILED, because they call for different
+    // responses: a failed run is something to investigate, an interrupted one
+    // is something to re-run (issue #1107). The counts below say how much of
+    // it is left to re-run.
+    const result = facts.interrupted ? 'INTERRUPTED' : report.succeeded ? 'ok' : 'FAILED';
+    const lines = ['', `RESULT  ${result}`];
 
     if (facts.emptySelection) {
         lines.push(row('apps', '0 selected - nothing was done'));
@@ -590,7 +641,7 @@ export const renderRunVerdictLines = (report) => {
         return lines;
     }
 
-    lines.push(row('apps', `${facts.okApps} ok, ${facts.failedApps} failed`));
+    lines.push(row('apps', appCountSummary(facts)));
 
     const { seen, captured, blurred, excluded, cleared, noIcon } = verdictCounts(report);
 

--- a/src/lib/util/run-report.js
+++ b/src/lib/util/run-report.js
@@ -25,6 +25,13 @@ import {
 } from './run-live.js';
 import { toOptionValueList } from './option-values.js';
 import { measureImageFiles } from './image-dir.js';
+import {
+    isInterrupted,
+    interruptSignal,
+    beginInterruptibleRun,
+    endInterruptibleRun,
+} from './interrupt.js';
+import { isAbortArtifact } from './abort-artifact.js';
 
 /**
  * The run report: one object holding what a run resolved and decided, read by
@@ -489,6 +496,81 @@ const markAppFailed = (report, appId) => {
 };
 
 /**
+ * Mark the app that was in flight when the signal arrived (issue #1107).
+ *
+ * Not the same as failing it, and the distinction is the point. Shutdown works
+ * by closing the browser under the run, so the app's last await rejects and it
+ * arrives in the same catch a genuinely broken app would - identical from
+ * there, and counted identically unless something says otherwise. An operator
+ * reading `1 failed` after pressing Ctrl-C would go looking for a problem with
+ * that app, and there is none: it was abandoned, and on both platforms an
+ * abandoned app is left exactly as it was, because every write happens after
+ * the capture loop the interrupt cut short.
+ *
+ * `remove-sheet-icons` is the exception worth knowing about: it writes per
+ * sheet, so an app interrupted there is genuinely part-cleared. It is still
+ * `interrupted` rather than `failed` - nothing went wrong - and the verdict's
+ * cleared count says how far it got.
+ *
+ * @param {object} report - The report.
+ * @param {string} appId - The app that was abandoned.
+ *
+ * @returns {void}
+ */
+const markAppInterrupted = (report, appId) => {
+    const entry = report.apps.find((app) => app.id === appId);
+
+    if (entry) {
+        entry.interrupted = true;
+    } else {
+        addAppToReport(report, { id: appId }).interrupted = true;
+    }
+};
+
+/**
+ * Mark the app the loop is currently inside, and clear it on the way out.
+ *
+ * The report needs to know which app was in flight when a signal landed, and
+ * only the loop can say: by the time `stampInterruptOutcome` runs, on the
+ * watchdog and second-signal paths, the worker has not returned and no other
+ * field distinguishes "still running" from "finished". Inferring it from a
+ * timing field is what this replaced, and that inference was wrong for dry
+ * runs and one refactor away from being wrong for real ones (issue #1107).
+ *
+ * A no-op until the processor has created the entry. That is not a gap: an app
+ * abandoned before it recorded anything has nothing to report about either, and
+ * `appsNotStarted` accounts for it.
+ *
+ * @param {object} report - The report.
+ * @param {string} appId - The app now being processed.
+ *
+ * @returns {void}
+ */
+const markAppInFlight = (report, appId) => {
+    const entry = report.apps.find((app) => app.id === appId);
+
+    if (entry) {
+        entry.inFlight = true;
+    }
+};
+
+/**
+ * Clear the in-flight mark. Belongs in a `finally`.
+ *
+ * @param {object} report - The report.
+ * @param {string} appId - The app that has finished, however it finished.
+ *
+ * @returns {void}
+ */
+const clearAppInFlight = (report, appId) => {
+    const entry = report.apps.find((app) => app.id === appId);
+
+    if (entry) {
+        entry.inFlight = false;
+    }
+};
+
+/**
  * Record how the app selection resolved.
  *
  * The provenance counts are the cheap line #993 asks for: "the tag matched 40
@@ -567,6 +649,8 @@ export const addAppToReport = (report, { id, name, sheetCount }) => {
         sheets: [],
         mediaFilesToDelete: null,
         failed: false,
+        interrupted: false,
+        inFlight: false,
     };
     report.apps.push(entry);
 
@@ -816,6 +900,114 @@ export const recordPlannedSheet = (
 };
 
 /**
+ * Stamp the interrupt facts onto the report, if the run was interrupted.
+ *
+ * Called from {@link emitRunVerdictOnce} rather than only after the app loop,
+ * because the loop is exactly what does not return on two of the three paths
+ * that reach the verdict: a second signal and the shutdown watchdog both render
+ * while the run is still in flight. Doing it in one place is what stops the
+ * watchdog's report saying `FAILED` and counting the app it caught mid-flight
+ * as `ok` - which is what it did before this moved here.
+ *
+ * Idempotent, so the ordinary path calling it before the verdict and a signal
+ * path calling it again cannot double-count.
+ *
+ * @param {object} report - The report.
+ * @param {number} totalApps - Size of the deduplicated selection the loop walked.
+ *
+ * @returns {void}
+ */
+const stampInterruptOutcome = (report, totalApps) => {
+    if (!isInterrupted() || report.interrupted) {
+        return;
+    }
+
+    // Read from the flag the loop sets and clears around each app, not
+    // inferred. This used to test `typeof app.durationMs !== 'number'`, which
+    // was wrong for dry runs - only the real-run worker stamps a duration, so
+    // every fully-planned app looked like it was still in flight and an
+    // interrupted dry run reported `0 ok, N interrupted`. It was fragile for
+    // real runs too: the day anyone stamps `durationMs` at app *start* for a
+    // live elapsed timer, every abandoned app would silently become `ok`.
+    // The loop knows which app it is in; asking it is one line and cannot rot.
+    for (const app of report.apps) {
+        if (app.inFlight && !app.failed) {
+            app.interrupted = true;
+        }
+    }
+
+    report.interrupted = { signal: interruptSignal() };
+    report.appsNotStarted = Math.max(0, (totalApps ?? report.apps.length) - report.apps.length);
+
+    // Not a success whatever the loop counted: it broke off before reaching
+    // the apps it was asked to process, and the exit code says 130/143.
+    report.succeeded = false;
+};
+
+/**
+ * The run whose verdict has not been emitted yet, and the rung and board
+ * context it must be emitted on.
+ *
+ * A module-level registry, exactly like the active live view in `run-live.js`
+ * and for the same reason: the signal handler has to reach the run report, and
+ * it lives in a local inside `runOverAppsWithReport` fifteen frames below where
+ * the signal arrives.
+ *
+ * @type {{report: object, rung: string, ctx: object|null}|null}
+ */
+let pendingVerdict = null;
+
+/**
+ * Emit the run verdict, at most once per run (issue #1107).
+ *
+ * Three paths can reach the end of an interrupted run, and exactly one verdict
+ * must be printed whichever gets there first:
+ *
+ *   - the run unwinds normally and `runOverAppsWithReport` finishes;
+ *   - the operator sends a second signal while it is still unwinding;
+ *   - the shutdown watchdog fires because the unwinding stalled.
+ *
+ * The registry is cleared before the block is rendered, not after, so a render
+ * that throws still cannot produce a second verdict on a later call.
+ *
+ * @returns {boolean} `true` if this call emitted the verdict.
+ */
+export const emitRunVerdictOnce = () => {
+    const pending = pendingVerdict;
+
+    if (!pending) {
+        return false;
+    }
+
+    pendingVerdict = null;
+
+    const { report, rung, ctx, totalApps } = pending;
+
+    // The interrupt paths reach here with the run still in flight, so the
+    // fields the renderers read may not have been stamped yet.
+    report.finishedAt ??= Date.now();
+    stampInterruptOutcome(report, totalApps);
+    report.succeeded ??= false;
+
+    // The animated region is erased and the cursor restored before the
+    // verdict renders, so it goes to a quiet terminal through the ordinary
+    // board path. A no-op when the signal handler already restored it.
+    activeLiveView()?.stop();
+
+    emitBlockOnRung({
+        rung,
+        plainEmit: () => {
+            for (const line of renderRunVerdictLines(report)) {
+                logger.info(line);
+            }
+        },
+        renderBoardBlock: () => renderBoardVerdict(report, ctx),
+    });
+
+    return true;
+};
+
+/**
  * The report-carrying app loop every dry-run-capable worker shares: build the
  * report, record the selection and the plan, render the plan block, run the
  * loop against the planner or the processor, and render the verdict.
@@ -908,79 +1100,148 @@ export const runOverAppsWithReport = async ({
 
     const removal = isRemovalReport(report);
 
-    const result = await runOverApps(
-        appIds,
-        {
-            logPrefix: dryRun ? logPrefix.plan : logPrefix.process,
-            action: dryRun ? 'plan' : 'process',
-            emptySelectionHint,
-        },
-        dryRun
-            ? async (appId) => {
-                  try {
-                      return await planApp(appId, report);
-                  } catch (err) {
-                      // A planner that failed after recording its rows would
-                      // otherwise render as a clean, fully-planned app - on
-                      // the mode whose report is the entire product.
-                      markAppFailed(report, appId);
-                      throw err;
-                  }
-              }
-            : async (appId, position) => {
-                  const appStartedAt = Date.now();
-                  // The loop's own position, not a re-count: one owner for
-                  // the number the log line, the live block and the committed
-                  // row all state (issue #1110).
-                  activeLiveView()?.appStarted({ n: position.n, total: position.total, id: appId });
-                  try {
-                      const result = await processApp(appId, report);
+    // One owner for "how many apps were selected", shared by the verdict
+    // registration and the post-loop stamping below.
+    const totalApps = new Set(appIds).size;
 
-                      // Every attempted app must have an entry, or the
-                      // verdict's ok-count silently undercounts a processor
-                      // that recorded nothing.
-                      if (!report.apps.some((app) => app.id === appId)) {
-                          addAppToReport(report, { id: appId });
+    // From here to the `finally` below, a signal shuts the run down
+    // gracefully instead of exiting on the spot: there is work to unwind and a
+    // report to render. Outside this region - the wizard, `browser install`,
+    // `doctor` - the signal handler exits immediately, because waiting would
+    // buy the operator nothing (issue #1107).
+    beginInterruptibleRun();
+
+    // Registered before the first app so that a signal arriving at any point
+    // in the loop finds a verdict to emit, even from the watchdog.
+    //
+    // Real runs only. A dry run's product is `renderDryRunReport`, and a
+    // verdict block is not something it may ever print: the counts come from
+    // the planned-sheet rows, so an interrupted dry run would have announced
+    // captures and thumbnails uploaded for a run that connected read-only and
+    // changed nothing. Gating here rather than discarding after the loop is
+    // what closes the window - a discard can only run if the loop returns, and
+    // the signal paths reach the verdict while it is still going.
+    if (!dryRun) {
+        pendingVerdict = { report, rung, ctx, totalApps };
+    }
+
+    let result;
+    try {
+        result = await runOverApps(
+            appIds,
+            {
+                logPrefix: dryRun ? logPrefix.plan : logPrefix.process,
+                action: dryRun ? 'plan' : 'process',
+                emptySelectionHint,
+            },
+            dryRun
+                ? async (appId) => {
+                      markAppInFlight(report, appId);
+                      try {
+                          return await planApp(appId, report);
+                      } catch (err) {
+                          // A planner that failed after recording its rows would
+                          // otherwise render as a clean, fully-planned app - on
+                          // the mode whose report is the entire product.
+                          //
+                          // Same three-way split as the real-run twin below: an
+                          // app abandoned by a signal is not one whose planning
+                          // broke, and telling a dry run's reader to "fix the
+                          // errors above" when the only event was their own
+                          // Ctrl-C is the confusion this change exists to remove.
+                          if (isInterrupted() && isAbortArtifact(err)) {
+                              markAppInterrupted(report, appId);
+                          } else {
+                              markAppFailed(report, appId);
+                          }
+                          throw err;
+                      } finally {
+                          clearAppInFlight(report, appId);
                       }
+                  }
+                : async (appId, position) => {
+                      const appStartedAt = Date.now();
+                      // The loop's own position, not a re-count: one owner for
+                      // the number the log line, the live block and the committed
+                      // row all state (issue #1110).
+                      activeLiveView()?.appStarted({
+                          n: position.n,
+                          total: position.total,
+                          id: appId,
+                      });
+                      markAppInFlight(report, appId);
+                      try {
+                          const result = await processApp(appId, report);
 
-                      return result;
-                  } catch (err) {
-                      // Recorded before the loop's own catch logs it, so the
-                      // verdict's failed-app count cannot disagree with the
-                      // error lines above it.
-                      markAppFailed(report, appId);
-                      throw err;
-                  } finally {
-                      // Both paths above guarantee the entry exists by now.
-                      // Stamped by the loop, not the processors: one clock
-                      // for both platform twins.
-                      const entry = report.apps.find((app) => app.id === appId);
-                      if (entry) {
-                          entry.durationMs = Date.now() - appStartedAt;
-                          if (board) {
-                              // Appended as each app finishes. With a live
-                              // view active the identical row is committed
-                              // above the animated region instead of being
-                              // appended raw - one renderer, two carriers.
-                              const row = renderBoardAppRow(
-                                  entry,
-                                  { n: position.n, total: position.total, removal },
-                                  ctx
-                              );
-                              const live = activeLiveView();
-                              if (live) {
-                                  live.appFinished(entry, row);
-                              } else {
-                                  process.stdout.write(row);
+                          // Every attempted app must have an entry, or the
+                          // verdict's ok-count silently undercounts a processor
+                          // that recorded nothing.
+                          if (!report.apps.some((app) => app.id === appId)) {
+                              addAppToReport(report, { id: appId });
+                          }
+
+                          return result;
+                      } catch (err) {
+                          // Recorded before the loop's own catch logs it, so the
+                          // verdict's failed-app count cannot disagree with the
+                          // error lines above it.
+                          //
+                          // An app that was in flight when the signal arrived
+                          // arrives here too - shutdown closes the browser under
+                          // it, so its last await rejects like any other failure.
+                          // The flag is the only thing that can tell the two
+                          // apart from inside this catch (issue #1107).
+                          // Same test the app loop applies, so the report's
+                          // classification and the loop's counts cannot
+                          // disagree about one app.
+                          if (isInterrupted() && isAbortArtifact(err)) {
+                              markAppInterrupted(report, appId);
+                          } else {
+                              markAppFailed(report, appId);
+                          }
+                          throw err;
+                      } finally {
+                          // Both paths above guarantee the entry exists by now.
+                          // Stamped by the loop, not the processors: one clock
+                          // for both platform twins.
+                          const entry = report.apps.find((app) => app.id === appId);
+                          if (entry) {
+                              entry.inFlight = false;
+                              entry.durationMs = Date.now() - appStartedAt;
+                              if (board) {
+                                  // Appended as each app finishes. With a live
+                                  // view active the identical row is committed
+                                  // above the animated region instead of being
+                                  // appended raw - one renderer, two carriers.
+                                  const row = renderBoardAppRow(
+                                      entry,
+                                      { n: position.n, total: position.total, removal },
+                                      ctx
+                                  );
+                                  const live = activeLiveView();
+                                  if (live) {
+                                      live.appFinished(entry, row);
+                                  } else {
+                                      process.stdout.write(row);
+                                  }
                               }
                           }
                       }
                   }
-              }
-    );
+        );
+    } finally {
+        endInterruptibleRun();
+    }
 
     report.finishedAt = Date.now();
-    report.succeeded = result;
+
+    if (isInterrupted()) {
+        // Through the same helper the signal paths use, so the three routes to
+        // a verdict cannot describe the same run differently.
+        stampInterruptOutcome(report, totalApps);
+    } else {
+        report.succeeded = result;
+    }
 
     // The collapse (issue #1075): the animated region is erased and the
     // cursor restored *before* the verdict renders, so the verdict below
@@ -995,19 +1256,15 @@ export const runOverAppsWithReport = async ({
         // The report is the entire product of a dry run, so no rung - `off`
         // included - suppresses it. On the board rung the plan block above
         // already rendered as a board; the per-sheet decisions stay in the
-        // log, where their reasons are.
+        // log, where their reasons are. Nothing to discard: a dry run never
+        // registered a verdict in the first place.
         renderDryRunReport(report);
     } else {
-        emitBlockOnRung({
-            rung,
-            plainEmit: () => {
-                for (const line of renderRunVerdictLines(report)) {
-                    logger.info(line);
-                }
-            },
-            renderBoardBlock: () => renderBoardVerdict(report, ctx),
-        });
+        // Through the once-only seam, not inline: a second signal or the
+        // shutdown watchdog can reach the same verdict from the signal
+        // handler, and the operator must see it exactly once (issue #1107).
+        emitRunVerdictOnce();
     }
 
-    return result;
+    return isInterrupted() ? false : result;
 };

--- a/src/lib/util/sheet-list.js
+++ b/src/lib/util/sheet-list.js
@@ -7,6 +7,7 @@ import errorCodes from 'enigma.js/error-codes.js';
 
 import { logger } from '../../globals.js';
 import { getErrorCategory } from './error-categorizer.js';
+import { isInterrupted } from './interrupt.js';
 
 /**
  * The `qData` projection every caller needs: enough to place a sheet and see its thumbnail.
@@ -284,10 +285,11 @@ const describeCloseEvent = (err) => {
  *     invoked once per sheet, with the 1-based sheet number. Returns `SHEET_SKIPPED` to
  *     record that it did nothing for that sheet.
  *
- * @returns {Promise<{attempted: number, failed: number, skipped: number, changed: number, assertAllProcessed: () => void}>}
+ * @returns {Promise<{attempted: number, failed: number, skipped: number, changed: number, interrupted: boolean, assertAllProcessed: () => void}>}
  *     The counts - `changed` being only the sheets the worker completed, so neither a failed
- *     sheet nor the one that killed the session is included - plus a check to call once the
- *     engine session has been released.
+ *     sheet nor the one that killed the session is included - plus `interrupted`, set when the
+ *     loop stopped because the run was signalled rather than because a sheet went wrong, and a
+ *     check to call once the engine session has been released.
  */
 export const runOverSheets = async (sheets, ctx, processSheet) => {
     const { logPrefix, appId, action, ErrorClass, requireAttempt = false } = ctx;
@@ -297,8 +299,22 @@ export const runOverSheets = async (sheets, ctx, processSheet) => {
     let skipped = 0;
     let iSheetNum = 1;
     let sessionFailure;
+    let interrupted = false;
 
     for (const sheet of sheets) {
+        // The sheet boundary is where an interrupted run stops within an app
+        // (issue #1107). It matters most for `remove-sheet-icons`, which is
+        // the one path that writes per sheet rather than per app: stopping
+        // here is what keeps the report's cleared count true instead of
+        // clearing more icons on the way out.
+        if (isInterrupted()) {
+            interrupted = true;
+            logger.info(
+                `${logPrefix}: Interrupted while processing app ${appId}, stopping at sheet ${iSheetNum} of ${sheets.length}`
+            );
+            break;
+        }
+
         try {
             const outcome = await processSheet(sheet, iSheetNum);
 
@@ -311,6 +327,20 @@ export const runOverSheets = async (sheets, ctx, processSheet) => {
         } catch (err) {
             // A sheet that threw was attempted, whatever it was about to return.
             attempted += 1;
+
+            // Shutdown closes the browser under the run, so the sheet that
+            // was in flight rejects with `Target closed` - which
+            // `isSessionLevelFailure` matches, and would otherwise be reported
+            // as a lost engine session. The engine was fine; the operator
+            // stopped the run. Checked first so the wrong explanation is never
+            // the one logged (issue #1107).
+            if (isInterrupted()) {
+                interrupted = true;
+                logger.info(
+                    `${logPrefix}: Sheet ${iSheetNum} in app ${appId} was abandoned when the run was interrupted`
+                );
+                break;
+            }
 
             if (isSessionLevelFailure(err)) {
                 // Not this sheet's fault, and every sheet after it would fail identically.
@@ -335,6 +365,7 @@ export const runOverSheets = async (sheets, ctx, processSheet) => {
         failed,
         skipped,
         changed,
+        interrupted,
         assertAllProcessed: () => {
             // Surface the real cause, not a sheet count that would blame the sheets.
             if (sessionFailure) {
@@ -344,6 +375,20 @@ export const runOverSheets = async (sheets, ctx, processSheet) => {
             if (failed > 0) {
                 throw new ErrorClass(
                     `Failed to ${action} ${failed} of ${attempted} sheet(s) in app ${appId}`
+                );
+            }
+
+            // Last of the three, deliberately (issue #1107). An interrupted app
+            // still has to throw, so the caller stops and the app loop counts
+            // it - but a real failure outranks the interrupt, because the two
+            // ask the operator for different things and only one of them is
+            // still true after a re-run. Checked first, an interrupt at sheet 5
+            // erased four genuine failures at sheets 1-4: the app was reported
+            // as merely abandoned, `failedApps` was 0, and the operator re-ran
+            // without ever learning those sheets were broken.
+            if (interrupted) {
+                throw new ErrorClass(
+                    `App ${appId} was abandoned when the run was interrupted, after ${changed} sheet(s) had been processed`
                 );
             }
 

--- a/src/lib/util/signal-handlers.js
+++ b/src/lib/util/signal-handlers.js
@@ -1,0 +1,444 @@
+/**
+ * Graceful shutdown on `SIGINT` and `SIGTERM` (issue #1107).
+ *
+ * Before this existed, BSI had no signal handling at all. Ctrl-C, `docker stop`
+ * or a CI timeout killed the process outright, and the cost was not the leaked
+ * websocket or the stranded Chromium - it was that **the operator was left with
+ * no record of what had already been written**.
+ *
+ * Both platform workers have the same shape per app: open an engine session,
+ * launch a browser, capture every sheet, close the browser, upload the images,
+ * point the sheets at them. The last step is the write, and it is irreversible.
+ * Interrupt a fifty-app run and apps 1..k have new thumbnails in Sense, app k+1
+ * was abandoned before its write, and apps k+2 onwards were never touched -
+ * with nothing anywhere saying what k was. `remove-sheet-icons` is worse: it
+ * writes per sheet, so an interrupted app is genuinely part-cleared.
+ *
+ * ## How the shutdown actually works
+ *
+ * A signal cannot be thrown into an in-flight promise. The listener runs
+ * synchronously while the run is parked on a Puppeteer round trip somewhere far
+ * below, and there is no way to inject a rejection into that await from here.
+ * So the signal path does not unwind the run - it makes the things the run is
+ * waiting on fail, and lets the error paths that already exist do the unwinding:
+ *
+ *   1. Record the interrupt. That aborts the shared controller, so every
+ *      pending `sleep()` - the `--pagewait` between sheets - rejects at once.
+ *   2. Close the browser, through `closeBrowserQuietly` and the teardown
+ *      registry in `interrupt.js`. Every in-flight Puppeteer await rejects,
+ *      which propagates into the processor's `catch`, and `withEngineSession`'s
+ *      `finally` releases the websocket on the way past.
+ *   3. The app loop and the sheet loop see the flag at their next boundary and
+ *      stop starting work.
+ *   4. The run report renders what was done, and the process exits 130 or 143.
+ *
+ * Reusing that teardown rather than writing a second one is the point.
+ * `withEngineSession`'s own header records that six hand-rolled copies of the
+ * close sequence had already drifted, and only some of them closed on the happy
+ * path. A separate shutdown path would be the seventh.
+ *
+ * ## Why speed is a design constraint, not a nicety
+ *
+ * `docker stop` sends `SIGTERM` and then `SIGKILL` roughly ten seconds later
+ * regardless of what the process is doing, and a single sheet capture can sit
+ * on a ninety-second page timeout. Waiting for the current sheet - let alone the
+ * current app - would blow through that window and make Ctrl-C feel ignored.
+ * Closing the browser and aborting the sleeps is what keeps shutdown inside it.
+ *
+ * That is also why the shutdown never waits on anything it cannot bound:
+ *
+ *   - **A second signal exits immediately.** Standard CLI behaviour, and the
+ *     guard against a shutdown that itself hangs - which would be worse than no
+ *     handler at all.
+ *   - **A watchdog exits anyway.** `docker stop` sends one signal and there is
+ *     nobody at a keyboard to send a second, so the second-signal escape does
+ *     not cover the container case. {@link INTERRUPT_EXIT_WATCHDOG_MS} bounds
+ *     it instead.
+ *   - **A signal outside a run exits at once.** The wizard, `browser install`
+ *     and `doctor` have no report to render and nothing registered to unwind,
+ *     so there is nothing to wait for. `runOverAppsWithReport` is the only
+ *     caller that opens an interruptible region.
+ *
+ * Both exit paths emit the run verdict first, through the once-only seam in
+ * `run-report.js`, so a stalled shutdown still prints what the report holds
+ * rather than dying silently - and the operator never sees it twice.
+ *
+ * ## Why this is not part of `fatal-handlers.js`
+ *
+ * That module is about crashes: an eighty-line header on issue #946's 479,178
+ * crash dumps, a re-entry guard, and a crash-dump writer. An interrupt is not a
+ * crash. It writes no dump, it is not a bug, and its exit code says a person
+ * stopped the run rather than that the run broke. Only the shape is borrowed -
+ * every dependency injectable so the handlers can be tested without killing the
+ * test process, listeners recorded so a re-install removes exactly what it
+ * added, and a reset for tests.
+ */
+
+import { logger as defaultLogger } from '../../globals.js';
+import { restoreLiveTerminal } from './run-live.js';
+import { flushAndExit } from './flush-exit.js';
+import { emitRunVerdictOnce } from './run-report.js';
+import {
+    isInterrupted,
+    markInterrupted,
+    interruptExitCode,
+    runInterruptActions,
+    hasInterruptibleWork,
+} from './interrupt.js';
+
+// ---------------------------------------------------------------------------
+// Module-level constants and state
+// ---------------------------------------------------------------------------
+
+/**
+ * The signals handled. All three mean "stop", and all three get the same
+ * treatment.
+ *
+ * `SIGHUP` is here for a reason that is easy to miss: it is what a closing
+ * terminal or a dropped SSH session sends, and BSI runs are long enough that
+ * losing a connection mid-run is an ordinary event rather than an exotic one.
+ *
+ * It also cannot be left out now that `launchBrowserForApp` turns Puppeteer's
+ * own handlers off. Node's default disposition for SIGHUP terminates the
+ * process *without* running `process.on('exit')` - measured: exit 129, no exit
+ * hook - and that hook is the last thing standing between a dropped connection
+ * and an orphaned Chromium, which is spawned `detached` into its own process
+ * group and so survives the terminal that started it. Handling it here means
+ * the browser is closed through the same teardown registry as the other two.
+ */
+export const HANDLED_SIGNALS = Object.freeze(['SIGINT', 'SIGTERM', 'SIGHUP']);
+
+/**
+ * How long (ms) graceful shutdown gets before the process exits anyway.
+ *
+ * Eight seconds, chosen against `docker stop`: it sends `SIGTERM`, waits ten
+ * seconds, then `SIGKILL`s. Exiting at eight leaves room for the verdict to be
+ * written and the process to go, so the report lands rather than being killed
+ * halfway through it. Under Ctrl-C the operator has the second-signal escape
+ * long before this fires, so in practice it only ever runs in a container or a
+ * CI job where nobody is watching.
+ *
+ * Longer would risk the SIGKILL; shorter would cut off an app that was seconds
+ * from finishing its writes.
+ */
+export const INTERRUPT_EXIT_WATCHDOG_MS = 8000;
+
+/** True once the process has been told to exit, so it can never be told twice. */
+let exiting = false;
+
+/** Handle for the watchdog timer, cleared when the process exits. */
+let watchdogTimer = null;
+
+/**
+ * Every listener the current installation registered, so a re-install or a
+ * reset removes exactly what it added.
+ *
+ * @type {Array<{emitter: import('node:events').EventEmitter, event: string, listener: Function}>}
+ */
+let installedListeners = [];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Logs one line, never throwing.
+ *
+ * The console transport may have just been restored from a silenced live view,
+ * or the stream may be gone entirely. Failing to log must not stop the process
+ * from exiting.
+ *
+ * @param {object} logger - Logger with `warn` and `info` methods.
+ * @param {string} level - Level to log at.
+ * @param {string} message - The line.
+ *
+ * @returns {void}
+ */
+const logQuietly = (logger, level, message) => {
+    try {
+        logger[level](message);
+    } catch {
+        // Nothing left to log with. Carry on to the exit.
+    }
+};
+
+/** ANSI "show cursor". The counterpart of the sequence a prompt writes to hide it. */
+export const SHOW_CURSOR = '\u001B[?25h';
+
+/**
+ * Restores the terminal, never throwing.
+ *
+ * Runs before anything is logged, for the same reason the crash path in
+ * `fatal-handlers.js` does it in that order: under the live run view (issue
+ * #1075) the console transport is silenced and the cursor hidden, so the line
+ * below would be invisible and the operator's prompt left mangled. It also
+ * means the verdict renders to a quiet terminal through the ordinary board
+ * path.
+ *
+ * The unconditional show-cursor afterwards covers the case the live view's own
+ * hook cannot: the interactive wizard hides the cursor itself, and a signal at
+ * a prompt used to leave it hidden for the rest of the session - measured on
+ * `main`, where the process was killed outright and nothing restored it. BSI
+ * owns that exit now, so it owns putting the cursor back. Writing it when
+ * nothing hid it is harmless; leaving it hidden is not.
+ *
+ * Only to a TTY. Piped output must not gain an escape sequence, which is the
+ * same rule the rest of the terminal handling follows.
+ *
+ * @param {object} deps - Resolved dependencies for this installation.
+ *
+ * @returns {void}
+ */
+const restoreQuietly = (deps) => {
+    try {
+        deps.restoreTerminal();
+    } catch {
+        // Exiting is the one thing this handler must always do.
+    }
+
+    try {
+        if (deps.stdout?.isTTY) {
+            deps.stdout.write(SHOW_CURSOR);
+        }
+    } catch {
+        // A stream that has gone away cannot be tidied. Carry on to the exit.
+    }
+};
+
+/**
+ * Emits the run verdict, never throwing.
+ *
+ * Idempotent at the other end: `emitRunVerdictOnce` clears the pending verdict
+ * before rendering it, so whichever of the three shutdown paths arrives first
+ * is the one that prints, and the others are no-ops.
+ *
+ * @returns {void}
+ */
+const emitVerdictQuietly = () => {
+    try {
+        emitRunVerdictOnce();
+    } catch {
+        // A report that cannot be rendered must not stop the exit.
+    }
+};
+
+/**
+ * Exits the process, at most once per process lifetime.
+ *
+ * @param {object} deps - Resolved dependencies for this installation.
+ *
+ * @returns {void}
+ */
+const exitOnce = (deps) => {
+    if (exiting) return;
+    exiting = true;
+
+    if (watchdogTimer !== null) {
+        clearTimeout(watchdogTimer);
+        watchdogTimer = null;
+    }
+
+    // Through the flush, never `deps.exit` directly: the verdict was written
+    // microseconds ago and on a pipe it is still in the stream's buffer. A
+    // bare exit here discards the report on `docker stop` - the one path it
+    // exists for. See `flush-exit.js` for the measurements.
+    deps.flushAndExit(interruptExitCode(), { exit: deps.exit });
+};
+
+/**
+ * Arms the watchdog that force-exits if graceful shutdown stalls.
+ *
+ * `unref`'d so it can never by itself keep an otherwise healthy process alive -
+ * a run that shuts down in two seconds must not sit here for another six.
+ *
+ * @param {object} deps - Resolved dependencies for this installation.
+ *
+ * @returns {void}
+ */
+const armWatchdog = (deps) => {
+    try {
+        watchdogTimer = setTimeout(() => {
+            logQuietly(
+                deps.logger,
+                'warn',
+                `Shutdown did not finish within ${deps.watchdogMs / 1000}s. Exiting now - the report below covers what had been recorded by this point.`
+            );
+            emitVerdictQuietly();
+            exitOnce(deps);
+        }, deps.watchdogMs);
+
+        if (typeof watchdogTimer.unref === 'function') watchdogTimer.unref();
+    } catch {
+        // Without a watchdog the second signal is still an escape, and the
+        // run is still unwinding on its own.
+    }
+};
+
+/**
+ * Handles the second (or later) signal: exit now, without waiting for anything.
+ *
+ * @param {string} signal - The signal received.
+ * @param {object} deps - Resolved dependencies for this installation.
+ *
+ * @returns {void}
+ */
+const handleForceExit = (signal, deps) => {
+    if (exiting) return;
+
+    restoreQuietly(deps);
+    logQuietly(deps.logger, 'warn', `Second ${signal} received. Exiting immediately.`);
+    emitVerdictQuietly();
+    exitOnce(deps);
+};
+
+/**
+ * Handles the first signal.
+ *
+ * @param {string} signal - The signal received.
+ * @param {object} deps - Resolved dependencies for this installation.
+ *
+ * @returns {void}
+ */
+const handleFirstSignal = (signal, deps) => {
+    // Aborts the shared controller, so every pending sleep rejects. Done
+    // before the browser close, so a run parked on a --pagewait starts
+    // unwinding at the same moment as one parked on a page navigation.
+    markInterrupted(signal);
+
+    restoreQuietly(deps);
+
+    // Nothing to unwind and no report to wait for: the wizard, `browser
+    // install`, `doctor`. Waiting here would make Ctrl-C look ignored for
+    // eight seconds and then exit with the same code anyway.
+    if (!hasInterruptibleWork()) {
+        logQuietly(deps.logger, 'warn', `${signal} received. Exiting.`);
+        exitOnce(deps);
+        return;
+    }
+
+    logQuietly(
+        deps.logger,
+        'warn',
+        `${signal} received. Stopping the run and reporting what has already been done - press Ctrl-C again to exit immediately.`
+    );
+
+    // Fired, not awaited. This listener is synchronous, and the point of these
+    // actions is to make the awaits below reject so the run unwinds - waiting
+    // for the browser to finish closing would delay the very thing it exists
+    // to trigger.
+    runInterruptActions();
+
+    armWatchdog(deps);
+};
+
+/**
+ * Removes the listeners registered by a previous installation.
+ *
+ * @returns {void}
+ */
+const removeInstalledListeners = () => {
+    for (const { emitter, event, listener } of installedListeners) {
+        try {
+            emitter.removeListener(event, listener);
+        } catch {
+            // Best effort: an emitter that cannot remove listeners is
+            // replaced wholesale by the new installation anyway.
+        }
+    }
+    installedListeners = [];
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Installs the `SIGINT` and `SIGTERM` handlers.
+ *
+ * Call this in the entry point beside `installFatalHandlers()`. Calling it more
+ * than once is safe: the previous listeners are removed first, so there is
+ * never more than one listener per signal.
+ *
+ * Every dependency is injectable so the handlers can be unit-tested without
+ * killing the test process.
+ *
+ * @param {object} [options] - Dependency overrides. All are optional.
+ * @param {object} [options.logger] - Logger with `warn` and `info`. Defaults to the global logger.
+ * @param {Function} [options.exit] - Exit function. Defaults to `process.exit`.
+ * @param {import('node:events').EventEmitter} [options.target] - Emitter to listen on. Defaults to `process`.
+ * @param {number} [options.watchdogMs] - Watchdog delay in ms. Defaults to {@link INTERRUPT_EXIT_WATCHDOG_MS}.
+ * @param {Function} [options.restoreTerminal] - Terminal restore hook, run before anything is
+ *     logged. Defaults to the live run view's `restoreLiveTerminal`.
+ * @param {import('node:stream').Writable} [options.stdout] - Stream the show-cursor sequence is
+ *     written to when it is a TTY. Defaults to `process.stdout`.
+ * @param {Function} [options.flushAndExit] - Drain-then-exit helper. Defaults to the real
+ *     {@link flushAndExit}; injected by tests that assert on the exit code directly.
+ *
+ * @returns {void}
+ */
+export const installSignalHandlers = ({
+    logger = defaultLogger,
+    restoreTerminal = restoreLiveTerminal,
+    /**
+     * Default exit function: terminate the process with the given code.
+     *
+     * @param {number} code - Process exit code.
+     *
+     * @returns {void}
+     */
+    exit = (code) => process.exit(code),
+    target = process,
+    watchdogMs = INTERRUPT_EXIT_WATCHDOG_MS,
+    stdout = process.stdout,
+    flushAndExit: flush = flushAndExit,
+} = {}) => {
+    removeInstalledListeners();
+
+    const deps = { logger, exit, watchdogMs, restoreTerminal, stdout, flushAndExit: flush };
+
+    for (const signal of HANDLED_SIGNALS) {
+        /**
+         * Listener for one signal.
+         *
+         * @param {string} received - The signal name Node passes in.
+         *
+         * @returns {void}
+         */
+        const listener = (received = signal) => {
+            if (isInterrupted()) {
+                handleForceExit(received, deps);
+                return;
+            }
+
+            handleFirstSignal(received, deps);
+        };
+
+        try {
+            target.on(signal, listener);
+            installedListeners.push({ emitter: target, event: signal, listener });
+        } catch {
+            // A target that cannot take a listener leaves the default
+            // behaviour in place, which is what happened before this existed.
+        }
+    }
+};
+
+/**
+ * Removes the installed listeners and clears the exit and watchdog state.
+ *
+ * Exists for tests. Production code installs the handlers once and never
+ * resets them. Does not touch `interrupt.js` - call `resetInterruptState()`
+ * for that.
+ *
+ * @returns {void}
+ */
+export const resetSignalHandlerState = () => {
+    removeInstalledListeners();
+
+    exiting = false;
+
+    if (watchdogTimer !== null) {
+        clearTimeout(watchdogTimer);
+        watchdogTimer = null;
+    }
+};


### PR DESCRIPTION
Closes #1107.

Butler Sheet Icons had no signal handling anywhere in `src/`. Ctrl-C, `docker stop` or a CI timeout killed it outright, and the cost was not the leaked websocket or the stranded Chromium — it was that **the operator was left with no record of what had already been written**. Thumbnails go into Sense app by app and cannot be undone, so interrupting a fifty-app run left apps 1..k updated, app k+1 abandoned, and nothing anywhere saying what k was.

## How it works

A signal cannot be thrown into an in-flight promise, so the shutdown does not unwind the run directly. It makes the things the run is waiting on fail, and lets the error paths that already exist do the unwinding:

1. Record the interrupt — which aborts every pending `sleep`, so a long `--pagewait` does not have to run out its clock.
2. Close the browser through a teardown registry, so in-flight Puppeteer awaits reject.
3. The app and sheet loops see the flag at their next boundary and stop starting work.
4. The run report renders what was done, and the process exits 130 / 143 / 129.

That reuses `withEngineSession` and `closeBrowserQuietly` rather than growing a second teardown — the mistake `withEngineSession`'s own header was written about. A second signal, or an 8s watchdog, ends a shutdown that stalls.

## Decisions

| | |
| --- | --- |
| Exit codes | `130` / `143` / `129` — the signal convention, matching what a shell already reported when the process was killed. Documented rather than folded into #1090's graded table: an interrupt is not a run outcome. |
| `sleep()` | Aborts on interrupt. Without it shutdown waits out `--pagewait`, which blows `docker stop`'s grace period at the values operators are told to use. |
| Watchdog | Yes — `docker stop` sends one signal and there is nobody to send a second. |
| Interrupted app | Its own state on the report, distinct from failed. #1096 is still open, so this does not wait on it. |

## What a live run and a review pass caught

Unit tests could not see any of these; each came from executing the thing rather than reading it.

- **Puppeteer defeated the whole feature.** `@puppeteer/browsers` handles SIGINT itself with `this.kill(); process.exit(130)`. It hid well — 130 is the code BSI uses too, so an interrupted run looked correct from the shell, and only the missing report gave it away on a live run against the lab.
- **The report was discarded on a pipe.** A bare `process.exit()` throws away stdout's buffer: measured at 333 of 400 lines delivered, verdict among the losses. Invisible on a TTY, and exactly what `docker logs` reads. Fixed with a drain-then-exit helper, bounded so shutdown still cannot hang.
- **An interrupted Cloud removal deleted icons it never cleared.** It fell through into the media deletion, so untouched sheets kept references to files it then deleted. Irreversible.
- **Writes that landed were reported as zero.** The update step saves per sheet, but the throw skipped the recorder.
- **Every QSEoW Ctrl-C asked the operator to email support**, because the logout ran against the browser the shutdown had just closed.
- **SIGHUP orphaned Chromium** — a regression from switching Puppeteer's handlers off, since Node's default for SIGHUP skips `process.on('exit')`.

Also fixed: an interrupted `--dry-run` reported a verdict block it must never print and marked every planned app interrupted; a genuine failure coinciding with a signal lost its error line and its place in the failed count; the ASCII board marker broke column alignment on Windows and CI; and the wizard said "the run reported a failure" under a verdict that had just said INTERRUPTED.

## Verification

- **3396 unit tests + 6 integration tests**, lint clean.
- The integration tests spawn real child processes taking real signals, including one that drives the actual CLI binary. **Mutation-checked**: commenting out `installSignalHandlers()` fails it. Before these existed, deleting the entire feature from the entry point left all tests green.
- **Live against the QSEoW lab** (CI confirmed idle): interrupt with stdout piped — report intact, 0.03s shutdown at `--pagewait 45`, zero error lines, no leaked Chromium; SIGHUP — exits 129 and cleans up; a clean run — exits 0 with thumbnails applied.
- **Write proof via QRS**: an interrupted run left the content library's `staticcontentreference` dates untouched, while a control run that completed bumped them.

## Not covered

The Cloud tenant was not exercised live and the container `docker stop` path is unverified locally — both share the code paths tested against QSEoW, so they are left to CI and release testing.

A doc page is staged in `docs/to-doc-site/`, including the instruction to correct the published live-view page's now-false Ctrl-C caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
