### PR TITLE
Tell a pre-action hook which options the operator supplied

### DIFF
--- a/src/lib/extensions/__tests__/apply.test.js
+++ b/src/lib/extensions/__tests__/apply.test.js
@@ -198,6 +198,60 @@ describe('runBeforeAction', () => {
 });
 
 describe('the beforeAction hook', () => {
+    // The values alone cannot say which of them the operator actually gave: `opts()` reports a
+    // default and a typed value identically, and by hook time dotenv has merged every BSI_* variable
+    // into the environment. Commander's record is the only thing that can separate them, so core
+    // computes it and hands it over rather than leaving an extension to guess.
+    test('is told which options the operator supplied, and which are defaults', async () => {
+        const { program } = buildProgram();
+        const seen = [];
+
+        applyExtensions(program, {
+            ...nothing(),
+            options: [
+                { path: 'qseow create-sheet-thumbnails', option: new Option('--brand-logo <p>') },
+                {
+                    path: 'qseow create-sheet-thumbnails',
+                    option: new Option('--untouched <p>').default('a default'),
+                },
+            ],
+            hooks: { beforeAction: (path, options, context) => seen.push({ options, context }) },
+        });
+
+        await program.parseAsync(
+            ['qseow', 'create-sheet-thumbnails', '--brand-logo', '/tmp/logo.png'],
+            { from: 'user' }
+        );
+
+        expect(seen[0].options.untouched).toBe('a default');
+        expect([...seen[0].context.supplied]).toContain('brandLogo');
+        expect([...seen[0].context.supplied]).not.toContain('untouched');
+    });
+
+    test('counts an environment-supplied value as supplied', async () => {
+        const { program } = buildProgram();
+        const seen = [];
+
+        process.env.BSI_BRAND_LOGO = '/from/env.png';
+
+        applyExtensions(program, {
+            ...nothing(),
+            options: [
+                {
+                    path: 'qseow create-sheet-thumbnails',
+                    option: new Option('--brand-logo <p>').env('BSI_BRAND_LOGO'),
+                },
+            ],
+            hooks: { beforeAction: (_path, _options, context) => seen.push(context) },
+        });
+
+        await program.parseAsync(['qseow', 'create-sheet-thumbnails'], { from: 'user' });
+
+        delete process.env.BSI_BRAND_LOGO;
+
+        expect([...seen[0].supplied]).toContain('brandLogo');
+    });
+
     test('receives the command path and the parsed options', async () => {
         const { program } = buildProgram();
         const seen = [];

--- a/src/lib/extensions/apply.js
+++ b/src/lib/extensions/apply.js
@@ -31,6 +31,33 @@
  */
 
 /**
+ * Which of a command's options the user actually supplied.
+ *
+ * The values alone cannot answer this. `opts()` reports a default and a typed value identically, and
+ * by the time a hook runs `dotenv` has already merged every `BSI_*` variable into the environment,
+ * so reading the environment cannot separate them either. Commander's own record can, and it is the
+ * only thing that can - which is why this is computed here and handed over, rather than left as
+ * something an extension is expected to work out.
+ *
+ * `cli` and `env` both count as supplied: an operator who set an environment variable asked for that
+ * value just as deliberately as one who typed it.
+ *
+ * @param {import('commander').Command} command - The command about to run.
+ *
+ * @returns {Set<string>} Attribute names whose value the operator supplied.
+ */
+const suppliedOptionsOf = (command) =>
+    new Set(
+        command.options
+            .map((option) => option.attributeName())
+            .filter((attribute) => {
+                const source = command.getOptionValueSource(attribute);
+
+                return source === 'cli' || source === 'env';
+            })
+    );
+
+/**
  * Runs after the command line has been parsed and before the action handler is dispatched, so a run
  * that was never going to be allowed to proceed fails at startup rather than partway through.
  *
@@ -46,6 +73,8 @@
  * @callback BeforeAction
  * @param {string} path - Space-separated path of the command that is about to run.
  * @param {object} options - The options that command will run with.
+ * @param {{supplied: Set<string>}} context - What core knows that the options bag cannot express.
+ *     `supplied` names the options whose value the operator actually gave, as opposed to a default.
  *
  * @returns {void|Promise<void>} Nothing, or a promise the caller will await.
  */
@@ -160,7 +189,9 @@ export const applyExtensions = (program, extensions) => {
     // option. Both are genuine failures of the same command line, and reordering would mean
     // contributing options after the relaxation call, which is exactly what cannot be done.
     program.hook('preAction', (_hookedCommand, actionCommand) =>
-        hooks.beforeAction(pathOfCommand(actionCommand), actionCommand.opts())
+        hooks.beforeAction(pathOfCommand(actionCommand), actionCommand.opts(), {
+            supplied: suppliedOptionsOf(actionCommand),
+        })
     );
 };
 
@@ -181,9 +212,11 @@ export const applyExtensions = (program, extensions) => {
  * @param {SeamDescription} extensions - The description, which may describe no hooks at all.
  * @param {string} path - Space-separated command path, e.g. `'qseow create-sheet-thumbnails'`.
  * @param {object} options - The options the run will actually use.
+ * @param {{supplied: Set<string>}} [context] - What core knows that the options bag cannot express.
+ *     Defaulted so a caller with nothing to add need not construct one.
  *
  * @returns {void|Promise<void>} Whatever the hook returns, so an async hook is awaited by the
  *     caller. Nothing at all when no hook is described, which is the committed default's case.
  */
-export const runBeforeAction = (extensions, path, options) =>
-    extensions?.hooks?.beforeAction?.(path, options);
+export const runBeforeAction = (extensions, path, options, context = { supplied: new Set() }) =>
+    extensions?.hooks?.beforeAction?.(path, options, context);

--- a/src/lib/interactive/index.js
+++ b/src/lib/interactive/index.js
@@ -388,7 +388,13 @@ export const runInteractive = async ({
         // options bag held `interactive: true` and little else; these are the options the run will
         // actually use. Throwing here aborts before the run starts, which is the same promise the
         // hook makes on an ordinary command line. Does nothing unless this build describes a hook.
-        await runBeforeAction(extensions, path, options);
+        // Every value here came from the operator: the wizard's own answers, plus whatever they
+        // supplied on the command line or through the environment and were therefore not asked
+        // about again. There is no Commander record to consult - these options were assembled from
+        // answers rather than parsed - so the bag's own keys are the honest answer.
+        await runBeforeAction(extensions, path, options, {
+            supplied: new Set(Object.keys(options)),
+        });
 
         runtime.write('\n');
 


### PR DESCRIPTION
Closes #1141.

A pre-action hook could see what a command's options *are*, but not which of them anyone actually
asked for — and that gap could not be closed from the extension's side.

## Why the extension cannot work it out

- `opts()` carries values, not provenance: a defaulted value and a typed one look identical.
- `process.env` cannot help either. `dotenv/config` runs first thing in `src/butler-sheet-icons.js`,
  so by the time any hook runs, every `BSI_*` variable is in the environment whether it came from a
  shell or a `.env` file — and an option's default is indistinguishable from a value that arrived
  that way.
- An `argParser` does see a supplied value, but Commander never runs one for a boolean flag, so any
  switch taking no value would be invisible. That is already the documented reason a different
  design was rejected elsewhere in this repo.

Commander knows, through `getOptionValueSource()`, and core is the only side holding the command.

## What changes

```js
hooks.beforeAction(path, options, { supplied: new Set(['imagedir']) });
```

`cli` and `env` both count as supplied — someone who set an environment variable asked for that value
as deliberately as someone who typed it. An object rather than a bare `Set`, so a later addition
costs a property instead of a fourth positional argument.

## The interactive call site is the interesting half

`runBeforeAction` is called a second time from `runInteractive`, after the wizard has assembled its
answers (#1140). Those options never went through Commander parsing, so there is **no**
`getOptionValueSource` record for them.

Passing the command object would have covered the parse path and silently missed this one — the more
important of the two, since it is the call that sees what the run will actually use. So the contract
carries the provenance rather than the command: one contract, two correct implementations, and no
call site quietly answering "I don't know". In the wizard every value came from the operator, so the
bag's own keys are the honest answer.

## Compatibility

Additive. A hook taking two parameters is unaffected, and `runBeforeAction` defaults the new argument
so a caller with nothing to add need not construct one.

## Verification

**3518 tests, all passing**, `npm run lint` clean — exit code checked directly rather than through a
pipe, which is how a lint failure slipped past me recently.

Two new tests cover the rules that matter: a value typed on the command line and one arriving through
its `BSI_*` variable both count as supplied, while an option left at its default does not — asserted
against the same command in the same run, so the distinction is real rather than incidental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
