### PR TITLE
Describe the pre-action hook in terms of what core actually knows

### DIFF
--- a/src/lib/extensions/__tests__/apply-ordering.test.js
+++ b/src/lib/extensions/__tests__/apply-ordering.test.js
@@ -122,36 +122,39 @@ const run = async (tail, { option, hooks = {}, afterRelaxation = false } = {}) =
 
 describe('an option contributed at the call site', () => {
     test('parses like any other option', async () => {
-        const { reached, error } = await run([...COMPLETE_QSEOW, '--brand-logo', '/tmp/logo.png'], {
-            option: new Option('--brand-logo <path>', 'a contributed option'),
-        });
+        const { reached, error } = await run(
+            [...COMPLETE_QSEOW, '--extra-file', '/tmp/extra.txt'],
+            {
+                option: new Option('--extra-file <path>', 'a contributed option'),
+            }
+        );
 
         expect(error).toBeUndefined();
-        expect(reached.opts.brandLogo).toBe('/tmp/logo.png');
+        expect(reached.opts.extraFile).toBe('/tmp/extra.txt');
     });
 
     // The one nobody expects to work: `dotenv/config` has already run, and the option did not exist
     // when it did. It resolves because Commander reads `process.env` at parse time rather than at
     // declaration time - so a contributed option gets the same env binding as every core option.
     test('resolves its .env() binding, even though it was added after dotenv ran', async () => {
-        process.env.BSI_BRAND_LOGO = '/from/env.png';
+        process.env.BSI_EXTRA_FILE = '/from/env.txt';
 
         const { reached, error } = await run(COMPLETE_QSEOW, {
-            option: new Option('--brand-logo <path>', 'a contributed option').env('BSI_BRAND_LOGO'),
+            option: new Option('--extra-file <path>', 'a contributed option').env('BSI_EXTRA_FILE'),
         });
 
         expect(error).toBeUndefined();
-        expect(reached.opts.brandLogo).toBe('/from/env.png');
+        expect(reached.opts.extraFile).toBe('/from/env.txt');
     });
 
     test("participates in Commander's own missing-mandatory check when mandatory", async () => {
         const { reached, error } = await run(COMPLETE_QSEOW, {
-            option: new Option('--brand-logo <path>', 'a contributed option').makeOptionMandatory(),
+            option: new Option('--extra-file <path>', 'a contributed option').makeOptionMandatory(),
         });
 
         expect(reached).toBeUndefined();
         expect(error.code).toBe('commander.missingMandatoryOptionValue');
-        expect(error.message).toBe("error: required option '--brand-logo <path>' not specified");
+        expect(error.message).toBe("error: required option '--extra-file <path>' not specified");
     });
 });
 
@@ -159,9 +162,9 @@ describe('the position of the call is the thing being protected', () => {
     // Contributed before the relaxation call, a mandatory option is cleared with all the others and
     // the wizard is reachable. This is the whole reason the call site is where it is.
     test('a contributed mandatory option is relaxed by -i, like a core one', async () => {
-        const option = new Option('--brand-logo <path>', 'a contributed option')
+        const option = new Option('--extra-file <path>', 'a contributed option')
             .makeOptionMandatory()
-            .env('BSI_BRAND_LOGO');
+            .env('BSI_EXTRA_FILE');
 
         const { reached, error } = await run(['qseow', 'create-sheet-thumbnails', '-i'], {
             option,
@@ -172,9 +175,9 @@ describe('the position of the call is the thing being protected', () => {
     });
 
     test('and it is mandatory again by the time a handler runs', async () => {
-        const option = new Option('--brand-logo <path>', 'a contributed option')
+        const option = new Option('--extra-file <path>', 'a contributed option')
             .makeOptionMandatory()
-            .env('BSI_BRAND_LOGO');
+            .env('BSI_EXTRA_FILE');
 
         await run(['qseow', 'create-sheet-thumbnails', '-i'], { option });
 
@@ -186,7 +189,7 @@ describe('the position of the call is the thing being protected', () => {
     // every other command line, which is exactly what makes it worth a test rather than a comment.
     test('contributing after the relaxation call breaks -i', async () => {
         const { reached, error } = await run(['qseow', 'create-sheet-thumbnails', '-i'], {
-            option: new Option('--brand-logo <path>', 'a contributed option').makeOptionMandatory(),
+            option: new Option('--extra-file <path>', 'a contributed option').makeOptionMandatory(),
             afterRelaxation: true,
         });
 
@@ -199,15 +202,15 @@ describe('the beforeAction hook against the real tree', () => {
     test('names the command that is about to run, and sees its options', async () => {
         const seen = [];
 
-        const { error } = await run([...COMPLETE_QSEOW, '--brand-logo', '/tmp/logo.png'], {
-            option: new Option('--brand-logo <path>', 'a contributed option'),
+        const { error } = await run([...COMPLETE_QSEOW, '--extra-file', '/tmp/extra.txt'], {
+            option: new Option('--extra-file <path>', 'a contributed option'),
             hooks: { beforeAction: (path, options) => seen.push({ path, options }) },
         });
 
         expect(error).toBeUndefined();
         expect(seen).toHaveLength(1);
         expect(seen[0].path).toBe('qseow create-sheet-thumbnails');
-        expect(seen[0].options.brandLogo).toBe('/tmp/logo.png');
+        expect(seen[0].options.extraFile).toBe('/tmp/extra.txt');
         expect(seen[0].options.host).toBe('sense.acme.com');
     });
 
@@ -215,12 +218,12 @@ describe('the beforeAction hook against the real tree', () => {
         const { reached, error } = await run(COMPLETE_QSEOW, {
             hooks: {
                 beforeAction: () => {
-                    throw new Error('not entitled to --brand-logo');
+                    throw new Error('refused by the hook');
                 },
             },
         });
 
         expect(reached).toBeUndefined();
-        expect(error.message).toBe('not entitled to --brand-logo');
+        expect(error.message).toBe('refused by the hook');
     });
 });

--- a/src/lib/extensions/__tests__/apply.test.js
+++ b/src/lib/extensions/__tests__/apply.test.js
@@ -87,17 +87,17 @@ describe('contributed options', () => {
             options: [
                 {
                     path: 'qseow create-sheet-thumbnails',
-                    option: new Option('--brand-logo <path>', 'a contributed option'),
+                    option: new Option('--extra-file <path>', 'a contributed option'),
                 },
             ],
         });
 
         await program.parseAsync(
-            ['qseow', 'create-sheet-thumbnails', '--brand-logo', '/tmp/logo.png'],
+            ['qseow', 'create-sheet-thumbnails', '--extra-file', '/tmp/extra.txt'],
             { from: 'user' }
         );
 
-        expect(runs[0].brandLogo).toBe('/tmp/logo.png');
+        expect(runs[0].extraFile).toBe('/tmp/extra.txt');
     });
 
     test('reach a command through its alias too', () => {
@@ -179,12 +179,12 @@ describe('runBeforeAction', () => {
             ...nothing(),
             hooks: {
                 beforeAction: () => {
-                    throw new Error('not entitled');
+                    throw new Error('refused by the hook');
                 },
             },
         };
 
-        expect(() => runBeforeAction(description, 'qseow x', {})).toThrow('not entitled');
+        expect(() => runBeforeAction(description, 'qseow x', {})).toThrow('refused by the hook');
     });
 
     // The committed default's every-run path: no hook described, nothing happens, no crash.
@@ -209,7 +209,7 @@ describe('the beforeAction hook', () => {
         applyExtensions(program, {
             ...nothing(),
             options: [
-                { path: 'qseow create-sheet-thumbnails', option: new Option('--brand-logo <p>') },
+                { path: 'qseow create-sheet-thumbnails', option: new Option('--extra-file <p>') },
                 {
                     path: 'qseow create-sheet-thumbnails',
                     option: new Option('--untouched <p>').default('a default'),
@@ -219,12 +219,12 @@ describe('the beforeAction hook', () => {
         });
 
         await program.parseAsync(
-            ['qseow', 'create-sheet-thumbnails', '--brand-logo', '/tmp/logo.png'],
+            ['qseow', 'create-sheet-thumbnails', '--extra-file', '/tmp/extra.txt'],
             { from: 'user' }
         );
 
         expect(seen[0].options.untouched).toBe('a default');
-        expect([...seen[0].context.supplied]).toContain('brandLogo');
+        expect([...seen[0].context.supplied]).toContain('extraFile');
         expect([...seen[0].context.supplied]).not.toContain('untouched');
     });
 
@@ -232,14 +232,14 @@ describe('the beforeAction hook', () => {
         const { program } = buildProgram();
         const seen = [];
 
-        process.env.BSI_BRAND_LOGO = '/from/env.png';
+        process.env.BSI_EXTRA_FILE = '/from/env.txt';
 
         applyExtensions(program, {
             ...nothing(),
             options: [
                 {
                     path: 'qseow create-sheet-thumbnails',
-                    option: new Option('--brand-logo <p>').env('BSI_BRAND_LOGO'),
+                    option: new Option('--extra-file <p>').env('BSI_EXTRA_FILE'),
                 },
             ],
             hooks: { beforeAction: (_path, _options, context) => seen.push(context) },
@@ -247,9 +247,9 @@ describe('the beforeAction hook', () => {
 
         await program.parseAsync(['qseow', 'create-sheet-thumbnails'], { from: 'user' });
 
-        delete process.env.BSI_BRAND_LOGO;
+        delete process.env.BSI_EXTRA_FILE;
 
-        expect([...seen[0].supplied]).toContain('brandLogo');
+        expect([...seen[0].supplied]).toContain('extraFile');
     });
 
     test('receives the command path and the parsed options', async () => {
@@ -259,19 +259,19 @@ describe('the beforeAction hook', () => {
         applyExtensions(program, {
             ...nothing(),
             options: [
-                { path: 'qseow create-sheet-thumbnails', option: new Option('--brand-logo <p>') },
+                { path: 'qseow create-sheet-thumbnails', option: new Option('--extra-file <p>') },
             ],
             hooks: { beforeAction: (path, options) => seen.push({ path, options }) },
         });
 
         await program.parseAsync(
-            ['qseow', 'create-sheet-thumbnails', '--brand-logo', '/tmp/logo.png'],
+            ['qseow', 'create-sheet-thumbnails', '--extra-file', '/tmp/extra.txt'],
             { from: 'user' }
         );
 
         expect(seen).toHaveLength(1);
         expect(seen[0].path).toBe('qseow create-sheet-thumbnails');
-        expect(seen[0].options.brandLogo).toBe('/tmp/logo.png');
+        expect(seen[0].options.extraFile).toBe('/tmp/extra.txt');
     });
 
     test('reports a contributed top-level command by its own name', async () => {
@@ -301,14 +301,14 @@ describe('the beforeAction hook', () => {
             ...nothing(),
             hooks: {
                 beforeAction: () => {
-                    throw new Error('not entitled');
+                    throw new Error('refused by the hook');
                 },
             },
         });
 
         await expect(
             program.parseAsync(['qseow', 'create-sheet-thumbnails'], { from: 'user' })
-        ).rejects.toThrow('not entitled');
+        ).rejects.toThrow('refused by the hook');
         expect(runs).toHaveLength(0);
     });
 

--- a/src/lib/extensions/__tests__/interactive-enforcement.test.js
+++ b/src/lib/extensions/__tests__/interactive-enforcement.test.js
@@ -90,12 +90,12 @@ describe('a wizard run reaches the beforeAction hook', () => {
 
     test('before the run starts, so throwing stops it', async () => {
         beforeAction.mockImplementation(() => {
-            throw new Error('not entitled');
+            throw new Error('refused by the hook');
         });
 
         await expect(
             runInteractive({ path: PATH, runtime: scriptedRuntime(answers()) })
-        ).rejects.toThrow('not entitled');
+        ).rejects.toThrow('refused by the hook');
 
         expect(qseowCreateThumbnails).not.toHaveBeenCalled();
     });
@@ -116,7 +116,7 @@ describe('a wizard run reaches the beforeAction hook', () => {
         expect(qseowCreateThumbnails).toHaveBeenCalledTimes(1);
     });
 
-    // Cancelling never reaches the run, so there is nothing to be entitled to.
+    // Cancelling never reaches the run, so there is nothing for the hook to refuse.
     test('but a cancelled wizard never calls it', async () => {
         await runInteractive({
             path: PATH,

--- a/src/lib/extensions/apply.js
+++ b/src/lib/extensions/apply.js
@@ -206,8 +206,8 @@ export const applyExtensions = (program, extensions) => {
  *
  * `runInteractive` therefore calls this again with the options the wizard assembled, immediately
  * before the run starts. Both calls are kept rather than moving the check wholesale: the first
- * still catches a licensed option typed on the command line alongside `-i`, and catches it before
- * the wizard asks anything.
+ * still catches a contributed option typed on the command line alongside `-i`, and catches it
+ * before the wizard asks anything.
  *
  * @param {SeamDescription} extensions - The description, which may describe no hooks at all.
  * @param {string} path - Space-separated command path, e.g. `'qseow create-sheet-thumbnails'`.

--- a/src/lib/interactive/index.js
+++ b/src/lib/interactive/index.js
@@ -383,7 +383,7 @@ export const runInteractive = async ({
             );
         }
 
-        // The authoritative entitlement point for an interactive run, and the reason this call
+        // The authoritative enforcement point for an interactive run, and the reason this call
         // exists at all. The `preAction` hook fired before the first question was asked, when the
         // options bag held `interactive: true` and little else; these are the options the run will
         // actually use. Throwing here aborts before the run starts, which is the same promise the


### PR DESCRIPTION
## What & why

Two comments and a set of test fixtures described the extension point using vocabulary for a concept
core does not have, which made the code read as though it knew more about a variant build than it
actually does. No behaviour change.

- **`runBeforeAction`'s JSDoc** said the first of its two calls "catches a licensed option". Core has
  no notion of an option being licensed — a description contributes options, and a hook may refuse a
  run for reasons core never sees. *Contributed* is what core actually knows.
- **`runInteractive`** called the second invocation "the authoritative entitlement point". It is the
  point at which a hook can still stop the run, which is what enforcement means — and what the
  neighbouring `interactive-enforcement.test.js` is already called.
- **The tests** threw `not entitled` as their stand-in refusal and used `--brand-logo` as their
  stand-in contributed option. Together those read as a specific product decision rather than as
  fixtures. `refused by the hook` says what the assertion is actually for, and `--extra-file` looks
  like the placeholder it is.

## How it was verified

- `npm run lint` — clean. Prettier reflowed a few lines in the test files where the shorter option
  name changed the wrapping; that is the whole of the non-comment diff.
- `npm run test:unit` — **3518 tests across 131 suites, all passing**. The renamed fixtures are
  exercised by `src/lib/extensions/__tests__/apply.test.js`,
  `apply-ordering.test.js` and `interactive-enforcement.test.js`, which are the three files changed,
  so a bad rename would show up as a failure rather than as a silently skipped assertion.
- No browser or Qlik Sense behaviour is touched — this is comments and test fixture names.

## Docs

Internal only.
