### PR TITLE
Check out the released commit rather than a tag the draft release has not created yet

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1024,6 +1024,10 @@ jobs:
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       release_tag_name: ${{ steps.release.outputs['tag_name'] }}
+      # The commit release-please released. Unlike the tag, this exists the moment the
+      # release object does - a draft release carries a tag *name* but no ref, so the
+      # tag cannot be checked out until someone publishes. Issue #1145.
+      release_sha: ${{ steps.release.outputs['sha'] }}
       release_version: ${{ steps.release.outputs['version'] }}
       release_upload_url: ${{ steps.release.outputs['upload_url'] }}
     env:
@@ -1086,9 +1090,12 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Without this, the default checkout is `github.sha` - the commit that happened to
-          # trigger this run, which is not the commit release-please just tagged. See the note
+          # trigger this run, which is not the commit release-please just released. See the note
           # on the same step in release-macos-arm64 for what that shipped.
-          ref: ${{ needs.release-please.outputs.release_tag_name }}
+          #
+          # The sha rather than the tag: the release is a draft, and a draft has no tag ref
+          # until it is published. Issue #1145.
+          ref: ${{ needs.release-please.outputs.release_sha }}
           fetch-depth: 2
           persist-credentials: false
 
@@ -1190,7 +1197,11 @@ jobs:
           # that shipped all three 4.1.0 binaries built from the commit before the version bump,
           # so they reported "App version: 4.0.0": the SEA build embeds package.json as an asset
           # and globals.js reads the version straight out of it.
-          ref: ${{ needs.release-please.outputs.release_tag_name }}
+          #
+          # The sha rather than the tag, because release-please is configured to cut a *draft*
+          # release and a draft has no tag ref - GitHub creates it at publication. Checking out
+          # the tag name failed all four release jobs on 5.0.0. Issue #1145.
+          ref: ${{ needs.release-please.outputs.release_sha }}
           persist-credentials: false
 
       - name: Setup Node.js
@@ -1293,7 +1304,11 @@ jobs:
           # that shipped all three 4.1.0 binaries built from the commit before the version bump,
           # so they reported "App version: 4.0.0": the SEA build embeds package.json as an asset
           # and globals.js reads the version straight out of it.
-          ref: ${{ needs.release-please.outputs.release_tag_name }}
+          #
+          # The sha rather than the tag, because release-please is configured to cut a *draft*
+          # release and a draft has no tag ref - GitHub creates it at publication. Checking out
+          # the tag name failed all four release jobs on 5.0.0. Issue #1145.
+          ref: ${{ needs.release-please.outputs.release_sha }}
           persist-credentials: false
 
       # Fail before spending ten minutes on a build that cannot be signed.
@@ -1400,7 +1415,11 @@ jobs:
           # that shipped all three 4.1.0 binaries built from the commit before the version bump,
           # so they reported "App version: 4.0.0": the SEA build embeds package.json as an asset
           # and globals.js reads the version straight out of it.
-          ref: ${{ needs.release-please.outputs.release_tag_name }}
+          #
+          # The sha rather than the tag, because release-please is configured to cut a *draft*
+          # release and a draft has no tag ref - GitHub creates it at publication. Checking out
+          # the tag name failed all four release jobs on 5.0.0. Issue #1145.
+          ref: ${{ needs.release-please.outputs.release_sha }}
           persist-credentials: false
 
       - name: Setup Node.js


### PR DESCRIPTION
Fixes #1145.

## What & why

All four release jobs failed on 5.0.0 at `Checkout the released tag`, while every test, integration and docker job was green and `release-please` itself succeeded:

```
git fetch --depth=1 origin +refs/tags/butler-sheet-icons-v5.0.0*:refs/tags/…
The process '/usr/bin/git' failed with exit code 1
```

**The tag does not exist when those jobs run.** release-please is configured to cut a **draft** release, and a draft carries a tag *name* on the release object without creating a ref — GitHub creates that at publication. Its own output for the run says it plainly:

```
tag_name : butler-sheet-icons-v5.0.0
html_url : …/releases/tag/untagged-3f4214c5673691de9344
```

Confirmed independently: `GET /git/ref/tags/butler-sheet-icons-v5.0.0` → 404, and `git ls-remote --tags` does not list it while every published release's tag is present.

**This is not a regression in draft mode.** `"draft": true` has been set since `release-please-config.json` was created, through 3.11.0, 4.0.0 and 4.1.0. What changed is the checkout — before #1130 these jobs had no `ref:` at all and built `github.sha`, so publication state never mattered. 5.0.0 is the first release cut since, which is why it surfaced now.

#1130 was fixing something real and worse: without a `ref` the jobs built whatever commit started the run, which shipped all three 4.1.0 binaries stamped 4.0.0. The goal was right, the handle was not.

## The fix

`release-please-action` already emits the released commit, and this workflow already echoed it one step later:

```
sha : cba639fd715ade742eaa51b8f75869d604aff532
```

It was never exposed as a job output. So: expose `release_sha`, and point the four checkouts at it.

This keeps both properties #1130 wanted — a build pinned to a known commit, immune to the `github.sha` race — without depending on a ref that draft mode withholds by design. A sha is also the better provenance anchor of the two, since a tag can be moved and a sha cannot.

**Only the four `ref:` inputs change.** Every other use of `release_tag_name` names the release to upload to, the artifact filename, or a log line, and is correct as the tag name — I checked all 15 remaining uses individually.

## How it was verified

- The diagnosis was confirmed empirically on the live 5.0.0 run, four independent ways (REST 404, `git ls-remote`, the runner's own fetch matching nothing across three retries with no auth error, and GitHub's `untagged-…` URL).
- **The fix is proven by the same run.** Creating `refs/tags/butler-sheet-icons-v5.0.0` at `cba639f` by hand and re-running the failed jobs took `release-linux`, `release-macos-arm64` and `sbom-build` from failure to success, uploading `…-linux.zip`, `…-macos-arm64.zip` and `manifest.spdx.json`. That isolates the checkout as the only cause. This PR makes the same thing happen without the manual tag.
- `check-yaml` passes on the edited workflow.
- `zizmor` over `.github/workflows/` reports **214 findings / 28 informational on this branch and 214 / 28 on `main`** — byte-identical, so the change introduces nothing.

`release-win64` remains red on that run, for an unrelated reason the preflight diagnoses itself: the SimplySign session on the signing runner is not open, so the certificate matches but the private key is unreachable. That is a human step on that machine and nothing to do with this change.

## Docs

Internal only — CI wiring, no user-visible behaviour. The four comment blocks explaining the `github.sha` race now also say why it is the sha rather than the tag, so the next person does not "tidy" it back.
