### PR TITLE
QSEoW adopts the sheet capture/blur extraction Cloud already has

### DIFF
--- a/src/lib/qseow/__tests__/sheet_screenshot.test.js
+++ b/src/lib/qseow/__tests__/sheet_screenshot.test.js
@@ -1,0 +1,248 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+const write = jest.fn().mockResolvedValue(undefined);
+const blur = jest.fn(() => ({ write }));
+const jimpRead = jest.fn().mockResolvedValue({ blur });
+
+jest.unstable_mockModule('jimp', () => ({
+    Jimp: { read: jimpRead },
+}));
+
+jest.unstable_mockModule('../../../globals.js', () => ({
+    sleep: jest.fn().mockResolvedValue(undefined),
+}));
+
+const { sleep } = await import('../../../globals.js');
+const { captureSheetImage, blurSheetImage } = await import('../sheet-screenshot.js');
+
+const mockLogger = {
+    info: jest.fn(),
+    error: jest.fn(),
+    verbose: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+};
+
+const APP_URL = 'https://sense.example.com/app/aaaa-bbbb';
+const IMG_DIR = './img';
+const APP_ID = 'aaaa-bbbb';
+const SHEET = { qInfo: { qId: 'engine-sheet-1' }, qMeta: { title: 'Sales overview' } };
+const PAGE_TIMEOUT = 90000;
+
+const BASE_OPTIONS = { pagewait: 5, includesheetpart: '1', blurFactor: 5 };
+
+/**
+ * Builds a puppeteer page stub whose element handle records its screenshot calls.
+ *
+ * @returns {object} A page-shaped object with mocked `goto`, `waitForSelector` and `$`.
+ */
+const createPage = () => {
+    const elementHandle = { screenshot: jest.fn().mockResolvedValue(undefined) };
+
+    return {
+        goto: jest.fn().mockResolvedValue(undefined),
+        waitForSelector: jest.fn().mockResolvedValue(undefined),
+        $: jest.fn().mockResolvedValue(elementHandle),
+        // Sheet-loading detection (#1119). Defaults to "not loading", so every existing
+        // test here describes a sheet that had finished rendering.
+        evaluate: jest.fn().mockResolvedValue(false),
+        elementHandle,
+    };
+};
+
+/**
+ * Runs `captureSheetImage` with defaults for everything a test does not care about.
+ *
+ * @param {object} page - Page stub from `createPage`.
+ * @param {object} [optionOverrides] - Fields to merge over the base options.
+ *
+ * @returns {Promise<object>} The captured-file descriptor the function returns.
+ */
+const capture = (page, optionOverrides = {}) =>
+    captureSheetImage(
+        page,
+        APP_URL,
+        IMG_DIR,
+        APP_ID,
+        SHEET,
+        1,
+        { ...BASE_OPTIONS, ...optionOverrides },
+        mockLogger,
+        PAGE_TIMEOUT
+    );
+
+/**
+ * Runs `blurSheetImage` against the file name `capture` would have produced.
+ *
+ * @param {object} [optionOverrides] - Fields to merge over the base options.
+ *
+ * @returns {Promise<object>} The blurred-file descriptor the function returns.
+ */
+const blurIt = (optionOverrides = {}) =>
+    blurSheetImage(
+        `${IMG_DIR}/qseow/${APP_ID}/thumbnail-${APP_ID}-1.png`,
+        IMG_DIR,
+        APP_ID,
+        1,
+        { ...BASE_OPTIONS, ...optionOverrides },
+        mockLogger
+    );
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    write.mockResolvedValue(undefined);
+    blur.mockImplementation(() => ({ write }));
+    jimpRead.mockResolvedValue({ blur });
+});
+
+describe('captureSheetImage', () => {
+    test('navigates to the sheet, using the configured page timeout', async () => {
+        const page = createPage();
+        await capture(page);
+
+        expect(page.goto).toHaveBeenCalledWith(`${APP_URL}/sheet/engine-sheet-1`, {
+            waitUntil: 'networkidle2',
+            timeout: PAGE_TIMEOUT,
+        });
+    });
+
+    test('waits for the configured page settle time', async () => {
+        const page = createPage();
+        await capture(page, { pagewait: 7 });
+
+        expect(sleep).toHaveBeenCalledWith(7000);
+    });
+
+    test('screenshots the sheet element, not the whole viewport', async () => {
+        const page = createPage();
+        await capture(page);
+
+        expect(page.elementHandle.screenshot).toHaveBeenCalledWith({
+            path: `${IMG_DIR}/qseow/${APP_ID}/thumbnail-${APP_ID}-1.png`,
+        });
+        expect(page.screenshot).toBeUndefined();
+    });
+
+    describe('sheet part selection', () => {
+        test('uses the grid selector for part 1', async () => {
+            const page = createPage();
+            await capture(page, { includesheetpart: '1' });
+
+            expect(page.waitForSelector).toHaveBeenCalledWith('#grid-wrap');
+        });
+
+        test('uses the selection-bar selector for part 3', async () => {
+            const page = createPage();
+            await capture(page, { includesheetpart: '3' });
+
+            expect(page.waitForSelector).toHaveBeenCalledWith('#qv-stage-container > div');
+        });
+
+        test('uses the page container selector for part 4', async () => {
+            const page = createPage();
+            await capture(page, { includesheetpart: '4' });
+
+            expect(page.waitForSelector).toHaveBeenCalledWith('#qv-page-container');
+        });
+    });
+
+    describe('return value', () => {
+        test('names the file after the app and the sheet position', async () => {
+            const page = createPage();
+            const result = await capture(page);
+
+            expect(result).toEqual({
+                fileName: `${IMG_DIR}/qseow/${APP_ID}/thumbnail-${APP_ID}-1.png`,
+                fileNameShort: `thumbnail-${APP_ID}-1.png`,
+            });
+        });
+    });
+
+    describe('error handling', () => {
+        test('rejects when navigation fails', async () => {
+            const page = createPage();
+            page.goto.mockRejectedValue(new Error('net::ERR_CONNECTION_REFUSED'));
+
+            await expect(capture(page)).rejects.toThrow('net::ERR_CONNECTION_REFUSED');
+        });
+
+        test('rejects when the sheet element never appears', async () => {
+            const page = createPage();
+            page.waitForSelector.mockRejectedValue(new Error('waiting for selector failed'));
+
+            await expect(capture(page)).rejects.toThrow('waiting for selector failed');
+        });
+    });
+
+    describe('a thumbnail captured while the sheet was still loading', () => {
+        test('says so, naming the sheet and the option that fixes it', async () => {
+            const page = createPage();
+            page.evaluate.mockResolvedValue(true);
+
+            await capture(page, { pagewait: 5 });
+
+            expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+            const warning = mockLogger.warn.mock.calls[0][0];
+            expect(warning).toContain('Sales overview');
+            expect(warning).toContain('pagewait');
+        });
+
+        test('still captures the thumbnail rather than quietly dropping the sheet', async () => {
+            const page = createPage();
+            page.evaluate.mockResolvedValue(true);
+
+            await capture(page);
+
+            expect(page.elementHandle.screenshot).toHaveBeenCalledTimes(1);
+        });
+    });
+});
+
+describe('blurSheetImage', () => {
+    test('writes a blurred copy alongside the screenshot', async () => {
+        await blurIt();
+
+        expect(jimpRead).toHaveBeenCalledWith(
+            `${IMG_DIR}/qseow/${APP_ID}/thumbnail-${APP_ID}-1.png`
+        );
+        expect(write).toHaveBeenCalledWith(
+            `${IMG_DIR}/qseow/${APP_ID}/thumbnail-${APP_ID}-1-blurred.png`
+        );
+    });
+
+    test('applies the configured blur factor', async () => {
+        await blurIt({ blurFactor: 12 });
+
+        expect(blur).toHaveBeenCalledWith(12);
+    });
+
+    test('clamps a blur factor below 1 up to 1', async () => {
+        await blurIt({ blurFactor: 0 });
+
+        expect(blur).toHaveBeenCalledWith(1);
+    });
+
+    test('clamps a blur factor above 100 down to 100', async () => {
+        await blurIt({ blurFactor: 250 });
+
+        expect(blur).toHaveBeenCalledWith(100);
+    });
+
+    test('accepts a blur factor supplied as a string', async () => {
+        await blurIt({ blurFactor: '8' });
+
+        expect(blur).toHaveBeenCalledWith(8);
+    });
+
+    test('returns the blurred file basename', async () => {
+        const result = await blurIt();
+
+        expect(result).toEqual({ fileNameShortBlurred: `thumbnail-${APP_ID}-1-blurred.png` });
+    });
+
+    test('rejects when the blurred image cannot be produced', async () => {
+        write.mockRejectedValue(new Error('disk full'));
+
+        await expect(blurIt()).rejects.toThrow('disk full');
+    });
+});

--- a/src/lib/qseow/qseow-process-app.js
+++ b/src/lib/qseow/qseow-process-app.js
@@ -1,7 +1,5 @@
-import { Jimp } from 'jimp';
-
 import { setupEnigmaConnection } from './qseow-enigma.js';
-import { logger, sleep } from '../../globals.js';
+import { logger } from '../../globals.js';
 import { qseowUploadToContentLibrary } from './qseow-upload.js';
 import { qseowUpdateSheetThumbnails } from './qseow-updatesheets.js';
 import { determineSheetExcludeStatus } from './determine-sheet-exclude-status.js';
@@ -21,13 +19,12 @@ import { createAppImageDir } from '../util/image-dir.js';
 import { activeLiveView } from '../util/run-live.js';
 import { addAppToReport, recordPlannedSheet, recordAppOutcome } from '../util/run-report.js';
 import { appProgressLine, sheetProgressLine } from '../util/run-report-render.js';
-import { QSEOW_SHEET_PART_SELECTORS } from './sheet-parts.js';
+import { captureSheetImage, blurSheetImage } from './sheet-screenshot.js';
 import { qseowLogoutQuietly } from './qseow-logout.js';
 import { getQseowHubSelectors } from './qseow-selectors.js';
 import { logError, describeWithCauses } from '../util/log-error.js';
 import { openQseowAppOverviewPage, captureQseowOverviewAfter } from './qseow-app-session.js';
 import { parseTrueFalseOption } from '../util/true-false-option.js';
-import { sheetWasStillLoading, stillLoadingWarning } from '../util/sheet-loading.js';
 
 /**
  * Processes a Qlik Sense Enterprise on Windows (QSEoW) application to generate
@@ -276,85 +273,39 @@ export const qseowProcessApp = async (appId, options, report = null) => {
                                     })
                                 );
                             } else {
-                                // Build URL to current sheet
-                                const sheetUrl = `${appUrl}/sheet/${sheet.qInfo.qId}`;
-                                logger.debug(`Sheet URL: ${sheetUrl}`);
+                                const { fileName, fileNameShort } = await captureSheetImage(
+                                    page,
+                                    appUrl,
+                                    imgDir,
+                                    appId,
+                                    sheet,
+                                    iSheetNum,
+                                    options,
+                                    logger,
+                                    pageTimeout
+                                );
 
-                                // Open sheet in browser, then take screen shot
-                                await Promise.all([
-                                    page.goto(sheetUrl, {
-                                        waitUntil: 'networkidle2',
-                                        timeout: pageTimeout,
-                                    }),
-                                ]);
-
-                                await sleep(options.pagewait * 1000);
-
-                                const fileName = `${imgDir}/qseow/${appId}/thumbnail-${appId}-${iSheetNum}.png`;
-                                const fileNameShort = `thumbnail-${appId}-${iSheetNum}.png`;
-
-                                // Which part of the sheet to capture. The map is the single source
-                                // of truth for the values --includesheetpart accepts - see
-                                // sheet-parts.js.
-                                const selector =
-                                    QSEOW_SHEET_PART_SELECTORS[options.includesheetpart];
-
-                                // Ensure that the element we're interested in is loaded
-                                await page.waitForSelector(selector);
-                                const sheetMainPart = await page.$(selector);
-
-                                // Checked before the shutter rather than after: the two are
-                                // milliseconds apart, and of the two ways to be wrong, a
-                                // spurious warning is far cheaper than staying silent about a
-                                // thumbnail that shows the loading screen.
-                                if (await sheetWasStillLoading(page, logger)) {
-                                    logger.warn(
-                                        stillLoadingWarning(
-                                            'QSEOW APP',
-                                            iSheetNum,
-                                            sheet?.qMeta?.title,
-                                            options.pagewait
-                                        )
-                                    );
-                                }
-
-                                await sheetMainPart.screenshot({
-                                    path: fileName,
-                                });
                                 createdFiles.push({
                                     sheetPos: iSheetNum,
                                     blurred: false,
                                     fileNameShort,
                                 });
 
-                                // Blur image and store as separate file
-                                const fileNameBlurred = `${imgDir}/qseow/${appId}/thumbnail-${appId}-${iSheetNum}-blurred.png`;
-                                const fileNameShortBlurred = `thumbnail-${appId}-${iSheetNum}-blurred.png`;
-
-                                // Create blurred image from the already taken screenshot
-                                // Load the image from disk, blur it, then save it back to disk with new name
                                 try {
-                                    let blurFactor;
-
-                                    // Blur factor should be between 1 and 100
-                                    if (options?.blurFactor < 1) {
-                                        blurFactor = 1; // Min blur value
-                                    } else if (options?.blurFactor > 100) {
-                                        blurFactor = 100; // Max blur value
-                                    } else {
-                                        blurFactor = parseInt(options?.blurFactor, 10);
-                                    }
-
-                                    // Use Jimp instead of Sharp
-                                    const image = await Jimp.read(fileName);
-                                    await image.blur(blurFactor).write(fileNameBlurred);
+                                    const { fileNameShortBlurred } = await blurSheetImage(
+                                        fileName,
+                                        imgDir,
+                                        appId,
+                                        iSheetNum,
+                                        options,
+                                        logger
+                                    );
 
                                     createdFiles.push({
                                         sheetPos: iSheetNum,
                                         blurred: true,
                                         fileNameShort: fileNameShortBlurred,
                                     });
-                                    logger.verbose(`Created blurred image: ${fileNameBlurred}`);
 
                                     // Recorded and logged only now: both files
                                     // exist, so `captured` (or `blurred`) is a

--- a/src/lib/qseow/sheet-parts.js
+++ b/src/lib/qseow/sheet-parts.js
@@ -4,7 +4,7 @@
  * The keys are the option's allowed values and the values are the CSS selectors the screenshot is
  * taken from, so the set of values BSI accepts is by construction the set it can actually render.
  * The `Option` declaration in `src/lib/commands/qseow/index.js`, the guard in
- * `qseow-create-thumbnails.js` and the screenshot code in `qseow-process-app.js` all derive from
+ * `qseow-create-thumbnails.js` and the screenshot code in `sheet-screenshot.js` all derive from
  * this one map rather than restating the list: a value accepted somewhere but missing a selector
  * here reaches `page.waitForSelector()` with nothing to wait for, and fails with an error that
  * says nothing about the option that caused it.

--- a/src/lib/qseow/sheet-screenshot.js
+++ b/src/lib/qseow/sheet-screenshot.js
@@ -1,0 +1,123 @@
+import { Jimp } from 'jimp';
+
+import { sleep } from '../../globals.js';
+import { QSEOW_SHEET_PART_SELECTORS } from './sheet-parts.js';
+import { sheetWasStillLoading, stillLoadingWarning } from '../util/sheet-loading.js';
+
+/**
+ * Navigates to a sheet and captures it to disk.
+ *
+ * Split from the blur step below rather than folded into one function as the Cloud twin does
+ * (`../cloud/sheet-screenshot.js`), because the two failures mean different things on QSEoW and
+ * that difference is load-bearing: a capture failure fails the whole run, while a blur failure
+ * drops the one sheet, is counted, and lets the run continue. Cloud treats both the same way.
+ * Reconciling that is #1091 step 4's job, not this extraction's - this step is behaviour-preserving.
+ *
+ * @param {object} page - Puppeteer page instance.
+ * @param {string} appUrl - URL of the app.
+ * @param {string} imgDir - Directory to save images.
+ * @param {string} appId - App ID.
+ * @param {object} sheet - Sheet object.
+ * @param {number} iSheetNum - Sheet number.
+ * @param {object} options - Options object.
+ * @param {object} logger - Logger instance.
+ * @param {number} pageTimeout - Navigation timeout in milliseconds.
+ *
+ * @returns {Promise<{ fileName: string, fileNameShort: string }>} The captured file, full path and
+ *     basename. The basename is what the upload and update steps carry.
+ */
+export async function captureSheetImage(
+    page,
+    appUrl,
+    imgDir,
+    appId,
+    sheet,
+    iSheetNum,
+    options,
+    logger,
+    pageTimeout
+) {
+    // Build URL to current sheet
+    const sheetUrl = `${appUrl}/sheet/${sheet.qInfo.qId}`;
+    logger.debug(`Sheet URL: ${sheetUrl}`);
+
+    // Open sheet in browser, then take screen shot
+    await Promise.all([
+        page.goto(sheetUrl, {
+            waitUntil: 'networkidle2',
+            timeout: pageTimeout,
+        }),
+    ]);
+
+    await sleep(options.pagewait * 1000);
+
+    const fileName = `${imgDir}/qseow/${appId}/thumbnail-${appId}-${iSheetNum}.png`;
+    const fileNameShort = `thumbnail-${appId}-${iSheetNum}.png`;
+
+    // Which part of the sheet to capture. The map is the single source
+    // of truth for the values --includesheetpart accepts - see
+    // sheet-parts.js.
+    const selector = QSEOW_SHEET_PART_SELECTORS[options.includesheetpart];
+
+    // Ensure that the element we're interested in is loaded
+    await page.waitForSelector(selector);
+    const sheetMainPart = await page.$(selector);
+
+    // Checked before the shutter rather than after: the two are
+    // milliseconds apart, and of the two ways to be wrong, a
+    // spurious warning is far cheaper than staying silent about a
+    // thumbnail that shows the loading screen.
+    if (await sheetWasStillLoading(page, logger)) {
+        logger.warn(
+            stillLoadingWarning('QSEOW APP', iSheetNum, sheet?.qMeta?.title, options.pagewait)
+        );
+    }
+
+    await sheetMainPart.screenshot({
+        path: fileName,
+    });
+
+    return { fileName, fileNameShort };
+}
+
+/**
+ * Creates a blurred copy of an already-captured sheet image.
+ *
+ * Loads the image from disk, blurs it, and writes it back under a new name. Throws on failure and
+ * leaves the decision about what that means to the caller - see the note on
+ * {@link captureSheetImage}.
+ *
+ * @param {string} fileName - Full path of the already-captured image.
+ * @param {string} imgDir - Directory to save images.
+ * @param {string} appId - App ID.
+ * @param {number} iSheetNum - Sheet number.
+ * @param {object} options - Options object.
+ * @param {object} logger - Logger instance.
+ *
+ * @returns {Promise<{ fileNameShortBlurred: string }>} Basename of the blurred file.
+ *
+ * @throws {Error} Whatever Jimp throws when the image cannot be read, blurred or written.
+ */
+export async function blurSheetImage(fileName, imgDir, appId, iSheetNum, options, logger) {
+    const fileNameBlurred = `${imgDir}/qseow/${appId}/thumbnail-${appId}-${iSheetNum}-blurred.png`;
+    const fileNameShortBlurred = `thumbnail-${appId}-${iSheetNum}-blurred.png`;
+
+    let blurFactor;
+
+    // Blur factor should be between 1 and 100
+    if (options?.blurFactor < 1) {
+        blurFactor = 1; // Min blur value
+    } else if (options?.blurFactor > 100) {
+        blurFactor = 100; // Max blur value
+    } else {
+        blurFactor = parseInt(options?.blurFactor, 10);
+    }
+
+    // Use Jimp instead of Sharp
+    const image = await Jimp.read(fileName);
+    await image.blur(blurFactor).write(fileNameBlurred);
+
+    logger.verbose(`Created blurred image: ${fileNameBlurred}`);
+
+    return { fileNameShortBlurred };
+}


### PR DESCRIPTION
## What & why

Step 1 of #1091: **QSEoW adopts the capture/blur extraction Cloud already has.** The issue calls this
the step to do first — no interface is invented, the target shape already exists in production on one
platform, and it removes the single largest asymmetry between the twins.

`qseow-process-app.js` inlined roughly 130 lines of navigate → capture → blur inside a nested loop.
That work now lives in `src/lib/qseow/sheet-screenshot.js`, mirroring `src/lib/cloud/sheet-screenshot.js`.

## One deliberate difference from the Cloud twin

Cloud exposes a single `takeSheetScreenshot`. QSEoW gets **two** functions, `captureSheetImage` and
`blurSheetImage`, because the two failures mean different things here and that difference is
load-bearing:

| Failure | QSEoW today | Cloud today |
| --- | --- | --- |
| Capture fails | Propagates; the run fails | Propagates |
| Blur fails | Sheet dropped, counted in `blurFailures`, **run continues** | Propagates |

Folding them into one function would have quietly converted a capture failure into a counted blur
failure — a behaviour change, and step 1 is explicitly behaviour-preserving. The split sits exactly
where QSEoW's existing `try`/`catch` boundary already sat. Reconciling the two platforms' failure
semantics is step 4's job, and the module documents that.

For the same reason, QSEoW keeps pushing **two** `createdFiles` entries per sheet where Cloud pushes
one — that shape is consumed differently downstream on each platform, and changing it here would be a
behaviour change rather than a refactor.

## The new test is the point, not a side effect

Cloud had `__tests__/sheet_screenshot.test.js`; QSEoW had none. That is precisely the defect class
#1091 exists to fix — the issue's own evidence list includes *"a replacement command-level test
written for the QSEoW refactor and not the identical Cloud one"*.

So QSEoW now has the mirror suite, 18 tests. It closed the only two uncovered statements in the new
module — the blur-factor clamps, which Cloud tested and QSEoW did not — taking it to **100%, matching
Cloud exactly.**

## How it was verified

- **No existing test was edited.** The only test file added is the new mirror suite. Per the issue,
  a test that has to change is a signal the step changed behaviour, and none did.
- Full unit suite green.
- Coverage did not drop: `qseow/sheet-screenshot.js` is at 100%, the same as its Cloud twin, and
  `qseow-process-app.js` is unchanged in coverage terms — the extracted code was already exercised
  through it.
- `npm run lint` clean, `prettier --check` clean.
- The diff shows the `catch` block, the `createdFiles` pushes and the progress/report calls as
  unchanged lines: only the capture and blur bodies moved.

Not run: the live QSEoW integration suite, which needs the lab. The issue asks for that before
**step 4** is considered done; this step is a pure move with the unit suites as its gate.

## What this does not do

Steps 2–4 of #1091 are untouched. In particular QSEoW still uses a plain `for` loop where Cloud uses
the shared `runOverSheets` from `src/lib/util/sheet-list.js` — adopting that changes error handling
and `assertAllProcessed` semantics, so it belongs in its own step rather than riding along here.

Refs #1091
