### PR TITLE
Accept a pasted URL for the tenant and server host, and let the wizard repair a refused value

### DIFF
--- a/docs/to-doc-site/tenant-url-and-host-accept-a-pasted-url.md
+++ b/docs/to-doc-site/tenant-url-and-host-accept-a-pasted-url.md
@@ -1,0 +1,141 @@
+# The tenant URL and server host now accept a pasted URL
+
+Butler Sheet Icons documents `--tenanturl` as taking either a full URL or a bare host name:
+
+```
+--tenanturl <url>   URL or host of Qlik Sense cloud tenant.
+                    Example: "https://tenant.eu.qlikcloud.com" or "tenant.eu.qlikcloud.com"
+```
+
+Until now only the bare host really worked. Both forms now do, on Qlik Sense Cloud and on Qlik
+Sense Enterprise on Windows alike, and `--host` says so in its own help text.
+
+::: warning Requires BSI X.Y.Z or later
+:::
+
+## What used to happen
+
+With `https://` in front of the tenant URL, a run got further than it should have. The startup
+checks are all made over the Qlik REST API, which accepted the value, so the run header confirmed
+the tenant with a green tick and listed the apps it was about to update:
+
+```
+  ✓ tenant            https://plabs.eu.qlikcloud.com
+  ✓ app list          1 apps · 1 named
+```
+
+The first app then failed:
+
+```
+warn: CLOUD PROCESS APP: The engine session to Qlik Sense Cloud tenant https://plabs.eu.qlikcloud.com was closed from the other end, code 1006. Whatever is still using this session will fail from here on.
+error: CLOUD APP: getaddrinfo ENOTFOUND https
+✗ 1/1  5838acc6-1139-4a3...                failed        3s
+```
+
+`getaddrinfo ENOTFOUND https` is a DNS failure, and the name it could not look up is `https`. The
+value was being used to build an address of the form `wss://https://plabs.eu.qlikcloud.com/...`,
+which is not a valid address for anything. Nothing in that message named the option responsible,
+and the green tick above it pointed away from the real cause.
+
+The same applied to `--host` on Qlik Sense Enterprise on Windows, where a pasted server URL broke
+the connection to the engine, to the repository service, and to the hub.
+
+## What happens now
+
+Butler Sheet Icons reads the value as a URL and keeps only the host name from it. All of these
+mean the same thing:
+
+| What you supply                    | What Butler Sheet Icons uses |
+| ---------------------------------- | ---------------------------- |
+| `tenant.eu.qlikcloud.com`          | `tenant.eu.qlikcloud.com`    |
+| `https://tenant.eu.qlikcloud.com`  | `tenant.eu.qlikcloud.com`    |
+| `https://tenant.eu.qlikcloud.com/` | `tenant.eu.qlikcloud.com`    |
+| `HTTPS://Tenant.EU.Qlikcloud.com`  | `tenant.eu.qlikcloud.com`    |
+| `http://tenant.eu.qlikcloud.com`   | `tenant.eu.qlikcloud.com`    |
+
+The host name comes back in lower case, which is how DNS treats it anyway.
+
+This applies wherever the value can be supplied - on the command line, through the environment
+variable, in a `.env` file, and in the interactive wizard - and to every command that connects to
+Qlik Sense: the three `qscloud` commands through `--tenanturl`, and the two `qseow` commands
+through `--host`.
+
+::: tip The scheme only names the host - it does not choose the protocol
+Stripping `http://` does not turn off TLS. On Qlik Sense Enterprise on Windows the protocol is
+decided by `--secure`, which defaults to `true`; a server that really is reached over plain
+`http://` needs `--secure false` as before. On Qlik Sense Cloud the connection is always `https`.
+:::
+
+## What is still refused, and why
+
+Only a host name is accepted. Anything else that can appear in a URL is refused at startup, with a
+message that says what to do instead - because every one of those parts has its own option, and
+silently dropping it would produce a run that fails later and far from the cause.
+
+**A path**, which is the commonest case: a complete page address copied from the browser while
+looking at an app.
+
+```
+error: option '--host <host>' argument 'https://sense.example.com/form/hub' is invalid. Enter the host on its own, for example "sense.example.com" - a path is not part of it. A virtual proxy prefix, if there is one, goes in --prefix.
+```
+
+On Qlik Sense Enterprise on Windows the `/form` part of such an address is often the virtual proxy
+prefix, and that goes in `--prefix`. The hint says _if there is one_ on purpose: an address such as
+`https://sense.example.com/hub` has a path but no prefix, and nothing from it belongs in `--prefix`.
+On Qlik Sense Cloud the message is the same without the hint, naming `--tenanturl` and that
+platform's example:
+
+```
+error: option '--tenanturl <url>' argument 'https://tenant.eu.qlikcloud.com/sense/app/x' is invalid. Enter the host on its own, for example "tenant.eu.qlikcloud.com" - a path is not part of it.
+```
+
+**A port**, as in `https://sense.example.com:8443`. The ports have their own options -
+`--engineport`, `--qrsport` and, on `qseow create-sheet-thumbnails`, `--port` for the hub - and
+each is appended to the host by the part of Butler Sheet Icons that uses it.
+
+```
+error: option '--host <host>' argument 'https://sense.example.com:8443' is invalid. A port is not part of the host - the ports have their own options. Enter the host on its own, for example "sense.example.com".
+```
+
+**Credentials**, as in `https://user:password@sense.example.com`. The logon user and the API user
+have their own options. Butler Sheet Icons refuses a host that carries a password rather than
+stripping it, and the message does not repeat the value - a host with a password in it would
+otherwise be printed in every log line that names the server.
+
+**A blank value.** An environment variable that is set but empty - a `BSI_QSEOW_CST_HOST=` line in
+a `.env` file or a unit file - used to be accepted as a host, and the run then failed some way in.
+It is now refused where it can be fixed, naming the variable:
+
+```
+error: option '--host <host>' value '' from env 'BSI_QSEOW_CST_HOST' is invalid. Enter the host, for example "sense.example.com".
+```
+
+## The wizard can now repair a bad value from `.env`
+
+Until now, a value in `.env` that Butler Sheet Icons refused stopped `-i` before the wizard opened,
+with the error above and nothing else - the wizard that exists to correct such values could not be
+reached from the one situation that most needed it. That was true of every validated option, not
+only the host: a mistyped `BSI_QSEOW_CST_ENGINE_PORT` did the same.
+
+Now the wizard opens. It names the value it could not use, repeats the reason, and asks the
+question with the rejected value pre-filled, so fixing it is an edit rather than a retype:
+
+```
+Supplied, but not usable as given, so asked about below:
+  ✗ --host (from BSI_QSEOW_CST_HOST): Enter the host on its own, for example "sense.example.com" - a path is not part of it. A virtual proxy prefix, if there is one, goes in --prefix.
+```
+
+Choosing _Save the answers to .env_ at the end writes the corrected value back, so the next run
+passes without being asked.
+
+## For the doc site
+
+The help text of `--host` changed on both `qseow` commands, so their generated option tables
+need refreshing:
+
+```bash
+npm run docs:cli-tables -- ../butler-sheet-icons-docs/docs/reference/qseow.md --write
+```
+
+(adjust the page path to wherever the `qseow` option tables live). The `--tenanturl` description
+is unchanged.

--- a/src/lib/commands/__tests__/commands.test.js
+++ b/src/lib/commands/__tests__/commands.test.js
@@ -478,6 +478,123 @@ describe('--browser-cache-dir (issue #1024)', () => {
     });
 });
 
+describe('--tenanturl and --host accept a pasted URL (issue #1148)', () => {
+    // Every option that names a Sense host, on both platforms. The list is the point:
+    // the promise "URL or host" was written into three qscloud descriptions while the
+    // tolerance for the URL form lived in the REST client alone, so a value with a
+    // scheme passed the pre-flight and then failed on the engine session with
+    // `getaddrinfo ENOTFOUND https`.
+    const leaf = (parent, name) => parent.commands.find((cmd) => cmd.name() === name);
+
+    const carriers = [
+        [
+            'qscloud create-sheet-thumbnails',
+            '--tenanturl',
+            () => thumbnailCommand(buildQscloudCommand()),
+        ],
+        [
+            'qscloud list-collections',
+            '--tenanturl',
+            () => leaf(buildQscloudCommand(), 'list-collections'),
+        ],
+        [
+            'qscloud remove-sheet-icons',
+            '--tenanturl',
+            () => leaf(buildQscloudCommand(), 'remove-sheet-icons'),
+        ],
+        ['qseow create-sheet-thumbnails', '--host', () => thumbnailCommand(buildQseowCommand())],
+        [
+            'qseow remove-sheet-icons',
+            '--host',
+            () => leaf(buildQseowCommand(), 'remove-sheet-icons'),
+        ],
+    ];
+
+    const optionOn = (build, flag) => {
+        const option = build().options.find((opt) => opt.long === flag);
+
+        if (!option) {
+            throw new Error(`Option ${flag} not found`);
+        }
+
+        return option;
+    };
+
+    /**
+     * Parse one option in isolation with the variable behind it set to `value`.
+     *
+     * @param {import('commander').Option} option - The option.
+     * @param {string} value - What the environment variable holds.
+     *
+     * @returns {{ opts: object, error: Error|undefined }} The parsed bag, or the error.
+     */
+    const parseFromEnv = (option, value) => {
+        const saved = process.env[option.envVar];
+        process.env[option.envVar] = value;
+
+        try {
+            const parent = new Command();
+            parent.exitOverride().configureOutput({ writeErr: () => {} });
+            parent.addOption(option);
+            parent.parse(['node', 'test']);
+
+            return { opts: parent.opts(), error: undefined };
+        } catch (error) {
+            return { opts: undefined, error };
+        } finally {
+            if (saved === undefined) {
+                delete process.env[option.envVar];
+            } else {
+                process.env[option.envVar] = saved;
+            }
+        }
+    };
+
+    test.each(carriers)('%s normalises %s on the command line', (_name, flag, build) => {
+        const option = optionOn(build, flag);
+        const parent = new Command();
+        parent.exitOverride();
+        parent.addOption(option);
+        parent.parseOptions([flag, 'https://sense.example.com/']);
+
+        expect(parent.opts()[option.attributeName()]).toBe('sense.example.com');
+    });
+
+    // Commander runs parseArg on environment values too, which matters more here than
+    // on the command line: the reported run took its tenant url from a .env file.
+    test.each(carriers)('%s normalises %s from the environment', (_name, flag, build) => {
+        const option = optionOn(build, flag);
+        const { opts, error } = parseFromEnv(option, 'https://sense.example.com');
+
+        expect(error).toBeUndefined();
+        expect(opts[option.attributeName()]).toBe('sense.example.com');
+    });
+
+    // Commander's missing-mandatory check tests for `undefined`, so a variable that is
+    // set but empty satisfies it and the run would start against no host at all. The
+    // parser is the only thing that can report it, and it names the variable.
+    test.each(carriers)(
+        '%s refuses a set-but-empty %s variable, naming it',
+        (_name, flag, build) => {
+            const option = optionOn(build, flag);
+            const { error } = parseFromEnv(option, '');
+
+            expect(error).toBeDefined();
+            expect(error.code).toBe('commander.invalidArgument');
+            expect(error.message).toContain(`from env '${option.envVar}'`);
+            expect(error.message).toContain('Enter the host');
+        }
+    );
+
+    // The description is the promise; the parser is what keeps it. Both platforms, not
+    // only the one whose option is built by the factory - the QSEoW twin once had the
+    // parser without the promise, so its help and the generated doc-site table said
+    // "IP/FQDN" while the doc page said a URL works.
+    test.each(carriers)('%s says in its help text that a URL is accepted', (_name, flag, build) => {
+        expect(optionOn(build, flag).description).toContain('https://');
+    });
+});
+
 describe('--sense-version choices', () => {
     test('uses the shared QSEoW version list and defaults to 2026-May', () => {
         const option = thumbnailCommand(buildQseowCommand()).options.find(

--- a/src/lib/commands/helpers.js
+++ b/src/lib/commands/helpers.js
@@ -1,4 +1,5 @@
 import { InvalidArgumentError, Option } from 'commander';
+import { hostOptionParser } from '../util/host-option.js';
 
 /**
  * Validates that the provided CLI argument represents a non-negative integer within optional bounds.
@@ -159,6 +160,32 @@ const collectChoices =
     };
 
 /**
+ * The `--tenanturl` option, for the three qscloud commands.
+ *
+ * A factory rather than a shared instance: Commander registers an Option with the command it
+ * is added to, and each command binds its own environment variable - the one thing each
+ * caller supplies.
+ *
+ * Declared once because the promise and the behaviour have to travel together. The help text
+ * offering both a URL and a bare host was written in three places while the tolerance for the
+ * URL form existed in one, which is issue #1148: the description and the parser that honours it
+ * now live in the same declaration, and the wizard derives its prompt and its validator from
+ * that same Option.
+ *
+ * @param {string} envVar - The command's own environment variable, e.g. `BSI_QSCLOUD_CST_TENANTURL`.
+ *
+ * @returns {Option} A new `--tenanturl` option.
+ */
+const buildTenantUrlOption = (envVar) =>
+    new Option(
+        '--tenanturl <url>',
+        'URL or host of Qlik Sense cloud tenant. Example: "https://tenant.eu.qlikcloud.com" or "tenant.eu.qlikcloud.com"'
+    )
+        .argParser(hostOptionParser({ example: 'tenant.eu.qlikcloud.com' }))
+        .makeOptionMandatory()
+        .env(envVar);
+
+/**
  * The `--browser-cache-dir` option, for the commands that read or write the browser cache.
  *
  * A factory rather than a shared instance, because Commander stores parsed values on the
@@ -216,6 +243,7 @@ export {
     collectPositiveIntegers,
     collectAppIds,
     collectChoices,
+    buildTenantUrlOption,
     buildBrowserCacheDirOption,
     buildBrowserExecutablePathOption,
 };

--- a/src/lib/commands/qscloud/__tests__/qscloud_wizard.test.js
+++ b/src/lib/commands/qscloud/__tests__/qscloud_wizard.test.js
@@ -22,6 +22,7 @@ jest.unstable_mockModule('../../../cloud/cloud-create-thumbnails.js', () => ({
 }));
 
 const { runInteractive } = await import('../../../interactive/index.js');
+const { default: QlikSaas } = await import('../../../cloud/cloud-repo.js');
 const { scriptedRuntime } = await import('../../../interactive/test-helpers/scripted-runtime.js');
 const { labelForApp, labelForCollection } =
     await import('../create-sheet-thumbnails.interactive.js');
@@ -745,6 +746,41 @@ describe('the run itself', () => {
         // Synthetic questions must never reach the worker.
         expect(options._appSource).toBeUndefined();
         expect(options._advanced).toBeUndefined();
+    });
+
+    // The wizard is a third way into the same option, and it does not go through
+    // Commander's own argv parsing - `answersToOptions` builds an argv from the
+    // answers and hands it to `parseOptions()`, which is what makes the option's
+    // `argParser` apply here too. Issue #1148 was reported from a run whose value
+    // came from `.env` by way of this path.
+    test('a pasted tenant url reaches the worker as a bare host', async () => {
+        const runtime = scriptedRuntime(
+            baseAnswers({ tenanturl: 'https://acme.eu.qlikcloud.com/', _review: 'run' })
+        );
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(qscloudCreateThumbnails).toHaveBeenCalledTimes(1);
+        expect(qscloudCreateThumbnails.mock.calls[0][0].tenanturl).toBe('acme.eu.qlikcloud.com');
+    });
+
+    // Not only the worker: the connection probe runs mid-conversation on the answer
+    // as stored, and `QlikSaas` tests for a lower-case scheme before prepending one.
+    // A probe handed the raw `HTTPS://…` built `https://HTTPS://…` and failed under
+    // the API-key prompt - for a value the CLI accepts. The driver now stores the
+    // parsed value, so everything that reads the answer sees what the run will see.
+    test('the connection probe, the review and the echoed line all see the bare host', async () => {
+        const runtime = scriptedRuntime(
+            baseAnswers({ tenanturl: 'HTTPS://acme.eu.qlikcloud.com/', _review: 'run' })
+        );
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(QlikSaas).toHaveBeenCalledWith(
+            expect.objectContaining({ url: 'acme.eu.qlikcloud.com' })
+        );
+        expect(runtime.output()).toContain('--tenanturl acme.eu.qlikcloud.com');
+        expect(runtime.output()).not.toContain('HTTPS://');
     });
 
     test('never prints the API key', async () => {

--- a/src/lib/commands/qscloud/create-sheet-thumbnails.js
+++ b/src/lib/commands/qscloud/create-sheet-thumbnails.js
@@ -11,6 +11,7 @@ import {
     parsePositiveInteger,
     collectPositiveIntegers,
     collectAppIds,
+    buildTenantUrlOption,
     buildBrowserCacheDirOption,
     buildBrowserExecutablePathOption,
 } from '../helpers.js';
@@ -87,14 +88,7 @@ const buildCloudCreateSheetThumbnailsCommand = () => {
                 .default('12.612.0')
                 .env('BSI_QSCLOUD_CST_SCHEMAVERSION')
         )
-        .addOption(
-            new Option(
-                '--tenanturl <url>',
-                'URL or host of Qlik Sense cloud tenant. Example: "https://tenant.eu.qlikcloud.com" or "tenant.eu.qlikcloud.com"'
-            )
-                .makeOptionMandatory()
-                .env('BSI_QSCLOUD_CST_TENANTURL')
-        )
+        .addOption(buildTenantUrlOption('BSI_QSCLOUD_CST_TENANTURL'))
         .addOption(
             new Option('--apikey <key>', 'API key used to access the Sense APIs')
                 .makeOptionMandatory()

--- a/src/lib/commands/qscloud/list-collections.js
+++ b/src/lib/commands/qscloud/list-collections.js
@@ -3,6 +3,7 @@ import { logger, appVersion } from '../../../globals.js';
 import { logRunHeader } from '../../util/run-report-render.js';
 import { qscloudListCollections } from '../../cloud/cloud-collections.js';
 import { runCommand } from '../run-command.js';
+import { buildTenantUrlOption } from '../helpers.js';
 
 /**
  * Commander action that lists available Qlik Sense Cloud collections through the worker module.
@@ -35,14 +36,7 @@ const buildCloudListCollectionsCommand = () => {
                 .default('info')
                 .env('BSI_QSCLOUD_LC_LOG_LEVEL')
         )
-        .addOption(
-            new Option(
-                '--tenanturl <url>',
-                'URL or host of Qlik Sense cloud tenant. Example: "https://tenant.eu.qlikcloud.com" or "tenant.eu.qlikcloud.com"'
-            )
-                .makeOptionMandatory()
-                .env('BSI_QSCLOUD_LC_TENANTURL')
-        )
+        .addOption(buildTenantUrlOption('BSI_QSCLOUD_LC_TENANTURL'))
         .addOption(
             new Option('--apikey <key>', 'API key used to access the Sense APIs')
                 .makeOptionMandatory()

--- a/src/lib/commands/qscloud/remove-sheet-icons.js
+++ b/src/lib/commands/qscloud/remove-sheet-icons.js
@@ -3,7 +3,7 @@ import { addDryRunOption } from '../dry-run-option.js';
 import { setLoggingLevel } from '../../../globals.js';
 import { qscloudRemoveSheetIcons } from '../../cloud/cloud-remove-sheet-icons.js';
 import { runCommand } from '../run-command.js';
-import { collectAppIds } from '../helpers.js';
+import { collectAppIds, buildTenantUrlOption } from '../helpers.js';
 
 /**
  * Commander action that removes sheet icons from specified Qlik Sense Cloud apps.
@@ -60,14 +60,7 @@ const buildCloudRemoveSheetIconsCommand = () => {
                 .default('12.612.0')
                 .env('BSI_QSCLOUD_RSI_SCHEMAVERSION')
         )
-        .addOption(
-            new Option(
-                '--tenanturl <url>',
-                'URL or host of Qlik Sense cloud tenant. Example: "https://tenant.eu.qlikcloud.com" or "tenant.eu.qlikcloud.com"'
-            )
-                .makeOptionMandatory()
-                .env('BSI_QSCLOUD_RSI_TENANTURL')
-        )
+        .addOption(buildTenantUrlOption('BSI_QSCLOUD_RSI_TENANTURL'))
         .addOption(
             new Option('--apikey <key>', 'API key used to access the Sense APIs')
                 .makeOptionMandatory()

--- a/src/lib/commands/qseow-connection-options.js
+++ b/src/lib/commands/qseow-connection-options.js
@@ -1,6 +1,7 @@
 import { Option } from 'commander';
 
 import { parsePositiveInteger } from './helpers.js';
+import { hostOptionParser } from '../util/host-option.js';
 
 /**
  * The engine schema versions the Enigma loader accepts.
@@ -57,7 +58,23 @@ const SCHEMA_VERSIONS = [
  * @returns {Record<string, Option>} New option instances, keyed by flag name.
  */
 export const buildQseowConnectionOptions = (envPrefix) => ({
-    host: new Option('--host <host>', 'Qlik Sense server IP/FQDN')
+    // The description and the parser travel together: the promise that a URL is
+    // accepted is only true because the parser reduces it to a host before the
+    // engine url, the app and hub urls and the QRS hostname each prepend their own
+    // scheme. See `hostOptionParser` and issue #1148. The hint is conditional on
+    // purpose - a pasted `https://server/hub` has a path and no prefix, and telling
+    // its owner to move `hub` into --prefix would produce a run that authenticates
+    // and never renders.
+    host: new Option(
+        '--host <host>',
+        'Host name or IP address of the Qlik Sense server, with or without "https://" in front. Example: "sense.example.com" or "https://sense.example.com"'
+    )
+        .argParser(
+            hostOptionParser({
+                example: 'sense.example.com',
+                pathHint: 'A virtual proxy prefix, if there is one, goes in --prefix.',
+            })
+        )
         .makeOptionMandatory()
         .env(`${envPrefix}_HOST`),
 

--- a/src/lib/commands/qseow/__tests__/qseow_wizard.test.js
+++ b/src/lib/commands/qseow/__tests__/qseow_wizard.test.js
@@ -964,6 +964,42 @@ describe('the run itself', () => {
         expect(options._filtering).toBeUndefined();
     });
 
+    // The Cloud twin's test, for the same reason: `--host` is read by the engine
+    // url, the app and hub urls and the QRS hostname, all of which prepend a
+    // scheme of their own. See issue #1148.
+    test('a pasted server url reaches the worker as a bare host', async () => {
+        const runtime = scriptedRuntime(
+            baseAnswers({ host: 'https://sense.acme.com/', _review: 'run' })
+        );
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(qseowCreateThumbnails).toHaveBeenCalledTimes(1);
+        expect(qseowCreateThumbnails.mock.calls[0][0].host).toBe('sense.acme.com');
+    });
+
+    // The QRS lookups run mid-conversation on the answers as stored, and QRS does
+    // not tolerate a scheme in the hostname: handed the raw answer, the content
+    // library check failed naming the library, and the app picker silently fell
+    // back to free text. The driver now stores the parsed value.
+    test('the QRS probes see the bare host, not the pasted url', async () => {
+        let seenByProbe;
+        qseowVerifyContentLibraryExists.mockImplementation(async (options) => {
+            seenByProbe = { ...options };
+
+            return true;
+        });
+
+        const runtime = scriptedRuntime(baseAnswers({ host: 'https://sense.acme.com/' }));
+
+        await runInteractive({ path: PATH, runtime });
+
+        expect(seenByProbe.host).toBe('sense.acme.com');
+        expect(listAllApps).toHaveBeenCalledWith(
+            expect.objectContaining({ host: 'sense.acme.com' })
+        );
+    });
+
     test('never prints the logon password', async () => {
         const runtime = scriptedRuntime(baseAnswers({ _review: 'run' }));
 
@@ -1019,5 +1055,63 @@ describe('--dry-run combined with -i (#993)', () => {
         expect(qseowCreateThumbnails).toHaveBeenCalledTimes(1);
         expect(qseowCreateThumbnails.mock.calls[0][0].dryRun).toBeUndefined();
         expect(runtime.output()).not.toContain('DRY RUN');
+    });
+});
+
+describe('a supplied value the parse refused', () => {
+    // The launcher hands these over separately from the presets: they sit on the
+    // command because the relaxation kept the parse alive, but they are not answers
+    // the run could use. The wizard asks about them, says why, and opens the prompt
+    // on the refused text so fixing it is an edit rather than a retype.
+    const refused = {
+        host: {
+            value: 'https://sense.acme.com/form/hub',
+            message: 'Enter the host on its own - a path is not part of it.',
+            source: 'env',
+        },
+    };
+
+    test('is asked about, with the parser message shown first', async () => {
+        const runtime = scriptedRuntime(baseAnswers());
+
+        await runInteractive({ path: PATH, runtime, rejectedOptions: refused });
+
+        expect(runtime.asked.map((entry) => entry.key)).toContain('host');
+        expect(runtime.output()).toContain(
+            'Supplied, but not usable as given, so asked about below'
+        );
+        expect(runtime.output()).toContain('--host (from BSI_QSEOW_CST_HOST)');
+        expect(runtime.output()).toContain('a path is not part of it');
+    });
+
+    test('opens the prompt on the refused value', async () => {
+        const runtime = scriptedRuntime(baseAnswers());
+
+        await runInteractive({ path: PATH, runtime, rejectedOptions: refused });
+
+        const host = runtime.asked.find((entry) => entry.key === 'host');
+        expect(host.default).toBe('https://sense.acme.com/form/hub');
+    });
+
+    // Required again, although the variable is set: `specFromOption` counts a set
+    // variable as a supplied answer, and a blank would otherwise be accepted and
+    // then dropped from the command line - leaving the run with no host at all.
+    test('is required again, so a blank answer is refused', async () => {
+        const runtime = scriptedRuntime(baseAnswers({ host: ['', 'sense.acme.com'] }));
+        const saved = process.env.BSI_QSEOW_CST_HOST;
+        process.env.BSI_QSEOW_CST_HOST = refused.host.value;
+
+        try {
+            await runInteractive({ path: PATH, runtime, rejectedOptions: refused });
+        } finally {
+            if (saved === undefined) {
+                delete process.env.BSI_QSEOW_CST_HOST;
+            } else {
+                process.env.BSI_QSEOW_CST_HOST = saved;
+            }
+        }
+
+        const attempts = runtime.asked.filter((entry) => entry.key === 'host');
+        expect(attempts).toHaveLength(2);
     });
 });

--- a/src/lib/interactive/__tests__/ask-questions.test.js
+++ b/src/lib/interactive/__tests__/ask-questions.test.js
@@ -179,6 +179,56 @@ describe('askQuestions', () => {
     });
 });
 
+describe('the stored answer', () => {
+    // The validator runs the option's parser and keeps only the verdict. The
+    // answer stored for later questions - and for the probes, the review table and
+    // the echoed command line - is the parsed value, so everything that reads it
+    // sees what the run will see (issue #1148).
+    test('is what the option parser makes of the text, when that is a string', async () => {
+        const option = {
+            parseArg: (value) =>
+                String(value)
+                    .trim()
+                    .replace(/^https?:\/\//, ''),
+        };
+        const runtime = scriptedRuntime({ host: '  https://sense.acme.com ' });
+
+        const answers = await askQuestions([spec({ key: 'host', option })], ctx(), { runtime });
+
+        expect(answers.host).toBe('sense.acme.com');
+    });
+
+    test('is left as typed when the parser returns something other than a string', async () => {
+        const option = { parseArg: () => 42 };
+        const runtime = scriptedRuntime({ k: 'typed' });
+
+        const answers = await askQuestions([spec({ option })], ctx(), { runtime });
+
+        expect(answers.k).toBe('typed');
+    });
+
+    test('is left as typed for anything but a text prompt', async () => {
+        const option = { parseArg: () => 'never' };
+        const runtime = scriptedRuntime({ k: 'b' });
+
+        const answers = await askQuestions(
+            [spec({ type: 'select', choices: ['a', 'b'], option })],
+            ctx(),
+            { runtime }
+        );
+
+        expect(answers.k).toBe('b');
+    });
+
+    test('is left as typed when there is no parser', async () => {
+        const runtime = scriptedRuntime({ k: '  spaced  ' });
+
+        const answers = await askQuestions([spec()], ctx(), { runtime });
+
+        expect(answers.k).toBe('  spaced  ');
+    });
+});
+
 describe('live choices', () => {
     test('are fetched with the answers given so far', async () => {
         // "The app fetcher was called with the tenant url the user typed",

--- a/src/lib/interactive/__tests__/launch.test.js
+++ b/src/lib/interactive/__tests__/launch.test.js
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
-import { presetOptionsFrom, presetSourcesFrom } from '../launch.js';
+import { presetOptionsFrom, presetSourcesFrom, rejectedOptionsFrom } from '../launch.js';
+import { relaxMandatoryOptionsIfInteractive } from '../mandatory-relaxation.js';
 import { addInteractiveOption } from '../interactive-option.js';
 import { buildQseowCommand } from '../../commands/qseow/index.js';
 
@@ -138,5 +139,67 @@ describe('presetSourcesFrom', () => {
 
     test('tolerates being handed no command at all', () => {
         expect(presetSourcesFrom(undefined)).toEqual({});
+    });
+});
+
+describe('a value the parse refused', () => {
+    /**
+     * Parse under the real relaxation, as the entry point does, so a refused value
+     * survives the parse and is recorded.
+     *
+     * @param {string[]} tail - Argv after the command path.
+     *
+     * @returns {import('commander').Command} The parsed leaf.
+     */
+    const parseRelaxed = (tail) => {
+        const namespace = buildQseowCommand();
+        const leaf = namespace.commands[0];
+
+        if (!leaf.options.some((option) => option.long === '--interactive')) {
+            addInteractiveOption(leaf);
+        }
+        leaf.exitOverride().configureOutput({ writeOut: () => {}, writeErr: () => {} });
+        leaf._actionHandler = undefined;
+        leaf.action(() => {});
+
+        const argv = ['node', 'bsi', ...tail];
+        relaxMandatoryOptionsIfInteractive(leaf, argv);
+        leaf.parse(argv);
+
+        return leaf;
+    };
+
+    test('is not a preset, so the wizard asks about it', () => {
+        process.env.BSI_QSEOW_CST_HOST = 'https://sense.acme.com/form/hub';
+
+        const leaf = parseRelaxed(['-i']);
+
+        expect(presetOptionsFrom(leaf)).not.toHaveProperty('host');
+        expect(presetSourcesFrom(leaf)).not.toHaveProperty('host');
+    });
+
+    test('is handed over separately, with its message and origin', () => {
+        process.env.BSI_QSEOW_CST_HOST = 'https://sense.acme.com/form/hub';
+
+        const rejected = rejectedOptionsFrom(parseRelaxed(['-i']));
+
+        expect(rejected.host).toEqual({
+            value: 'https://sense.acme.com/form/hub',
+            message: expect.stringContaining('a path is not part of it'),
+            source: 'env',
+        });
+    });
+
+    test('leaves the values that passed where they were', () => {
+        process.env.BSI_QSEOW_CST_HOST = 'https://sense.acme.com/form/hub';
+
+        const leaf = parseRelaxed(['--apiuserdir', 'INTERNAL', '-i']);
+
+        expect(presetOptionsFrom(leaf).apiuserdir).toBe('INTERNAL');
+    });
+
+    test('tolerates a command that was never parsed under the relaxation', () => {
+        expect(rejectedOptionsFrom(parseQseow(['-i']))).toEqual({});
+        expect(rejectedOptionsFrom(undefined)).toEqual({});
     });
 });

--- a/src/lib/interactive/__tests__/mandatory-relaxation.test.js
+++ b/src/lib/interactive/__tests__/mandatory-relaxation.test.js
@@ -1,6 +1,10 @@
 import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
 import { Command } from 'commander';
-import { wantsInteractive, relaxMandatoryOptionsIfInteractive } from '../mandatory-relaxation.js';
+import {
+    wantsInteractive,
+    relaxMandatoryOptionsIfInteractive,
+    rejectedOptionValues,
+} from '../mandatory-relaxation.js';
 import { addInteractiveOption } from '../interactive-option.js';
 import { specsFromCommand } from '../option-introspect.js';
 import { buildQseowCommand } from '../../commands/qseow/index.js';
@@ -262,6 +266,94 @@ describe('a literal -i used as an option value does not relax anything', () => {
 
         expect(program.reached.opts.qliksensetag).toBe('-i');
         expect(program.reached.opts.interactive).toBeUndefined();
+    });
+});
+
+describe('a supplied value the parser refuses', () => {
+    // Commander runs every argParser during the parse and exits on the first
+    // refusal, before preAction and before any interactive code. A stale value in
+    // .env therefore used to kill the wizard that exists to correct it (issue
+    // #1148). With -i really set the parse now survives, and the refusal is handed
+    // to the wizard instead.
+    test('no longer stops -i from reaching the wizard', async () => {
+        process.env.BSI_QSEOW_CST_HOST = 'https://sense.acme.com/form/hub';
+
+        const { reached, error } = await run([...QSEOW, '-i']);
+
+        expect(error).toBeUndefined();
+        expect(reached.opts.interactive).toBe(true);
+    });
+
+    test('is recorded for the wizard, with the message and where it came from', async () => {
+        process.env.BSI_QSEOW_CST_HOST = 'https://sense.acme.com/form/hub';
+
+        const { reached } = await run([...QSEOW, '--engineport', 'abc', '-i']);
+        const rejected = rejectedOptionValues(reached.cmd);
+
+        expect(rejected.host).toEqual({
+            value: 'https://sense.acme.com/form/hub',
+            message: expect.stringContaining('a path is not part of it'),
+            source: 'env',
+        });
+        expect(rejected.engineport).toEqual({
+            value: 'abc',
+            message: 'Engine port must be a non-negative integer.',
+            source: 'cli',
+        });
+    });
+
+    test('a command whose values all passed records nothing', async () => {
+        const { reached } = await run([...QSEOW, '--host', 'sense.acme.com', '-i']);
+
+        expect(rejectedOptionValues(reached.cmd)).toEqual({});
+        expect(reached.opts.host).toBe('sense.acme.com');
+    });
+
+    // The parsers are part of the tree the wizard reads: specsFromCommand() builds
+    // each prompt's validator from option.parseArg, so a still-wrapped parser would
+    // accept at the prompt the very value it had just refused.
+    test('every parser is its own again once a handler runs', async () => {
+        process.env.BSI_QSEOW_CST_HOST = 'https://sense.acme.com/form/hub';
+
+        const { reached } = await run([...QSEOW, '-i']);
+        const host = reached.cmd.options.find((option) => option.long === '--host');
+
+        expect(() => host.parseArg('https://sense.acme.com/form/hub', undefined)).toThrow(
+            /a path is not part of it/
+        );
+    });
+
+    // The false positive again: a literal -i as a value relaxed the parse, so the
+    // refusal has to be raised by hand - and first, because Commander refuses a
+    // value while parsing, before it ever looks for missing options.
+    test('is still fatal when -i was only a value, with Commander wording', async () => {
+        const argv = [
+            ...QSEOW,
+            '--host',
+            'https://sense.acme.com/form/hub',
+            '--qliksensetag',
+            '-i',
+        ];
+        const before = await run(argv, { relax: false, withFlag: false });
+        const after = await run(argv);
+
+        expect(after.reached).toBeUndefined();
+        expect(after.error.code).toBe('commander.invalidArgument');
+        expect(after.error.message).toBe(before.error.message);
+        expect(after.error.message).toContain(
+            "argument 'https://sense.acme.com/form/hub' is invalid"
+        );
+    });
+
+    test('and a refused environment value is reported naming the variable, as Commander does', async () => {
+        process.env.BSI_QSEOW_CST_ENGINE_PORT = 'abc';
+        const argv = [...QSEOW, '--qliksensetag', '-i'];
+        const before = await run(argv, { relax: false, withFlag: false });
+        const after = await run(argv);
+
+        expect(after.error.code).toBe('commander.invalidArgument');
+        expect(after.error.message).toBe(before.error.message);
+        expect(after.error.message).toContain("from env 'BSI_QSEOW_CST_ENGINE_PORT'");
     });
 });
 

--- a/src/lib/interactive/ask-questions.js
+++ b/src/lib/interactive/ask-questions.js
@@ -412,6 +412,45 @@ export const configFor = (spec, choices, theme) => ({
 });
 
 /**
+ * The answer as the option's own parser would store it.
+ *
+ * The validator has just run the parser and kept only its verdict, so without this
+ * the answer stored for later questions is the raw text - and the raw text is not
+ * always what the run will use. `--tenanturl` reduces a pasted URL to a host, and a
+ * wizard probe that connected with the raw value worked or failed by luck: the
+ * QSEoW QRS lookups did not tolerate the scheme, the Cloud REST client happened to
+ * (issue #1148). Storing the parsed value here means every later reader - the
+ * probes, the review table, the echoed command line, the saved `.env` - sees the
+ * value the run will see.
+ *
+ * Only for a text prompt, and only when the parser returns a string. A
+ * `<true|false>` option's parser returns a boolean that the confirm prompt already
+ * produces, a variadic parser accumulates, and a select's parser is the choices
+ * check. Anything that would change the answer's shape is left as typed, which is
+ * exactly what every answer was before this existed.
+ *
+ * @param {import('./option-introspect.js').QuestionSpec} spec - The question.
+ * @param {unknown} raw - What was typed.
+ *
+ * @returns {unknown} The parsed value when it is a string, otherwise `raw`.
+ */
+const normalized = (spec, raw) => {
+    if (spec.type !== 'input' || typeof spec.option?.parseArg !== 'function') {
+        return raw;
+    }
+
+    try {
+        const parsed = spec.option.parseArg(String(raw), undefined);
+
+        return typeof parsed === 'string' ? parsed : raw;
+    } catch {
+        // The validator accepted it, so this is a parser that throws for reasons
+        // of its own - keep the text rather than guess.
+        return raw;
+    }
+};
+
+/**
  * Ask a list of questions and collect the answers.
  *
  * The runtime is injected rather than imported, which is what makes the whole
@@ -490,7 +529,7 @@ export const askQuestions = async (specs, ctx = {}, { runtime = defaultRuntime }
 
             // Answers are written back as we go, so a later question's `when` or
             // `choices` sees everything said so far.
-            answers[spec.key] = asked.type === 'list' ? splitEntries(raw) : raw;
+            answers[spec.key] = asked.type === 'list' ? splitEntries(raw) : normalized(spec, raw);
 
             if (!spec.probe) {
                 break;

--- a/src/lib/interactive/index.js
+++ b/src/lib/interactive/index.js
@@ -89,6 +89,10 @@ const review = async ({ path, specs, answers, runtime, theme, symbols }) => {
  * @param {object} [args.presetOptions] - Answers already known, used as starting values.
  * @param {object} [args.presetSources] - Where each of those came from, `cli` or `env`, keyed the
  *     same way. Used to name the environment variable behind a value whose check fails.
+ * @param {object} [args.rejectedOptions] - Supplied values the command's own parse refused, keyed
+ *     the same way: `{ value, message, source }`. Not answers - they are asked about, opened on
+ *     the refused value and introduced with the parser's message - and not presets, which is why
+ *     the launcher keeps them out of `presetOptions`.
  * @param {object} [args.runtime] - Prompt runtime. Injectable for tests.
  * @param {string} [args.cwd] - Directory a saved `.env` is written to. Injectable for tests.
  *
@@ -99,6 +103,7 @@ export const runInteractive = async ({
     path,
     presetOptions = {},
     presetSources = {},
+    rejectedOptions = {},
     runtime = defaultRuntime,
     cwd = process.cwd(),
 } = {}) => {
@@ -136,9 +141,21 @@ export const runInteractive = async ({
     const symbols = getSymbols();
     const theme = buildTheme({ symbols });
 
+    // A variable whose value the parse refused is treated as unset from here on:
+    // the question it would have answered is required again, and the refused text
+    // is not offered as a default - it is opened on below, which is different,
+    // because a default is something the wizard vouches for.
+    const env = { ...process.env };
+
+    for (const option of command.options) {
+        if (option.attributeName() in rejectedOptions && option.envVar) {
+            delete env[option.envVar];
+        }
+    }
+
     // Derived from the command every time, so a newly added option is asked
     // about without anyone editing the wizard.
-    const specs = specsFromCommand(command);
+    const specs = specsFromCommand(command, { env });
 
     const refined = wizard.refine ? wizard.refine(specs, { answers: presetOptions }) : specs;
 
@@ -205,6 +222,14 @@ export const runInteractive = async ({
         )
         .map((spec) =>
             spec.key in presetOptions ? openingOn(spec, presetOptions[spec.key]) : spec
+        )
+        // A refused value is opened on too, so correcting it is an edit rather than
+        // a retype - but only where the prompt takes text. A select offered a value
+        // that is not one of its choices would not know what to do with it.
+        .map((spec) =>
+            spec.key in rejectedOptions && (spec.type === 'input' || spec.type === 'list')
+                ? openingOn(spec, rejectedOptions[spec.key].value)
+                : spec
         )
         .map((spec) => (checkOnly(spec) ? { ...spec, checkOnly: true } : spec));
 
@@ -290,6 +315,31 @@ export const runInteractive = async ({
         runtime.write(
             `${theme.style.help(`Supplied, but asked about again so you can change it for this run: ${overridden.join(', ')}.`)}\n`
         );
+    }
+
+    const rejected = specs.filter((spec) => spec.key in rejectedOptions);
+
+    if (rejected.length > 0) {
+        // Said here, before the first question, and again nowhere else: the
+        // question itself then reads as any other question does. The message is
+        // the parser's own - the same sentence the prompt would have shown had
+        // the value been typed there - and the variable is named because that is
+        // what has to be edited for the next run to pass without being asked.
+        runtime.write(
+            `${theme.style.help('Supplied, but not usable as given, so asked about below:')}\n`
+        );
+
+        for (const spec of rejected) {
+            const { message, source } = rejectedOptions[spec.key];
+            const origin =
+                source === 'env' && spec.option?.envVar
+                    ? `${nameOf(spec)} (from ${spec.option.envVar})`
+                    : source === 'cli'
+                      ? `${nameOf(spec)} (from the command line)`
+                      : nameOf(spec);
+
+            runtime.write(`  ${theme.style.error(`${origin}:`)} ${message}\n`);
+        }
     }
 
     for (;;) {

--- a/src/lib/interactive/launch.js
+++ b/src/lib/interactive/launch.js
@@ -4,6 +4,7 @@ import { assertInteractiveCapable } from './tty.js';
 import { isPromptCancellation } from './prompt-runtime.js';
 import { runInteractive } from './index.js';
 import { isInteractiveOption } from './interactive-option.js';
+import { rejectedOptionValues } from './mandatory-relaxation.js';
 
 /**
  * Every option the user actually supplied, with its value and where it came from.
@@ -19,12 +20,19 @@ import { isInteractiveOption } from './interactive-option.js';
  * skipping those would hide most of the questions behind values the user never
  * chose.
  *
+ * A value the parse refused is not supplied either, however it arrived. It sits
+ * on the command because the relaxation kept it there, but it is not an answer
+ * the run could use, and treating it as one would hide the question behind a
+ * value that is about to fail. Those go to the wizard separately, through
+ * {@link rejectedOptionsFrom}, so they can be asked about and explained.
+ *
  * @param {import('commander').Command} command - The parsed command.
  *
  * @returns {Array<[string, {value: unknown, source: string}]>} One entry per supplied option.
  */
 const suppliedEntries = (command) => {
     const entries = [];
+    const rejected = rejectedOptionValues(command);
 
     for (const option of command?.options ?? []) {
         // The flag that started the wizard is not an answer to anything, and
@@ -37,7 +45,7 @@ const suppliedEntries = (command) => {
         const key = option.attributeName();
         const source = command.getOptionValueSource(key);
 
-        if (source === 'cli' || source === 'env') {
+        if ((source === 'cli' || source === 'env') && !(key in rejected)) {
             entries.push([key, { value: command.getOptionValue(key), source }]);
         }
     }
@@ -77,6 +85,19 @@ export const presetSourcesFrom = (command) =>
     Object.fromEntries(suppliedEntries(command).map(([key, { source }]) => [key, source]));
 
 /**
+ * The supplied values the parse refused, for the wizard to ask about.
+ *
+ * Recorded by the relaxation that let the parse survive them (see
+ * `relaxMandatoryOptionsIfInteractive`), and read back here so the wizard opens
+ * each such question on the refused value and says why it is being asked.
+ *
+ * @param {import('commander').Command} command - The parsed command.
+ *
+ * @returns {object} `{ value, message, source }` per option attribute name, refused values only.
+ */
+export const rejectedOptionsFrom = (command) => rejectedOptionValues(command);
+
+/**
  * Run a leaf command's wizard instead of the command itself.
  *
  * Routed through `runCommand()` so the exit code behaves exactly as it does for
@@ -103,6 +124,7 @@ export const launchInteractive = async (logPrefix, path, command) =>
                     path,
                     presetOptions: presetOptionsFrom(command),
                     presetSources: presetSourcesFrom(command),
+                    rejectedOptions: rejectedOptionsFrom(command),
                 });
             } catch (err) {
                 if (isPromptCancellation(err)) {

--- a/src/lib/interactive/mandatory-relaxation.js
+++ b/src/lib/interactive/mandatory-relaxation.js
@@ -57,8 +57,52 @@ const commandAndAncestors = (command) => {
 };
 
 /**
- * Let a wizard past Commander's missing-mandatory check, without changing what
- * happens to anybody else.
+ * The invalid-value error Commander would have raised, reproduced for the
+ * false-positive path below.
+ *
+ * Two spellings, because Commander has two: a value typed on the command line is
+ * an "argument", a value read from a variable names the variable - and the
+ * variable is the one the operator has to go and edit.
+ *
+ * @param {import('commander').Option} option - The option whose value was refused.
+ * @param {unknown} value - The refused value.
+ * @param {string} source - Commander's record of where it came from, `cli` or `env`.
+ * @param {Error} err - The `InvalidArgumentError` the parser threw.
+ *
+ * @returns {string} The message, as Commander prints it.
+ */
+const invalidValueMessage = (option, value, source, err) =>
+    source === 'env'
+        ? `error: option '${option.flags}' value '${value}' from env '${option.envVar}' is invalid. ${err.message}`
+        : `error: option '${option.flags}' argument '${value}' is invalid. ${err.message}`;
+
+/**
+ * What each wizard-bound command's parse refused, keyed by the command.
+ *
+ * A `WeakMap` rather than a property on the command, so nothing is added to
+ * Commander's object and the record goes away with the command.
+ *
+ * @type {WeakMap<import('commander').Command, Record<string, {value: unknown, message: string, source: string}>>}
+ */
+const rejectionsByCommand = new WeakMap();
+
+/**
+ * The supplied values a wizard's own parse refused, so the wizard can ask about
+ * them instead of the command dying on them.
+ *
+ * Empty for a command that was not parsed under the relaxation, or whose values
+ * all passed. Keyed by option attribute name, as the wizard's answers are.
+ *
+ * @param {import('commander').Command} command - The parsed leaf command.
+ *
+ * @returns {Record<string, {value: unknown, message: string, source: string}>} The
+ *     refused value, the parser's message and where the value came from, per option.
+ */
+export const rejectedOptionValues = (command) => rejectionsByCommand.get(command) ?? {};
+
+/**
+ * Let a wizard past Commander's missing-mandatory check and its value parsers,
+ * without changing what happens to anybody else.
  *
  * `qseow create-sheet-thumbnails` declares 18 mandatory options, 6 of which have
  * no default and so can actually fail the check. Commander runs that check
@@ -66,21 +110,35 @@ const commandAndAncestors = (command) => {
  * would be rejected before a single line of interactive code ran. The options
  * are therefore cleared for the duration of the parse.
  *
+ * The parsers are relaxed for the same reason. Commander runs each option's
+ * `argParser` on the command line *and* on the environment during the parse, and
+ * an `InvalidArgumentError` there exits the process - so a stale
+ * `BSI_QSEOW_CST_ENGINE_PORT=abc` or a `BSI_QSEOW_CST_HOST` carrying a path in a
+ * `.env` file killed `-i` before the wizard that exists to correct such values
+ * could open (issue #1148). Instead, for the duration of the parse, a refused
+ * value is recorded and kept as it was, and the wizard then asks about it -
+ * showing the parser's own message, which is the same text the prompt would
+ * have shown had the value been typed there.
+ *
  * Two things make that safe rather than merely convenient:
  *
  * 1. `makeOptionMandatory(false)` is Commander's own public API for this, and is
- *    in its typings. Nothing here writes to an undocumented field.
+ *    in its typings. `parseArg` is the field `.argParser()` sets, read by
+ *    Commander and by the wizard's validator alike. Nothing here writes to an
+ *    undocumented field.
  * 2. The relaxation lasts only as long as the parse. The `preAction` hook
- *    restores every option it cleared before any handler runs, so nothing
+ *    restores every option it touched before any handler runs, so nothing
  *    downstream ever observes a relaxed command. That matters concretely:
  *    `specsFromCommand()` reads `option.mandatory` to decide which questions are
- *    required, and against a still-relaxed command it would quietly decide that
- *    nothing is.
+ *    required and `option.parseArg` to build their validators, and against a
+ *    still-relaxed command it would quietly decide that nothing is required and
+ *    nothing needs checking.
  *
  * The same hook closes the `-i`-as-a-value false positive. Once the parse is
- * done, whether the flag was really set is knowable, and if it was not the
- * missing-mandatory check is re-run by hand - reproducing Commander's message
- * and error code exactly. So for any command line that does not genuinely ask
+ * done, whether the flag was really set is knowable, and if it was not, the
+ * first refused value is reported and then the missing-mandatory check re-run by
+ * hand - reproducing Commander's messages and error codes exactly, in the order
+ * Commander raises them. So for any command line that does not genuinely ask
  * for a wizard, behaviour is identical to not calling this function at all.
  *
  * Called once, on the root program, before `parseAsync`.
@@ -98,6 +156,12 @@ export const relaxMandatoryOptionsIfInteractive = (program, argv = process.argv)
     /** @type {Map<import('commander').Command, import('commander').Option[]>} */
     const cleared = new Map();
 
+    /** @type {Map<import('commander').Option, Function>} Each wrapped parser, by option. */
+    const wrapped = new Map();
+
+    /** @type {Map<import('commander').Option, {value: unknown, err: Error}>} First refusal per option. */
+    const refused = new Map();
+
     const relax = (command) => {
         const mandatory = command.options.filter((option) => option.mandatory);
 
@@ -109,6 +173,37 @@ export const relaxMandatoryOptionsIfInteractive = (program, argv = process.argv)
             }
         }
 
+        for (const option of command.options) {
+            if (typeof option.parseArg !== 'function') {
+                continue;
+            }
+
+            const original = option.parseArg;
+            wrapped.set(option, original);
+
+            option.parseArg = (value, previous) => {
+                try {
+                    return original(value, previous);
+                } catch (err) {
+                    // Only the refusal Commander itself would act on. Anything else
+                    // is a parser bug, and hiding it would be worse than the exit.
+                    if (err?.code !== 'commander.invalidArgument') {
+                        throw err;
+                    }
+
+                    if (!refused.has(option)) {
+                        refused.set(option, { value, err });
+                    }
+
+                    // Kept rather than dropped, so the option still counts as
+                    // supplied and the wizard can open its question on the value
+                    // being complained about. Never used as a value: the wizard
+                    // asks, and the false-positive path below exits first.
+                    return value;
+                }
+            };
+        }
+
         for (const child of command.commands) {
             relax(child);
         }
@@ -116,7 +211,7 @@ export const relaxMandatoryOptionsIfInteractive = (program, argv = process.argv)
 
     relax(program);
 
-    if (cleared.size === 0) {
+    if (cleared.size === 0 && wrapped.size === 0) {
         return true;
     }
 
@@ -131,12 +226,59 @@ export const relaxMandatoryOptionsIfInteractive = (program, argv = process.argv)
             }
         }
 
+        for (const [option, original] of wrapped) {
+            option.parseArg = original;
+        }
+
+        // The refusals on the path that ran, in Commander's order: the acting
+        // command's options before its ancestors', and within a command in
+        // declaration order - which is the order Commander parsed them.
+        const rejected = [];
+
+        for (const command of commandAndAncestors(actionCommand)) {
+            for (const option of command.options) {
+                if (refused.has(option)) {
+                    const key = option.attributeName();
+                    const { value, err } = refused.get(option);
+
+                    rejected.push({
+                        key,
+                        option,
+                        value,
+                        err,
+                        source: command.getOptionValueSource(key),
+                    });
+                }
+            }
+        }
+
         if (actionCommand.opts()[INTERACTIVE_OPTION_ATTRIBUTE]) {
+            rejectionsByCommand.set(
+                actionCommand,
+                Object.fromEntries(
+                    rejected.map(({ key, value, err, source }) => [
+                        key,
+                        { value, message: err.message, source },
+                    ])
+                )
+            );
+
             return;
         }
 
         // The flag was not really set, so this command line was never entitled
-        // to skip the check. Re-run it, reporting exactly what Commander would.
+        // to skip anything. Re-run both checks, reporting exactly what Commander
+        // would - a refused value first, because Commander refuses it while
+        // parsing, before it ever looks for missing options.
+        if (rejected.length > 0) {
+            const { option, value, source, err } = rejected[0];
+
+            actionCommand.error(invalidValueMessage(option, value, source, err), {
+                exitCode: err.exitCode,
+                code: err.code,
+            });
+        }
+
         for (const command of commandAndAncestors(actionCommand)) {
             for (const option of cleared.get(command) ?? []) {
                 if (command.getOptionValue(option.attributeName()) === undefined) {

--- a/src/lib/util/__tests__/host-option.test.js
+++ b/src/lib/util/__tests__/host-option.test.js
@@ -1,0 +1,203 @@
+import { describe, test, expect } from '@jest/globals';
+import { InvalidArgumentError } from 'commander';
+import SenseUtilities from 'enigma.js/sense-utilities.js';
+import { hostOptionParser } from '../host-option.js';
+import { redactSensitivePatterns } from '../redact-secrets.js';
+
+const parseTenant = hostOptionParser({ example: 'tenant.eu.qlikcloud.com' });
+const parseHost = hostOptionParser({
+    example: 'sense.example.com',
+    pathHint: 'A virtual proxy prefix, if there is one, goes in --prefix.',
+});
+
+describe('hostOptionParser', () => {
+    test('a bare host is what comes back out', () => {
+        expect(parseTenant('tenant.eu.qlikcloud.com')).toBe('tenant.eu.qlikcloud.com');
+    });
+
+    test.each([
+        ['https://tenant.eu.qlikcloud.com', 'tenant.eu.qlikcloud.com'],
+        ['http://tenant.eu.qlikcloud.com', 'tenant.eu.qlikcloud.com'],
+        // A browser address bar hands over the trailing slash along with the
+        // scheme, and left in place it produces `wss://host//app/<id>`.
+        ['https://tenant.eu.qlikcloud.com/', 'tenant.eu.qlikcloud.com'],
+        ['tenant.eu.qlikcloud.com/', 'tenant.eu.qlikcloud.com'],
+        ['https://tenant.eu.qlikcloud.com//', 'tenant.eu.qlikcloud.com'],
+        ['  https://tenant.eu.qlikcloud.com  ', 'tenant.eu.qlikcloud.com'],
+        // One slash short of a scheme. The regex this replaced let it through
+        // verbatim, reproducing `getaddrinfo ENOTFOUND https` with a green tick
+        // at the prompt.
+        ['https:tenant.eu.qlikcloud.com', 'tenant.eu.qlikcloud.com'],
+        // Protocol-relative, as some tools copy it.
+        ['//tenant.eu.qlikcloud.com', 'tenant.eu.qlikcloud.com'],
+        ['https:\\\\tenant.eu.qlikcloud.com', 'tenant.eu.qlikcloud.com'],
+    ])('%s becomes %s', (input, expected) => {
+        expect(parseTenant(input)).toBe(expected);
+    });
+
+    // Host names are case-insensitive, and this is what DNS resolves either way.
+    test('the host comes back as the URL parser spells it', () => {
+        expect(parseTenant('HTTPS://Tenant.EU.Qlikcloud.COM')).toBe('tenant.eu.qlikcloud.com');
+        expect(parseHost('bücher.example')).toBe('xn--bcher-kva.example');
+    });
+
+    test.each([['192.168.1.10'], ['localhost'], ['[2001:db8::1]'], ['sense.example.com.']])(
+        'a host that is not a domain name, %s, passes through intact',
+        (host) => {
+            expect(parseHost(host)).toBe(host);
+        }
+    );
+
+    test('an IPv6 literal keeps its brackets, which is how the engine url needs it', () => {
+        const host = parseHost('https://[2001:db8::1]/');
+
+        expect(host).toBe('[2001:db8::1]');
+        expect(SenseUtilities.buildUrl({ host, port: 4747, secure: true, appId: 'a' })).toBe(
+            'wss://[2001:db8::1]:4747/app/a'
+        );
+    });
+
+    describe('refusals', () => {
+        // InvalidArgumentError specifically: Commander turns it into an option
+        // error naming the flag and the value, and the wizard's validator shows
+        // `err.message` inline under the prompt.
+        test('are InvalidArgumentErrors, so Commander and the wizard both report them', () => {
+            expect(() => parseHost('https://sense.example.com/form/hub')).toThrow(
+                InvalidArgumentError
+            );
+        });
+
+        // Both options this serves are mandatory with no default, and Commander's
+        // missing-mandatory check does not catch a variable that is set but empty
+        // - so blank has to be refused here, or `BSI_QSEOW_CST_HOST=` runs against
+        // nothing. It is also the wizard's only "required" check once an option
+        // has a parser.
+        test('a blank value is refused, naming what to enter', () => {
+            expect(() => parseHost('')).toThrow('Enter the host, for example "sense.example.com".');
+            expect(() => parseHost('   ')).toThrow(
+                'Enter the host, for example "sense.example.com".'
+            );
+        });
+
+        test('a path is refused rather than silently dropped', () => {
+            expect(() => parseHost('https://sense.example.com/form/hub')).toThrow(
+                /a path is not part of it/
+            );
+        });
+
+        // Dropping `/form` would leave a run that authenticates and then fails
+        // ninety seconds later on a selector that says nothing about a prefix.
+        // The hint is conditional on purpose: `https://server/hub` has a path and
+        // no prefix, and "goes in --prefix" would be wrong advice for it.
+        test('refusing a path names where a prefix belongs, when the caller says so', () => {
+            expect(() => parseHost('https://sense.example.com/hub')).toThrow(
+                'A virtual proxy prefix, if there is one, goes in --prefix.'
+            );
+            expect(() => parseTenant('https://tenant.eu.qlikcloud.com/sense/app/x')).toThrow(
+                /a path is not part of it/
+            );
+            expect(() => parseTenant('https://tenant.eu.qlikcloud.com/sense/app/x')).not.toThrow(
+                /--prefix/
+            );
+        });
+
+        test.each([
+            ['a query string', 'https://tenant.eu.qlikcloud.com?qlik-web-integration-id=abc'],
+            ['a fragment', 'https://tenant.eu.qlikcloud.com#/hub'],
+        ])('%s is refused as a path, not glued onto the host', (_label, input) => {
+            expect(() => parseTenant(input)).toThrow(/a path is not part of it/);
+        });
+
+        // The port has its own options on QSEoW, and every consumer appends one
+        // to the host - so `host:8443` became `wss://host:8443:4747/…`, the
+        // same shape #1148 was about.
+        test.each([['https://sense.example.com:8443/'], ['sense.example.com:4242']])(
+            'a port, as in %s, is refused and pointed at the port options',
+            (input) => {
+                expect(() => parseHost(input)).toThrow(
+                    /A port is not part of the host - the ports have their own options/
+                );
+            }
+        );
+
+        test('a scheme other than http(s) is reported as such, not as a path', () => {
+            expect(() => parseHost('ftp://sense.example.com')).toThrow(
+                /Only "https:\/\/" and "http:\/\/" are recognised/
+            );
+            // Even with nothing after it: the regex this replaced stripped the
+            // trailing slashes first and accepted `ftp:` as a host.
+            expect(() => parseHost('ftp://')).toThrow(
+                /Only "https:\/\/" and "http:\/\/" are recognised/
+            );
+        });
+
+        test.each([['https://'], ['/'], ['///'], ['://'], ['sense example.com']])(
+            '%s is refused as not a host name, without inventing a scheme to blame',
+            (input) => {
+                expect(() => parseHost(input)).toThrow(/That is not a host name/);
+                expect(() => parseHost(input)).not.toThrow(/scheme/);
+            }
+        );
+
+        test('the message quotes the platform its option belongs to', () => {
+            expect(() => parseTenant('https://')).toThrow(/tenant\.eu\.qlikcloud\.com/);
+            expect(() => parseHost('https://')).toThrow(/sense\.example\.com/);
+        });
+    });
+
+    describe('credentials in the host', () => {
+        const PASTED = 'https://svc-bsi:Sup3rSecret@sense.example.com';
+
+        test('are refused, with the options they belong in named instead', () => {
+            expect(() => parseHost(PASTED)).toThrow(/Credentials are not part of the host/);
+            expect(() => parseHost('svc-bsi:Sup3rSecret@sense.example.com')).toThrow(
+                /Credentials are not part of the host/
+            );
+        });
+
+        // The log redactor recognises embedded credentials only behind a scheme,
+        // and the scheme is exactly what this parser removes - so a parser that
+        // returned `user:pass@host` would have every log line that prints the
+        // host print the password. Refusing is what keeps the redactor's
+        // guarantee: nothing this parser returns can carry credentials, and
+        // nothing it says repeats them.
+        test('never reach a log line, because neither the host nor the message carries them', () => {
+            let message;
+            try {
+                parseHost(PASTED);
+            } catch (err) {
+                message = err.message;
+            }
+
+            expect(message).not.toContain('Sup3rSecret');
+            expect(message).not.toContain('svc-bsi');
+            // The pre-fix shape, for contrast: with the scheme gone the redactor
+            // no longer sees credentials to redact.
+            expect(redactSensitivePatterns(`on host ${PASTED}`)).toContain('[REDACTED]@');
+            expect(
+                redactSensitivePatterns('on host svc-bsi:Sup3rSecret@sense.example.com')
+            ).toContain('Sup3rSecret');
+        });
+    });
+});
+
+// The point of the parser, stated as the URL that failed in issue #1148.
+// `SenseUtilities.buildUrl` is what both platforms' engine connections call, and
+// it prepends a scheme of its own, so it is only correct when handed a bare host.
+describe('the engine url a pasted tenant url used to break', () => {
+    const PASTED = 'https://tenant.eu.qlikcloud.com';
+
+    test('the parsed value produces the engine url the tenant answers on', () => {
+        expect(
+            SenseUtilities.buildUrl({ host: parseTenant(PASTED), secure: true, appId: 'app-1' })
+        ).toBe('wss://tenant.eu.qlikcloud.com/app/app-1');
+    });
+
+    test('the QSEoW twin is fixed by the same parser', () => {
+        const host = parseHost('https://sense.example.com');
+
+        expect(SenseUtilities.buildUrl({ host, port: 4747, secure: true, appId: 'app-1' })).toBe(
+            'wss://sense.example.com:4747/app/app-1'
+        );
+    });
+});

--- a/src/lib/util/host-option.js
+++ b/src/lib/util/host-option.js
@@ -1,0 +1,139 @@
+import { InvalidArgumentError } from 'commander';
+
+/** The two schemes an administrator plausibly pastes in front of a Sense host. */
+const HTTP_SCHEME = /^https?:/i;
+
+/** Any other `scheme://`, which is a mistake worth naming rather than guessing at. */
+const OTHER_SCHEME = /^[a-z][a-z0-9+.-]*:\/\//i;
+
+/**
+ * Builds a Commander `argParser` that reduces a pasted URL to the bare host the
+ * rest of the codebase expects, and refuses anything that is not one host.
+ *
+ * This exists because `--tenanturl` and `--host` are read by two families of code
+ * that disagree about the value's shape, and nothing used to normalise it between
+ * the option and either of them (issue #1148):
+ *
+ * - **Tolerant.** `QlikSaas` prepends `https://` only when it is missing, so a
+ *   scheme-ful tenant url passes through and works. Every Cloud REST call goes
+ *   through it - the connection test, the app list, the collection list, the media
+ *   library upload.
+ * - **Intolerant.** `setupEnigmaConnection` and the app-url builders on both
+ *   platforms assume a bare host and prepend the scheme themselves. Given
+ *   `https://tenant.eu.qlikcloud.com` they produce `wss://https://tenant…` and
+ *   `https://https://tenant…`, and `ws` then resolves a host literally called
+ *   `https` - reported as `getaddrinfo ENOTFOUND https`, which names neither the
+ *   option nor the value.
+ *
+ * The split is what made this expensive to diagnose rather than merely wrong: the
+ * pre-flight is all REST, so a scheme-ful value was confirmed with a green tick and
+ * then failed several steps later.
+ *
+ * **Normalising at the option covers every way a value arrives.** Commander runs
+ * `parseArg` on command-line values and on environment variables, and the wizard
+ * runs it too - as the prompt's validator, and again when `answersToOptions` hands
+ * the answers to a real `parseOptions()`. Normalising at the consumers instead
+ * would mean the same rule in five places, which is how #476 came to be fixed in
+ * the REST client alone while the help text promised both forms for all of them.
+ *
+ * **Parsed with `URL`, not with a regex.** A host is the part of a URL between
+ * the scheme and the first `/`, and the platform's URL parser already knows where
+ * the port, the path, the query, the fragment and any embedded credentials start.
+ * Two hand-written regexes knew about the scheme and a trailing slash and let
+ * everything else through - `https://host:8443` became the host `host:8443`, and
+ * the engine url `wss://host:8443:4747/…` failed exactly as #1148 had. A value
+ * with no scheme is parsed as if it had `https://`, which is what makes a bare
+ * host and a protocol-relative `//host` both work.
+ *
+ * **Anything beyond the host is refused, not stripped**, because each of those
+ * parts has somewhere else to go and dropping it silently produces a run that
+ * fails late and far from the cause:
+ *
+ * - A *path* may be a virtual proxy prefix, which has its own option, and
+ *   reducing `https://sense.example.com/form/hub` to `sense.example.com` would
+ *   leave QSEoW authenticating and then failing ninety seconds later on a
+ *   selector that says nothing about a prefix - the failure
+ *   `normalizeVirtualProxyPrefix` was written to prevent.
+ * - A *port* collides with `--port`, `--engineport` and `--qrsport`, all of which
+ *   are appended to the host by their consumers.
+ * - *Credentials* (`user:password@host`) have their own options, and a host that
+ *   carried them would put a password into every log line that prints the host -
+ *   the log redactor recognises embedded credentials only behind a scheme, and
+ *   the scheme is exactly what this parser removes.
+ *
+ * None of the messages repeat the value. On the command line Commander already
+ * quotes it, in the wizard it is on the line above, and a message that echoed a
+ * value with credentials in it would be the leak the last point exists to avoid.
+ *
+ * **A blank value is refused too.** Both options this serves are mandatory with
+ * no default, and Commander's missing-mandatory check does not catch a variable
+ * that is set but empty - `BSI_QSEOW_CST_HOST=` in a unit file parses to `''` and
+ * the run starts against nothing. Refusing it here names the option and, for a
+ * variable, the variable. It also keeps the wizard honest: a prompt whose option
+ * has a parser relies on that parser for its "required" check, and an empty host
+ * would otherwise be accepted and the run pointed at `localhost`.
+ *
+ * @param {object} config - Parser configuration.
+ * @param {string} config.example - A host to quote when refusing a value, in this
+ *     platform's own vocabulary.
+ * @param {string} [config.pathHint] - One extra sentence appended when a path is
+ *     refused, naming where that part of the URL belongs instead.
+ *
+ * @returns {(value: string) => string} A Commander `argParser`. The host comes back
+ *     as the URL parser spells it: lower-cased, and an internationalised name in
+ *     its punycode form - which is the name DNS resolves either way.
+ *
+ * @throws {InvalidArgumentError} When the value is blank, is not a host name, uses a
+ *     scheme other than http or https, or carries a port, a path, a query, a
+ *     fragment or credentials.
+ */
+export const hostOptionParser =
+    ({ example, pathHint = '' }) =>
+    (value) => {
+        const trimmed = String(value ?? '').trim();
+        const enterTheHost = `Enter the host on its own, for example "${example}".`;
+
+        if (trimmed === '') {
+            throw new InvalidArgumentError(`Enter the host, for example "${example}".`);
+        }
+
+        // Checked before parsing: `new URL('ftp://x')` succeeds, and the mistake
+        // would otherwise be reported as whatever the parse happened to find.
+        if (!HTTP_SCHEME.test(trimmed) && OTHER_SCHEME.test(trimmed)) {
+            throw new InvalidArgumentError(
+                `Only "https://" and "http://" are recognised in front of a host. ${enterTheHost}`
+            );
+        }
+
+        let url;
+        try {
+            // `https:sense.example.com` - one slash missing - is still an http(s)
+            // value to the URL parser, which is why the test above is on the
+            // scheme alone rather than on `scheme://`.
+            url = new URL(HTTP_SCHEME.test(trimmed) ? trimmed : `https://${trimmed}`);
+        } catch {
+            throw new InvalidArgumentError(`That is not a host name. ${enterTheHost}`);
+        }
+
+        if (url.username !== '' || url.password !== '') {
+            throw new InvalidArgumentError(
+                `Credentials are not part of the host - the logon user and the API user have their own options. ${enterTheHost}`
+            );
+        }
+
+        if (url.port !== '') {
+            throw new InvalidArgumentError(
+                `A port is not part of the host - the ports have their own options. ${enterTheHost}`
+            );
+        }
+
+        // A trailing slash, or several, is part of the same paste as the scheme
+        // and means nothing. Anything else after the host is a path.
+        if (!/^\/*$/.test(url.pathname) || url.search !== '' || url.hash !== '') {
+            throw new InvalidArgumentError(
+                `${enterTheHost.slice(0, -1)} - a path is not part of it.${pathHint ? ` ${pathHint}` : ''}`
+            );
+        }
+
+        return url.hostname;
+    };


### PR DESCRIPTION
## What & why

`--tenanturl` has promised "URL or host" since 3.2.3, but only the bare host worked end to end: the REST client tolerated a scheme while the engine websocket url and the browser app url prepend their own, so `https://tenant.eu.qlikcloud.com` passed the pre-flight with a green tick and then failed on the first app with `getaddrinfo ENOTFOUND https`. `--host` on QSEoW had the same consumers and no tolerance anywhere.

Both options now carry a Commander `argParser` built on Node's `URL` that reduces a pasted URL to the bare host and refuses anything that is not one - a path, port, query, fragment, credentials or a blank value - with a message naming where that part belongs. One rule covers the command line, the environment and the wizard, because Commander runs the parser on all three.

The second commit fixes what the review of the first turned up in the wizard, and it is deliberately broader than the host: a value in `.env` that any parser refuses used to kill `-i` before the wizard that exists to correct such values could open (a mistyped `BSI_QSEOW_CST_ENGINE_PORT` did it too). The relaxation now also relaxes the parsers for the duration of the parse, and the wizard asks about the refused value with the parser's message and the prompt pre-filled. The driver also stores a text answer as its parser returns it, so the probes, review table, echoed command line and saved `.env` all see the value the run will use.

Fixes #1148

## How it was verified

- `src/lib/util/__tests__/host-option.test.js` - 35 cases, including the shapes that slipped past the first version (`host:8443`, `https:host`, `ftp://`, `user:pw@host`, `//host`) and a check that neither the returned host nor any message can carry credentials.
- `src/lib/commands/__tests__/commands.test.js` - all five carrier options normalise on the command line and from the environment, refuse a set-but-empty variable naming it, and say in their help text that a URL is accepted.
- `src/lib/interactive/__tests__/mandatory-relaxation.test.js`, `launch.test.js`, `ask-questions.test.js`, and both wizard suites - a refused env value reaches the wizard and is asked about; a literal `-i` used as a value still gets Commander's error, asserted byte-identical to an unrelaxed run.
- Mutation-checked: disabling the credentials refusal, the answer normalisation, or the parser relaxation each fails the tests that cover it (2 / 3 / 6 failures).
- Real CLI from the worktree: `BSI_QSEOW_CST_HOST='https://sense.acme.com/form' bsi qseow create-sheet-thumbnails -i` now reaches the wizard; the same value without `-i` is refused at parse; a `.env` holding `https://no-such-tenant.invalid/` reaches the network layer as `no-such-tenant.invalid`.
- Full unit suite: 132 suites / 3594 tests, exit 0. `eslint --max-warnings 0` clean. Commit 1 verified green in isolation before commit 2 was added.

## Docs

`docs/to-doc-site/tenant-url-and-host-accept-a-pasted-url.md`. The `--host` help text changed, so the generated `qseow` option tables need regenerating when the page is published; `--tenanturl` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
