### PR TITLE
Canary the extensions override on Windows and Linux

### DIFF
--- a/.github/workflows/extensions-canary.yaml
+++ b/.github/workflows/extensions-canary.yaml
@@ -1,0 +1,112 @@
+name: extensions-canary
+
+# Does the `#extensions` build-time override still work once the binary is packaged?
+#
+# ---------------------------------------------------------------------------------------------
+# Why this exists
+# ---------------------------------------------------------------------------------------------
+#
+# The override landed with issue #1135 and was verified on macOS/arm64 only. This repo ships SEA
+# binaries for macOS, Windows and Linux, and its signature failure mode is "works everywhere except
+# inside the packaged binary": the Windows signing timestamp URL changed from http to https in May
+# 2026 and nothing noticed until the 4.0.0 release failed in August, which is why
+# windows-signing-canary.yaml exists at all.
+#
+# Most of the override is bundle-time and platform-agnostic - esbuild resolves an alias long before
+# anything platform-specific happens. One part is not. `scripts/bundle.mjs` resolves
+# EXTENSIONS_MODULE to an absolute path and hands it to esbuild as an alias value and to
+# pathToFileURL; on Windows that is a C:\ path with backslashes, and until this workflow ran, that
+# had never happened anywhere. Issue #1137.
+#
+# It also asserts node:crypto works inside the packaged binary. `src/lib/qseow/qseow-logout.js`
+# imports it, so every binary already depends on it, and nothing checked that the native binding
+# survived packaging on any platform.
+#
+# ---------------------------------------------------------------------------------------------
+# What it does NOT cover
+# ---------------------------------------------------------------------------------------------
+#
+# Signing. scripts/release-win.ps1 strips Node's signature before postject and re-applies one
+# after, a sequence neither macOS nor Linux has an equivalent of - and covering it needs the
+# win-code-sign self-hosted runner with a live SimplySign session, which no routine canary can
+# depend on. windows-signing-canary.yaml in `full` mode covers that path for the ordinary build,
+# and an override build differs from it only in the contents of one bundled module. That is an
+# inference, and it is deliberately recorded as one rather than presented as a result.
+#
+# macOS is not in the matrix either. It is the platform the override was verified on by hand, and
+# the one the local build script exercises on every developer machine.
+#
+# ---------------------------------------------------------------------------------------------
+# Reading the result
+# ---------------------------------------------------------------------------------------------
+#
+# Every assertion prints `ok` or `FAIL`, and the job fails with the full list rather than at the
+# first problem - a platform difference is more useful reported whole. The run also builds a binary
+# with no override at all and asserts it is unchanged, so a green run says the normal build is fine
+# as well as the exotic one.
+#
+# No secrets are read, so this is safe to run for a pull request from a fork.
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/bundle.mjs'
+      - 'scripts/extensions-canary.mjs'
+      - 'src/lib/extensions/**'
+      - 'build-script/sea-config.json'
+      - '.github/workflows/extensions-canary.yaml'
+      # Dependency bumps belong here as much as the source does. bundle.mjs aliases `commander` to
+      # this tree's copy for an override build and fails the build when the majors differ, so a
+      # commander bump changes the behaviour this canary guards without touching a single file
+      # above it. The same goes for esbuild, since the override is an esbuild `alias`.
+      - 'package.json'
+      - 'package-lock.json'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: extensions-canary-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  canary:
+    name: extensions override in a packaged binary (${{ matrix.os }})
+    strategy:
+      # Report both platforms rather than cancelling the sibling on first failure. The whole point
+      # is to find a platform difference, and a difference is only visible when both legs report.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    # Two full SEA builds per leg - bundle, blob, copy, inject, twice - plus the install. Measured
+    # at well under this; the bound is here so a hung postject costs minutes rather than hours.
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      # Same reasoning as pr-unit-tests.yaml: npm 11.x resolves this lockfile differently between
+      # patch releases, and setup-node has no npm-version input.
+      - name: Pin npm
+        # zizmor: ignore[adhoc-packages] - setup-node has no npm-version input, so npm 12
+        # cannot arrive any other way. Pinned to an exact version rather than a range.
+        run: | # zizmor: ignore[adhoc-packages]
+          npm install -g npm@12.0.2
+          npm --version
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build, package and interrogate the binaries
+        run: node scripts/extensions-canary.mjs

--- a/scripts/extensions-canary.mjs
+++ b/scripts/extensions-canary.mjs
@@ -1,0 +1,359 @@
+#!/usr/bin/env node
+// Platform: Cross-platform (macOS, Linux, Windows)
+// Requires: Node.js
+
+/**
+ * Does the `#extensions` build-time override still work once the binary has been packaged?
+ *
+ * The override landed with issue #1135 and was only ever exercised on macOS/arm64. This repo ships
+ * SEA binaries for three platforms, and its signature failure mode is "works everywhere except
+ * inside the packaged binary" - the Windows signing timestamp URL changed in May 2026 and nothing
+ * noticed until a release failed in August. Issue #1137.
+ *
+ * A Node script rather than a workflow step written twice, for the same reason `scripts/bundle.mjs`
+ * is one: the alternative is the same logic in bash and in PowerShell, and the two drift. That is
+ * the problem #1128 was filed about.
+ *
+ * What it asserts, on whichever platform it runs:
+ *
+ *   1. A binary built WITH an override registers what the override describes - a whole command, an
+ *      option on a command that already exists, and the `beforeAction` hook.
+ *   2. `node:crypto` still works inside that packaged binary. `src/lib/qseow/qseow-logout.js`
+ *      imports it, so every binary already depends on it, and nothing asserted it survived
+ *      packaging on any platform.
+ *   3. A binary built WITHOUT an override is unchanged - none of the above is present, and the
+ *      version is what it should be.
+ *
+ * Signing is deliberately not part of this. The two signing canaries already cover that path, and
+ * the question here is packaging and module resolution. See #1137 for the gap that leaves on
+ * Windows, where the release script strips and re-applies a signature around postject.
+ *
+ * Usage:
+ *   node scripts/extensions-canary.mjs
+ */
+
+import { spawnSync } from 'node:child_process';
+import { chmodSync, copyFileSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+
+const require = createRequire(import.meta.url);
+
+const BUILD_DIR = 'build';
+
+/**
+ * The throwaway extensions module, written into `build/` rather than a system temp directory.
+ *
+ * That is not laziness about temp files: the module imports `commander`, and
+ * `scripts/bundle.mjs` both imports it to read `seamVersion` and refuses a build whose Commander
+ * major differs from core's. Somewhere under the repo root is the only place a bare `commander`
+ * specifier resolves to the same copy core uses. `build/` is already git-ignored and already
+ * cleaned by the release scripts.
+ */
+const MODULE_PATH = join(BUILD_DIR, 'canary-extensions.mjs');
+
+/** Named for what it is, so nobody finds it in a process list and wonders. */
+const BINARY_PATH = join(BUILD_DIR, process.platform === 'win32' ? 'bsi-canary.exe' : 'bsi-canary');
+
+/** Markers the contributed code prints, matched in the assertions below. */
+const COMMAND_MARKER = 'CANARY_COMMAND_RAN';
+const HOOK_MARKER = 'CANARY_HOOK_RAN';
+const CRYPTO_MARKER = 'CANARY_CRYPTO';
+
+const EXTENSIONS_MODULE_SOURCE = `import { Command, Option } from 'commander';
+import { createHash, randomBytes, generateKeyPairSync, sign, verify } from 'node:crypto';
+
+// Exercises node:crypto's native binding from inside the packaged binary. Several primitives
+// rather than one, because the interesting question is whether the binding survives packaging at
+// all, and a single hash would not touch the asymmetric paths.
+const cryptoSmoke = () => {
+    const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+    const data = Buffer.from('butler-sheet-icons canary');
+    const signature = sign(null, data, privateKey);
+
+    return {
+        hash: createHash('sha256').update(data).digest('hex').slice(0, 8),
+        randomBytes: randomBytes(8).length,
+        roundTrip: verify(null, data, publicKey, signature),
+        rejectsTampered: !verify(null, Buffer.from('tampered'), publicKey, signature),
+    };
+};
+
+export const extensions = {
+    seamVersion: 1,
+    commands: [
+        new Command('canary-check')
+            .description('Canary: report what this binary can do.')
+            .action(() => {
+                console.log('${COMMAND_MARKER}');
+                console.log('${CRYPTO_MARKER} ' + JSON.stringify(cryptoSmoke()));
+            }),
+    ],
+    options: [
+        {
+            path: 'qseow create-sheet-thumbnails',
+            option: new Option('--canary-note <text>', 'Canary: a contributed option.'),
+        },
+    ],
+    hooks: {
+        beforeAction: (path) => {
+            console.log('${HOOK_MARKER} ' + path);
+        },
+    },
+};
+`;
+
+/**
+ * Run a command, failing the canary if it does not succeed.
+ *
+ * @param {string} label - What this step is, for the failure message.
+ * @param {string} command - Executable to run.
+ * @param {string[]} args - Arguments.
+ * @param {object} [env] - Extra environment variables.
+ *
+ * @returns {void} Nothing.
+ *
+ * @throws {Error} When the command exits non-zero, so a failed build is not mistaken for a passed
+ *     assertion further down.
+ */
+const run = (label, command, args, env = {}) => {
+    console.log(`\n--- ${label}`);
+
+    const result = spawnSync(command, args, {
+        stdio: 'inherit',
+        env: { ...process.env, ...env },
+        shell: false,
+    });
+
+    if (result.error) {
+        throw result.error;
+    }
+
+    if (result.status !== 0) {
+        throw new Error(`${label} failed with status ${result.status}`);
+    }
+};
+
+/** Assertions that failed, collected so one run reports every problem rather than the first. */
+const failures = [];
+
+/**
+ * Record whether one expectation held.
+ *
+ * @param {string} description - What was expected.
+ * @param {boolean} passed - Whether it held.
+ * @param {string} [detail] - Extra context shown when it did not.
+ *
+ * @returns {void} Nothing.
+ */
+const check = (description, passed, detail = '') => {
+    console.log(`  ${passed ? 'ok  ' : 'FAIL'}  ${description}`);
+
+    if (!passed) {
+        failures.push(`${description}${detail ? ` - ${detail}` : ''}`);
+    }
+};
+
+/**
+ * Run the packaged binary, assert it exited cleanly, and return what it printed.
+ *
+ * stdout and stderr are joined: Commander writes help to stdout and errors to stderr, and an
+ * assertion that cares which one a string arrived on would be asserting Commander's behaviour
+ * rather than the binary's.
+ *
+ * The exit status is asserted **here** rather than at each call site, because every caller wants
+ * the same thing and one that forgot would be the bug: a binary that prints all the right markers
+ * and then dies during teardown - an unhandled rejection inside a contributed hook is exactly the
+ * platform-specific fault this canary exists to find - would otherwise satisfy every assertion
+ * that reads its output, and the run would go green on a binary that crashed.
+ *
+ * @param {string} label - What this invocation is, for the assertion line.
+ * @param {string[]} args - Arguments to pass to the binary.
+ *
+ * @returns {{output: string, status: number}} What it printed, and how it exited.
+ */
+const runBinary = (label, args) => {
+    const result = spawnSync(BINARY_PATH, args, { encoding: 'utf8', shell: false });
+
+    if (result.error) {
+        throw result.error;
+    }
+
+    check(`${label} exits cleanly`, result.status === 0, `exit status ${result.status}`);
+
+    return { output: `${result.stdout ?? ''}${result.stderr ?? ''}`, status: result.status };
+};
+
+/**
+ * Bundle, package and inject a SEA binary from the current source tree.
+ *
+ * Mirrors what the release scripts do, minus real code signing: bundle, generate the blob, copy the
+ * running Node executable, inject.
+ *
+ * macOS gets an **ad-hoc** signature, exactly as `build-script/build-macos.sh` does. That is not a
+ * step towards signing coverage - it needs no certificate and asserts no identity - it is simply
+ * that arm64 macOS refuses to run an unsigned binary at all, so without it this script could not be
+ * developed or tried on the machine most likely to be running it. Windows and Linux need nothing:
+ * Windows runs a binary whose signature postject invalidated, and Linux has no such notion. Real
+ * signing stays with the two signing canaries, per #1137.
+ *
+ * @param {string} [extensionsModule] - Value for `EXTENSIONS_MODULE`, or undefined for a plain build.
+ *
+ * @returns {void} Nothing. Leaves the binary at `BINARY_PATH`.
+ */
+const buildBinary = (extensionsModule) => {
+    // Set to the empty string rather than omitted for a plain build. `run()` merges over
+    // `process.env`, so omitting it would let an EXTENSIONS_MODULE exported in the surrounding
+    // shell reach the build that is supposed to have none - and the leg whose entire claim is
+    // "no override was applied" would be assuming it rather than asserting it. bundle.mjs already
+    // treats an empty value as absent.
+    const env = { EXTENSIONS_MODULE: extensionsModule ?? '' };
+
+    run('esbuild bundle', process.execPath, ['scripts/bundle.mjs', 'bundle'], env);
+    run('SEA blob', process.execPath, [
+        '--experimental-sea-config',
+        'build-script/sea-config.json',
+    ]);
+
+    rmSync(BINARY_PATH, { force: true });
+    copyFileSync(process.execPath, BINARY_PATH);
+
+    // The release scripts use `cp`, which carries the execute bit across. copyFileSync does too on
+    // the platforms measured, but the canary would fail confusingly rather than informatively if it
+    // ever did not - and an exec bit is not the platform difference this exists to find.
+    if (process.platform !== 'win32') {
+        chmodSync(BINARY_PATH, 0o755);
+    }
+
+    if (process.platform === 'darwin') {
+        run('strip signature', 'codesign', ['--remove-signature', BINARY_PATH]);
+    }
+
+    run('postject inject', process.execPath, ['scripts/bundle.mjs', 'inject', BINARY_PATH]);
+
+    if (process.platform === 'darwin') {
+        run('ad-hoc sign', 'codesign', ['--sign', '-', BINARY_PATH]);
+    }
+};
+
+console.log(`extensions canary - ${process.platform}/${process.arch}, node ${process.version}`);
+
+mkdirSync(BUILD_DIR, { recursive: true });
+writeFileSync(MODULE_PATH, EXTENSIONS_MODULE_SOURCE);
+
+// ---------------------------------------------------------------------------------------------
+// A binary built WITH an override
+//
+// MODULE_PATH is relative, so bundle.mjs resolves it to an absolute path and hands that to esbuild
+// as an alias value and to pathToFileURL. On Windows that is a C:\ path with backslashes, which is
+// the part of #1135 that had never run anywhere but macOS.
+// ---------------------------------------------------------------------------------------------
+buildBinary(MODULE_PATH);
+
+console.log('\n=== with an override ===');
+
+const contributed = runBinary('the contributed command', ['canary-check']);
+
+check('the contributed command runs', contributed.output.includes(COMMAND_MARKER));
+check('the beforeAction hook fires', contributed.output.includes(HOOK_MARKER));
+check(
+    'the hook is given the command path',
+    contributed.output.includes(`${HOOK_MARKER} canary-check`),
+    contributed.output.trim()
+);
+
+const cryptoLine = contributed.output.split('\n').find((line) => line.includes(CRYPTO_MARKER));
+const braceAt = cryptoLine ? cryptoLine.indexOf('{') : -1;
+
+// Parsed defensively rather than inline. An unguarded JSON.parse here would throw out of the
+// script on a line that arrived malformed or interleaved, skipping every remaining assertion and
+// the whole no-override half of the run - so the report would be a stack trace instead of a list
+// naming which checks failed, which is the opposite of what `failures` exists for.
+let cryptoResult = {};
+let parseError = braceAt >= 0 ? '' : 'no readable marker line';
+
+if (braceAt >= 0) {
+    try {
+        cryptoResult = JSON.parse(cryptoLine.slice(braceAt));
+    } catch (err) {
+        parseError = err.message;
+    }
+}
+
+check(
+    'the packaged binary reported a readable node:crypto result',
+    parseError === '',
+    `${parseError}${cryptoLine ? ` - ${cryptoLine.trim()}` : ''}`
+);
+
+check('node:crypto hashes inside the packaged binary', cryptoResult.hash?.length === 8);
+check('node:crypto produces random bytes', cryptoResult.randomBytes === 8);
+check('node:crypto completes a sign/verify round trip', cryptoResult.roundTrip === true);
+check('node:crypto rejects a payload that does not match', cryptoResult.rejectsTampered === true);
+
+const contributedHelp = runBinary('help for a command carrying a contributed option', [
+    'qseow',
+    'create-sheet-thumbnails',
+    '--help',
+]);
+
+check(
+    'a contributed option reaches an existing command',
+    contributedHelp.output.includes('--canary-note')
+);
+
+// ---------------------------------------------------------------------------------------------
+// A binary built WITHOUT one - the build every release actually makes
+// ---------------------------------------------------------------------------------------------
+buildBinary(undefined);
+
+console.log('\n=== without an override ===');
+
+const version = runBinary('--version', ['--version']);
+const expectedVersion = require('../package.json').version;
+
+check(
+    `--version reports ${expectedVersion}`,
+    version.output.trim() === expectedVersion,
+    version.output.trim()
+);
+
+const plainHelp = runBinary('--help', ['--help']);
+
+check('the contributed command is absent', !plainHelp.output.includes('canary-check'));
+
+const plainCommandHelp = runBinary('help for the unmodified command', [
+    'qseow',
+    'create-sheet-thumbnails',
+    '--help',
+]);
+
+check('the contributed option is absent', !plainCommandHelp.output.includes('--canary-note'));
+check(
+    'the ordinary command tree is intact',
+    plainHelp.output.includes('qseow') && plainHelp.output.includes('qscloud')
+);
+
+rmSync(MODULE_PATH, { force: true });
+rmSync(BINARY_PATH, { force: true });
+
+if (failures.length > 0) {
+    console.error(`\n${failures.length} assertion(s) failed:`);
+
+    for (const failure of failures) {
+        console.error(`  - ${failure}`);
+    }
+
+    // `process.exitCode`, never `process.exit()` - the codebase's standing rule, and it matters
+    // most precisely here. A hard exit discards whatever is still buffered, which on a TTY is
+    // invisible because terminal writes are synchronous, but a CI log collector is a pipe.
+    // `src/lib/util/flush-exit.js` carries the measurement: 400 lines followed by a hard exit
+    // delivered 333 and lost the final report block entirely. The list just written *is* this
+    // canary's whole diagnostic value on a platform nobody can reproduce locally, and the two
+    // exceptions the rule allows both exist for Puppeteer and enigma handles that can hang a
+    // shutdown. Nothing here holds the event loop open - every step is spawnSync - so the process
+    // ends on its own the moment this returns.
+    process.exitCode = 1;
+} else {
+    console.log('\nAll assertions passed.');
+}


### PR DESCRIPTION
Closes #1137.

The `#extensions` override from #1135 was verified on macOS/arm64 only, and this repo ships SEA
binaries for three platforms. **This PR is also how the answer arrives** — the two legs below have
never run anywhere, so the CI result on this PR is the finding, not a formality.

## What it checks

A binary built **with** an override:

- the contributed command runs
- the contributed option reaches a command that already exists
- the `beforeAction` hook fires, with the right command path
- `node:crypto` still works inside the packaged binary

A binary built **without** one — the build every release actually makes:

- none of the above is present
- `--version` is correct and the ordinary command tree is intact

Every invocation also asserts the binary exited cleanly, so a binary that prints the right output and
then crashes during teardown cannot pass.

## Why a Node script rather than workflow steps

Same reason `scripts/bundle.mjs` is one script and not seven copies (#1128): the alternative here is
the same logic written once in bash and once in PowerShell, and the two drift. `scripts/bundle.mjs`
now owns the flag set for all seven build call sites, and this reuses it rather than re-deriving it.

## The part that is genuinely platform-sensitive

Most of the override is bundle-time and platform-agnostic — esbuild resolves an alias long before
anything platform-specific happens. One part is not:

```js
const extensionsModule = process.env.EXTENSIONS_MODULE
    ? resolve(process.env.EXTENSIONS_MODULE)
    : undefined;
```

That absolute path goes to esbuild as an `alias` value and to `pathToFileURL()`. On Windows it is a
`C:\…` path with backslashes, and nobody has ever run it there.

## Where it runs, and the gap that leaves

`ubuntu-latest` and `windows-latest`. Standard runners, **no signing, no secrets**, so it is safe for
a pull request from a fork.

That is a deliberate trade. `scripts/release-win.ps1` strips Node's signature before postject and
re-applies one after — a sequence neither macOS nor Linux has — and covering it needs the
`win-code-sign` self-hosted runner with a live SimplySign session, which no routine canary can depend
on. `windows-signing-canary.yaml` in `full` mode already covers that path for the ordinary build, and
an override build differs from it only in the contents of one bundled module. That is an inference,
and it is recorded as one in #1137 rather than presented as a result.

macOS is not in the matrix: it is the platform the override was already verified on, and the local
build script exercises it on every developer machine. The script does apply an **ad-hoc** signature on
macOS, purely because arm64 refuses to run an unsigned binary at all — no certificate, no identity, no
relation to signing coverage.

## Verification so far

macOS/arm64 locally: 18 assertions, exit 0. Three negative controls, because a canary that can only
pass is worthless:

| Broken deliberately | Result |
| --- | --- |
| An assertion that cannot match | 3 failures listed, **exit 1** |
| Same, with stdout as a pipe | full failure list still delivered |
| A truncated JSON marker line | named failure + the no-override leg still ran |

`zizmor` clean on the workflow, eslint clean on the script, and `check yaml` passes in pre-commit.

Nothing under `src/`, so the unit suites are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
