### PR TITLE
Cloud adopts the shared app-context read QSEoW already has

### DIFF
--- a/src/lib/cloud/__tests__/cloud_app_context.test.js
+++ b/src/lib/cloud/__tests__/cloud_app_context.test.js
@@ -1,0 +1,59 @@
+import { jest, describe, test, expect } from '@jest/globals';
+
+import { readCloudAppContext } from '../cloud-app-context.js';
+
+const APP_ID = 'test-app-id';
+
+/**
+ * Builds a saas stub returning the given app metadata.
+ *
+ * @param {object} attributes - The app's `attributes` object.
+ *
+ * @returns {object} A saas-shaped object with `Get`.
+ */
+const createSaas = (attributes) => ({
+    Get: jest.fn().mockResolvedValue({ attributes }),
+});
+
+describe('readCloudAppContext', () => {
+    test('reads the app from the apps endpoint', async () => {
+        const saasInstance = createSaas({ name: 'Test App' });
+
+        await readCloudAppContext(APP_ID, saasInstance);
+
+        expect(saasInstance.Get).toHaveBeenCalledWith('apps/test-app-id');
+    });
+
+    test('returns the metadata it read', async () => {
+        const saasInstance = createSaas({ name: 'Test App', publishTime: null });
+
+        const { appMetadata } = await readCloudAppContext(APP_ID, saasInstance);
+
+        expect(appMetadata.attributes.name).toBe('Test App');
+    });
+
+    test('reports an app with a publish time as published', async () => {
+        const saasInstance = createSaas({ publishTime: '2021-09-01T12:34:56.789Z' });
+
+        const { appIsPublished } = await readCloudAppContext(APP_ID, saasInstance);
+
+        expect(appIsPublished).toBe(true);
+    });
+
+    test('reports an app with no publish time as unpublished', async () => {
+        const saasInstance = createSaas({ publishTime: null });
+
+        const { appIsPublished } = await readCloudAppContext(APP_ID, saasInstance);
+
+        expect(appIsPublished).toBe(false);
+    });
+
+    test('reports an empty publish time as unpublished', async () => {
+        // The field is a string, and Qlik returns '' rather than null in some responses.
+        const saasInstance = createSaas({ publishTime: '' });
+
+        const { appIsPublished } = await readCloudAppContext(APP_ID, saasInstance);
+
+        expect(appIsPublished).toBe(false);
+    });
+});

--- a/src/lib/cloud/__tests__/cloud_delete_thumbnails.test.js
+++ b/src/lib/cloud/__tests__/cloud_delete_thumbnails.test.js
@@ -1,6 +1,9 @@
 import { jest, describe, test, expect, beforeEach } from '@jest/globals';
 
-import { deleteCloudAppThumbnail } from '../cloud-delete-thumbnails.js';
+import {
+    deleteCloudAppThumbnail,
+    clearExistingCloudThumbnails,
+} from '../cloud-delete-thumbnails.js';
 
 const mockLogger = {
     info: jest.fn(),
@@ -81,5 +84,77 @@ describe('deleteCloudAppThumbnail', () => {
         ).rejects.toThrow();
 
         expect(mockLogger.error).toHaveBeenCalled();
+    });
+});
+
+describe('clearExistingCloudThumbnails', () => {
+    /**
+     * Builds a saas stub whose media library contains the given entries.
+     *
+     * @param {object} [opts] - Stub behaviour.
+     * @param {Array} [opts.mediaList] - What `media/list` returns.
+     * @param {Array} [opts.thumbnails] - What `media/list/thumbnails` returns.
+     *
+     * @returns {object} A saas-shaped object with `Get` and `Delete`.
+     */
+    const createSaas = ({ mediaList = [], thumbnails = [] } = {}) => ({
+        Get: jest.fn((path) =>
+            Promise.resolve(path.endsWith('/thumbnails') ? thumbnails : mediaList)
+        ),
+        Delete: jest.fn().mockResolvedValue({ statusCode: 204 }),
+    });
+
+    const THUMBNAIL_FOLDER = { type: 'directory', name: 'thumbnails' };
+
+    test('does nothing when the app has no thumbnails folder', async () => {
+        const saasInstance = createSaas({ mediaList: [{ type: 'directory', name: 'other' }] });
+
+        await clearExistingCloudThumbnails(APP_ID, saasInstance, mockLogger);
+
+        expect(saasInstance.Get).toHaveBeenCalledTimes(1);
+        expect(saasInstance.Delete).not.toHaveBeenCalled();
+    });
+
+    test('deletes every image in the thumbnails folder', async () => {
+        const saasInstance = createSaas({
+            mediaList: [THUMBNAIL_FOLDER],
+            thumbnails: [
+                { type: 'image', name: 'thumbnail-1.png' },
+                { type: 'image', name: 'thumbnail-2.png' },
+            ],
+        });
+
+        await clearExistingCloudThumbnails(APP_ID, saasInstance, mockLogger);
+
+        expect(saasInstance.Delete).toHaveBeenCalledTimes(2);
+    });
+
+    test('leaves entries that are not images alone', async () => {
+        const saasInstance = createSaas({
+            mediaList: [THUMBNAIL_FOLDER],
+            thumbnails: [
+                { type: 'image', name: 'thumbnail-1.png' },
+                { type: 'directory', name: 'nested' },
+            ],
+        });
+
+        await clearExistingCloudThumbnails(APP_ID, saasInstance, mockLogger);
+
+        expect(saasInstance.Delete).toHaveBeenCalledTimes(1);
+    });
+
+    test('throws when the existing thumbnails cannot be listed', async () => {
+        // Capturing over an app whose old images are in an unknown state is worse than stopping.
+        const saasInstance = createSaas({ mediaList: [THUMBNAIL_FOLDER] });
+        saasInstance.Get.mockImplementation((path) =>
+            path.endsWith('/thumbnails')
+                ? Promise.reject(new Error('403 Forbidden'))
+                : Promise.resolve([THUMBNAIL_FOLDER])
+        );
+
+        await expect(
+            clearExistingCloudThumbnails(APP_ID, saasInstance, mockLogger)
+        ).rejects.toThrow('Error getting existing thumbnails');
+        expect(saasInstance.Delete).not.toHaveBeenCalled();
     });
 });

--- a/src/lib/cloud/__tests__/cloud_delete_thumbnails.test.js
+++ b/src/lib/cloud/__tests__/cloud_delete_thumbnails.test.js
@@ -3,6 +3,7 @@ import { jest, describe, test, expect, beforeEach } from '@jest/globals';
 import {
     deleteCloudAppThumbnail,
     clearExistingCloudThumbnails,
+    listExistingCloudThumbnails,
 } from '../cloud-delete-thumbnails.js';
 
 const mockLogger = {
@@ -156,5 +157,84 @@ describe('clearExistingCloudThumbnails', () => {
             clearExistingCloudThumbnails(APP_ID, saasInstance, mockLogger)
         ).rejects.toThrow('Error getting existing thumbnails');
         expect(saasInstance.Delete).not.toHaveBeenCalled();
+    });
+});
+
+describe('listExistingCloudThumbnails', () => {
+    /**
+     * Builds a saas stub whose media library contains the given entries.
+     *
+     * @param {object} [opts] - Stub behaviour.
+     * @param {Array} [opts.mediaList] - What `media/list` returns.
+     * @param {Array} [opts.thumbnails] - What `media/list/thumbnails` returns.
+     *
+     * @returns {object} A saas-shaped object with `Get`.
+     */
+    const createSaas = ({ mediaList = [], thumbnails = [] } = {}) => ({
+        Get: jest.fn((path) =>
+            Promise.resolve(path.endsWith('/thumbnails') ? thumbnails : mediaList)
+        ),
+    });
+
+    const FOLDER = { type: 'directory', name: 'thumbnails' };
+
+    test('returns nothing, without a second call, when there is no thumbnails folder', async () => {
+        const saasInstance = createSaas({ mediaList: [{ type: 'directory', name: 'other' }] });
+
+        const result = await listExistingCloudThumbnails(APP_ID, saasInstance, mockLogger, 'TEST');
+
+        expect(result).toEqual([]);
+        expect(saasInstance.Get).toHaveBeenCalledTimes(1);
+    });
+
+    test('returns only the images, not the directories beside them', async () => {
+        const saasInstance = createSaas({
+            mediaList: [FOLDER],
+            thumbnails: [
+                { type: 'image', name: 'thumbnail-1.png' },
+                { type: 'directory', name: 'nested' },
+                { type: 'image', name: 'thumbnail-2.png' },
+            ],
+        });
+
+        const result = await listExistingCloudThumbnails(APP_ID, saasInstance, mockLogger, 'TEST');
+
+        expect(result.map((item) => item.name)).toEqual(['thumbnail-1.png', 'thumbnail-2.png']);
+    });
+
+    test('throws when the folder exists but its contents cannot be listed', async () => {
+        const saasInstance = createSaas({ mediaList: [FOLDER] });
+        saasInstance.Get.mockImplementation((path) =>
+            path.endsWith('/thumbnails')
+                ? Promise.reject(new Error('403 Forbidden'))
+                : Promise.resolve([FOLDER])
+        );
+
+        await expect(
+            listExistingCloudThumbnails(APP_ID, saasInstance, mockLogger, 'TEST')
+        ).rejects.toThrow('Error getting existing thumbnails');
+    });
+});
+
+describe('clearExistingCloudThumbnails return value', () => {
+    test('reports how many images it deleted, for the caller to record', async () => {
+        const saasInstance = {
+            Get: jest.fn((path) =>
+                Promise.resolve(
+                    path.endsWith('/thumbnails')
+                        ? [
+                              { type: 'image', name: 'a.png' },
+                              { type: 'image', name: 'b.png' },
+                              { type: 'directory', name: 'nested' },
+                          ]
+                        : [{ type: 'directory', name: 'thumbnails' }]
+                )
+            ),
+            Delete: jest.fn().mockResolvedValue({ statusCode: 204 }),
+        };
+
+        const deleted = await clearExistingCloudThumbnails(APP_ID, saasInstance, mockLogger);
+
+        expect(deleted).toBe(2);
     });
 });

--- a/src/lib/cloud/__tests__/process_cloud_app.test.js
+++ b/src/lib/cloud/__tests__/process_cloud_app.test.js
@@ -88,6 +88,10 @@ const mockBrowserDetect = jest.unstable_mockModule('../../browser/browser-detect
 
 const mockCloudDeleteThumbnails = jest.unstable_mockModule('../cloud-delete-thumbnails.js', () => ({
     deleteCloudAppThumbnail: jest.fn().mockResolvedValue(true),
+    // The pre-flight clear moved out of this module; its own behaviour is covered in
+    // cloud_delete_thumbnails.test.js. No test here ever exercised it - every saas stub
+    // answers media/list with an empty array, so the thumbnails folder never existed.
+    clearExistingCloudThumbnails: jest.fn().mockResolvedValue(undefined),
 }));
 
 const mockSheetScreenshot = jest.unstable_mockModule('../sheet-screenshot.js', () => ({

--- a/src/lib/cloud/cloud-app-context.js
+++ b/src/lib/cloud/cloud-app-context.js
@@ -1,0 +1,31 @@
+/**
+ * Reads the per-app facts that both the real run and the dry-run planner need.
+ *
+ * These two lines existed twice - once in `process-cloud-app.js` and once in `cloud-plan-app.js`,
+ * whose copy carried the comment "same read, same endpoint as the real run". That comment is an
+ * accurate description of a duplication held together by review, which is the control
+ * ptarmiganlabs/butler-sheet-icons#1091 says has been the failing one. QSEoW settled the same
+ * question the other way: `readQseowAppContext` exists precisely "so the two modes cannot drift
+ * apart", and this is Cloud adopting that.
+ *
+ * Deliberately a read and nothing else. Clearing the app's existing thumbnails is a side effect the
+ * real run performs and the planner must not - see `clearExistingCloudThumbnails`.
+ *
+ * @param {string} appId - Qlik Sense app ID.
+ * @param {object} saasInstance - QlikSaas instance for the tenant.
+ *
+ * @returns {Promise<{ appMetadata: object, appIsPublished: boolean }>} The app's metadata and
+ *     whether it is published.
+ */
+export const readCloudAppContext = async (appId, saasInstance) => {
+    // Get app name
+    const appMetadata = await saasInstance.Get(`apps/${appId}`);
+
+    // Is app published?
+    // appMetadata.attributes.publishTime is a string like "2021-09-01T12:34:56.789Z"
+
+    // If empty the app is not published
+    const appIsPublished = !!appMetadata.attributes.publishTime;
+
+    return { appMetadata, appIsPublished };
+};

--- a/src/lib/cloud/cloud-delete-thumbnails.js
+++ b/src/lib/cloud/cloud-delete-thumbnails.js
@@ -1,3 +1,5 @@
+import { logError } from '../util/log-error.js';
+
 /**
  * Deletes a single thumbnail image from a Qlik Sense Cloud app's media library.
  *
@@ -32,3 +34,58 @@ export async function deleteCloudAppThumbnail(thumbnailImg, appId, saasInstance,
         throw new Error('Error deleting existing thumbnail', { cause: err });
     }
 }
+
+/**
+ * Removes every thumbnail already in an app's media library, before new ones are captured.
+ *
+ * Cloud clears the old images and QSEoW does not - a real difference between the platforms, not an
+ * oversight, and one ptarmiganlabs/butler-sheet-icons#1091 records as staying per-platform. Pulled
+ * out of `process-cloud-app.js` so that module's pre-flight is two named calls rather than forty
+ * inline lines, which is what #1091 step 3 assumed was already true.
+ *
+ * The dry-run planner deliberately does not call this: planning an app must not change it.
+ *
+ * @param {string} appId - Qlik Sense app ID.
+ * @param {object} saasInstance - QlikSaas instance for the tenant.
+ * @param {object} logger - Logger instance.
+ *
+ * @returns {Promise<void>} Resolves once every existing thumbnail image has been deleted.
+ *
+ * @throws {Error} When the existing thumbnails cannot be listed. Capturing over an app whose old
+ *     images are in an unknown state is worse than stopping.
+ */
+export const clearExistingCloudThumbnails = async (appId, saasInstance, logger) => {
+    // Does the app have a thumbnail folder in its media library?
+    logger.verbose(`Getting media list for app ${appId}, media path is "apps/${appId}/media/list"`);
+    const mediaList = await saasInstance.Get(`apps/${appId}/media/list`);
+
+    const hasThumbnailFolder = mediaList.find((item) => {
+        const thumbnailFolderExists = item.type === 'directory' && item.name === 'thumbnails';
+        return thumbnailFolderExists;
+    });
+
+    if (!hasThumbnailFolder) {
+        return;
+    }
+
+    // "thumbnails" folder exists in app's media library
+    logger.debug(`App ${appId} has a "thumbnails" folder in its media library`);
+
+    // Remove all existing thumbnail images from this app
+    let existingThumbnails;
+    try {
+        logger.verbose(
+            `Getting existing thumbnails for app ${appId}, media path is "apps/${appId}/media/list/thumbnails"`
+        );
+        existingThumbnails = await saasInstance.Get(`apps/${appId}/media/list/thumbnails`);
+    } catch (err) {
+        logError('CREATE THUMBNAILS 2: Error getting existing thumbnails', err);
+        throw new Error('Error getting existing thumbnails', { cause: err });
+    }
+
+    for (const thumbnailImg of existingThumbnails) {
+        if (thumbnailImg.type === 'image') {
+            await deleteCloudAppThumbnail(thumbnailImg, appId, saasInstance, logger);
+        }
+    }
+};

--- a/src/lib/cloud/cloud-delete-thumbnails.js
+++ b/src/lib/cloud/cloud-delete-thumbnails.js
@@ -36,6 +36,59 @@ export async function deleteCloudAppThumbnail(thumbnailImg, appId, saasInstance,
 }
 
 /**
+ * Lists the thumbnail images already in an app's media library.
+ *
+ * Three places needed this: the pre-flight clear before a capture run, the delete pass in
+ * `cloud-remove-sheet-icons.js`, and that command's dry-run counterpart. All three carried their own
+ * copy of the same folder predicate and the same two endpoints, and the last two are a real-run and
+ * planner pair - so the dry run and the run it predicts could come to disagree about how many files
+ * would be deleted. That is the drift ptarmiganlabs/butler-sheet-icons#1091 exists to remove.
+ *
+ * Returns only entries of type `image`; the folder listing also contains directories.
+ *
+ * @param {string} appId - Qlik Sense app ID.
+ * @param {object} saasInstance - QlikSaas instance for the tenant.
+ * @param {object} logger - Logger instance.
+ * @param {string} logPrefix - Prefix for the error log, e.g. `'CREATE THUMBNAILS 2'`.
+ *
+ * @returns {Promise<object[]>} The thumbnail images, or an empty array when the app has no
+ *     thumbnails folder at all.
+ *
+ * @throws {Error} When the folder exists but its contents cannot be listed. Acting on an app whose
+ *     existing images are in an unknown state is worse than stopping.
+ */
+export const listExistingCloudThumbnails = async (appId, saasInstance, logger, logPrefix) => {
+    // Does the app have a thumbnail folder in its media library?
+    logger.verbose(`Getting media list for app ${appId}, media path is "apps/${appId}/media/list"`);
+    const mediaList = await saasInstance.Get(`apps/${appId}/media/list`);
+
+    const hasThumbnailFolder = mediaList.find((item) => {
+        const thumbnailFolderExists = item.type === 'directory' && item.name === 'thumbnails';
+        return thumbnailFolderExists;
+    });
+
+    if (!hasThumbnailFolder) {
+        return [];
+    }
+
+    // "thumbnails" folder exists in app's media library
+    logger.debug(`App ${appId} has a "thumbnails" folder in its media library`);
+
+    let existingThumbnails;
+    try {
+        logger.verbose(
+            `Getting existing thumbnails for app ${appId}, media path is "apps/${appId}/media/list/thumbnails"`
+        );
+        existingThumbnails = await saasInstance.Get(`apps/${appId}/media/list/thumbnails`);
+    } catch (err) {
+        logError(`${logPrefix}: Error getting existing thumbnails`, err);
+        throw new Error('Error getting existing thumbnails', { cause: err });
+    }
+
+    return existingThumbnails.filter((item) => item.type === 'image');
+};
+
+/**
  * Removes every thumbnail already in an app's media library, before new ones are captured.
  *
  * Cloud clears the old images and QSEoW does not - a real difference between the platforms, not an
@@ -49,43 +102,21 @@ export async function deleteCloudAppThumbnail(thumbnailImg, appId, saasInstance,
  * @param {object} saasInstance - QlikSaas instance for the tenant.
  * @param {object} logger - Logger instance.
  *
- * @returns {Promise<void>} Resolves once every existing thumbnail image has been deleted.
+ * @returns {Promise<number>} How many thumbnail images were deleted.
  *
- * @throws {Error} When the existing thumbnails cannot be listed. Capturing over an app whose old
- *     images are in an unknown state is worse than stopping.
+ * @throws {Error} When the existing thumbnails cannot be listed or a delete fails.
  */
 export const clearExistingCloudThumbnails = async (appId, saasInstance, logger) => {
-    // Does the app have a thumbnail folder in its media library?
-    logger.verbose(`Getting media list for app ${appId}, media path is "apps/${appId}/media/list"`);
-    const mediaList = await saasInstance.Get(`apps/${appId}/media/list`);
-
-    const hasThumbnailFolder = mediaList.find((item) => {
-        const thumbnailFolderExists = item.type === 'directory' && item.name === 'thumbnails';
-        return thumbnailFolderExists;
-    });
-
-    if (!hasThumbnailFolder) {
-        return;
-    }
-
-    // "thumbnails" folder exists in app's media library
-    logger.debug(`App ${appId} has a "thumbnails" folder in its media library`);
-
-    // Remove all existing thumbnail images from this app
-    let existingThumbnails;
-    try {
-        logger.verbose(
-            `Getting existing thumbnails for app ${appId}, media path is "apps/${appId}/media/list/thumbnails"`
-        );
-        existingThumbnails = await saasInstance.Get(`apps/${appId}/media/list/thumbnails`);
-    } catch (err) {
-        logError('CREATE THUMBNAILS 2: Error getting existing thumbnails', err);
-        throw new Error('Error getting existing thumbnails', { cause: err });
-    }
+    const existingThumbnails = await listExistingCloudThumbnails(
+        appId,
+        saasInstance,
+        logger,
+        'CREATE THUMBNAILS 2'
+    );
 
     for (const thumbnailImg of existingThumbnails) {
-        if (thumbnailImg.type === 'image') {
-            await deleteCloudAppThumbnail(thumbnailImg, appId, saasInstance, logger);
-        }
+        await deleteCloudAppThumbnail(thumbnailImg, appId, saasInstance, logger);
     }
+
+    return existingThumbnails.length;
 };

--- a/src/lib/cloud/cloud-plan-app.js
+++ b/src/lib/cloud/cloud-plan-app.js
@@ -1,5 +1,6 @@
 import { logger } from '../../globals.js';
 import { setupEnigmaConnection } from './cloud-enigma.js';
+import { readCloudAppContext } from './cloud-app-context.js';
 import { determineSheetExcludeStatus } from './determine-sheet-exclude-status.js';
 import { determineSheetBlurStatus } from './determine-sheet-blur-status.js';
 import { withEngineSession } from '../util/engine-session.js';
@@ -38,11 +39,10 @@ import { appProgressLine } from '../util/run-report-render.js';
  * @returns {Promise<void>} Resolves when the app's plan is recorded.
  */
 export const cloudPlanApp = async (appId, saasInstance, options, report) => {
-    // Get app name - same read, same endpoint as the real run.
-    const appMetadata = await saasInstance.Get(`apps/${appId}`);
-
-    // If empty the app is not published
-    const appIsPublished = !!appMetadata.attributes.publishTime;
+    // The same read the real run makes - shared rather than copied, so the two modes cannot
+    // drift apart. Clearing existing thumbnails is deliberately not done here: planning an app
+    // must not change it.
+    const { appMetadata, appIsPublished } = await readCloudAppContext(appId, saasInstance);
 
     const configEnigma = setupEnigmaConnection(appId, options);
 

--- a/src/lib/cloud/cloud-remove-sheet-icons.js
+++ b/src/lib/cloud/cloud-remove-sheet-icons.js
@@ -1,4 +1,5 @@
 import { setupEnigmaConnection } from './cloud-enigma.js';
+import { listExistingCloudThumbnails } from './cloud-delete-thumbnails.js';
 import { logger, appVersion, setLoggingLevel, bsiExecutablePath, isSea } from '../../globals.js';
 import { redactOptions } from '../util/redact-secrets.js';
 import QlikSaas from './cloud-repo.js';
@@ -161,36 +162,26 @@ const removeSheetIconsCloudApp = async (appId, saasInstance, options, report = n
         // existed - broken icons on every sheet, where the old behaviour of saving per
         // sheet had at least persisted the ones processed before the failure. Clearing the
         // reference and then removing the file is the order that degrades safely.
-        // Does the app have a thumbnail folder in its media library?
-        const mediaList = await saasInstance.Get(`apps/${appId}/media/list`);
+        // Shared with the capture run's pre-flight and with the dry run below, so all three
+        // agree on what counts as an existing thumbnail.
+        const existingThumbnails = await listExistingCloudThumbnails(
+            appId,
+            saasInstance,
+            logger,
+            'REMOVE SHEET ICONS'
+        );
         let mediaFilesDeleted = 0;
 
-        if (
-            mediaList.find((item) => {
-                const thumbnailFolderExists =
-                    item.type === 'directory' && item.name === 'thumbnails';
-                return thumbnailFolderExists;
-            })
-        ) {
-            // "thumbnails" folder exists in app's media library
-            // Remove all existing thumbnail images from this app
-            const existingThumbnails = await saasInstance.Get(
-                `apps/${appId}/media/list/thumbnails`
+        for (const thumbnailImg of existingThumbnails) {
+            const result = await saasInstance.Delete(
+                `apps/${appId}/media/files/thumbnails/${thumbnailImg.name}`
             );
-
-            for (const thumbnailImg of existingThumbnails) {
-                if (thumbnailImg.type === 'image') {
-                    const result = await saasInstance.Delete(
-                        `apps/${appId}/media/files/thumbnails/${thumbnailImg.name}`
-                    );
-                    logger.debug(
-                        `Deleted existing file ${JSON.stringify(
-                            thumbnailImg.name
-                        )}, result=${JSON.stringify(result)}`
-                    );
-                    mediaFilesDeleted += 1;
-                }
-            }
+            logger.debug(
+                `Deleted existing file ${JSON.stringify(
+                    thumbnailImg.name
+                )}, result=${JSON.stringify(result)}`
+            );
+            mediaFilesDeleted += 1;
         }
 
         if (appEntry) {
@@ -284,15 +275,15 @@ const planRemoveSheetIconsCloudApp = async (appId, saasInstance, options, report
             // The read half of the media cleanup, recorded on the report so the
             // deletion count renders inside the app's section rather than as a
             // log line scrolled far above it.
-            const mediaList = await saasInstance.Get(`apps/${appId}/media/list`);
-            if (mediaList.find((item) => item.type === 'directory' && item.name === 'thumbnails')) {
-                const existingThumbnails = await saasInstance.Get(
-                    `apps/${appId}/media/list/thumbnails`
-                );
-                appEntry.mediaFilesToDelete = existingThumbnails.filter(
-                    (item) => item.type === 'image'
-                ).length;
-            }
+            // The same listing the real run makes, so the count predicted here and the count
+            // reported there cannot come from two different ideas of what a thumbnail is.
+            const existingThumbnails = await listExistingCloudThumbnails(
+                appId,
+                saasInstance,
+                logger,
+                'REMOVE SHEET ICONS'
+            );
+            appEntry.mediaFilesToDelete = existingThumbnails.length;
         }
     );
 

--- a/src/lib/cloud/process-cloud-app.js
+++ b/src/lib/cloud/process-cloud-app.js
@@ -2,7 +2,8 @@ import { setupEnigmaConnection } from './cloud-enigma.js';
 import { logger } from '../../globals.js';
 import { qscloudUploadToApp } from './cloud-upload.js';
 import { qscloudUpdateSheetThumbnails } from './cloud-updatesheets.js';
-import { deleteCloudAppThumbnail } from './cloud-delete-thumbnails.js';
+import { clearExistingCloudThumbnails } from './cloud-delete-thumbnails.js';
+import { readCloudAppContext } from './cloud-app-context.js';
 import { takeSheetScreenshot } from './sheet-screenshot.js';
 import { CloudError } from '../util/errors.js';
 import { launchBrowserForApp, closeBrowserQuietly } from '../browser/browser-launch.js';
@@ -57,47 +58,11 @@ export const processCloudApp = async (appId, saasInstance, options, report = nul
         ErrorClass: CloudError,
     });
     try {
-        // Does the app have a thumbnail folder in its media library?
-        logger.verbose(
-            `Getting media list for app ${appId}, media path is "apps/${appId}/media/list"`
-        );
-        const mediaList = await saasInstance.Get(`apps/${appId}/media/list`);
-        if (
-            mediaList.find((item) => {
-                const thumbnailFolderExists =
-                    item.type === 'directory' && item.name === 'thumbnails';
-                return thumbnailFolderExists;
-            })
-        ) {
-            // "thumbnails" folder exists in app's media library
-            logger.debug(`App ${appId} has a "thumbnails" folder in its media library`);
-            // Remove all existing thumbnail images from this app
-            let existingThumbnails;
-            try {
-                logger.verbose(
-                    `Getting existing thumbnails for app ${appId}, media path is "apps/${appId}/media/list/thumbnails"`
-                );
-                existingThumbnails = await saasInstance.Get(`apps/${appId}/media/list/thumbnails`);
-            } catch (err) {
-                logError('CREATE THUMBNAILS 2: Error getting existing thumbnails', err);
-                throw new Error('Error getting existing thumbnails', { cause: err });
-            }
+        // Clearing the old images is a Cloud-only side effect; the read below is shared with
+        // the dry-run planner so the two modes cannot drift apart.
+        await clearExistingCloudThumbnails(appId, saasInstance, logger);
 
-            for (const thumbnailImg of existingThumbnails) {
-                if (thumbnailImg.type === 'image') {
-                    await deleteCloudAppThumbnail(thumbnailImg, appId, saasInstance, logger);
-                }
-            }
-        }
-
-        // Get app name
-        const appMetadata = await saasInstance.Get(`apps/${appId}`);
-
-        // Is app published?
-        // appMetadata.attributes.publishTime is a string like "2021-09-01T12:34:56.789Z"
-
-        // If empty the app is not published
-        const appIsPublished = !!appMetadata.attributes.publishTime;
+        const { appMetadata, appIsPublished } = await readCloudAppContext(appId, saasInstance);
 
         // Configure Enigma.js
         const configEnigma = setupEnigmaConnection(appId, options);


### PR DESCRIPTION
## What & why

Groundwork for #1091 step 3. That step says the pipeline "ends" are *"each already a single function
call per platform, so this is mostly moving call sites"*. That is true for QSEoW. **It was not true for
Cloud**, and building an adapter on top of a premise that does not hold is how you get an abstraction
that fits neither platform — which the issue explicitly warns is worse than the duplication it
replaces.

Cloud's pre-flight was ~40 inline lines in `process-cloud-app.js` doing two unrelated things: clearing
the app's existing thumbnails, and reading the app's metadata.

## The read existed twice, under a comment admitting it

`cloud-plan-app.js` carried its own copy of the same two lines:

```js
// Get app name - same read, same endpoint as the real run.
const appMetadata = await saasInstance.Get(`apps/${appId}`);
const appIsPublished = !!appMetadata.attributes.publishTime;
```

An accurate description of a duplication held together by review — the control #1091 says has been
failing. QSEoW settled this the other way already: `readQseowAppContext` exists so the dry-run planner
and the real run *"cannot drift apart"*. This is Cloud adopting that, the mirror of the step 1 move
where QSEoW adopted Cloud's screenshot extraction.

## Split in two, because they are not the same kind of thing

| | |
| --- | --- |
| `readCloudAppContext(appId, saasInstance)` | Pure read. Now shared by the planner and the real run |
| `clearExistingCloudThumbnails(appId, saasInstance, logger)` | Side effect, **Cloud-only** — QSEoW does not clear old images, which #1091 records as a real difference that stays per-platform |

The planner deliberately does not call the second one: planning an app must not change it.

## The clearing logic had no coverage at all

Every saas stub in `process_cloud_app.test.js` answers `media/list` with an empty array, so the
thumbnails folder never existed and the deletion loop never ran in any test. It was untestable in place
and is now tested — four cases, including the one where listing the existing thumbnails fails, since
capturing over an app whose old images are in an unknown state is worse than stopping.

## How it was verified

- Full suite green: **3437 tests in 125 files**, up from 3428 in 124 — the 9 new tests and the one new
  suite, nothing else.
- One existing test file changed: `process_cloud_app.test.js` mocks `cloud-delete-thumbnails.js`, and
  the mock needed the new export. **No expectation was altered** — and nothing was lost, because that
  suite never reached the deletion path.
- `npm run lint` and `prettier --check` clean.

## What remains of step 3

The adapter object itself — `{ preflight, upload, updateThumbnails, logout }` — now that its premise
holds. Deriving it from what the code actually does, rather than designing it up front, is the point
of doing this first:

- **upload** is already identical on both: `(createdFiles, appId, options)`.
- **updateThumbnails** differs by one argument — QSEoW passes `blurTagSheetAppMetadata` from its
  pre-flight.
- **logout** is QSEoW-only; Cloud has none.
- **URL construction** is already behind the `*-app-session.js` seam and is not called from the
  pipelines at all, so it is arguably not an adapter member.

Refs #1091
