### PR TITLE
Define the esbuild and postject steps once, in scripts/bundle.mjs

### DIFF
--- a/build-script/build-macos.sh
+++ b/build-script/build-macos.sh
@@ -2,14 +2,7 @@
 # Execute this script from the repository's root folder
 
 # Create a single JS file using esbuild
-./node_modules/.bin/esbuild src/butler-sheet-icons.js  \
-  --bundle  \
-  --outfile=./build/build.cjs  \
-  --format=cjs  \
-  --platform=node  \
-  --target=node24  \
-  --inject:./src/lib/util/import-meta-url.js  \
-  --define:import.meta.url=import_meta_url
+node scripts/bundle.mjs bundle
 
 # Generate blob to be injected into the binary
 echo ""
@@ -30,7 +23,7 @@ codesign --remove-signature ./build/butler-sheet-icons
 echo ""
 echo "Injecting SEA blob into the executable..."
 ls -la ./build
-npx postject ./build/butler-sheet-icons NODE_SEA_BLOB ./build/sea-prep.blob --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2 --macho-segment-name NODE_SEA
+node scripts/bundle.mjs inject ./build/butler-sheet-icons
 
 # Sign the binary
 echo ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
                 "eslint-plugin-prettier": "^5.5.6",
                 "globals": "^17.6.0",
                 "jest": "^30.4.2",
+                "postject": "1.0.0-alpha.6",
                 "prettier": "^3.8.4",
                 "snyk": "^1.1305.2"
             },
@@ -7317,6 +7318,32 @@
             "license": "MIT",
             "engines": {
                 "node": ">=14.19.0"
+            }
+        },
+        "node_modules/postject": {
+            "version": "1.0.0-alpha.6",
+            "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
+            "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "commander": "^9.4.0"
+            },
+            "bin": {
+                "postject": "dist/cli.js"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/postject/node_modules/commander": {
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+            "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || >=14"
             }
         },
         "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
         "eslint-plugin-prettier": "^5.5.6",
         "globals": "^17.6.0",
         "jest": "^30.4.2",
+        "postject": "1.0.0-alpha.6",
         "prettier": "^3.8.4",
         "snyk": "^1.1305.2"
     },

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+// Platform: Cross-platform (macOS, Linux, Windows)
+// Requires: Node.js
+
+/**
+ * The two SEA packaging steps that every build shares, defined once.
+ *
+ * Bundling and blob injection used to be written out in full in seven places - three release
+ * scripts, three insider scripts and the local dev script - in a mix of bash and PowerShell. The
+ * flag sets were identical, which is exactly the problem: a flag changed in six of them and missed
+ * in the seventh produces a binary that differs on one platform or one channel only, and that
+ * difference surfaces inside the packaged SEA binary rather than in any test. Issue #1128.
+ *
+ * `scripts/lib/macos-signing-keychain.sh` was extracted for the same reason, after two
+ * hand-maintained copies had already drifted.
+ *
+ * Being a Node script rather than a shell library is deliberate: it removes the bash-vs-PowerShell
+ * split rather than centralising each half separately, and it lets the one genuinely
+ * platform-specific argument - macOS's `--macho-segment-name` - be derived from `process.platform`
+ * instead of depending on which file the caller happens to be in.
+ *
+ * Usage:
+ *   node scripts/bundle.mjs bundle
+ *   node scripts/bundle.mjs inject <binary path>
+ */
+
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { build } from 'esbuild';
+
+const require = createRequire(import.meta.url);
+
+/** Set by every CI build; defaulted so the local dev script needs no environment. */
+const distFileName = process.env.DIST_FILE_NAME ?? 'butler-sheet-icons';
+
+const OUTFILE = './build/build.cjs';
+const BLOB = './build/sea-prep.blob';
+
+/** Must match the fuse Node itself looks for. Changing it breaks every binary. */
+const SENTINEL_FUSE = 'NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2';
+
+/** Mach-O only. Derived below rather than hand-placed at each call site. */
+const MACHO_SEGMENT_NAME = 'NODE_SEA';
+
+/**
+ * Bundle the CLI into a single CJS file for the SEA blob.
+ *
+ * `format: 'cjs'` is not a preference: Node's SEA blob takes one CommonJS file. It is also why
+ * top-level `await` cannot be used anywhere in the bundle - esbuild rejects it for this format,
+ * while plain `node` accepts it, so it would pass the test suite and fail the release build.
+ *
+ * The `inject` + `define` pair rewrites `import.meta.url`, which has no meaning once the ESM
+ * sources are flattened into CJS.
+ *
+ * @returns {Promise<void>} Resolves when the bundle has been written.
+ */
+const bundle = async () => {
+    await build({
+        entryPoints: [`src/${distFileName}.js`],
+        bundle: true,
+        outfile: OUTFILE,
+        format: 'cjs',
+        platform: 'node',
+        target: 'node24',
+        inject: ['./src/lib/util/import-meta-url.js'],
+        define: { 'import.meta.url': 'import_meta_url' },
+    });
+};
+
+/**
+ * Inject the SEA blob into a copy of the Node executable.
+ *
+ * postject is invoked through its own CLI entry point with `node`, rather than through `npx` or the
+ * `.bin` shim, so there is no dependence on npx cache state and no `.cmd` special case on Windows.
+ * It is a pinned devDependency for the same reason - five of the seven previous call sites resolved
+ * to whatever version happened to be latest.
+ *
+ * The caller must strip the executable's existing signature first: postject rewrites the binary,
+ * which invalidates any signature already on it.
+ *
+ * @param {string} binaryPath - The Node executable copy to inject into.
+ *
+ * @returns {void}
+ *
+ * @throws {Error} When postject exits non-zero, so the build stops rather than shipping an
+ *     executable with no blob in it.
+ */
+const inject = (binaryPath) => {
+    const args = [
+        require.resolve('postject/dist/cli.js'),
+        binaryPath,
+        'NODE_SEA_BLOB',
+        BLOB,
+        '--sentinel-fuse',
+        SENTINEL_FUSE,
+    ];
+
+    if (process.platform === 'darwin') {
+        args.push('--macho-segment-name', MACHO_SEGMENT_NAME);
+    }
+
+    const result = spawnSync(process.execPath, args, { stdio: 'inherit' });
+
+    if (result.error) {
+        throw result.error;
+    }
+
+    if (result.status !== 0) {
+        throw new Error(`postject exited with status ${result.status}`);
+    }
+};
+
+const [step, target] = process.argv.slice(2);
+
+if (step === 'bundle') {
+    await bundle();
+} else if (step === 'inject') {
+    if (!target) {
+        console.error('Usage: node scripts/bundle.mjs inject <binary path>');
+        process.exit(1);
+    }
+    inject(target);
+} else {
+    console.error('Usage: node scripts/bundle.mjs <bundle|inject> [binary path]');
+    process.exit(1);
+}

--- a/scripts/insider-build-linux.sh
+++ b/scripts/insider-build-linux.sh
@@ -10,7 +10,7 @@ sed -i "s/\"version\": \".*\"/\"version\": \"${CURRENT_VERSION}-$GIT_SHA\"/" pac
 mkdir -p ./build
 
 # Create a single JS file using esbuild
-./node_modules/.bin/esbuild src/${DIST_FILE_NAME}.js --bundle --outfile=./build/build.cjs --format=cjs --platform=node --target=node24 --inject:./src/lib/util/import-meta-url.js --define:import.meta.url=import_meta_url
+node scripts/bundle.mjs bundle
 
 # Generate blob to be injected into the binary
 node --experimental-sea-config build-script/sea-config.json
@@ -19,7 +19,7 @@ node --experimental-sea-config build-script/sea-config.json
 cp "$(node -p 'process.execPath')" ${DIST_FILE_NAME}
 
 # Inject the blob
-npx postject ${DIST_FILE_NAME} NODE_SEA_BLOB ./build/sea-prep.blob --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2
+node scripts/bundle.mjs inject ${DIST_FILE_NAME}
 
 # Compress insider's build
 tar -czf "${DIST_FILE_NAME}--linux-x64--${GITHUB_SHA}.tgz" "${DIST_FILE_NAME}"

--- a/scripts/insider-build-mac.sh
+++ b/scripts/insider-build-mac.sh
@@ -18,7 +18,7 @@ sed -i '' "s/\"version\": \".*\"/\"version\": \"${CURRENT_VERSION}-$GIT_SHA\"/" 
 mkdir -p ./build
 
 # Create a single JS file using esbuild
-./node_modules/.bin/esbuild src/${DIST_FILE_NAME}.js --bundle --outfile=./build/build.cjs --format=cjs --platform=node --target=node24 --inject:./src/lib/util/import-meta-url.js --define:import.meta.url=import_meta_url
+node scripts/bundle.mjs bundle
 
 # Generate blob to be injected into the binary
 node --experimental-sea-config build-script/sea-config.json
@@ -30,7 +30,7 @@ cp "$(node -p 'process.execPath')" ${DIST_FILE_NAME}
 codesign --remove-signature ${DIST_FILE_NAME}
 
 # Inject the blob
-npx postject ${DIST_FILE_NAME} NODE_SEA_BLOB ./build/sea-prep.blob --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2 --macho-segment-name NODE_SEA
+node scripts/bundle.mjs inject ${DIST_FILE_NAME}
 
 # Wired to the signals as well as EXIT: a cancelled workflow run is killed, not exited, and the
 # old EXIT-only trap is how a build could leave its keychain behind on this Mac.

--- a/scripts/insider-build-win.ps1
+++ b/scripts/insider-build-win.ps1
@@ -67,7 +67,7 @@ $GIT_SHA = (git rev-parse --short HEAD)
 New-Item -ItemType Directory -Force -Path ./build | Out-Null
 
 # Create a single JS file using esbuild
-./node_modules/.bin/esbuild "src/${env:DIST_FILE_NAME}.js" --bundle --outfile=./build/build.cjs --format=cjs --platform=node --target=node24 --inject:./src/lib/util/import-meta-url.js --define:import.meta.url=import_meta_url
+node scripts/bundle.mjs bundle
 
 # Generate blob to be injected into the binary
 node --experimental-sea-config build-script/sea-config.json
@@ -85,7 +85,7 @@ dir
 # stays outside the signing gate below for that reason.
 Invoke-BsiStripSignature -Path "./${env:DIST_FILE_NAME}.exe" -Signtool $signtool
 
-npx postject "${env:DIST_FILE_NAME}.exe" NODE_SEA_BLOB ./build/sea-prep.blob --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2
+node scripts/bundle.mjs inject "${env:DIST_FILE_NAME}.exe"
 
 # -------------------
 # Settle whether this host can sign, by signing a scratch file.

--- a/scripts/release-linux.sh
+++ b/scripts/release-linux.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 mkdir -p ./build
 
 # Create a single JS file using esbuild
-./node_modules/.bin/esbuild src/${DIST_FILE_NAME}.js --bundle --outfile=./build/build.cjs --format=cjs --platform=node --target=node24 --inject:./src/lib/util/import-meta-url.js --define:import.meta.url=import_meta_url
+node scripts/bundle.mjs bundle
 
 # Generate blob to be injected into the binary
 node --experimental-sea-config build-script/sea-config.json
@@ -13,8 +13,8 @@ node --experimental-sea-config build-script/sea-config.json
 # Get a copy of the Node executable
 cp $(command -v node) ${DIST_FILE_NAME}
 
-# Inject the blob using a pinned postject version
-npx --yes postject@1.0.0-alpha.6 ${DIST_FILE_NAME} NODE_SEA_BLOB ./build/sea-prep.blob --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2
+# Inject the blob
+node scripts/bundle.mjs inject ${DIST_FILE_NAME}
 
 # -------------------
 # Clean up

--- a/scripts/release-macos.sh
+++ b/scripts/release-macos.sh
@@ -12,7 +12,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 mkdir -p ./build
 
 # Create a single JS file using esbuild
-./node_modules/.bin/esbuild src/${DIST_FILE_NAME}.js --bundle --outfile=./build/build.cjs --format=cjs --platform=node --target=node24 --inject:./src/lib/util/import-meta-url.js --define:import.meta.url=import_meta_url
+node scripts/bundle.mjs bundle
 
 # Generate blob to be injected into the binary
 node --experimental-sea-config build-script/sea-config.json
@@ -24,7 +24,7 @@ cp $(command -v node) ${DIST_FILE_NAME}
 codesign --remove-signature ${DIST_FILE_NAME}
 
 # Inject the blob
-npx postject@1.0.0-alpha.6 ${DIST_FILE_NAME} NODE_SEA_BLOB ./build/sea-prep.blob --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2 --macho-segment-name NODE_SEA
+node scripts/bundle.mjs inject ${DIST_FILE_NAME}
 
 # Wired to the signals as well as EXIT: a cancelled workflow run is killed, not exited, and the
 # old EXIT-only trap is how a build could leave its keychain behind on a self-hosted Mac.

--- a/scripts/release-win.ps1
+++ b/scripts/release-win.ps1
@@ -60,7 +60,7 @@ else {
 New-Item -ItemType Directory -Force -Path ./build | Out-Null
 
 # Create a single JS file using esbuild
-./node_modules/.bin/esbuild "src/${env:DIST_FILE_NAME}.js" --bundle --outfile=./build/build.cjs --format=cjs --platform=node --target=node24 --inject:./src/lib/util/import-meta-url.js --define:import.meta.url=import_meta_url
+node scripts/bundle.mjs bundle
 
 # Generate blob to be injected into the binary
 node --experimental-sea-config build-script/sea-config.json
@@ -77,7 +77,7 @@ node -e "require('fs').copyFileSync(process.execPath, '${env:DIST_FILE_NAME}.exe
 # with, which alarms users and antivirus far more than no signature at all.
 Invoke-BsiStripSignature -Path "./${env:DIST_FILE_NAME}.exe" -Signtool $signtool
 
-npx --no-install postject "${env:DIST_FILE_NAME}.exe" NODE_SEA_BLOB ./build/sea-prep.blob --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2
+node scripts/bundle.mjs inject "${env:DIST_FILE_NAME}.exe"
 
 # -------------------
 # Sign the executable.


### PR DESCRIPTION
## What & why

Closes #1128. The esbuild bundle step and the postject injection step were each written out in full
in **seven** places — three release scripts, three insider scripts, and the local dev script — across
bash and PowerShell. All seven esbuild flag sets were identical, which is the problem rather than the
consolation: a flag changed in six and missed in the seventh yields a binary that differs on one
platform or channel only, and that shows up inside the packaged SEA binary rather than in any test.

Both steps now live in `scripts/bundle.mjs`, called as `node scripts/bundle.mjs bundle` and
`node scripts/bundle.mjs inject <binary>`.

A Node script rather than a shell library, deliberately: it removes the bash-vs-PowerShell split
instead of centralising each half separately, and it lets the one genuinely platform-specific
argument — macOS's `--macho-segment-name` — be derived from `process.platform` rather than depend on
which file the caller happens to be in. `scripts/lib/macos-signing-keychain.sh` set the precedent
here, extracted after two hand-maintained copies had drifted.

**postject is now a pinned devDependency** (`1.0.0-alpha.6`, exact, not a caret range) and is invoked
as `node <postject/dist/cli.js>`. Five of the seven previous call sites were unpinned, and the Windows
one used `npx --no-install` against a package that was not a dependency at all — so it depended on
npx cache state on the runner. Invoking the CLI entry point directly also removes the `.cmd` shim
special case on Windows.

## How it was verified

- **The bundle is byte-identical.** Built `build/build.cjs` with the old CLI invocation and with
  `scripts/bundle.mjs`, and compared:
  `ff18fc984810cfc0bff7135edf92f6d518c94cf47f3b8403280de265aafd3f90` both times. The esbuild JS API
  translation changes nothing about the output.
- **Full SEA build end to end on macOS** via `build-script/build-macos.sh`: bundle → blob → copy node
  → strip signature → inject → sign. The binary reports `4.1.0`, and
  `qseow create-sheet-thumbnails --help` renders correctly.
- **The macOS-only flag is applied on macOS and derived, not hand-placed.**
  `otool -l ./build/butler-sheet-icons` shows `segname NODE_SEA` present.
- `npm run lint` clean; `npx prettier --check` clean on the new and changed files.
- Unit suite run; no `src/` file is touched by this change.

Not verified locally, because they need their runners: the Windows and Linux release and insider
paths. The `inject` step is one code path with a `process.platform` branch, and the Linux/Windows
branch is simply the macOS one minus `--macho-segment-name`, but a CI run on those targets is the
real check.

## Docs

Internal only — no user-facing behaviour changes.
