### PR TITLE
Enforce the extension point's boundary in lint and at commit time

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,25 @@ repos:
                     build.cjs
                 )$
 
+          # src/lib/extensions/ is a build seam: EXTENSIONS_MODULE makes `#extensions`
+          # resolve elsewhere at bundle time, and the committed default is what every
+          # build here uses instead. A file added beside it is either contract surface
+          # or something an override build half-replaces, so the directory carries an
+          # explicit allowlist and this rejects anything not on it. Issue #1139.
+          #
+          # Deliberately an allowlist: a denylist fails silently a year later, this fails
+          # closed at the moment the decision is being made. `files` does the filtering,
+          # so the script only ever sees staged paths under that directory - and because
+          # it inspects what is staged, `git add -f` makes no difference.
+          - id: extension-point-allowlist
+            name: extension point allowlist
+            entry: node scripts/check-extension-point.mjs
+            language: system
+            # Matches the directory itself as well as its contents: replacing the whole
+            # directory with a symlink stages the single path `src/lib/extensions`, and a
+            # trailing-slash pattern would let exactly that through.
+            files: '^src/lib/extensions(/|$)'
+
           # Keeps the GitNexus index current instead of relying on an agent to notice
           # it has gone stale. Inert until `npm run gitnexus:install` has been run in
           # the clone, and never blocks a git operation — see the script's header and

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,6 +9,44 @@ import jsdoc from 'eslint-plugin-jsdoc';
 const BOUNDARY_MESSAGE =
     'Import prompts through src/lib/interactive/prompt-runtime.js instead. It is the only module allowed to depend on the prompt library, so the library can be replaced by editing one file if it misbehaves inside the SEA binary.';
 
+// Shared by the two blocks that enforce the extension-point boundary, so the exemption for
+// prompt-runtime.js below cannot quietly become an exemption from this rule too. Issue #1139.
+const SEAM_MESSAGE =
+    'Import the extension point through the `#extensions` specifier instead. A relative path resolves under node and Jest, so it passes every test, and then silently ignores the build-time override - esbuild cannot alias a relative specifier. The failure appears only inside the packaged binary. Nothing under src/lib/extensions/ is reachable from core except `#extensions`, and apply.js and version.js beside it.';
+
+/**
+ * The extension-point boundary, as no-restricted-imports patterns.
+ *
+ * `**\/extensions/index.js` catches the module being imported by path rather than through the
+ * specifier. `**\/extensions/*\/**` catches anything reaching into a subdirectory of it - a
+ * directory an override build replaces wholesale, so a file core imports from inside it is either
+ * unversioned contract surface or half of a split the build did not intend.
+ *
+ * `apply.js` and `version.js` are deliberately absent: both are core-side code that lives beside
+ * the seam rather than behind it, and core imports them by path today.
+ *
+ * **Do not anchor these on `lib/extensions/` to make them more specific.** These patterns match the
+ * import *string*, not the resolved path, and a sibling module writes `../extensions/index.js` with
+ * no `lib/` in it at all - which is exactly how `src/lib/interactive/index.js` would reach the seam.
+ * Measured: `**\/lib/extensions/index.js` catches `./lib/extensions/index.js` and misses
+ * `../extensions/index.js`, so tightening the anchor opens the more likely hole of the two.
+ *
+ * The accepted cost is that a future directory named `extensions` anywhere under `src/` inherits
+ * this rule. There is none today; if one appears, rename it or scope this block by `files`.
+ */
+const SEAM_IMPORT_PATTERNS = [
+    {
+        group: ['**/extensions/index.js', '**/extensions/*/**'],
+        message: SEAM_MESSAGE,
+    },
+];
+
+/** The dynamic-import half of the same boundary. See the note on the prompt-library selector. */
+const SEAM_IMPORT_SELECTOR = {
+    selector: 'ImportExpression > Literal[value=/extensions\\/(index\\.js|[^/]+\\/)/]',
+    message: SEAM_MESSAGE,
+};
+
 export default [
     // Correctness rules - no-undef, no-unused-vars and friends. Without these the lint step
     // checks formatting and JSDoc only, so an undefined variable or a stale import passes
@@ -103,6 +141,7 @@ export default [
                             group: ['@inquirer/*', 'inquirer'],
                             message: BOUNDARY_MESSAGE,
                         },
+                        ...SEAM_IMPORT_PATTERNS,
                     ],
                 },
             ],
@@ -117,7 +156,26 @@ export default [
                     selector: 'ImportExpression > Literal[value=/^(@inquirer\\/|inquirer$)/]',
                     message: BOUNDARY_MESSAGE,
                 },
+                SEAM_IMPORT_SELECTOR,
             ],
+        },
+    },
+
+    // The extension-point boundary for the one file the block above exempts (#1139).
+    //
+    // Both boundaries have to be declared in the *same* rule for any given file, because flat
+    // config replaces a rule's options rather than merging them: a second block naming
+    // `no-restricted-imports` for the same files silently switches the first one off. Measured
+    // against this ESLint version - two blocks, and only the later block's patterns fired.
+    //
+    // So the block above carries both, and this one exists solely because that block ignores
+    // prompt-runtime.js and would therefore exempt it from the seam boundary as a side effect.
+    // Same patterns, from the same constant, so the two cannot drift.
+    {
+        files: ['src/lib/interactive/prompt-runtime.js'],
+        rules: {
+            'no-restricted-imports': ['error', { patterns: SEAM_IMPORT_PATTERNS }],
+            'no-restricted-syntax': ['error', SEAM_IMPORT_SELECTOR],
         },
     },
 ];

--- a/scripts/check-extension-point.mjs
+++ b/scripts/check-extension-point.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+// Platform: Cross-platform (macOS, Linux, Windows)
+// Requires: Node.js
+
+/**
+ * Refuse a commit that adds an unlisted file under `src/lib/extensions/`.
+ *
+ * That directory is not ordinary source. It is the one place the build substitutes at bundle time:
+ * `EXTENSIONS_MODULE` makes `#extensions` resolve somewhere else entirely, and the committed
+ * default is what every build in this repository uses instead. Issue #1139.
+ *
+ * So a file added beside the default is one of two things, and neither is casual. Either it is
+ * contract surface, which needs the versioning and the coordinated change the extension contract
+ * describes - or it is something an override build half-replaces, because the module behind
+ * `#extensions` then comes from elsewhere while this file still comes from core, and the two
+ * disagree about what the seam is.
+ *
+ * An **allowlist**, not a pattern, and deliberately so. A denylist fails silently and later:
+ * someone adds a file in a year, no rule mentions it, and nothing says a word. An allowlist fails
+ * closed - a new file is refused until somebody edits the list, which is exactly the moment the
+ * decision is being made. The contract expects this directory to change rarely, so the cost is a
+ * one-line edit at the point of a deliberate change.
+ *
+ * The ESLint rule in `eslint.config.js` is the other half of the same boundary and cannot cover
+ * this one: lint sees imports, and a file nobody imports yet is still contract surface.
+ *
+ * `.gitignore` is not an option either. A trailing-slash pattern does not match a symlink of that
+ * name, and an ignored path is still committable with `git add -f`. This inspects what is actually
+ * staged, so `-f` makes no difference.
+ *
+ * Usage:
+ *   node scripts/check-extension-point.mjs <path>...
+ *
+ * Invoked by pre-commit with the staged paths under that directory. With no arguments it checks
+ * every file currently in the directory, which is what the test uses.
+ */
+
+import { readdirSync } from 'node:fs';
+
+const DIRECTORY = 'src/lib/extensions';
+
+/**
+ * Every file allowed to live under the extension point, by exact path.
+ *
+ * Adding to this list is the deliberate act the guard exists to require. Before doing so, be sure
+ * the file belongs in core rather than behind the seam: anything a variant build supplies belongs
+ * in that build's own module, not here.
+ */
+const ALLOWED = new Set([
+    'src/lib/extensions/index.js',
+    'src/lib/extensions/apply.js',
+    'src/lib/extensions/version.js',
+    'src/lib/extensions/__tests__/apply.test.js',
+    'src/lib/extensions/__tests__/apply-ordering.test.js',
+    'src/lib/extensions/__tests__/extensions.test.js',
+    'src/lib/extensions/__tests__/interactive-enforcement.test.js',
+]);
+
+/**
+ * Every file currently under the directory, as repo-relative forward-slash paths.
+ *
+ * @returns {string[]} Paths, in no particular order.
+ */
+const filesUnder = () =>
+    readdirSync(DIRECTORY, { recursive: true, withFileTypes: true })
+        .filter((entry) => !entry.isDirectory())
+        .map((entry) => normalise(`${entry.parentPath}/${entry.name}`));
+
+// Git hands over forward-slash paths; Windows path handling does not. Compare one way only.
+const normalise = (path) => path.split('\\').join('/');
+
+/**
+ * Whether a path is the extension point or something inside it.
+ *
+ * The directory **itself** counts, not only its contents. A trailing-slash test alone would let
+ * through the one shape this guard most needs to catch: the whole directory replaced by a symlink,
+ * which git stages as the single path `src/lib/extensions` with nothing after it. That is the same
+ * trailing-slash blind spot that rules `.gitignore` out as a control here.
+ *
+ * @param {string} path - A repo-relative, forward-slash path.
+ *
+ * @returns {boolean} True when the path is at or below the extension point.
+ */
+const isInDirectory = (path) => path === DIRECTORY || path.startsWith(`${DIRECTORY}/`);
+
+const supplied = process.argv.slice(2).map(normalise);
+
+// With no arguments the whole directory is the subject, so the allowlist can be checked in both
+// directions. With staged paths it cannot: git hands over only what changed, and every file left
+// untouched would look missing.
+const walkingWholeDirectory = supplied.length === 0;
+const candidates = walkingWholeDirectory ? filesUnder() : supplied;
+
+const unlisted = candidates.filter((path) => isInDirectory(path) && !ALLOWED.has(path));
+const missing = walkingWholeDirectory
+    ? [...ALLOWED].filter((path) => !candidates.includes(path))
+    : [];
+
+if (missing.length > 0) {
+    console.error(`\n${DIRECTORY}/ is missing files its allowlist says belong there:\n`);
+
+    for (const path of missing) {
+        console.error(`  ${path}`);
+    }
+
+    console.error(
+        '\nEither the file was removed without updating ALLOWED in scripts/check-extension-point.mjs,\nor the removal was not intended.\n'
+    );
+
+    process.exitCode = 1;
+}
+
+if (unlisted.length > 0) {
+    console.error(
+        `\n${DIRECTORY}/ is a build seam, not an ordinary source directory, and these files are not on its allowlist:\n`
+    );
+
+    for (const path of unlisted) {
+        console.error(`  ${path}`);
+    }
+
+    console.error(
+        [
+            '',
+            'The build can substitute what this directory resolves to, so a file added here is either',
+            'contract surface that needs versioning, or something an override build half-replaces.',
+            '',
+            'If the file genuinely belongs in core, add its exact path to ALLOWED in',
+            'scripts/check-extension-point.mjs, in the same commit and on purpose.',
+            'If it belongs to a build that supplies its own extensions module, it belongs there instead.',
+            '',
+        ].join('\n')
+    );
+
+    process.exitCode = 1;
+}

--- a/src/__tests__/eslint-boundaries.test.js
+++ b/src/__tests__/eslint-boundaries.test.js
@@ -1,0 +1,159 @@
+import { describe, test, expect, beforeAll } from '@jest/globals';
+import { ESLint } from 'eslint';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Behavioural, deliberately. `eslint.config.test.js` beside this asserts the *shape* of the config
+// array, which cannot see the failure that matters most here: flat config replaces a rule's options
+// rather than merging them, so a second block naming `no-restricted-imports` for the same files
+// silently switches the first one off. Measured against this ESLint version - two blocks, and only
+// the later block's patterns fired, while every shape assertion still passed. These tests run the
+// real config over real source text instead. Issue #1139.
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+let eslint;
+
+beforeAll(() => {
+    eslint = new ESLint({ cwd: repoRoot });
+});
+
+/**
+ * Lint a snippet as if it were a file at `filePath`, and return the rules that fired.
+ *
+ * @param {string} code - Source to lint.
+ * @param {string} filePath - Repo-relative path to attribute it to, since the rules are path-scoped.
+ *
+ * @returns {Promise<Array<{ruleId: string, message: string}>>} One entry per message.
+ */
+const rulesFiredFor = async (code, filePath) => {
+    // `filePath` is passed through as given, forward slashes and all. Built with `path.join` it
+    // would carry backslashes on Windows, where the unit suite also runs (pr-unit-tests.yaml), and
+    // the config scopes every rule with forward-slash globs like `src/**/*.js`.
+    const [result] = await eslint.lintText(code, { filePath });
+
+    return result.messages.map(({ ruleId, message }) => ({ ruleId, message }));
+};
+
+/**
+ * Whether a rule fired, and the message it carried.
+ *
+ * @param {Array<{ruleId: string, message: string}>} fired - What lint reported.
+ * @param {string} ruleId - The rule to look for.
+ *
+ * @returns {{fired: boolean, message: string}} Whether it fired, and the first message if so.
+ */
+const forRule = (fired, ruleId) => {
+    const hit = fired.find((entry) => entry.ruleId === ruleId);
+
+    return { fired: Boolean(hit), message: hit?.message ?? '' };
+};
+
+describe('the extension-point boundary', () => {
+    test.each([
+        [
+            'a relative import of the module',
+            "import { extensions } from './lib/extensions/index.js';",
+        ],
+        ['a deeper relative import', "import { extensions } from '../extensions/index.js';"],
+        ['reaching into a subdirectory', "import brand from '../extensions/features/branding.js';"],
+    ])('rejects %s', async (_name, code) => {
+        const { fired, message } = forRule(
+            await rulesFiredFor(code, 'src/lib/probe.js'),
+            'no-restricted-imports'
+        );
+
+        expect(fired).toBe(true);
+        expect(message).toContain('#extensions');
+    });
+
+    // no-restricted-imports does not reach a dynamic import, which is why the config carries a
+    // second selector for it - the same gap the prompt-library boundary had to close.
+    // Both alternatives of the selector, because they are separately fragile: the second embeds a
+    // raw `/` inside a character class within an esquery attribute regex, and nothing but a test
+    // would notice if a future esquery parsed that differently.
+    test.each([
+        [
+            'the module itself',
+            "export const load = async () => import('./lib/extensions/index.js');",
+        ],
+        [
+            'a subdirectory of it',
+            "export const load = async () => import('../extensions/features/branding.js');",
+        ],
+    ])('rejects a dynamic import of %s', async (_name, code) => {
+        const { fired, message } = forRule(
+            await rulesFiredFor(code, 'src/lib/probe.js'),
+            'no-restricted-syntax'
+        );
+
+        expect(fired).toBe(true);
+        expect(message).toContain('#extensions');
+    });
+
+    test.each([
+        ['the specifier itself', "import { extensions } from '#extensions';"],
+        [
+            'the core-side helper beside it',
+            "import { applyExtensions } from './lib/extensions/apply.js';",
+        ],
+        ['the version module', "import { SEAM_VERSION } from './lib/extensions/version.js';"],
+    ])('allows %s', async (_name, code) => {
+        const fired = await rulesFiredFor(code, 'src/lib/probe.js');
+
+        expect(forRule(fired, 'no-restricted-imports').fired).toBe(false);
+        expect(forRule(fired, 'no-restricted-syntax').fired).toBe(false);
+    });
+
+    // prompt-runtime.js is exempt from the prompt-library boundary. It must not be exempt from this
+    // one as a side effect, which is the only reason the config carries a second block at all.
+    test('still applies inside the file the prompt-library boundary exempts', async () => {
+        const { fired, message } = forRule(
+            await rulesFiredFor(
+                "import { extensions } from '../extensions/index.js';",
+                'src/lib/interactive/prompt-runtime.js'
+            ),
+            'no-restricted-imports'
+        );
+
+        expect(fired).toBe(true);
+        expect(message).toContain('#extensions');
+    });
+});
+
+describe('the prompt-library boundary still holds', () => {
+    // The regression this whole file exists to catch. Adding the seam patterns as a *separate*
+    // config block would have switched this off everywhere, and every shape assertion in
+    // eslint.config.test.js would still have passed.
+    test('rejects a prompt-library import from ordinary source', async () => {
+        const { fired, message } = forRule(
+            await rulesFiredFor("import { select } from '@inquirer/prompts';", 'src/lib/probe.js'),
+            'no-restricted-imports'
+        );
+
+        expect(fired).toBe(true);
+        expect(message).toContain('prompt-runtime.js');
+    });
+
+    test('rejects a dynamic prompt-library import too', async () => {
+        const { fired, message } = forRule(
+            await rulesFiredFor(
+                "export const load = async () => import('@inquirer/prompts');",
+                'src/lib/probe.js'
+            ),
+            'no-restricted-syntax'
+        );
+
+        expect(fired).toBe(true);
+        expect(message).toContain('prompt-runtime.js');
+    });
+
+    test('and still exempts prompt-runtime.js itself', async () => {
+        const fired = await rulesFiredFor(
+            "import { select } from '@inquirer/prompts';",
+            'src/lib/interactive/prompt-runtime.js'
+        );
+
+        expect(forRule(fired, 'no-restricted-imports').fired).toBe(false);
+    });
+});

--- a/src/__tests__/extension-point-allowlist.test.js
+++ b/src/__tests__/extension-point-allowlist.test.js
@@ -1,0 +1,166 @@
+import { describe, test, expect } from '@jest/globals';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// The other half of the extension-point boundary (#1139). The ESLint rule covers imports; this
+// covers files, because a file nobody imports yet is still contract surface in a directory the
+// build can substitute wholesale.
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const SCRIPT = 'scripts/check-extension-point.mjs';
+
+/**
+ * Run the allowlist check over a set of paths.
+ *
+ * @param {string[]} paths - Repo-relative paths to check. Empty means "whatever is in the directory".
+ *
+ * @returns {{status: number, output: string}} Exit status and everything it printed.
+ */
+const check = (paths) => {
+    const result = spawnSync(process.execPath, [SCRIPT, ...paths], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+    });
+
+    return { status: result.status, output: `${result.stdout ?? ''}${result.stderr ?? ''}` };
+};
+
+/**
+ * Run the check against a throwaway tree containing exactly the files named.
+ *
+ * The whole-directory mode reads the real `src/lib/extensions/`, so proving what it does about a
+ * file that has gone missing would otherwise mean deleting one from the working tree mid-test and
+ * hoping the restore runs. A fixture costs nothing and cannot leave the repo broken.
+ *
+ * @param {string[]} files - Repo-relative paths to create under the temporary root.
+ *
+ * @returns {{status: number, output: string}} Exit status and everything it printed.
+ */
+const checkFixture = (files) => {
+    const root = mkdtempSync(path.join(os.tmpdir(), 'extension-point-'));
+
+    try {
+        for (const file of files) {
+            const target = path.join(root, file);
+
+            mkdirSync(path.dirname(target), { recursive: true });
+            writeFileSync(target, 'export const placeholder = 1;\n');
+        }
+
+        mkdirSync(path.join(root, 'scripts'), { recursive: true });
+
+        const result = spawnSync(process.execPath, [path.join(repoRoot, SCRIPT)], {
+            cwd: root,
+            encoding: 'utf8',
+        });
+
+        return { status: result.status, output: `${result.stdout ?? ''}${result.stderr ?? ''}` };
+    } finally {
+        rmSync(root, { recursive: true, force: true });
+    }
+};
+
+/** Everything the allowlist says belongs under the extension point. */
+const ALL_LISTED = [
+    'src/lib/extensions/index.js',
+    'src/lib/extensions/apply.js',
+    'src/lib/extensions/version.js',
+    'src/lib/extensions/__tests__/apply.test.js',
+    'src/lib/extensions/__tests__/apply-ordering.test.js',
+    'src/lib/extensions/__tests__/extensions.test.js',
+    'src/lib/extensions/__tests__/interactive-enforcement.test.js',
+];
+
+describe('the extension point allowlist', () => {
+    // The one that does real work on every CI run rather than only in a pre-commit hook: it reads
+    // the directory as it actually is. A file added without a matching allowlist entry fails here
+    // even if the hook was bypassed with --no-verify, which is the only backstop available once a
+    // push has already happened.
+    test('the committed directory matches the allowlist exactly', () => {
+        const { status, output } = check([]);
+
+        expect(output).toBe('');
+        expect(status).toBe(0);
+    });
+
+    test.each([
+        ['the committed default', 'src/lib/extensions/index.js'],
+        ['the core-side helper', 'src/lib/extensions/apply.js'],
+        ['the version module', 'src/lib/extensions/version.js'],
+        ['a listed test', 'src/lib/extensions/__tests__/apply.test.js'],
+    ])('accepts %s', (_name, filePath) => {
+        expect(check([filePath]).status).toBe(0);
+    });
+
+    test.each([
+        ['a file in a new subdirectory', 'src/lib/extensions/features/branding.js'],
+        ['a flat file beside the default', 'src/lib/extensions/licence.js'],
+        ['an unlisted test', 'src/lib/extensions/__tests__/something-else.test.js'],
+    ])('rejects %s', (_name, filePath) => {
+        const { status, output } = check([filePath]);
+
+        expect(status).toBe(1);
+        expect(output).toContain(filePath);
+    });
+
+    test('says what to do about it, so the guard is not simply worked around', () => {
+        const { output } = check(['src/lib/extensions/features/branding.js']);
+
+        expect(output).toContain('allowlist');
+        expect(output).toContain(SCRIPT);
+    });
+
+    // The shape the trailing-slash blind spot lets through: the whole directory replaced by a
+    // symlink stages as this one path, with nothing after it.
+    test('rejects the directory itself, not only paths inside it', () => {
+        const { status, output } = check(['src/lib/extensions']);
+
+        expect(status).toBe(1);
+        expect(output).toContain('src/lib/extensions');
+    });
+
+    test('reports a listed file that is no longer there', () => {
+        const { status, output } = checkFixture(
+            ALL_LISTED.filter((f) => !f.endsWith('version.js'))
+        );
+
+        expect(status).toBe(1);
+        expect(output).toContain('missing');
+        expect(output).toContain('src/lib/extensions/version.js');
+    });
+
+    test('is silent when the fixture matches the allowlist exactly', () => {
+        const { status, output } = checkFixture(ALL_LISTED);
+
+        expect(output).toBe('');
+        expect(status).toBe(0);
+    });
+
+    test('reports an extra file and a missing one together', () => {
+        const { status, output } = checkFixture([
+            ...ALL_LISTED.filter((f) => !f.endsWith('version.js')),
+            'src/lib/extensions/licence.js',
+        ]);
+
+        expect(status).toBe(1);
+        expect(output).toContain('src/lib/extensions/version.js');
+        expect(output).toContain('src/lib/extensions/licence.js');
+    });
+
+    test('ignores paths outside the directory', () => {
+        expect(check(['src/globals.js', 'scripts/bundle.mjs']).status).toBe(0);
+    });
+
+    // Git reports staged paths with forward slashes on every platform, but a Windows contributor
+    // running the script by hand would not.
+    test('accepts a Windows-style path for a listed file', () => {
+        expect(check(['src\\lib\\extensions\\apply.js']).status).toBe(0);
+    });
+
+    test('rejects a Windows-style path for an unlisted one', () => {
+        expect(check(['src\\lib\\extensions\\features\\branding.js']).status).toBe(1);
+    });
+});


### PR DESCRIPTION
Closes #1139.

`src/lib/extensions/` is the one directory the build can substitute at bundle time. Two properties
depend on that, and neither was enforced.

## The two failures

**A relative import silently defeats the override.** It resolves under node and Jest, passes every
test, and then ignores `EXTENSIONS_MODULE` — esbuild cannot alias a relative specifier, which is why
the specifier is a `package.json` `imports` subpath at all. A build that reports success, a green
suite, and an override quietly not applied, discovered inside the packaged binary.

**A stray file in that directory is not what it looks like.** An override build replaces what
`#extensions` resolves to, not the directory — so a new file beside the committed default is either
contract surface needing versioning, or something an override half-replaces.

Two guards, because they catch different things: **lint sees imports, and a file nobody imports yet
is still contract surface.**

## Why the ESLint rule folds into the existing block

Not tidiness. Flat config **replaces** a rule's options rather than merging them, so a second block
naming `no-restricted-imports` for the same files silently switches the first one off. Measured
against this ESLint version: two blocks, and only the later block's patterns fired — while every
assertion in `eslint.config.test.js` still passed, because those check the config array's *shape*
rather than its behaviour. That would have disabled the `@inquirer` boundary without a single red test.

So both boundaries live in one rule, and a second small block covers `prompt-runtime.js` alone —
the file the first block exempts, which must not become exempt from this boundary as a side effect.
Both draw their patterns from one constant.

The patterns match the import *string*, not the resolved path, so they cannot be anchored on
`lib/extensions/`: a sibling module writes `../extensions/index.js` with no `lib/` in it, and
anchoring catches `./lib/extensions/index.js` while missing exactly the form the guard most needs.
Measured, and recorded in the JSDoc so it is not "tightened" later.

## Why the hook is an allowlist

A denylist fails silently a year later; an allowlist fails closed, at the moment someone is already
making a decision. It matches the directory **itself** as well as its contents — replacing the whole
directory with a symlink stages the single path `src/lib/extensions`, and a trailing-slash test would
let through precisely the shape that rules `.gitignore` out as a control here. With no arguments it
checks both directions, so a listed file that has been removed is reported too.

A Node script rather than shell, so it works for contributors on Windows.

## Verification

Every guard has a negative control, because one that has never been seen to fire is
indistinguishable from one that does not work:

| Broken deliberately | Result |
| --- | --- |
| Real `git commit` with a `git add -f`'d file | rejected, HEAD unchanged |
| Seam patterns removed from the config | 3 tests fail |
| Stray file added to the directory | suite fails |
| Allowlisted file removed | suite fails |
| Bare directory path passed to the check | rejected |

The ESLint tests are **behavioural** — they run the real config over real source text — and they
assert the `@inquirer` boundary still fires, which is the regression the merged-block design exists
to prevent. The allowlist tests use a temporary fixture tree rather than deleting files from the
working tree mid-test.

`npm run lint` clean, **131 suites / 3516 tests / 0 failures**.

## The honest limit

`git commit --no-verify` bypasses the hook, and no repo-side control fixes that for a public
repository — CI runs only after a push has already happened, which for a public repo *is* the
exposure. The unit test that reads the directory is a backstop, not a substitute: it catches an
unlisted file automatically, after the fact rather than instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
