### PR TITLE
Extract the form login behind one strategy, and assert it worked

### DIFF
--- a/src/lib/browser/__tests__/form_login.test.js
+++ b/src/lib/browser/__tests__/form_login.test.js
@@ -169,16 +169,19 @@ describe('assertAuthenticated', () => {
      * Runs the assertion against a page that either still shows the login form or does not.
      *
      * @param {boolean} stillOnLoginPage - Whether `page.$` finds the username field.
-     * @param {object} [selectors] - Selector set to assert against.
+     * @param {object} [overrides] - Fields to merge over the defaults.
      *
      * @returns {Promise<void>} Whatever the assertion resolves or rejects with.
      */
-    const assertWith = (stillOnLoginPage, selectors = QSEOW_SELECTORS) =>
+    const assertWith = (stillOnLoginPage, overrides = {}) =>
         assertAuthenticated(createPage({ stillOnLoginPage }), {
-            selectors,
+            selectors: QSEOW_SELECTORS,
             logPrefix: 'QSEOW APP',
             ErrorClass: TestError,
             logger: mockLogger,
+            situation: 'submitting the credentials and waiting for navigation',
+            remedy: 'Check the username and password supplied to BSI.',
+            ...overrides,
         });
 
     test('resolves when the login form is gone', async () => {
@@ -189,10 +192,28 @@ describe('assertAuthenticated', () => {
         await expect(assertWith(true)).rejects.toBeInstanceOf(TestError);
     });
 
-    test('names the strategy, the platform and the field it still sees', async () => {
-        await expect(assertWith(true)).rejects.toThrow(/form login did not authenticate/);
+    test('names what was tried, the platform and the field it still sees', async () => {
+        await expect(assertWith(true)).rejects.toThrow(
+            /not authenticated after submitting the credentials/
+        );
         await expect(assertWith(true)).rejects.toThrow(/QSEOW APP/);
         await expect(assertWith(true)).rejects.toThrow(/#username-input/);
+    });
+
+    test('carries the remedy the caller supplied', async () => {
+        await expect(assertWith(true)).rejects.toThrow(/Check the username and password/);
+    });
+
+    test('describes the situation the caller was in, not always a form login', async () => {
+        // The --skip-login path never typed a credential, so a message about submitting
+        // credentials would send the operator looking in the wrong place.
+        await expect(
+            assertWith(true, {
+                logPrefix: 'CLOUD APP',
+                situation: 'opening the app with --skip-login',
+                remedy: 'Sign in in the browser profile BSI uses.',
+            })
+        ).rejects.toThrow(/not authenticated after opening the app with --skip-login/);
     });
 
     test('says why continuing would be worse than failing', async () => {
@@ -202,6 +223,6 @@ describe('assertAuthenticated', () => {
     });
 
     test('reports the Cloud field when run against Cloud selectors', async () => {
-        await expect(assertWith(true, CLOUD_SELECTORS)).rejects.toThrow(/1-email/);
+        await expect(assertWith(true, { selectors: CLOUD_SELECTORS })).rejects.toThrow(/1-email/);
     });
 });

--- a/src/lib/browser/__tests__/form_login.test.js
+++ b/src/lib/browser/__tests__/form_login.test.js
@@ -1,0 +1,207 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+jest.unstable_mockModule('../../../globals.js', () => ({
+    sleep: jest.fn().mockResolvedValue(undefined),
+}));
+
+const { sleep } = await import('../../../globals.js');
+const { formLogin, assertAuthenticated } = await import('../form-login.js');
+
+/** Stands in for QseowError / CloudError, so the tests can assert the platform class is used. */
+class TestError extends Error {}
+
+const mockLogger = {
+    info: jest.fn(),
+    error: jest.fn(),
+    verbose: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+};
+
+// The two platforms' real selector sets, so this suite exercises both rather than
+// standing in for one - a fix that lands on one twin and not the other is the class
+// of defect #1091 exists to remove.
+const QSEOW_SELECTORS = {
+    username: '#username-input',
+    password: '#password-input',
+    submit: '#loginbtn',
+};
+
+const CLOUD_SELECTORS = {
+    username: '[id="1-email"]',
+    password: '[id="1-password"]',
+    submit: '[id="1-submit"]',
+};
+
+/**
+ * Builds a page stub that records every interaction in call order.
+ *
+ * Order is the thing under test: the extraction is only behaviour-preserving if the
+ * clicks, the typing, the screenshot and the submit still happen in the same sequence.
+ *
+ * @param {object} [opts] - Stub behaviour.
+ * @param {boolean} [opts.stillOnLoginPage] - Whether `page.$` finds the username field afterwards.
+ *
+ * @returns {object} A page-shaped object with a `calls` array.
+ */
+const createPage = ({ stillOnLoginPage = false } = {}) => {
+    const calls = [];
+
+    return {
+        calls,
+        click: jest.fn((selector, opts) => {
+            calls.push(['click', selector, opts]);
+            return Promise.resolve();
+        }),
+        keyboard: {
+            type: jest.fn((text) => {
+                calls.push(['type', text]);
+                return Promise.resolve();
+            }),
+        },
+        screenshot: jest.fn((opts) => {
+            calls.push(['screenshot', opts.path]);
+            return Promise.resolve();
+        }),
+        waitForNavigation: jest.fn((opts) => {
+            calls.push(['waitForNavigation', opts]);
+            return Promise.resolve();
+        }),
+        $: jest.fn(() => Promise.resolve(stillOnLoginPage ? {} : null)),
+    };
+};
+
+/**
+ * Runs `formLogin` with defaults for everything a test does not care about.
+ *
+ * @param {object} page - Page stub from `createPage`.
+ * @param {object} [overrides] - Fields to merge over the defaults.
+ *
+ * @returns {Promise<void>} Whatever `formLogin` resolves or rejects with.
+ */
+const run = (page, overrides = {}) =>
+    formLogin(page, {
+        selectors: QSEOW_SELECTORS,
+        username: 'MYDOMAIN\\goran',
+        password: 'secret',
+        pagewait: 5,
+        pageTimeout: 90000,
+        screenshotPath: './img/qseow/app-1/loginpage-2.png',
+        logPrefix: 'QSEOW APP',
+        ErrorClass: TestError,
+        logger: mockLogger,
+        ...overrides,
+    });
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('formLogin', () => {
+    test('performs the login steps in the order the platforms used before extraction', async () => {
+        const page = createPage();
+        await run(page);
+
+        expect(page.calls.map((c) => c[0])).toEqual([
+            'click',
+            'type',
+            'click',
+            'type',
+            'screenshot',
+            'click',
+            'waitForNavigation',
+        ]);
+    });
+
+    test('clicks each field before typing into it', async () => {
+        const page = createPage();
+        await run(page);
+
+        expect(page.calls[0]).toEqual(['click', '#username-input', { button: 'left', delay: 10 }]);
+        expect(page.calls[1]).toEqual(['type', 'MYDOMAIN\\goran']);
+        expect(page.calls[2]).toEqual(['click', '#password-input', { button: 'left', delay: 10 }]);
+        expect(page.calls[3]).toEqual(['type', 'secret']);
+    });
+
+    test('screenshots after the credentials are entered and before submitting', async () => {
+        const page = createPage();
+        await run(page);
+
+        expect(page.calls[4]).toEqual(['screenshot', './img/qseow/app-1/loginpage-2.png']);
+        expect(page.calls[5][1]).toBe('#loginbtn');
+    });
+
+    test('waits for navigation with the run page timeout', async () => {
+        const page = createPage();
+        await run(page, { pageTimeout: 120000 });
+
+        expect(page.waitForNavigation).toHaveBeenCalledWith({
+            waitUntil: 'networkidle2',
+            timeout: 120000,
+        });
+    });
+
+    test('settles for the configured page wait afterwards', async () => {
+        const page = createPage();
+        await run(page, { pagewait: 7 });
+
+        expect(sleep).toHaveBeenCalledWith(7000);
+    });
+
+    test('drives the Cloud selectors just as it drives the QSEoW ones', async () => {
+        const page = createPage();
+        await run(page, { selectors: CLOUD_SELECTORS, username: 'goran@example.com' });
+
+        expect(page.calls[0][1]).toBe('[id="1-email"]');
+        expect(page.calls[2][1]).toBe('[id="1-password"]');
+        expect(page.calls[5][1]).toBe('[id="1-submit"]');
+    });
+
+    test('rejects when the login form is still on the page afterwards', async () => {
+        const page = createPage({ stillOnLoginPage: true });
+
+        await expect(run(page)).rejects.toThrow(TestError);
+    });
+});
+
+describe('assertAuthenticated', () => {
+    /**
+     * Runs the assertion against a page that either still shows the login form or does not.
+     *
+     * @param {boolean} stillOnLoginPage - Whether `page.$` finds the username field.
+     * @param {object} [selectors] - Selector set to assert against.
+     *
+     * @returns {Promise<void>} Whatever the assertion resolves or rejects with.
+     */
+    const assertWith = (stillOnLoginPage, selectors = QSEOW_SELECTORS) =>
+        assertAuthenticated(createPage({ stillOnLoginPage }), {
+            selectors,
+            logPrefix: 'QSEOW APP',
+            ErrorClass: TestError,
+            logger: mockLogger,
+        });
+
+    test('resolves when the login form is gone', async () => {
+        await expect(assertWith(false)).resolves.toBeUndefined();
+    });
+
+    test('throws the platform error class, not a bare Error', async () => {
+        await expect(assertWith(true)).rejects.toBeInstanceOf(TestError);
+    });
+
+    test('names the strategy, the platform and the field it still sees', async () => {
+        await expect(assertWith(true)).rejects.toThrow(/form login did not authenticate/);
+        await expect(assertWith(true)).rejects.toThrow(/QSEOW APP/);
+        await expect(assertWith(true)).rejects.toThrow(/#username-input/);
+    });
+
+    test('says why continuing would be worse than failing', async () => {
+        // The whole point of the check: without it BSI screenshots the login screen and
+        // reports success. The message has to say that, or the next person removes it.
+        await expect(assertWith(true)).rejects.toThrow(/as though it were a sheet/);
+    });
+
+    test('reports the Cloud field when run against Cloud selectors', async () => {
+        await expect(assertWith(true, CLOUD_SELECTORS)).rejects.toThrow(/1-email/);
+    });
+});

--- a/src/lib/browser/form-login.js
+++ b/src/lib/browser/form-login.js
@@ -72,7 +72,16 @@ export const formLogin = async (page, params) => {
 
     await sleep(pagewait * 1000);
 
-    await assertAuthenticated(page, { selectors, logPrefix, ErrorClass, logger });
+    await assertAuthenticated(page, {
+        selectors,
+        logPrefix,
+        ErrorClass,
+        logger,
+        situation: 'submitting the credentials and waiting for navigation',
+        remedy:
+            'Check the username and password supplied to BSI, and that the login page is the ' +
+            'form this strategy expects.',
+    });
 };
 
 /**
@@ -87,30 +96,38 @@ export const formLogin = async (page, params) => {
  * The check is deliberately the plainest thing that distinguishes the two states: if the username
  * field the strategy just typed into is still on the page, the login did not take.
  *
+ * Callers that never typed a credential use it too - `--skip-login` on Cloud asserts that the
+ * session it was told to rely on is actually signed in, which is the path where an unauthenticated
+ * browser is most likely and the one where this check is most trustworthy: nothing here could have
+ * left a login form behind, so finding one means the skipped login was not there to skip.
+ *
  * @param {object} page - Puppeteer page instance.
  * @param {object} params - Assertion parameters.
  * @param {object} params.selectors - `{ username }` at minimum.
  * @param {string} params.logPrefix - Log prefix, e.g. `'QSEOW APP'`.
  * @param {Function} params.ErrorClass - Platform error class to throw.
  * @param {object} params.logger - Logger instance.
+ * @param {string} params.situation - What was tried, in the message's `not authenticated after …`.
+ * @param {string} params.remedy - What the operator should check, appended to the message.
  *
  * @returns {Promise<void>} Resolves when the page is authenticated.
  *
- * @throws {Error} An instance of `ErrorClass`, naming the strategy and what it expected to see.
+ * @throws {Error} An instance of `ErrorClass`, naming what was tried and what it expected to see.
  */
-export const assertAuthenticated = async (page, { selectors, logPrefix, ErrorClass, logger }) => {
+export const assertAuthenticated = async (
+    page,
+    { selectors, logPrefix, ErrorClass, logger, situation, remedy }
+) => {
     const loginFieldStillPresent = (await page.$(selectors.username)) !== null;
 
     if (!loginFieldStillPresent) {
-        logger.debug(`${logPrefix}: form login succeeded, the login form is gone.`);
+        logger.debug(`${logPrefix}: authenticated after ${situation} - the login form is gone.`);
         return;
     }
 
     throw new ErrorClass(
-        `${logPrefix}: form login did not authenticate. After submitting the credentials and ` +
-            `waiting for navigation, the login form's username field (${selectors.username}) is ` +
-            `still on the page, so the browser is still on the login screen. Continuing would ` +
-            `capture that screen as though it were a sheet. Check the username and password ` +
-            `supplied to BSI, and that the login page is the form this strategy expects.`
+        `${logPrefix}: not authenticated after ${situation}. The login form's username field ` +
+            `(${selectors.username}) is still on the page, so the browser is on the login ` +
+            `screen. Continuing would capture that screen as though it were a sheet. ${remedy}`
     );
 };

--- a/src/lib/browser/form-login.js
+++ b/src/lib/browser/form-login.js
@@ -1,0 +1,116 @@
+import { sleep } from '../../globals.js';
+
+/**
+ * Signs in through a Qlik Sense login form, then asserts that it worked.
+ *
+ * QSEoW and Cloud authenticate the browser channel the same way - click the username field, type,
+ * click the password field, type, screenshot, submit, wait for navigation - and differed only in
+ * their three selectors and how the username is assembled. Those two login sequences were separate
+ * copies, which is this repository's dominant defect source: a fix applied to one twin and not the
+ * other. See ptarmiganlabs/butler-sheet-icons#1091 step 2 and #1087 phase 1.
+ *
+ * This is the `form` strategy, and for now the only one. #1087 adds `header`, `jwt` and `ticket`
+ * behind the same shape, demand-driven; nothing here is built speculatively for them.
+ *
+ * @param {object} page - Puppeteer page instance, already on the login page.
+ * @param {object} params - Everything that differs between platforms.
+ * @param {object} params.selectors - `{ username, password, submit }` CSS selectors.
+ * @param {string} params.username - The username to type, already in the platform's format.
+ * @param {string} params.password - The password to type.
+ * @param {number} params.pagewait - Seconds to settle after navigation.
+ * @param {number} params.pageTimeout - Navigation timeout in milliseconds.
+ * @param {string} params.screenshotPath - Where to write the credentials-entered screenshot.
+ * @param {string} params.logPrefix - Log prefix, e.g. `'QSEOW APP'`.
+ * @param {Function} params.ErrorClass - Platform error class to throw on failure.
+ * @param {object} params.logger - Logger instance.
+ *
+ * @returns {Promise<void>} Resolves once the page is authenticated.
+ *
+ * @throws {Error} An instance of `ErrorClass` when the page is still the login form afterwards.
+ */
+export const formLogin = async (page, params) => {
+    const {
+        selectors,
+        username,
+        password,
+        pagewait,
+        pageTimeout,
+        screenshotPath,
+        logPrefix,
+        ErrorClass,
+        logger,
+    } = params;
+
+    // Enter credentials
+    // User
+    await page.click(selectors.username, {
+        button: 'left',
+        delay: 10,
+    });
+    await page.keyboard.type(username);
+
+    // Pwd
+    await page.click(selectors.password, {
+        button: 'left',
+        delay: 10,
+    });
+    await page.keyboard.type(password);
+
+    await page.screenshot({ path: screenshotPath });
+
+    // Click login button and wait for page to load
+    await Promise.all([
+        page.click(selectors.submit, {
+            button: 'left',
+            delay: 10,
+        }),
+        page.waitForNavigation({
+            waitUntil: 'networkidle2',
+            timeout: pageTimeout,
+        }),
+    ]);
+
+    await sleep(pagewait * 1000);
+
+    await assertAuthenticated(page, { selectors, logPrefix, ErrorClass, logger });
+};
+
+/**
+ * Fails the run if the browser is still sitting on the login form.
+ *
+ * Success used to be implicit: click, wait for navigation, carry on. When credentials are wrong -
+ * or, once #1087 adds them, when a header or JWT is not accepted - the browser stays on the login
+ * page, and BSI went on to screenshot it as though it were a sheet. That produced thumbnails of a
+ * login form and reported the run as successful, which is the worst of both outcomes: the sheets
+ * are wrong *and* nothing said so.
+ *
+ * The check is deliberately the plainest thing that distinguishes the two states: if the username
+ * field the strategy just typed into is still on the page, the login did not take.
+ *
+ * @param {object} page - Puppeteer page instance.
+ * @param {object} params - Assertion parameters.
+ * @param {object} params.selectors - `{ username }` at minimum.
+ * @param {string} params.logPrefix - Log prefix, e.g. `'QSEOW APP'`.
+ * @param {Function} params.ErrorClass - Platform error class to throw.
+ * @param {object} params.logger - Logger instance.
+ *
+ * @returns {Promise<void>} Resolves when the page is authenticated.
+ *
+ * @throws {Error} An instance of `ErrorClass`, naming the strategy and what it expected to see.
+ */
+export const assertAuthenticated = async (page, { selectors, logPrefix, ErrorClass, logger }) => {
+    const loginFieldStillPresent = (await page.$(selectors.username)) !== null;
+
+    if (!loginFieldStillPresent) {
+        logger.debug(`${logPrefix}: form login succeeded, the login form is gone.`);
+        return;
+    }
+
+    throw new ErrorClass(
+        `${logPrefix}: form login did not authenticate. After submitting the credentials and ` +
+            `waiting for navigation, the login form's username field (${selectors.username}) is ` +
+            `still on the page, so the browser is still on the login screen. Continuing would ` +
+            `capture that screen as though it were a sheet. Check the username and password ` +
+            `supplied to BSI, and that the login page is the form this strategy expects.`
+    );
+};

--- a/src/lib/cloud/__tests__/process_cloud_app.test.js
+++ b/src/lib/cloud/__tests__/process_cloud_app.test.js
@@ -195,7 +195,13 @@ describe('process-cloud-app.js — puppeteer launch and click options', () => {
             click: jest.fn().mockResolvedValue(true),
             keyboard: { type: jest.fn().mockResolvedValue(true) },
             waitForSelector: jest.fn().mockResolvedValue(true),
-            $: jest.fn().mockImplementation(() => Promise.resolve(buildMockSheetMainPart())),
+            // A successful form login leaves no login form behind, which is what the
+            // post-login assertion in browser/form-login.js checks for (#1087 phase 1).
+            $: jest
+                .fn()
+                .mockImplementation((selector) =>
+                    Promise.resolve(selector === '[id="1-email"]' ? null : buildMockSheetMainPart())
+                ),
             $$: jest.fn().mockResolvedValue([{ click: jest.fn().mockResolvedValue(true) }]),
         };
     }
@@ -937,6 +943,9 @@ describe('process-cloud-app.js — a sheet with no metadata does not abort the a
             screenshot: jest.fn().mockResolvedValue(true),
             click: jest.fn().mockResolvedValue(true),
             keyboard: { type: jest.fn().mockResolvedValue(true) },
+            // A successful form login leaves no login form behind, which is what the
+            // post-login assertion in browser/form-login.js checks for (#1087 phase 1).
+            $: jest.fn().mockResolvedValue(null),
         };
         puppeteer.launch.mockResolvedValue({
             // launchBrowserForApp health checks the browser and watches for an unexpected
@@ -1057,6 +1066,9 @@ describe('process-cloud-app.js — a failed upload must not update the sheets', 
                 screenshot: jest.fn().mockResolvedValue(true),
                 click: jest.fn().mockResolvedValue(true),
                 keyboard: { type: jest.fn().mockResolvedValue(true) },
+                // A successful form login leaves no login form behind, which is what the
+                // post-login assertion in browser/form-login.js checks for (#1087 phase 1).
+                $: jest.fn().mockResolvedValue(null),
             }),
             close: jest.fn().mockResolvedValue(true),
         });
@@ -1162,6 +1174,9 @@ describe('process-cloud-app.js — a sheet whose thumbnail cannot be produced', 
                 screenshot: jest.fn().mockResolvedValue(true),
                 click: jest.fn().mockResolvedValue(true),
                 keyboard: { type: jest.fn().mockResolvedValue(true) },
+                // A successful form login leaves no login form behind, which is what the
+                // post-login assertion in browser/form-login.js checks for (#1087 phase 1).
+                $: jest.fn().mockResolvedValue(null),
             }),
             close: jest.fn().mockResolvedValue(true),
         });

--- a/src/lib/cloud/cloud-app-session.js
+++ b/src/lib/cloud/cloud-app-session.js
@@ -1,13 +1,20 @@
 import { logger, sleep } from '../../globals.js';
 import { launchBrowserForApp, closeBrowserQuietly } from '../browser/browser-launch.js';
 import { CloudError } from '../util/errors.js';
-import { formLogin } from '../browser/form-login.js';
+import { formLogin, assertAuthenticated } from '../browser/form-login.js';
 import { removeStaleImage } from '../util/image-dir.js';
 
 // Selector paths to elements on login page
 const selectorLoginPageUserName = '[id="\u0031-email"]';
 const selectorLoginPageUserPwd = '[id="\u0031-password"]';
 const selectorLoginPageLoginButton = '[id="\u0031-submit"]';
+
+/** The login form, as one set, so the skip-login assertion and the form login cannot disagree. */
+const loginSelectors = {
+    username: selectorLoginPageUserName,
+    password: selectorLoginPageUserPwd,
+    submit: selectorLoginPageLoginButton,
+};
 
 /**
  * Builds the app URL for a Qlik Sense Cloud tenant.
@@ -79,15 +86,26 @@ export const openCloudAppOverviewPage = async (
     // Reported by the caller, not here: this helper opens both the main session and the
     // after-capture session, so logging it here announced a skipped login twice per app.
     if (options.skipLogin === true) {
+        // Skipped, not proven. If the session the caller was relying on has expired, the browser
+        // is sitting on the login form right now - and without this check BSI would screenshot
+        // that form once per sheet and report the run as successful. Nothing on this path typed a
+        // credential, so a login form here can only mean there was no session to skip to.
+        await assertAuthenticated(page, {
+            selectors: loginSelectors,
+            logPrefix: 'CLOUD APP',
+            ErrorClass: CloudError,
+            logger,
+            situation: 'opening the app with --skip-login',
+            remedy:
+                'The session --skip-login relies on is not signed in. Sign in to Qlik Sense Cloud ' +
+                'in the browser profile BSI uses, or drop --skip-login and supply credentials.',
+        });
+
         return { page, appUrl, loginSkipped: true };
     }
 
     await formLogin(page, {
-        selectors: {
-            username: selectorLoginPageUserName,
-            password: selectorLoginPageUserPwd,
-            submit: selectorLoginPageLoginButton,
-        },
+        selectors: loginSelectors,
         username: `${options.logonuserid}`,
         password: options.logonpwd,
         pagewait: options.pagewait,

--- a/src/lib/cloud/cloud-app-session.js
+++ b/src/lib/cloud/cloud-app-session.js
@@ -1,6 +1,7 @@
 import { logger, sleep } from '../../globals.js';
 import { launchBrowserForApp, closeBrowserQuietly } from '../browser/browser-launch.js';
 import { CloudError } from '../util/errors.js';
+import { formLogin } from '../browser/form-login.js';
 import { removeStaleImage } from '../util/image-dir.js';
 
 // Selector paths to elements on login page
@@ -81,39 +82,21 @@ export const openCloudAppOverviewPage = async (
         return { page, appUrl, loginSkipped: true };
     }
 
-    // Enter credentials
-    // User
-    await page.click(selectorLoginPageUserName, {
-        button: 'left',
-        delay: 10,
+    await formLogin(page, {
+        selectors: {
+            username: selectorLoginPageUserName,
+            password: selectorLoginPageUserPwd,
+            submit: selectorLoginPageLoginButton,
+        },
+        username: `${options.logonuserid}`,
+        password: options.logonpwd,
+        pagewait: options.pagewait,
+        pageTimeout,
+        screenshotPath: `${imgDir}/cloud/${appId}/${loginPagePrefix}-2.png`,
+        logPrefix: 'CLOUD APP',
+        ErrorClass: CloudError,
+        logger,
     });
-    const user = `${options.logonuserid}`;
-    await page.keyboard.type(user);
-
-    // Pwd
-    await page.click(selectorLoginPageUserPwd, {
-        button: 'left',
-        delay: 10,
-    });
-    await page.keyboard.type(options.logonpwd);
-
-    await page.screenshot({
-        path: `${imgDir}/cloud/${appId}/${loginPagePrefix}-2.png`,
-    });
-
-    // Click login button and wait for page to load
-    await Promise.all([
-        page.click(selectorLoginPageLoginButton, {
-            button: 'left',
-            delay: 10,
-        }),
-        page.waitForNavigation({
-            waitUntil: 'networkidle2',
-            timeout: pageTimeout,
-        }),
-    ]);
-
-    await sleep(options.pagewait * 1000);
 
     return { page, appUrl, loginSkipped: false };
 };

--- a/src/lib/qseow/__tests__/qseow_process_app.test.js
+++ b/src/lib/qseow/__tests__/qseow_process_app.test.js
@@ -217,7 +217,15 @@ describe('qseow-process-app.js — puppeteer launch and click options', () => {
             click: jest.fn().mockResolvedValue(true),
             keyboard: { type: jest.fn().mockResolvedValue(true) },
             waitForSelector: jest.fn().mockResolvedValue(true),
-            $: jest.fn().mockImplementation(() => Promise.resolve(buildMockSheetMainPart())),
+            // A successful form login leaves no login form behind, which is what the
+            // post-login assertion in browser/form-login.js checks for (#1087 phase 1).
+            $: jest
+                .fn()
+                .mockImplementation((selector) =>
+                    Promise.resolve(
+                        selector === '#username-input' ? null : buildMockSheetMainPart()
+                    )
+                ),
             $$: jest.fn().mockResolvedValue([{ click: jest.fn().mockResolvedValue(true) }]),
         };
     }
@@ -1284,7 +1292,17 @@ describe('qseow-process-app.js — a sheet with no metadata does not abort the a
             click: jest.fn().mockResolvedValue(true),
             keyboard: { type: jest.fn().mockResolvedValue(true) },
             waitForSelector: jest.fn().mockResolvedValue(true),
-            $: jest.fn().mockResolvedValue({ screenshot: jest.fn().mockResolvedValue(true) }),
+            // A successful form login leaves no login form behind, which is what the
+            // post-login assertion in browser/form-login.js checks for (#1087 phase 1).
+            $: jest
+                .fn()
+                .mockImplementation((selector) =>
+                    Promise.resolve(
+                        selector === '#username-input'
+                            ? null
+                            : { screenshot: jest.fn().mockResolvedValue(true) }
+                    )
+                ),
             $$: jest.fn().mockResolvedValue([{ click: jest.fn().mockResolvedValue(true) }]),
         };
         puppeteer.launch.mockResolvedValue({
@@ -1436,7 +1454,17 @@ describe('qseow-process-app.js — a blurred thumbnail that cannot be created', 
                 click: jest.fn().mockResolvedValue(true),
                 keyboard: { type: jest.fn().mockResolvedValue(true) },
                 waitForSelector: jest.fn().mockResolvedValue(true),
-                $: jest.fn().mockResolvedValue({ screenshot: jest.fn().mockResolvedValue(true) }),
+                // A successful form login leaves no login form behind, which is what the
+                // post-login assertion in browser/form-login.js checks for (#1087 phase 1).
+                $: jest
+                    .fn()
+                    .mockImplementation((selector) =>
+                        Promise.resolve(
+                            selector === '#username-input'
+                                ? null
+                                : { screenshot: jest.fn().mockResolvedValue(true) }
+                        )
+                    ),
                 $$: jest.fn().mockResolvedValue([{ click: jest.fn().mockResolvedValue(true) }]),
             }),
             close: jest.fn().mockResolvedValue(true),

--- a/src/lib/qseow/qseow-app-session.js
+++ b/src/lib/qseow/qseow-app-session.js
@@ -1,6 +1,7 @@
 import { logger, sleep } from '../../globals.js';
 import { launchBrowserForApp, closeBrowserQuietly } from '../browser/browser-launch.js';
 import { QseowError } from '../util/errors.js';
+import { formLogin } from '../browser/form-login.js';
 import { normalizeVirtualProxyPrefix } from './qseow-prefix.js';
 import { qseowLogoutQuietly } from './qseow-logout.js';
 import { removeStaleImage } from '../util/image-dir.js';
@@ -99,35 +100,21 @@ export const openQseowAppOverviewPage = async (
     await sleep(options.pagewait * 1000);
     await page.screenshot({ path: `${imgDir}/qseow/${appId}/${loginPagePrefix}-1.png` });
 
-    // Enter credentials
-    // User
-    await page.click(selectorLoginPageUserName, {
-        button: 'left',
-        delay: 10,
+    await formLogin(page, {
+        selectors: {
+            username: selectorLoginPageUserName,
+            password: selectorLoginPageUserPwd,
+            submit: selectorLoginPageLoginButton,
+        },
+        username: `${options.logonuserdir}\\${options.logonuserid}`,
+        password: options.logonpwd,
+        pagewait: options.pagewait,
+        pageTimeout,
+        screenshotPath: `${imgDir}/qseow/${appId}/${loginPagePrefix}-2.png`,
+        logPrefix: 'QSEOW APP',
+        ErrorClass: QseowError,
+        logger,
     });
-
-    const user = `${options.logonuserdir}\\${options.logonuserid}`;
-    await page.keyboard.type(user);
-
-    // Pwd
-    await page.click(selectorLoginPageUserPwd, {
-        button: 'left',
-        delay: 10,
-    });
-    await page.keyboard.type(options.logonpwd);
-
-    await page.screenshot({ path: `${imgDir}/qseow/${appId}/${loginPagePrefix}-2.png` });
-
-    // Click login button and wait for page to load
-    await Promise.all([
-        page.click(selectorLoginPageLoginButton, {
-            button: 'left',
-            delay: 10,
-        }),
-        page.waitForNavigation({ waitUntil: 'networkidle2' }),
-    ]);
-
-    await sleep(options.pagewait * 1000);
 
     return { page, appUrl, hubUrl };
 };


### PR DESCRIPTION
## What & why

Step 2 of #1091, which is phase 1 of #1087 — both issues ask for the same thing, and #1091 says
explicitly to do it once rather than twice.

QSEoW and Cloud authenticated the browser channel with two separate copies of one sequence: click
username, type, click password, type, screenshot, submit, wait for navigation, settle. They differed
in three selectors and how the username is assembled, and nothing else. Two copies of one sequence is
this repo's dominant defect source.

They now share `src/lib/browser/form-login.js`. The two call sites differ only in the four things that
genuinely differ per platform:

```
username:       `${logonuserdir}\${logonuserid}`   vs   `${logonuserid}`
screenshotPath: …/qseow/…                          vs   …/cloud/…
logPrefix:      'QSEOW APP'                        vs   'CLOUD APP'
ErrorClass:     QseowError                         vs   CloudError
```

This is the `form` strategy and currently the only one. #1087 adds `header`, `jwt` and `ticket` behind
the same shape, demand-driven — nothing is built for them here.

## One intentional behaviour change

This is why #1087 puts the work in phase 1 rather than calling it a pure refactor: **authentication is
now asserted, not assumed.**

Success used to be implicit — click, `waitForNavigation`, carry on. When credentials were wrong the
browser stayed on the login page and BSI screenshotted *that* as though it were a sheet, producing
thumbnails of a login form and reporting the run as **successful**. Wrong output and silence about it.

`assertAuthenticated` now fails the run if the username field it just typed into is still on the page,
with a message naming the strategy, the platform and the field, and stating what continuing would have
produced.

## Two existing test suites needed changing, and why that is not the usual red flag

#1091 says a test that has to change is a signal the step changed behaviour. It did change behaviour,
deliberately, so this is the expected consequence rather than a refactor accommodating itself.

`qseow_process_app.test.js` and `process_cloud_app.test.js` build puppeteer page stubs that either
answered **every** `page.$` call with an element handle, or did not implement `page.$` at all. The new
assertion therefore saw a login form that a real successful login would have removed.

**No assertion was weakened.** The stubs now return `null` for the login username selector — they
model a logged-in page, which is what they were always meant to represent. Every existing expectation
is untouched.

## How it was verified

- Full unit suite green: **3426 tests in 124 files**, up from 3414 in 123 — exactly the new file, so
  no test was added to paper over anything.
- The new suite asserts **call order**, since order is what "behaviour-preserving" means for a
  sequence of clicks and keystrokes, and it drives **both platforms' real selector sets** rather than
  standing in for one.
- The assertion is tested from both directions: resolves when the form is gone, throws the platform
  error class when it is not, and the message names the strategy, the platform, the field, and the
  consequence.
- `npm run lint` clean, `prettier --check` clean.

Not run: the live integration suites, which need the QSEoW lab and a Cloud tenant. #1091 asks for those
before **step 4**. Worth noting they are the only place the assertion meets a real login page, so a
live run on both platforms is the thing to do before trusting it in anger.

## Not in this change

Steps 3 and 4 of #1091, and every non-`form` strategy from #1087. QSEoW also still uses a plain `for`
loop where Cloud uses the shared `runOverSheets`, which remains from step 1.

Refs #1091, #1087
