### PR TITLE
Let a variant build add commands and options without patching the entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
     "description": "Creates thumbnail images based on sheets in Qlik Sense applications",
     "type": "module",
     "main": "src/butler-sheet-icons.js",
+    "imports": {
+        "#extensions": "./src/lib/extensions/index.js"
+    },
     "scripts": {
         "jest": "node --experimental-vm-modules --no-warnings node_modules/jest/bin/jest.js --runInBand",
         "jest:handles": "npm run jest -- --detectOpenHandles",

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -26,6 +26,9 @@
 
 import { spawnSync } from 'node:child_process';
 import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { build } from 'esbuild';
 
 const require = createRequire(import.meta.url);
@@ -43,6 +46,92 @@ const SENTINEL_FUSE = 'NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2';
 const MACHO_SEGMENT_NAME = 'NODE_SEA';
 
 /**
+ * Set by a variant build to substitute the module behind the `#extensions` specifier. Unset for
+ * every build in this repository, which is what makes the committed default the bundled one.
+ * Issue #1135.
+ */
+const extensionsModule = process.env.EXTENSIONS_MODULE
+    ? resolve(process.env.EXTENSIONS_MODULE)
+    : undefined;
+
+/**
+ * Stop a build whose extensions module targets a different contract version than this source tree.
+ *
+ * Both halves are always built together, so a mismatch belongs to the build rather than to the
+ * machine the binary later runs on - which is why this is checked here and asserted nowhere at
+ * runtime.
+ *
+ * @returns {Promise<void>} Resolves when the two versions agree; rejects otherwise, so the build
+ *     stops before esbuild has produced anything.
+ */
+const checkExtensionsVersion = async () => {
+    const { assertSeamVersion } = await import(
+        new URL('../src/lib/extensions/version.js', import.meta.url).href
+    );
+    const { extensions } = await import(pathToFileURL(extensionsModule).href);
+
+    assertSeamVersion(extensions, extensionsModule);
+};
+
+/**
+ * Core's own Commander, aliased into an override build so exactly one copy is bundled.
+ *
+ * Without this, an extensions module outside this tree resolves `commander` from its own
+ * `node_modules` and esbuild bundles a second copy. The two are different module instances, so a
+ * `Command` built by one and added to a tree owned by the other fails - and it fails at run time
+ * inside the packaged binary, after a build that reported success.
+ */
+const commanderEntry = require.resolve('commander');
+
+/**
+ * The version of Commander that a given file resolves.
+ *
+ * @param {string|URL} fromFile - The file to resolve from.
+ *
+ * @returns {string|undefined} The version, or undefined when it cannot be determined.
+ */
+const commanderVersionFrom = (fromFile) => {
+    try {
+        const entry = createRequire(fromFile).resolve('commander');
+
+        // `commander/package.json` is not listed in the package's `exports`, so requiring it as a
+        // subpath fails with ERR_PACKAGE_PATH_NOT_EXPORTED. Read from the package root instead.
+        return JSON.parse(readFileSync(join(dirname(entry), 'package.json'), 'utf8')).version;
+    } catch {
+        return undefined;
+    }
+};
+
+/**
+ * Stop a build whose extensions module was written against a different major of Commander.
+ *
+ * The alias above guarantees one Commander in the bundle, which removes the two-instances crash.
+ * What an alias cannot do is make code written against one major work against another, and that
+ * failure lands in the same expensive place: a `Command` built against Commander 12 and dispatched
+ * by core's 15 dies with `subCommand._prepareForParse is not a function`, at run time, on the
+ * machine of whoever received the binary. Comparing the two here turns it into a build failure.
+ *
+ * Best effort by design: when either version cannot be determined the build proceeds rather than
+ * being blocked by a guard that is itself unsure.
+ *
+ * @returns {void} Nothing. Returns normally when the majors agree or cannot be compared.
+ *
+ * @throws {Error} When the two majors differ, so the build stops before esbuild runs.
+ */
+const checkCommanderMatch = () => {
+    const core = commanderVersionFrom(import.meta.url);
+    const variant = commanderVersionFrom(pathToFileURL(extensionsModule));
+
+    if (!core || !variant || core.split('.')[0] === variant.split('.')[0]) {
+        return;
+    }
+
+    throw new Error(
+        `Commander mismatch: ${extensionsModule} resolves commander ${variant}, this source tree uses ${core}. Only core's copy is bundled, so a description built against a different major would fail at run time rather than here. Align the extensions module on commander ${core}.`
+    );
+};
+
+/**
  * Bundle the CLI into a single CJS file for the SEA blob.
  *
  * `format: 'cjs'` is not a preference: Node's SEA blob takes one CommonJS file. It is also why
@@ -55,6 +144,11 @@ const MACHO_SEGMENT_NAME = 'NODE_SEA';
  * @returns {Promise<void>} Resolves when the bundle has been written.
  */
 const bundle = async () => {
+    if (extensionsModule) {
+        await checkExtensionsVersion();
+        checkCommanderMatch();
+    }
+
     await build({
         entryPoints: [`src/${distFileName}.js`],
         bundle: true,
@@ -64,6 +158,9 @@ const bundle = async () => {
         target: 'node24',
         inject: ['./src/lib/util/import-meta-url.js'],
         define: { 'import.meta.url': 'import_meta_url' },
+        alias: extensionsModule
+            ? { '#extensions': extensionsModule, commander: commanderEntry }
+            : undefined,
     });
 };
 

--- a/src/butler-sheet-icons.js
+++ b/src/butler-sheet-icons.js
@@ -14,6 +14,8 @@ import { buildBrowserCommand } from './lib/commands/browser/index.js';
 import { buildDoctorCommand } from './lib/commands/doctor/index.js';
 import { buildInteractiveCommand } from './lib/interactive/interactive-command.js';
 import { relaxMandatoryOptionsIfInteractive } from './lib/interactive/mandatory-relaxation.js';
+import { extensions } from '#extensions';
+import { applyExtensions } from './lib/extensions/apply.js';
 
 // Process-level safety net: catch any error that escapes all try/catch blocks,
 // write a crash dump, and exit with code 1. Installed before anything else so
@@ -45,6 +47,13 @@ const program = new Command();
     program.addCommand(buildBrowserCommand());
     program.addCommand(buildDoctorCommand());
     program.addCommand(buildInteractiveCommand());
+
+    // Whatever this build adds on top of the commands above - nothing at all, unless the bundle
+    // was built against an extensions module. The position is forced rather than chosen: a
+    // contributed option has to exist before the relaxation call below, because Commander rejects
+    // a command line missing a mandatory option before any hook or handler runs. See
+    // src/lib/extensions/apply.js and issue #1135.
+    applyExtensions(program, extensions);
 
     // Must happen before the parse: Commander rejects a command line missing a
     // mandatory option before any hook or handler runs, so `-i` would never be

--- a/src/lib/extensions/__tests__/apply-ordering.test.js
+++ b/src/lib/extensions/__tests__/apply-ordering.test.js
@@ -1,0 +1,226 @@
+import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { Command, Option } from 'commander';
+import { applyExtensions } from '../apply.js';
+import { relaxMandatoryOptionsIfInteractive } from '../../interactive/mandatory-relaxation.js';
+import { addInteractiveOption } from '../../interactive/interactive-option.js';
+import { buildQseowCommand } from '../../commands/qseow/index.js';
+import { buildQscloudCommand } from '../../commands/qscloud/index.js';
+import { buildBrowserCommand } from '../../commands/browser/index.js';
+
+// Everything here is about *where* `applyExtensions` is called from, which is the one thing about
+// this seam that cannot be recovered by reading the function itself. `qseow create-sheet-thumbnails`
+// declares 18 mandatory options across a tree nobody rebuilds by hand, so the real builders are
+// used rather than a fixture: the failure being guarded against only exists at that scale.
+
+const ENV_SNAPSHOT = { ...process.env };
+
+beforeEach(() => {
+    // Every option in this codebase has an .env() binding, and a stray BSI_* variable in the
+    // developer's shell would satisfy a mandatory option and pass these tests for the wrong reason.
+    for (const key of Object.keys(process.env)) {
+        if (/^BS_?I?_/.test(key)) delete process.env[key];
+    }
+});
+
+afterEach(() => {
+    process.env = { ...ENV_SNAPSHOT };
+});
+
+/** Everything `qseow create-sheet-thumbnails` demands and does not default. */
+const COMPLETE_QSEOW = [
+    'qseow',
+    'create-sheet-thumbnails',
+    '--host',
+    'sense.acme.com',
+    '--apiuserdir',
+    'INTERNAL',
+    '--apiuserid',
+    'sa_api',
+    '--logonuserdir',
+    'INTERNAL',
+    '--logonuserid',
+    'sa_ui',
+    '--logonpwd',
+    'secret',
+];
+
+/**
+ * The real command tree, silenced and with its action handlers replaced.
+ *
+ * @returns {import('commander').Command} The program, recording the action reached on `.reached`.
+ */
+const buildProgram = () => {
+    const program = new Command();
+    const silence = { writeOut: () => {}, writeErr: () => {} };
+
+    program.name('butler-sheet-icons').exitOverride().configureOutput(silence);
+    program.reached = undefined;
+
+    for (const namespace of [buildQseowCommand(), buildQscloudCommand(), buildBrowserCommand()]) {
+        namespace.exitOverride().configureOutput(silence);
+
+        for (const leaf of namespace.commands) {
+            leaf.exitOverride().configureOutput(silence);
+
+            if (!leaf.options.some((option) => option.long === '--interactive')) {
+                addInteractiveOption(leaf);
+            }
+
+            // Replace the real action, which would connect to a Qlik server.
+            leaf._actionHandler = undefined;
+            leaf.action((opts, cmd) => {
+                program.reached = { opts, cmd };
+            });
+        }
+
+        program.addCommand(namespace);
+    }
+
+    return program;
+};
+
+/**
+ * Parse a command line with an option contributed through the seam.
+ *
+ * @param {string[]} tail - Argv after the program name.
+ * @param {object} [config] - Options.
+ * @param {import('commander').Option} [config.option] - The option to contribute.
+ * @param {object} [config.hooks] - Hooks to contribute alongside it.
+ * @param {boolean} [config.afterRelaxation] - Contribute *after* the relaxation call instead of
+ *     before it, which is the mistake the call-site position exists to prevent.
+ *
+ * @returns {Promise<object>} `{ reached, error, option }`.
+ */
+const run = async (tail, { option, hooks = {}, afterRelaxation = false } = {}) => {
+    const program = buildProgram();
+    const argv = ['node', 'bsi', ...tail];
+    const description = {
+        seamVersion: 1,
+        commands: [],
+        options: option ? [{ path: 'qseow create-sheet-thumbnails', option }] : [],
+        hooks,
+    };
+
+    if (!afterRelaxation) {
+        applyExtensions(program, description);
+    }
+
+    relaxMandatoryOptionsIfInteractive(program, argv);
+
+    if (afterRelaxation) {
+        applyExtensions(program, description);
+    }
+
+    try {
+        await program.parseAsync(argv);
+
+        return { reached: program.reached, error: undefined, option };
+    } catch (error) {
+        return { reached: program.reached, error, option };
+    }
+};
+
+describe('an option contributed at the call site', () => {
+    test('parses like any other option', async () => {
+        const { reached, error } = await run([...COMPLETE_QSEOW, '--brand-logo', '/tmp/logo.png'], {
+            option: new Option('--brand-logo <path>', 'a contributed option'),
+        });
+
+        expect(error).toBeUndefined();
+        expect(reached.opts.brandLogo).toBe('/tmp/logo.png');
+    });
+
+    // The one nobody expects to work: `dotenv/config` has already run, and the option did not exist
+    // when it did. It resolves because Commander reads `process.env` at parse time rather than at
+    // declaration time - so a contributed option gets the same env binding as every core option.
+    test('resolves its .env() binding, even though it was added after dotenv ran', async () => {
+        process.env.BSI_BRAND_LOGO = '/from/env.png';
+
+        const { reached, error } = await run(COMPLETE_QSEOW, {
+            option: new Option('--brand-logo <path>', 'a contributed option').env('BSI_BRAND_LOGO'),
+        });
+
+        expect(error).toBeUndefined();
+        expect(reached.opts.brandLogo).toBe('/from/env.png');
+    });
+
+    test("participates in Commander's own missing-mandatory check when mandatory", async () => {
+        const { reached, error } = await run(COMPLETE_QSEOW, {
+            option: new Option('--brand-logo <path>', 'a contributed option').makeOptionMandatory(),
+        });
+
+        expect(reached).toBeUndefined();
+        expect(error.code).toBe('commander.missingMandatoryOptionValue');
+        expect(error.message).toBe("error: required option '--brand-logo <path>' not specified");
+    });
+});
+
+describe('the position of the call is the thing being protected', () => {
+    // Contributed before the relaxation call, a mandatory option is cleared with all the others and
+    // the wizard is reachable. This is the whole reason the call site is where it is.
+    test('a contributed mandatory option is relaxed by -i, like a core one', async () => {
+        const option = new Option('--brand-logo <path>', 'a contributed option')
+            .makeOptionMandatory()
+            .env('BSI_BRAND_LOGO');
+
+        const { reached, error } = await run(['qseow', 'create-sheet-thumbnails', '-i'], {
+            option,
+        });
+
+        expect(error).toBeUndefined();
+        expect(reached.opts.interactive).toBe(true);
+    });
+
+    test('and it is mandatory again by the time a handler runs', async () => {
+        const option = new Option('--brand-logo <path>', 'a contributed option')
+            .makeOptionMandatory()
+            .env('BSI_BRAND_LOGO');
+
+        await run(['qseow', 'create-sheet-thumbnails', '-i'], { option });
+
+        expect(option.mandatory).toBe(true);
+    });
+
+    // Contributed after the relaxation call, the same option is never cleared, so Commander rejects
+    // the command line before a single line of interactive code runs. The failure is invisible on
+    // every other command line, which is exactly what makes it worth a test rather than a comment.
+    test('contributing after the relaxation call breaks -i', async () => {
+        const { reached, error } = await run(['qseow', 'create-sheet-thumbnails', '-i'], {
+            option: new Option('--brand-logo <path>', 'a contributed option').makeOptionMandatory(),
+            afterRelaxation: true,
+        });
+
+        expect(reached).toBeUndefined();
+        expect(error.code).toBe('commander.missingMandatoryOptionValue');
+    });
+});
+
+describe('the beforeAction hook against the real tree', () => {
+    test('names the command that is about to run, and sees its options', async () => {
+        const seen = [];
+
+        const { error } = await run([...COMPLETE_QSEOW, '--brand-logo', '/tmp/logo.png'], {
+            option: new Option('--brand-logo <path>', 'a contributed option'),
+            hooks: { beforeAction: (path, options) => seen.push({ path, options }) },
+        });
+
+        expect(error).toBeUndefined();
+        expect(seen).toHaveLength(1);
+        expect(seen[0].path).toBe('qseow create-sheet-thumbnails');
+        expect(seen[0].options.brandLogo).toBe('/tmp/logo.png');
+        expect(seen[0].options.host).toBe('sense.acme.com');
+    });
+
+    test('stops the run before the action handler when it throws', async () => {
+        const { reached, error } = await run(COMPLETE_QSEOW, {
+            hooks: {
+                beforeAction: () => {
+                    throw new Error('not entitled to --brand-logo');
+                },
+            },
+        });
+
+        expect(reached).toBeUndefined();
+        expect(error.message).toBe('not entitled to --brand-logo');
+    });
+});

--- a/src/lib/extensions/__tests__/apply.test.js
+++ b/src/lib/extensions/__tests__/apply.test.js
@@ -1,0 +1,293 @@
+import { describe, test, expect } from '@jest/globals';
+import { Command, Option } from 'commander';
+import { applyExtensions, runBeforeAction } from '../apply.js';
+
+const SILENT = { writeOut: () => {}, writeErr: () => {} };
+
+/**
+ * A small program shaped like the real one: a root, a namespace, and a leaf that records its run.
+ *
+ * Deliberately hand-built rather than the real tree - the behaviour under test is what
+ * `applyExtensions` does to a command tree, and a four-command fixture makes a failure readable.
+ * `apply-ordering.test.js` covers the same code against the real tree, where the interesting part
+ * is the 18 mandatory options rather than the wiring.
+ *
+ * @returns {object} `{ program, leaf, runs }` - the root, the leaf, and what the leaf recorded.
+ */
+const buildProgram = () => {
+    const runs = [];
+    const program = new Command().name('butler-sheet-icons').exitOverride().configureOutput(SILENT);
+    const namespace = new Command('qseow').exitOverride().configureOutput(SILENT);
+    const leaf = new Command('create-sheet-thumbnails')
+        .exitOverride()
+        .configureOutput(SILENT)
+        .alias('cst')
+        .action((opts) => runs.push(opts));
+
+    namespace.addCommand(leaf);
+    program.addCommand(namespace);
+
+    return { program, leaf, runs };
+};
+
+// A description that adds nothing, byte for byte what the committed module exports.
+const nothing = () => ({ seamVersion: 1, commands: [], options: [], hooks: {} });
+
+describe('an empty description', () => {
+    test('registers no commands and adds no hook', async () => {
+        const { program, runs } = buildProgram();
+        const before = program.commands.length;
+
+        applyExtensions(program, nothing());
+
+        expect(program.commands.length).toBe(before);
+        await program.parseAsync(['qseow', 'create-sheet-thumbnails'], { from: 'user' });
+        expect(runs).toHaveLength(1);
+    });
+
+    // Not defensive programming for its own sake: a description assembled by hand, in a test or in
+    // a variant build, is the likely source of a missing property, and the failure would otherwise
+    // be a TypeError from inside core.
+    test.each([
+        ['a description with no properties at all', {}],
+        ['no description', undefined],
+        ['null', null],
+    ])('tolerates %s', async (_name, description) => {
+        const { program, runs } = buildProgram();
+
+        expect(() => applyExtensions(program, description)).not.toThrow();
+        await program.parseAsync(['qseow', 'create-sheet-thumbnails'], { from: 'user' });
+        expect(runs).toHaveLength(1);
+    });
+});
+
+describe('contributed commands', () => {
+    test('are added to the root and run', async () => {
+        const { program } = buildProgram();
+        const ran = [];
+        const command = new Command('estate-report')
+            .exitOverride()
+            .configureOutput(SILENT)
+            .action(() => ran.push(true));
+
+        applyExtensions(program, { ...nothing(), commands: [command] });
+
+        expect(program.commands.map((c) => c.name())).toContain('estate-report');
+        await program.parseAsync(['estate-report'], { from: 'user' });
+        expect(ran).toEqual([true]);
+    });
+});
+
+describe('contributed options', () => {
+    test('are added to the command their path names, and parse', async () => {
+        const { program, runs } = buildProgram();
+
+        applyExtensions(program, {
+            ...nothing(),
+            options: [
+                {
+                    path: 'qseow create-sheet-thumbnails',
+                    option: new Option('--brand-logo <path>', 'a contributed option'),
+                },
+            ],
+        });
+
+        await program.parseAsync(
+            ['qseow', 'create-sheet-thumbnails', '--brand-logo', '/tmp/logo.png'],
+            { from: 'user' }
+        );
+
+        expect(runs[0].brandLogo).toBe('/tmp/logo.png');
+    });
+
+    test('reach a command through its alias too', () => {
+        const { program, leaf } = buildProgram();
+
+        applyExtensions(program, {
+            ...nothing(),
+            options: [{ path: 'qseow cst', option: new Option('--via-alias') }],
+        });
+
+        expect(leaf.options.map((o) => o.long)).toContain('--via-alias');
+    });
+
+    test('land on a top-level command when the path has one segment', () => {
+        const { program } = buildProgram();
+
+        applyExtensions(program, {
+            ...nothing(),
+            options: [{ path: 'qseow', option: new Option('--on-the-namespace') }],
+        });
+
+        const namespace = program.commands.find((c) => c.name() === 'qseow');
+        expect(namespace.options.map((o) => o.long)).toContain('--on-the-namespace');
+    });
+
+    // The one mistake that would otherwise be silent: the option simply would not appear, in
+    // `--help` or anywhere else, with nothing saying why.
+    test('throw when the path names a command that does not exist', () => {
+        const { program } = buildProgram();
+
+        expect(() =>
+            applyExtensions(program, {
+                ...nothing(),
+                options: [{ path: 'qseow no-such-command', option: new Option('--x') }],
+            })
+        ).toThrow(/targets 'qseow no-such-command'.*no command 'no-such-command' under 'qseow'/);
+    });
+
+    // The likeliest authoring mistake is omitting `path` altogether, and it must not surface as a
+    // bare TypeError from inside core naming neither the contribution nor the option.
+    test.each([
+        ['whitespace', '   '],
+        ['an empty string', ''],
+        ['undefined', undefined],
+        ['null', null],
+        ['a number', 3],
+    ])('throw a named error on %s', (_name, path) => {
+        const { program } = buildProgram();
+
+        expect(() =>
+            applyExtensions(program, {
+                ...nothing(),
+                options: [{ path, option: new Option('--x') }],
+            })
+        ).toThrow(/no usable command path/);
+    });
+});
+
+describe('runBeforeAction', () => {
+    test('calls the hook and returns what it returns, so an async hook can be awaited', async () => {
+        const seen = [];
+        const description = {
+            ...nothing(),
+            hooks: {
+                beforeAction: async (path, options) => {
+                    seen.push({ path, options });
+
+                    return 'done';
+                },
+            },
+        };
+
+        await expect(runBeforeAction(description, 'qseow x', { a: 1 })).resolves.toBe('done');
+        expect(seen).toEqual([{ path: 'qseow x', options: { a: 1 } }]);
+    });
+
+    test('propagates a throw, so the caller can abort the run', async () => {
+        const description = {
+            ...nothing(),
+            hooks: {
+                beforeAction: () => {
+                    throw new Error('not entitled');
+                },
+            },
+        };
+
+        expect(() => runBeforeAction(description, 'qseow x', {})).toThrow('not entitled');
+    });
+
+    // The committed default's every-run path: no hook described, nothing happens, no crash.
+    test.each([
+        ['a description with no hooks', { seamVersion: 1, commands: [], options: [] }],
+        ['a description describing nothing', nothing()],
+        ['no description at all', undefined],
+    ])('does nothing for %s', (_name, description) => {
+        expect(runBeforeAction(description, 'qseow x', {})).toBeUndefined();
+    });
+});
+
+describe('the beforeAction hook', () => {
+    test('receives the command path and the parsed options', async () => {
+        const { program } = buildProgram();
+        const seen = [];
+
+        applyExtensions(program, {
+            ...nothing(),
+            options: [
+                { path: 'qseow create-sheet-thumbnails', option: new Option('--brand-logo <p>') },
+            ],
+            hooks: { beforeAction: (path, options) => seen.push({ path, options }) },
+        });
+
+        await program.parseAsync(
+            ['qseow', 'create-sheet-thumbnails', '--brand-logo', '/tmp/logo.png'],
+            { from: 'user' }
+        );
+
+        expect(seen).toHaveLength(1);
+        expect(seen[0].path).toBe('qseow create-sheet-thumbnails');
+        expect(seen[0].options.brandLogo).toBe('/tmp/logo.png');
+    });
+
+    test('reports a contributed top-level command by its own name', async () => {
+        const { program } = buildProgram();
+        const seen = [];
+        const command = new Command('estate-report')
+            .exitOverride()
+            .configureOutput(SILENT)
+            .action(() => {});
+
+        applyExtensions(program, {
+            ...nothing(),
+            commands: [command],
+            hooks: { beforeAction: (path) => seen.push(path) },
+        });
+
+        await program.parseAsync(['estate-report'], { from: 'user' });
+        expect(seen).toEqual(['estate-report']);
+    });
+
+    // The reason the hook exists: a run that was never going to be allowed to proceed has to fail
+    // at startup, not after the first Sense app has been touched.
+    test('aborts the run when it throws, before the action handler', async () => {
+        const { program, runs } = buildProgram();
+
+        applyExtensions(program, {
+            ...nothing(),
+            hooks: {
+                beforeAction: () => {
+                    throw new Error('not entitled');
+                },
+            },
+        });
+
+        await expect(
+            program.parseAsync(['qseow', 'create-sheet-thumbnails'], { from: 'user' })
+        ).rejects.toThrow('not entitled');
+        expect(runs).toHaveLength(0);
+    });
+
+    // It runs under `parseAsync`, not at module evaluation, so it is allowed to be async - which is
+    // what lets it read something off disk or over a socket.
+    test('is awaited when async, and its rejection aborts the run', async () => {
+        const { program, runs } = buildProgram();
+        const order = [];
+
+        applyExtensions(program, {
+            ...nothing(),
+            hooks: {
+                beforeAction: async () => {
+                    await Promise.resolve();
+                    order.push('hook');
+                    throw new Error('async refusal');
+                },
+            },
+        });
+
+        await expect(
+            program.parseAsync(['qseow', 'create-sheet-thumbnails'], { from: 'user' })
+        ).rejects.toThrow('async refusal');
+        expect(order).toEqual(['hook']);
+        expect(runs).toHaveLength(0);
+    });
+
+    test('lets the run proceed when it returns normally', async () => {
+        const { program, runs } = buildProgram();
+
+        applyExtensions(program, { ...nothing(), hooks: { beforeAction: async () => {} } });
+
+        await program.parseAsync(['qseow', 'create-sheet-thumbnails'], { from: 'user' });
+        expect(runs).toHaveLength(1);
+    });
+});

--- a/src/lib/extensions/__tests__/extensions.test.js
+++ b/src/lib/extensions/__tests__/extensions.test.js
@@ -1,0 +1,62 @@
+import { describe, test, expect } from '@jest/globals';
+import { extensions } from '#extensions';
+import { SEAM_VERSION, assertSeamVersion } from '../version.js';
+
+// The import above is the point of this file as much as any assertion in it: it goes through the
+// `#extensions` specifier rather than a relative path, so it exercises the `package.json` `imports`
+// map under plain Jest, with no build step and no conditional wiring. Remove the map and this
+// suite fails to load.
+
+describe('the committed extensions module', () => {
+    test('describes nothing', () => {
+        expect(extensions).toEqual({
+            seamVersion: SEAM_VERSION,
+            commands: [],
+            options: [],
+            hooks: {},
+        });
+    });
+
+    test('carries all three contribution properties, so consumers need no defaulting', () => {
+        expect(Array.isArray(extensions.commands)).toBe(true);
+        expect(Array.isArray(extensions.options)).toBe(true);
+        expect(extensions.hooks).toEqual({});
+    });
+
+    // The claim §3.6 of the design rests on when it rules out a runtime check: the committed
+    // default cannot disagree with the version this tree implements. Asserted here so it stays
+    // true rather than being true by anyone's recollection.
+    test('matches the contract version this source tree implements', () => {
+        expect(() => assertSeamVersion(extensions, 'the committed default')).not.toThrow();
+    });
+});
+
+describe('assertSeamVersion', () => {
+    test('passes a description targeting this version', () => {
+        expect(() => assertSeamVersion({ seamVersion: SEAM_VERSION }, 'test')).not.toThrow();
+    });
+
+    test('rejects a description targeting an older version, naming both', () => {
+        expect(() => assertSeamVersion({ seamVersion: SEAM_VERSION - 1 }, '/tmp/other.js')).toThrow(
+            new RegExp(
+                `/tmp/other\\.js targets seamVersion ${SEAM_VERSION - 1}.*implements ${SEAM_VERSION}`
+            )
+        );
+    });
+
+    test('rejects a description targeting a newer version', () => {
+        expect(() => assertSeamVersion({ seamVersion: SEAM_VERSION + 1 }, 'newer')).toThrow(
+            /Extension contract mismatch/
+        );
+    });
+
+    // A module that exports the wrong thing, or nothing, reaches this the same way a version
+    // mismatch does - and stopping the build is the right answer to both.
+    test.each([
+        ['a description with no version', {}],
+        ['a description that is not an object', undefined],
+        ['a version that is a string', { seamVersion: String(SEAM_VERSION) }],
+    ])('rejects %s', (_name, description) => {
+        expect(() => assertSeamVersion(description, 'test')).toThrow(/Extension contract mismatch/);
+    });
+});

--- a/src/lib/extensions/__tests__/interactive-enforcement.test.js
+++ b/src/lib/extensions/__tests__/interactive-enforcement.test.js
@@ -1,0 +1,129 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+// `preAction` is not a sufficient enforcement point on its own: for `-i` the wizard runs *inside*
+// the action handler, so the hook fires before a single question has been asked. These tests drive
+// the real wizard end to end and assert the hook is given the options the run actually uses.
+
+const beforeAction = jest.fn();
+
+jest.unstable_mockModule('#extensions', () => ({
+    extensions: { seamVersion: 1, commands: [], options: [], hooks: { beforeAction } },
+}));
+
+const qseowVerifyCertificatesExist = jest.fn();
+const qseowVerifyContentLibraryExists = jest.fn();
+const listAppsByTag = jest.fn();
+const listAllApps = jest.fn();
+const qseowCreateThumbnails = jest.fn().mockResolvedValue(true);
+
+jest.unstable_mockModule('../../qseow/qseow-certificates.js', () => ({
+    qseowVerifyCertificatesExist,
+}));
+jest.unstable_mockModule('../../qseow/qseow-contentlibrary.js', () => ({
+    qseowVerifyContentLibraryExists,
+}));
+jest.unstable_mockModule('../../qseow/qseow-app-lookup.js', () => ({
+    listAppsByTag,
+    listAllApps,
+}));
+jest.unstable_mockModule('../../qseow/qseow-create-thumbnails.js', () => ({
+    qseowCreateThumbnails,
+}));
+
+const { runInteractive } = await import('../../interactive/index.js');
+const { scriptedRuntime } = await import('../../interactive/test-helpers/scripted-runtime.js');
+
+const PATH = 'qseow create-sheet-thumbnails';
+
+/**
+ * A complete set of wizard answers, ending in "Run it".
+ *
+ * @param {object} [overrides] - Answers to replace or add.
+ *
+ * @returns {object} Answers for the scripted runtime.
+ */
+const answers = (overrides = {}) => ({
+    host: 'sense.acme.com',
+    certfile: './cert/client.pem',
+    certkeyfile: './cert/client_key.pem',
+    apiuserdir: 'INTERNAL',
+    apiuserid: 'sa_api',
+    logonuserdir: 'ACME',
+    logonuserid: 'goran',
+    logonpwd: 'a-password',
+    _appSource: 'all',
+    appid: ['app-a'],
+    contentlibrary: 'Butler sheet thumbnails',
+    includesheetpart: '1',
+    _filtering: false,
+    _advanced: false,
+    _review: 'run',
+    ...overrides,
+});
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    // `clearMocks` clears calls but not implementations, so a hook left rejecting by one test would
+    // still be rejecting in the next one.
+    beforeAction.mockReset();
+    qseowVerifyCertificatesExist.mockResolvedValue(true);
+    qseowVerifyContentLibraryExists.mockResolvedValue(true);
+    listAllApps.mockResolvedValue([{ id: 'app-a', name: 'Finance' }]);
+    listAppsByTag.mockResolvedValue([]);
+    qseowCreateThumbnails.mockResolvedValue(true);
+});
+
+describe('a wizard run reaches the beforeAction hook', () => {
+    test('with the options the wizard assembled, not the near-empty ones from parse time', async () => {
+        await runInteractive({ path: PATH, runtime: scriptedRuntime(answers()) });
+
+        expect(beforeAction).toHaveBeenCalledTimes(1);
+
+        const [path, options] = beforeAction.mock.calls[0];
+
+        expect(path).toBe(PATH);
+        // The whole point: these are answers the wizard collected, none of which existed on the
+        // command line when Commander fired `preAction`.
+        expect(options.host).toBe('sense.acme.com');
+        expect(options.contentlibrary).toBe('Butler sheet thumbnails');
+    });
+
+    test('before the run starts, so throwing stops it', async () => {
+        beforeAction.mockImplementation(() => {
+            throw new Error('not entitled');
+        });
+
+        await expect(
+            runInteractive({ path: PATH, runtime: scriptedRuntime(answers()) })
+        ).rejects.toThrow('not entitled');
+
+        expect(qseowCreateThumbnails).not.toHaveBeenCalled();
+    });
+
+    test('and an async refusal stops it too', async () => {
+        beforeAction.mockRejectedValue(new Error('async refusal'));
+
+        await expect(
+            runInteractive({ path: PATH, runtime: scriptedRuntime(answers()) })
+        ).rejects.toThrow('async refusal');
+
+        expect(qseowCreateThumbnails).not.toHaveBeenCalled();
+    });
+
+    test('and a hook that returns normally lets the run proceed', async () => {
+        await runInteractive({ path: PATH, runtime: scriptedRuntime(answers()) });
+
+        expect(qseowCreateThumbnails).toHaveBeenCalledTimes(1);
+    });
+
+    // Cancelling never reaches the run, so there is nothing to be entitled to.
+    test('but a cancelled wizard never calls it', async () => {
+        await runInteractive({
+            path: PATH,
+            runtime: scriptedRuntime(answers({ _review: 'cancel' })),
+        });
+
+        expect(beforeAction).not.toHaveBeenCalled();
+        expect(qseowCreateThumbnails).not.toHaveBeenCalled();
+    });
+});

--- a/src/lib/extensions/apply.js
+++ b/src/lib/extensions/apply.js
@@ -1,0 +1,189 @@
+/**
+ * Registers what an extensions module describes onto the command tree.
+ *
+ * The module behind `#extensions` exports a plain value, not code that reaches into `program`
+ * itself. That is deliberate: core stays in control of what is registered and in what order, the
+ * description can be inspected in a test without a command tree to hand, and the committed default
+ * can be a literal - which is what lets the ordinary test suite cover the every-run path.
+ *
+ * Issue #1135.
+ */
+
+/**
+ * What a build contributes to the CLI beyond what core declares itself.
+ *
+ * @typedef {object} SeamDescription
+ * @property {number} seamVersion - The contract version this description targets.
+ * @property {import('commander').Command[]} commands - Whole commands to add to the root.
+ * @property {OptionContribution[]} options - Options to add to commands that already exist.
+ * @property {SeamHooks} hooks - Hooks, all of them optional.
+ */
+
+/**
+ * @typedef {object} OptionContribution
+ * @property {string} path - Space-separated command path, e.g. `'qseow create-sheet-thumbnails'`.
+ * @property {import('commander').Option} option - A fully built Commander option.
+ */
+
+/**
+ * @typedef {object} SeamHooks
+ * @property {BeforeAction} [beforeAction] - Runs once after parse, before the action handler runs.
+ */
+
+/**
+ * Runs after the command line has been parsed and before the action handler is dispatched, so a run
+ * that was never going to be allowed to proceed fails at startup rather than partway through.
+ *
+ * May be async: it runs under `parseAsync`, not at module evaluation. Throwing aborts the run.
+ *
+ * **It can run more than once for a single run, so it must be idempotent.** An interactive run
+ * calls it twice, and deliberately: once from the `preAction` hook, where the command line has been
+ * parsed but the wizard has not yet asked anything, and again once the wizard has assembled the
+ * options the run will actually use. Only the second call sees those, so a hook deciding anything
+ * from *which options were supplied* must treat the second as the authoritative one - on
+ * `-i` the first sees almost nothing. See `runBeforeAction`.
+ *
+ * @callback BeforeAction
+ * @param {string} path - Space-separated path of the command that is about to run.
+ * @param {object} options - The options that command will run with.
+ *
+ * @returns {void|Promise<void>} Nothing, or a promise the caller will await.
+ */
+
+/**
+ * The command at a space-separated path below the root.
+ *
+ * @param {import('commander').Command} program - The root command.
+ * @param {string} path - Space-separated command path, e.g. `'qseow create-sheet-thumbnails'`.
+ *
+ * @returns {import('commander').Command} The command that path names.
+ *
+ * @throws {Error} When `path` is not a usable string, or when no such command exists. A
+ *     contribution aimed at a command that is not there would otherwise be silently dropped, and
+ *     the option would go missing from `--help` with nothing anywhere saying why.
+ */
+const commandAtPath = (program, path) => {
+    // Checked before `.trim()` rather than after it. A contribution that omits `path` altogether is
+    // the likeliest way to get here, and letting it reach `.trim()` produces a bare TypeError from
+    // inside core, naming neither the contribution nor the option.
+    if (typeof path !== 'string' || path.trim() === '') {
+        throw new Error(
+            `Extension option contribution has no usable command path (received ${JSON.stringify(path)}).`
+        );
+    }
+
+    const segments = path.trim().split(/\s+/).filter(Boolean);
+
+    let command = program;
+
+    for (const segment of segments) {
+        const child = command.commands.find(
+            (candidate) => candidate.name() === segment || candidate.aliases().includes(segment)
+        );
+
+        if (!child) {
+            throw new Error(
+                `Extension option contribution targets '${path}', but there is no command '${segment}' under '${command.name()}'.`
+            );
+        }
+
+        command = child;
+    }
+
+    return command;
+};
+
+/**
+ * The space-separated path of a command, relative to the root.
+ *
+ * @param {import('commander').Command} command - The command that is about to run.
+ *
+ * @returns {string} The path, e.g. `'qseow create-sheet-thumbnails'`. Empty when the root itself is
+ *     the acting command.
+ */
+const pathOfCommand = (command) => {
+    const names = [];
+
+    for (let cmd = command; cmd?.parent; cmd = cmd.parent) {
+        names.unshift(cmd.name());
+    }
+
+    return names.join(' ');
+};
+
+/**
+ * Register everything a description asks for.
+ *
+ * **Where this is called from is forced, not preferred.** It must run after the command tree is
+ * built and before `relaxMandatoryOptionsIfInteractive`, because Commander rejects a command line
+ * missing a mandatory option before any hook or handler runs - so an option contributed after the
+ * relaxation call would parse normally in ordinary use and fail only under `-i`.
+ *
+ * An empty description is the normal case, not an edge case: it is what every build in this
+ * repository bundles. It registers nothing and adds no hook, so a build with no extensions behaves
+ * exactly as it would if this function were never called.
+ *
+ * The description is trusted rather than schema-validated. It is a value written by whoever built
+ * the binary, it was checked against {@link import('./version.js').SEAM_VERSION} when the bundle
+ * was made, and the one mistake that would otherwise be silent - an option aimed at a command that
+ * does not exist - is caught in `commandAtPath` above. The three list properties are defaulted
+ * below as leniency for a hand-written description; the contract still says all three are present.
+ *
+ * @param {import('commander').Command} program - The root command, with its own tree already built.
+ * @param {SeamDescription} extensions - What to register. Describing nothing is normal.
+ *
+ * @returns {void} Nothing. The command tree is modified in place.
+ */
+export const applyExtensions = (program, extensions) => {
+    const { commands = [], options = [], hooks = {} } = extensions ?? {};
+
+    for (const command of commands) {
+        program.addCommand(command);
+    }
+
+    for (const { path, option } of options) {
+        commandAtPath(program, path).addOption(option);
+    }
+
+    if (!hooks.beforeAction) {
+        return;
+    }
+
+    // One hook on the root covers every command: Commander collects preAction hooks from the acting
+    // command and all of its ancestors.
+    //
+    // It fires ahead of the one `relaxMandatoryOptionsIfInteractive` installs, because hooks run in
+    // registration order and this function is called first. That ordering is worth knowing about
+    // rather than working around: on a command line where `-i` appeared as an option *value* rather
+    // than as a request for a wizard, this hook runs before the relaxation hook re-runs Commander's
+    // missing-mandatory check, so a hook that throws reports its own failure instead of the missing
+    // option. Both are genuine failures of the same command line, and reordering would mean
+    // contributing options after the relaxation call, which is exactly what cannot be done.
+    program.hook('preAction', (_hookedCommand, actionCommand) =>
+        hooks.beforeAction(pathOfCommand(actionCommand), actionCommand.opts())
+    );
+};
+
+/**
+ * Run a description's `beforeAction` hook, if it has one.
+ *
+ * Exists because `preAction` is not a sufficient enforcement point on its own. Commander fires it
+ * before the action handler, and for `-i` the wizard runs *inside* that handler - so the hook sees
+ * `interactive: true` and almost nothing else, and a hook that decides from which options were
+ * supplied would wave the run through and then watch the wizard collect the very option it was
+ * meant to gate.
+ *
+ * `runInteractive` therefore calls this again with the options the wizard assembled, immediately
+ * before the run starts. Both calls are kept rather than moving the check wholesale: the first
+ * still catches a licensed option typed on the command line alongside `-i`, and catches it before
+ * the wizard asks anything.
+ *
+ * @param {SeamDescription} extensions - The description, which may describe no hooks at all.
+ * @param {string} path - Space-separated command path, e.g. `'qseow create-sheet-thumbnails'`.
+ * @param {object} options - The options the run will actually use.
+ *
+ * @returns {void|Promise<void>} Whatever the hook returns, so an async hook is awaited by the
+ *     caller. Nothing at all when no hook is described, which is the committed default's case.
+ */
+export const runBeforeAction = (extensions, path, options) =>
+    extensions?.hooks?.beforeAction?.(path, options);

--- a/src/lib/extensions/index.js
+++ b/src/lib/extensions/index.js
@@ -1,0 +1,18 @@
+/**
+ * What this build contributes to the CLI beyond what core declares itself.
+ *
+ * This is the committed default, and it describes nothing: no commands, no options, no hooks. That
+ * is a real, correct implementation of "there is nothing to add" rather than a placeholder - it is
+ * what every build in this repository bundles, and what `npm test` exercises. A throw, a warning or
+ * a `null` here would all mean the normal path is the untested one.
+ *
+ * A variant build replaces this module by pointing `EXTENSIONS_MODULE` at its own, which
+ * `scripts/bundle.mjs` turns into an esbuild alias for the `#extensions` specifier. Nothing is
+ * discovered at runtime: the module is chosen when the bundle is built, so it is compiled into the
+ * binary or it is not present at all. See issue #1135.
+ *
+ * The shape is documented as `SeamDescription` in `apply.js`, which is the only consumer.
+ *
+ * @type {import('./apply.js').SeamDescription}
+ */
+export const extensions = { seamVersion: 1, commands: [], options: [], hooks: {} };

--- a/src/lib/extensions/version.js
+++ b/src/lib/extensions/version.js
@@ -1,0 +1,38 @@
+/**
+ * The version of the extension contract that this source tree implements.
+ *
+ * Bumped only by a change that an existing description could not survive: a renamed property, a
+ * changed signature, or a property becoming required. Adding an optional hook or an optional
+ * property costs nothing, because core ignores what it does not recognise.
+ */
+export const SEAM_VERSION = 1;
+
+/**
+ * Fail a build whose extensions module targets a different contract version.
+ *
+ * Build time is the only place this check belongs. The two halves of a variant build are always
+ * built together, so a mismatch is a property of the build rather than of the machine the binary
+ * later runs on - and with no override set the committed default matches by construction, so a
+ * runtime assert would sit in every shipped binary guarding a condition that cannot occur there.
+ *
+ * Exported from here rather than written inline in `scripts/bundle.mjs` so that the comparison is
+ * covered by the test suite: `scripts/` is outside Jest's `roots`.
+ *
+ * @param {object} description - The description exported by the extensions module being bundled.
+ * @param {string} source - Where that module came from, for the error message.
+ *
+ * @returns {void} Nothing. Returns normally when the versions agree.
+ *
+ * @throws {Error} When the description targets a version other than {@link SEAM_VERSION}, so the
+ *     build stops before esbuild runs rather than producing a binary that misreads its own
+ *     extensions.
+ */
+export const assertSeamVersion = (description, source) => {
+    const targeted = description?.seamVersion;
+
+    if (targeted !== SEAM_VERSION) {
+        throw new Error(
+            `Extension contract mismatch: ${source} targets seamVersion ${targeted}, this source tree implements ${SEAM_VERSION}. Build both halves from matching revisions.`
+        );
+    }
+};

--- a/src/lib/interactive/index.js
+++ b/src/lib/interactive/index.js
@@ -13,6 +13,8 @@ import { loadWizard } from './registry.js';
 import { formatReviewTable } from './review-table.js';
 import { saveEnvFile, ENV_FILE } from './save-env-file.js';
 import { openingOn } from './spec-ops.js';
+import { extensions } from '#extensions';
+import { runBeforeAction } from '../extensions/apply.js';
 
 /** Heading for the checks that run before the first question is asked. */
 const CHECKED_UP_FRONT = 'Checking what you supplied';
@@ -380,6 +382,13 @@ export const runInteractive = async ({
                 '\nDRY RUN: --dry-run is in effect - the run below plans only, nothing will be changed.\n'
             );
         }
+
+        // The authoritative entitlement point for an interactive run, and the reason this call
+        // exists at all. The `preAction` hook fired before the first question was asked, when the
+        // options bag held `interactive: true` and little else; these are the options the run will
+        // actually use. Throwing here aborts before the run starts, which is the same promise the
+        // hook makes on an ordinary command line. Does nothing unless this build describes a hook.
+        await runBeforeAction(extensions, path, options);
 
         runtime.write('\n');
 


### PR DESCRIPTION
Closes #1135.

Adding one command, or one option to an existing command, meant editing `src/butler-sheet-icons.js`
and re-resolving that patch on every upgrade. This adds one extension point the build can back with
a different module instead.

## What lands

| File | What |
| --- | --- |
| `src/lib/extensions/index.js` | The committed default. Describes nothing. |
| `src/lib/extensions/apply.js` | `applyExtensions` — commands, options, one hook |
| `src/lib/extensions/version.js` | `SEAM_VERSION` and the build-time comparison |
| `package.json` | `"imports": { "#extensions": … }` |
| `src/butler-sheet-icons.js` | The call site |
| `src/lib/interactive/index.js` | The hook's second call point — see below |
| `scripts/bundle.mjs` | The build override, one place rather than seven |

The committed default is a real implementation of "there is nothing to add", not a placeholder or a
throw. That is what makes the every-run path the one the test suite covers, so a contract change
breaks the build loudly instead of drifting.

## Three things worth review attention

**The call site is forced, not chosen.** Contributions must land after the tree is built and before
`relaxMandatoryOptionsIfInteractive`, because Commander rejects a command line missing a mandatory
option before any hook or handler runs — so an option contributed later parses normally and fails
only under `-i`. `apply-ordering.test.js` contributes *after* the relaxation call on purpose and
asserts the failure, so the constraint is executable rather than a comment.

**`preAction` alone was not enough.** For `-i` the wizard runs *inside* the action handler, so at
`preAction` the options bag holds `interactive: true` and little else. Anything deciding from which
options were supplied would see none of them, allow the run, and then watch the wizard collect the
very option it was meant to act on. `runInteractive` therefore calls the hook again with the options
the wizard assembled. Both calls are kept — the first still catches an option typed alongside `-i`,
before any question is asked — so the hook must be idempotent, which its typedef now says.

**An override could bundle a second copy of Commander.** A module outside this tree resolves
`commander` from its own `node_modules`, and a `Command` built by one instance and added to a tree
owned by another fails — at run time, inside the packaged binary, after a build that reported
success. `scripts/bundle.mjs` now aliases `commander` to this tree's copy so exactly one is bundled,
and fails the build when the two resolved majors differ, since an alias cannot make code written
against one major work against another.

## Verification

macOS/arm64, through this repo's own SEA pipeline rather than a stand-in:

- **129 suites / 3488 tests / 0 failures.** `eslint --max-warnings 0` and prettier clean.
  `src/lib/extensions/` at 100% statements, branches, functions and lines.
- **Nothing changes for a normal build.** A packaged binary built from this branch produces output
  identical to one built from `main` — 301 lines of `--help`, `--version`, subcommand help, error
  paths and exit codes, diffed and byte-identical.
- **The override works inside a packaged binary**, not just under `node`: a contributed command runs,
  the hook fires with the right command path, and a contributed option appears in a core command's
  `--help`.
- **A mismatched Commander fails the build** rather than the binary: exits non-zero naming both
  versions. With matching majors, one copy is bundled (+1.4 KB rather than +113 KB).
- The Docker layout was checked separately, since that image runs the sources under plain node with
  no esbuild step: `package.json` and `src/lib/` are both copied, so the `imports` map resolves.

Windows and Linux are unverified — this is macOS/arm64 only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
