### PR TITLE
QSEoW adopts runOverSheets, so one bad sheet no longer discards the app

### DIFF
--- a/docs/to-doc-site/qseow-partial-thumbnail-update.md
+++ b/docs/to-doc-site/qseow-partial-thumbnail-update.md
@@ -1,0 +1,52 @@
+# A QSEoW app with one unusable sheet now updates the rest
+
+Until now, if Butler Sheet Icons could not capture one sheet in a Qlik Sense Enterprise on Windows
+app, it abandoned the whole app. No thumbnails were uploaded and nothing in the app changed — a
+single unreachable sheet discarded the work done on every other sheet in it.
+
+That is no longer the case. The sheets that were captured successfully are uploaded and applied. The
+sheet that failed keeps whatever icon it already had.
+
+::: warning Requires BSI 5.0.0 or later
+In earlier versions, one failed sheet meant the app was left completely untouched.
+:::
+
+## What you will see
+
+The app is still reported as failed, and the run still finishes with a non-zero exit code. Nothing
+about how failures are counted has changed — only how much work survives one.
+
+The error names how many sheets could not be done, out of how many were attempted:
+
+```
+Failed to create a thumbnail for 1 of 9 sheet(s) in app a1b2c3d4-...
+```
+
+Alongside it, the run report shows the sheets that were updated, so the account of what changed is
+accurate rather than reporting zero for work that was done.
+
+## Why this changed
+
+Qlik Sense Cloud has always behaved this way. Butler Sheet Icons was doing two different things on
+two platforms for the same failure, and the Windows behaviour was the accidental one — a consequence
+of how its sheet loop was written rather than a decision anyone made. The two now match.
+
+## What this means for you
+
+**If a scheduled job reported failure and you assumed nothing had changed, check again.** A failed
+run can now have applied thumbnails to some sheets. That is the intended improvement — losing eight
+good thumbnails because the ninth sheet was slow to render helped nobody — but it is a change in what
+a failed run leaves behind.
+
+If a sheet fails repeatedly, the usual causes are worth checking in this order:
+
+| Cause                                                 | What to try                                                         |
+| ----------------------------------------------------- | ------------------------------------------------------------------- |
+| The sheet takes longer to render than BSI waits       | Raise `--pagewait`, and see the browser timeout options             |
+| The sheet is empty, broken, or errors in Sense itself | Open it in a browser as the same user BSI signs in as               |
+| The whole app is affected, not one sheet              | This is usually authentication or the engine session, not the sheet |
+
+::: tip A sheet that fails keeps its existing icon
+It is never left pointing at an image that was not created. If the sheet had a thumbnail before the
+run, it still has that one afterwards.
+:::

--- a/src/lib/qseow/__tests__/qseow_process_app.test.js
+++ b/src/lib/qseow/__tests__/qseow_process_app.test.js
@@ -1348,6 +1348,42 @@ describe('qseow-process-app.js — a sheet with no metadata does not abort the a
         expect(qseowUploadToContentLibrary).toHaveBeenCalledTimes(1);
         expect(qseowUpdateSheetThumbnails).not.toHaveBeenCalled();
     });
+
+    test('uploads the sheets that worked when one sheet cannot be captured', async () => {
+        // Before #1091 step 1 finished, a capture failure threw straight out of QSEoW's bare
+        // sheet loop: the whole app was abandoned and nothing was uploaded, while the Cloud
+        // twin isolated the same failure to the one sheet and applied the rest. runOverSheets
+        // gives QSEoW that isolation, so this pins the behaviour the platforms now share.
+        setup([sheetItem('sheet-a', 1), sheetItem('sheet-b', 2)]);
+
+        const browser = await puppeteer.launch();
+        const page = await browser.newPage();
+        let sheetElementsHandedOut = 0;
+        page.$ = jest.fn().mockImplementation((selector) => {
+            // The login form is gone; anything else is a sheet element being captured.
+            if (selector === '#username-input') {
+                return Promise.resolve(null);
+            }
+            sheetElementsHandedOut += 1;
+            return Promise.resolve({
+                screenshot:
+                    sheetElementsHandedOut === 1
+                        ? jest.fn().mockRejectedValue(new Error('sheet element went away'))
+                        : jest.fn().mockResolvedValue(true),
+            });
+        });
+
+        // The app is still reported as failed - one sheet never got its thumbnail.
+        await expect(qseowProcessApp('test-app-id', options)).rejects.toThrow();
+
+        // But the sheet that worked was uploaded and applied, rather than discarded with it.
+        expect(qseowUploadToContentLibrary).toHaveBeenCalledTimes(1);
+        expect(qseowUpdateSheetThumbnails).toHaveBeenCalledTimes(1);
+
+        const uploaded = qseowUploadToContentLibrary.mock.calls[0][0];
+        expect(uploaded.length).toBeGreaterThan(0);
+        expect(uploaded.every((file) => file.sheetPos === 2)).toBe(true);
+    });
 });
 
 describe('qseow-process-app.js — a blurred thumbnail that cannot be created', () => {

--- a/src/lib/qseow/qseow-process-app.js
+++ b/src/lib/qseow/qseow-process-app.js
@@ -10,6 +10,8 @@ import { launchBrowserForApp, closeBrowserQuietly } from '../browser/browser-lau
 import {
     sortSheetsByRank,
     getSheetList,
+    runOverSheets,
+    SHEET_SKIPPED,
     SHEET_LIST_FIELDS_WITH_SHOW_CONDITION,
 } from '../util/sheet-list.js';
 import { withEngineSession } from '../util/engine-session.js';
@@ -77,6 +79,7 @@ export const qseowProcessApp = async (appId, options, report = null) => {
 
     // Create image directory for this app
     let blurFailures = 0;
+    let sheetRun;
 
     createAppImageDir({
         imagedir: options.imagedir,
@@ -137,8 +140,6 @@ export const qseowProcessApp = async (appId, options, report = null) => {
                 }
 
                 if (sheets.length > 0) {
-                    let iSheetNum = 1;
-
                     const browser = await launchBrowserForApp(options, {
                         appId,
                         logPrefix: 'QSEOW',
@@ -190,128 +191,67 @@ export const qseowProcessApp = async (appId, options, report = null) => {
                         // Sort sheets
                         sortSheetsByRank(sheets);
 
-                        // Loop over all sheets in app, processing each one unless excluded
-                        for (const sheet of sheets) {
-                            // The sheet boundary an interrupted run stops at,
-                            // mirroring the `runOverSheets` check the Cloud
-                            // twin gets for free (issue #1107). A capture
-                            // failure already throws straight out of this bare
-                            // loop, but a blur failure is caught per sheet and
-                            // continues - so without this, shutdown would work
-                            // through every remaining sheet failing each one.
-                            if (isInterrupted()) {
-                                throw new QseowError(
-                                    `App ${appId} was abandoned when the run was interrupted, at sheet ${iSheetNum} of ${sheets.length}`
-                                );
-                            }
+                        // Loop over all sheets in app, processing each one unless excluded.
+                        // runOverSheets carries the interrupt check, the per-sheet error
+                        // isolation and the session-failure detection that this loop used to
+                        // hand-mirror - see #1091 step 1.
+                        sheetRun = await runOverSheets(
+                            sheets,
+                            {
+                                logPrefix: 'QSEOW APP',
+                                appId,
+                                action: 'create a thumbnail for',
+                                ErrorClass: QseowError,
+                            },
+                            async (sheet, iSheetNum) => {
+                                // Get repository db sheet id from mapRepoEngineSheetId, using sheet.qInfo.qId as key
+                                const repoDbSheetId = mapRepoEngineSheetId.get(sheet.qInfo.qId);
+                                const engineSheetId = sheet.qInfo.qId;
 
-                            // Get repository db sheet id from mapRepoEngineSheetId, using sheet.qInfo.qId as key
-                            const repoDbSheetId = mapRepoEngineSheetId.get(sheet.qInfo.qId);
-                            const engineSheetId = sheet.qInfo.qId;
+                                // Should this sheet be processed, or is it on exclude list?
+                                // Options are
+                                // --exclude-sheet-tag <value>
+                                // --exclude-sheet-number <number...>
+                                // --exclude-sheet-title <title...>
+                                // --exclude-sheet-status <status...>
 
-                            // Should this sheet be processed, or is it on exclude list?
-                            // Options are
-                            // --exclude-sheet-tag <value>
-                            // --exclude-sheet-number <number...>
-                            // --exclude-sheet-title <title...>
-                            // --exclude-sheet-status <status...>
-
-                            const { excludeSheet, excludeReason, sheetIsHidden } =
-                                await determineSheetExcludeStatus(
-                                    app,
-                                    sheet,
-                                    options,
-                                    tagSheetAppMetadata,
-                                    iSheetNum,
-                                    repoDbSheetId,
-                                    engineSheetId,
-                                    logger
-                                );
-
-                            // The blur decision is applied later, in
-                            // updatesheets - computed here as well, from the
-                            // same module and the same inputs, so the progress
-                            // line and the report can say `blurred` where the
-                            // update step will use the blurred file.
-                            const { blurSheet, blurReason } = excludeSheet
-                                ? { blurSheet: false, blurReason: null }
-                                : determineSheetBlurStatus(
-                                      sheet,
-                                      options,
-                                      blurTagSheetAppMetadata,
-                                      iSheetNum,
-                                      logger
-                                  );
-
-                            // The ~230-column line with the sheet ids, description,
-                            // approved/published/hidden fields lives at verbose now;
-                            // the info line is the countable one-liner.
-                            logger.verbose(
-                                `${excludeSheet === true ? 'Excluded' : 'Processing'} sheet ${iSheetNum}: '${sheet.qMeta.title}', sheet id '${repoDbSheetId}', engine sheet id '${engineSheetId}', description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}', hidden '${sheetIsHidden}'`
-                            );
-
-                            if (excludeSheet === true) {
-                                // Recorded and logged immediately - the exclusion
-                                // is already a fact.
-                                if (appEntry) {
-                                    recordPlannedSheet(appEntry, {
-                                        n: iSheetNum,
-                                        title: sheet.qMeta.title,
-                                        excludeSheet,
-                                        excludeReason,
-                                        blurSheet,
-                                        blurReason,
-                                    });
-                                }
-                                logger.info(
-                                    sheetProgressLine({
-                                        n: iSheetNum,
-                                        total: sheets.length,
-                                        label: 'excluded',
-                                        title: sheet.qMeta.title,
-                                        reason: excludeReason,
-                                    })
-                                );
-                            } else {
-                                const { fileName, fileNameShort } = await captureSheetImage(
-                                    page,
-                                    appUrl,
-                                    imgDir,
-                                    appId,
-                                    sheet,
-                                    iSheetNum,
-                                    options,
-                                    logger,
-                                    pageTimeout
-                                );
-
-                                createdFiles.push({
-                                    sheetPos: iSheetNum,
-                                    blurred: false,
-                                    fileNameShort,
-                                });
-
-                                try {
-                                    const { fileNameShortBlurred } = await blurSheetImage(
-                                        fileName,
-                                        imgDir,
-                                        appId,
-                                        iSheetNum,
+                                const { excludeSheet, excludeReason, sheetIsHidden } =
+                                    await determineSheetExcludeStatus(
+                                        app,
+                                        sheet,
                                         options,
+                                        tagSheetAppMetadata,
+                                        iSheetNum,
+                                        repoDbSheetId,
+                                        engineSheetId,
                                         logger
                                     );
 
-                                    createdFiles.push({
-                                        sheetPos: iSheetNum,
-                                        blurred: true,
-                                        fileNameShort: fileNameShortBlurred,
-                                    });
+                                // The blur decision is applied later, in
+                                // updatesheets - computed here as well, from the
+                                // same module and the same inputs, so the progress
+                                // line and the report can say `blurred` where the
+                                // update step will use the blurred file.
+                                const { blurSheet, blurReason } = excludeSheet
+                                    ? { blurSheet: false, blurReason: null }
+                                    : determineSheetBlurStatus(
+                                          sheet,
+                                          options,
+                                          blurTagSheetAppMetadata,
+                                          iSheetNum,
+                                          logger
+                                      );
 
-                                    // Recorded and logged only now: both files
-                                    // exist, so `captured` (or `blurred`) is a
-                                    // fact rather than an intention. A sheet
-                                    // whose capture or blur failed leaves no
-                                    // row - the error lines tell that story.
+                                // The ~230-column line with the sheet ids, description,
+                                // approved/published/hidden fields lives at verbose now;
+                                // the info line is the countable one-liner.
+                                logger.verbose(
+                                    `${excludeSheet === true ? 'Excluded' : 'Processing'} sheet ${iSheetNum}: '${sheet.qMeta.title}', sheet id '${repoDbSheetId}', engine sheet id '${engineSheetId}', description '${sheet.qMeta.description}', approved '${sheet.qMeta.approved}', published '${sheet.qMeta.published}', hidden '${sheetIsHidden}'`
+                                );
+
+                                if (excludeSheet === true) {
+                                    // Recorded and logged immediately - the exclusion
+                                    // is already a fact.
                                     if (appEntry) {
                                         recordPlannedSheet(appEntry, {
                                             n: iSheetNum,
@@ -326,41 +266,103 @@ export const qseowProcessApp = async (appId, options, report = null) => {
                                         sheetProgressLine({
                                             n: iSheetNum,
                                             total: sheets.length,
-                                            label: blurSheet ? 'blurred' : 'captured',
+                                            label: 'excluded',
                                             title: sheet.qMeta.title,
-                                            reason: blurReason,
+                                            reason: excludeReason,
                                         })
                                     );
-                                } catch (err) {
-                                    logError(
-                                        'QSEOW CREATE BLURRED IMAGE: Failed to create blurred image',
-                                        err
+
+                                    return SHEET_SKIPPED;
+                                } else {
+                                    const { fileName, fileNameShort } = await captureSheetImage(
+                                        page,
+                                        appUrl,
+                                        imgDir,
+                                        appId,
+                                        sheet,
+                                        iSheetNum,
+                                        options,
+                                        logger,
+                                        pageTimeout
                                     );
 
-                                    // Drop this sheet entirely rather than leave the unblurred entry
-                                    // behind. The blur decision is made later, in updatesheets, from
-                                    // the CLI options alone - so leaving the entry meant the sheet was
-                                    // repointed at a `-blurred.png` that was never created, giving a
-                                    // broken icon. Dropping it means updatesheets skips the sheet and
-                                    // it keeps the icon it already had.
-                                    //
-                                    // --blur-sheet-* is a redaction control, so falling back to the
-                                    // plain screenshot is not an option either: it would publish the
-                                    // unredacted image the operator asked to hide.
-                                    for (let i = createdFiles.length - 1; i >= 0; i -= 1) {
-                                        if (createdFiles[i].sheetPos === iSheetNum) {
-                                            createdFiles.splice(i, 1);
+                                    createdFiles.push({
+                                        sheetPos: iSheetNum,
+                                        blurred: false,
+                                        fileNameShort,
+                                    });
+
+                                    try {
+                                        const { fileNameShortBlurred } = await blurSheetImage(
+                                            fileName,
+                                            imgDir,
+                                            appId,
+                                            iSheetNum,
+                                            options,
+                                            logger
+                                        );
+
+                                        createdFiles.push({
+                                            sheetPos: iSheetNum,
+                                            blurred: true,
+                                            fileNameShort: fileNameShortBlurred,
+                                        });
+
+                                        // Recorded and logged only now: both files
+                                        // exist, so `captured` (or `blurred`) is a
+                                        // fact rather than an intention. A sheet
+                                        // whose capture or blur failed leaves no
+                                        // row - the error lines tell that story.
+                                        if (appEntry) {
+                                            recordPlannedSheet(appEntry, {
+                                                n: iSheetNum,
+                                                title: sheet.qMeta.title,
+                                                excludeSheet,
+                                                excludeReason,
+                                                blurSheet,
+                                                blurReason,
+                                            });
                                         }
-                                    }
+                                        logger.info(
+                                            sheetProgressLine({
+                                                n: iSheetNum,
+                                                total: sheets.length,
+                                                label: blurSheet ? 'blurred' : 'captured',
+                                                title: sheet.qMeta.title,
+                                                reason: blurReason,
+                                            })
+                                        );
+                                    } catch (err) {
+                                        logError(
+                                            'QSEOW CREATE BLURRED IMAGE: Failed to create blurred image',
+                                            err
+                                        );
 
-                                    blurFailures += 1;
-                                    logger.error(
-                                        `QSEOW APP: Sheet ${iSheetNum} in app ${appId} was left unchanged because its blurred thumbnail could not be created`
-                                    );
+                                        // Drop this sheet entirely rather than leave the unblurred entry
+                                        // behind. The blur decision is made later, in updatesheets, from
+                                        // the CLI options alone - so leaving the entry meant the sheet was
+                                        // repointed at a `-blurred.png` that was never created, giving a
+                                        // broken icon. Dropping it means updatesheets skips the sheet and
+                                        // it keeps the icon it already had.
+                                        //
+                                        // --blur-sheet-* is a redaction control, so falling back to the
+                                        // plain screenshot is not an option either: it would publish the
+                                        // unredacted image the operator asked to hide.
+                                        for (let i = createdFiles.length - 1; i >= 0; i -= 1) {
+                                            if (createdFiles[i].sheetPos === iSheetNum) {
+                                                createdFiles.splice(i, 1);
+                                            }
+                                        }
+
+                                        blurFailures += 1;
+                                        logger.error(
+                                            `QSEOW APP: Sheet ${iSheetNum} in app ${appId} was left unchanged because its blurred thumbnail could not be created`
+                                        );
+                                    }
                                 }
+                                return undefined;
                             }
-                            iSheetNum += 1;
-                        }
+                        );
 
                         logger.verbose(`QSEoW APP: Done creating thumbnails`);
                     } finally {
@@ -396,6 +398,14 @@ export const qseowProcessApp = async (appId, options, report = null) => {
         logger.verbose(
             `Closed session after generating sheet thumbnail images for all sheets in QSEoW app ${appId} on host ${options.host}`
         );
+
+        // Only for the interrupt, mirroring the Cloud twin: a genuine partial failure falls
+        // through to the upload and update below so the sheets that did work are applied.
+        // The assertAllProcessed() at the very end of this function is what still reports
+        // the app as failed.
+        if (sheetRun?.interrupted) {
+            sheetRun.assertAllProcessed();
+        }
 
         // Upload to QSEoW content library
         await qseowUploadToContentLibrary(createdFiles, appId, options);
@@ -487,6 +497,10 @@ export const qseowProcessApp = async (appId, options, report = null) => {
 
     // Asserted last, and outside the try, so the sheets that did work are still uploaded
     // and applied.
+    // Capture failures are asserted before blur failures: a sheet that never produced an
+    // image is the more fundamental failure, and its message names the sheet count.
+    sheetRun?.assertAllProcessed();
+
     if (blurFailures > 0) {
         throw new QseowError(
             `Failed to create a blurred thumbnail for ${blurFailures} sheet(s) in app ${appId}`


### PR DESCRIPTION
## What & why

Finishes #1091 step 1 and **unblocks step 4**. The two `process-app` modules cannot collapse into one
pipeline while their sheet loops disagree about what a failed sheet means — and they did:

| One sheet's capture fails, mid-app | Before |
| --- | --- |
| **Cloud** (`runOverSheets`) | Sheet counted as failed, run continues, the thumbnails that worked are **uploaded and applied** |
| **QSEoW** (bare `for` loop) | Capture failure threw straight out — **the whole app abandoned, nothing uploaded** |

Both behaviours were documented in the code. Cloud's post-loop comment calls the fall-through
*"deliberate… so the sheets that did work are applied"*. QSEoW's loop comment described itself as
hand-mirroring *"the `runOverSheets` check the Cloud twin gets for free"* and noted that *"a capture
failure already throws straight out of this bare loop"* — a property of the loop rather than a
decision anyone made.

## This is a behaviour change, and it was a decision, not a refactor

Step 1 of #1091 called adopting `runOverSheets` a *"pure refactor"*. It is not — it changes what a
QSEoW run does when a capture fails, which is user-visible. It was raised as a product question and
settled in **Cloud's direction: partial upload.** Losing eight good thumbnails to one transient
failure is the worse outcome, and the app is still reported as failed either way.

**Worth calling out in release notes**: a QSEoW app with one unreachable sheet now uploads and applies
the rest, where it previously changed nothing.

## What else QSEoW gains

All of it previously Cloud-only:

- per-sheet error isolation
- session-level failure detection, which abandons the remaining sheets instead of failing each one
  identically against a dead engine session
- the interrupt check it used to hand-roll

`assertAllProcessed()` runs on the interrupt path and again at the very end **outside the try**,
mirroring Cloud, so the sheets that worked are uploaded before the app is reported failed. Capture
failures are asserted before the `blurFailures` throw — a sheet that never produced an image is the
more fundamental failure.

## The test gap this exposed

**No existing test needed changing.** For a deliberate behaviour change that is not reassurance, it is
the finding: nothing covered "a QSEoW sheet capture fails mid-app". Cloud had that test trio
(`leaves that sheet out…`, `still uploads and applies the sheets that did work`,
`reports the app as failed…`); QSEoW had none — the same one-twin-only gap #1091 exists to close.

The new test was **verified to fail against the old loop**, with `qseowUploadToContentLibrary` called
0 times instead of 1. A test that passes before and after the change would have pinned nothing.

## How it was verified

- Full unit suite green: 3442 tests in 125 files, up from 3441.
- New test proven to fail on the pre-change loop, then pass on the new one.
- `npm run lint` and `prettier --check` clean.
- The full **integration suite** was run against the real QSEoW lab and Cloud tenant earlier on this
  branch point — 12 suites, 51 tests, all passing — though note that was *before* this commit, so the
  new loop has not yet met a real Sense environment.

## What remains of step 4

With the loops unified, the two pipelines are step-for-step alignable. Still outstanding:

- the adapter object itself (`preflight`, `upload`, `updateThumbnails`, `logout`) — the remainder of
  step 3
- the `createdFiles` shape difference: QSEoW pushes two entries per sheet, Cloud one
- the capture split: QSEoW's `captureSheetImage`/`blurSheetImage` vs Cloud's single
  `takeSheetScreenshot`, which encode the platforms' different blur-failure semantics

Refs #1091
