### PR TITLE
fix: report a failed command line instead of crashing on a thrown hook

### DIFF
--- a/src/__tests__/butler-sheet-icons.test.js
+++ b/src/__tests__/butler-sheet-icons.test.js
@@ -652,3 +652,70 @@ describe('adding interactive mode changes nothing that already worked', () => {
         expect(result.stdout).not.toContain('interactive');
     });
 });
+
+describe('a failed command line is not a crash (issue #1150)', () => {
+    // A `beforeAction` hook that throws is a deliberate abort. Through the real dispatch it
+    // used to escape `parseAsync` into the unhandledRejection listener and produce a crash
+    // dump. Bundling with a throwing fixture is the only way to drive the real seam; the
+    // committed default contributes no hooks.
+    test('a throwing beforeAction hook reports its message without a crash dump', () => {
+        const __filename = fileURLToPath(import.meta.url);
+        const __dirname = path.dirname(__filename);
+        const repoRoot = path.resolve(__dirname, '../..');
+        const fixture = path.resolve(
+            __dirname,
+            '../lib/extensions/fixtures/throwing-before-action.js'
+        );
+        const dumpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bsi-no-crash-'));
+        // The bundle must live under the repo root: globals.js locates package.json
+        // relative to the injected import.meta.url, i.e. next to the bundle itself.
+        const buildDir = path.join(repoRoot, 'build');
+        fs.mkdirSync(buildDir, { recursive: true });
+        const outfile = path.join(buildDir, 'bsi-throwing-hook.cjs');
+
+        try {
+            const esbuild = path.join(repoRoot, 'node_modules', 'esbuild', 'bin', 'esbuild');
+            const build = childProcess.spawnSync(
+                'node',
+                [
+                    esbuild,
+                    path.resolve(__dirname, '../butler-sheet-icons.js'),
+                    '--bundle',
+                    '--platform=node',
+                    '--format=cjs',
+                    '--alias:#extensions=' + fixture,
+                    '--outfile=' + outfile,
+                    // Same pair bundle.mjs uses: import.meta.url has no meaning in a
+                    // flattened CJS bundle, and globals.js builds a require from it.
+                    '--inject:' + path.resolve(repoRoot, 'src/lib/util/import-meta-url.js'),
+                    '--define:import.meta.url=import_meta_url',
+                ],
+                { encoding: 'utf-8', timeout: 60000 }
+            );
+            expect(build.status).toBe(0);
+
+            const result = childProcess.spawnSync('node', [outfile, 'browser', 'list-installed'], {
+                encoding: 'utf-8',
+                timeout: 60000,
+                env: {
+                    ...process.env,
+                    BSI_CRASH_DUMP_DIR: dumpDir,
+                    BSI_CRASH_DUMP_ENABLE: '1',
+                    BSI_CRASH_DUMP_CREATE_JSON: '1',
+                    BSI_CRASH_DUMP_CREATE_TEXT: '1',
+                },
+            });
+
+            expect(result.status).toBe(1);
+            expect(result.stderr).toContain('beforeAction says no');
+            expect(result.stderr).not.toContain('CRASH DUMP');
+            expect(result.stderr).not.toContain('FATAL');
+            expect(fs.readdirSync(dumpDir).filter((name) => name.startsWith('crash_dump'))).toEqual(
+                []
+            );
+        } finally {
+            fs.rmSync(outfile, { force: true });
+            fs.rmSync(dumpDir, { recursive: true, force: true });
+        }
+    }, 120000);
+});

--- a/src/butler-sheet-icons.js
+++ b/src/butler-sheet-icons.js
@@ -2,7 +2,7 @@
 // so `.env` has to be in place before the command tree is built. It lives here rather than in
 // globals.js so that importing library code does not read a dotfile off disk - see issue #1014.
 import 'dotenv/config';
-import { Command } from 'commander';
+import { Command, CommanderError } from 'commander';
 import { appVersion } from './globals.js';
 import { installFatalHandlers } from './lib/util/fatal-handlers.js';
 import { installSignalHandlers } from './lib/util/signal-handlers.js';
@@ -61,7 +61,20 @@ const program = new Command();
     // and restores what it changed before any handler runs.
     relaxMandatoryOptionsIfInteractive(program, process.argv);
 
-    await program.parseAsync(process.argv);
+    // A throw from a `beforeAction` hook is a failed command line, not a crash:
+    // the hook's contract is "throwing aborts the run", so the run ends here
+    // with the message and a non-zero exit - the same way Commander reports a
+    // missing mandatory option - rather than falling through to the fatal
+    // handlers as an unhandled rejection with a crash dump (issue #1150).
+    // CommanderError is exempt: Commander has already printed and coded it.
+    try {
+        await program.parseAsync(process.argv);
+    } catch (err) {
+        if (!(err instanceof CommanderError || err?.code?.startsWith?.('commander.'))) {
+            console.error(`error: ${err.message ?? err}`);
+        }
+        process.exitCode = 1;
+    }
 
     // The one place the interrupted run is allowed to end the process, and the
     // second considered exception to the codebase's "set `process.exitCode`,

--- a/src/lib/extensions/fixtures/throwing-before-action.js
+++ b/src/lib/extensions/fixtures/throwing-before-action.js
@@ -1,0 +1,18 @@
+/**
+ * An extensions module whose `beforeAction` hook aborts the run, for testing what a deliberate
+ * throw does to the process (issue #1150).
+ *
+ * Bundled over `#extensions` by the test that uses it; never part of a shipped build.
+ *
+ * @type {import('../../apply.js').SeamDescription}
+ */
+export const extensions = {
+    seamVersion: 1,
+    commands: [],
+    options: [],
+    hooks: {
+        beforeAction: () => {
+            throw new Error('beforeAction says no');
+        },
+    },
+};


### PR DESCRIPTION
## Problem

A `beforeAction` hook that throws is a deliberate abort ("Throwing aborts the run", per `src/lib/extensions/apply.js`), but the throw escapes `await program.parseAsync(process.argv)` as an unhandled rejection, reaches `installFatalHandlers()` and produces a crash dump (#1150):

```
error: FATAL: Unhandled promise rejection: <the hook's message>
error: CRASH DUMP: Written to ./crash_dumps/...
```

An ordinary, expected outcome is reported as "something fell out of every try/catch in the application". The same path treats any error escaping `parseAsync` as a crash.

## Fix

Catch around `parseAsync` in `src/butler-sheet-icons.js`:

- `CommanderError` (a missing mandatory option and the like) is left alone — Commander has already printed and coded it;
- everything else gets `error: <message>` on stderr and `process.exitCode = 1`, with no crash dump — the same way a missing mandatory option is reported.

## Testing

New case in `src/__tests__/butler-sheet-icons.test.js` drives the real seam end to end: it bundles the CLI with esbuild against a committed fixture module whose `beforeAction` throws (`--alias:#extensions=…`, the same override `scripts/bundle.mjs` supports), runs the bundle with crash dumps enabled into a temp directory, and asserts:

- exit code 1,
- the hook's message on stderr,
- no `FATAL` line, no `CRASH DUMP` line, no `crash_dump*` files.

Differential: with the fix stashed, the test fails (crash dump + FATAL); with the fix, the full related suites pass (82 tests, 5 suites). `eslint --max-warnings 0` is clean.

Fixes #1150
