### PR TITLE
Report a deliberately stopped run as a failure rather than a crash

### DIFF
--- a/scripts/extensions-canary.mjs
+++ b/scripts/extensions-canary.mjs
@@ -33,7 +33,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { chmodSync, copyFileSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { chmodSync, copyFileSync, existsSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { join } from 'node:path';
 
@@ -59,6 +59,10 @@ const BINARY_PATH = join(BUILD_DIR, process.platform === 'win32' ? 'bsi-canary.e
 const COMMAND_MARKER = 'CANARY_COMMAND_RAN';
 const HOOK_MARKER = 'CANARY_HOOK_RAN';
 const CRYPTO_MARKER = 'CANARY_CRYPTO';
+const REFUSAL_MARKER = 'CANARY_REFUSED_THIS_RUN';
+
+/** Where the safety net writes, relative to the binary's working directory. */
+const CRASH_DUMP_DIR = 'crash_dumps';
 
 const EXTENSIONS_MODULE_SOURCE = `import { Command, Option } from 'commander';
 import { createHash, randomBytes, generateKeyPairSync, sign, verify } from 'node:crypto';
@@ -88,6 +92,12 @@ export const extensions = {
                 console.log('${COMMAND_MARKER}');
                 console.log('${CRYPTO_MARKER} ' + JSON.stringify(cryptoSmoke()));
             }),
+        new Command('canary-refuse')
+            .description('Canary: a command the hook stops before it runs.')
+            .addOption(new Option('--canary-fault', 'Canary: throw an unmarked error instead.'))
+            .action(() => {
+                console.log('THIS_ACTION_MUST_NOT_RUN');
+            }),
     ],
     options: [
         {
@@ -98,6 +108,18 @@ export const extensions = {
     hooks: {
         beforeAction: (path) => {
             console.log('${HOOK_MARKER} ' + path);
+
+            // Stopping a run deliberately, the way the contract says to: throw, and mark the error
+            // so it is reported as a failed command line rather than as a crash. Issue #1150.
+            if (path === 'canary-refuse') {
+                // Unmarked when asked for: a fault must still reach the safety net, or "no crash
+                // dump" would be satisfiable by simply removing the net.
+                if (process.argv.includes('--canary-fault')) {
+                    throw new TypeError('canary fault, not a refusal');
+                }
+
+                throw Object.assign(new Error('${REFUSAL_MARKER}'), { expected: true });
+            }
         },
     },
 };
@@ -180,6 +202,29 @@ const runBinary = (label, args) => {
     }
 
     check(`${label} exits cleanly`, result.status === 0, `exit status ${result.status}`);
+
+    return { output: `${result.stdout ?? ''}${result.stderr ?? ''}`, status: result.status };
+};
+
+/**
+ * Run the binary expecting it to refuse, and report how it refused.
+ *
+ * Separate from {@link runBinary} because that one asserts a clean exit, and the whole point here is
+ * a non-zero one. Issue #1150.
+ *
+ * @param {string} label - What is being checked, for the assertion text.
+ * @param {string[]} args - Arguments to pass to the binary.
+ *
+ * @returns {{output: string, status: number}} Combined output and exit status.
+ */
+const runBinaryExpectingFailure = (label, args) => {
+    const result = spawnSync(BINARY_PATH, args, { encoding: 'utf8', shell: false });
+
+    if (result.error) {
+        throw result.error;
+    }
+
+    check(`${label} exits non-zero`, result.status !== 0, `exit status ${result.status}`);
 
     return { output: `${result.stdout ?? ''}${result.stderr ?? ''}`, status: result.status };
 };
@@ -301,6 +346,51 @@ check(
     'a contributed option reaches an existing command',
     contributedHelp.output.includes('--canary-note')
 );
+
+// ---------------------------------------------------------------------------------------------
+// A hook that stops the run deliberately - issue #1150
+// ---------------------------------------------------------------------------------------------
+//
+// `src/lib/extensions/apply.js` documents throwing as the way a `beforeAction` hook aborts a run.
+// It did abort it, and then reported it as a crash: `FATAL: Unhandled promise rejection` plus a
+// crash dump on disk, because the rejection reached the process-level safety net with nobody
+// handling it. Both halves were behaving correctly and disagreeing about what the throw meant.
+//
+// Asserted here rather than only in a unit test because the unit tests were green throughout: they
+// call the hook directly, so nothing exercised the path between the throw and the process's
+// reaction to it. That path only exists in a real run.
+rmSync(CRASH_DUMP_DIR, { recursive: true, force: true });
+
+const refused = runBinaryExpectingFailure('a run the hook refuses', ['canary-refuse']);
+
+check(
+    'the refusal message is reported',
+    refused.output.includes(REFUSAL_MARKER),
+    refused.output.trim().split('\n').slice(-3).join(' | ')
+);
+check('the action handler did not run', !refused.output.includes('THIS_ACTION_MUST_NOT_RUN'));
+check(
+    'the refusal is not reported as an unhandled rejection',
+    !refused.output.includes('Unhandled promise rejection'),
+    refused.output.trim().split('\n').slice(-3).join(' | ')
+);
+check('the refusal writes no crash dump', !existsSync(CRASH_DUMP_DIR));
+
+// The other half of the same guarantee: an unmarked throw is a fault, and a fault still crashes.
+// Without this, "no crash dump" could be satisfied by removing the safety net altogether.
+const faulted = runBinaryExpectingFailure('a run the hook faults on', [
+    'canary-refuse',
+    '--canary-fault',
+]);
+
+check(
+    'an unmarked failure still takes the crash path',
+    faulted.output.includes('Unhandled promise rejection'),
+    faulted.output.trim().split('\n').slice(-3).join(' | ')
+);
+check('an unmarked failure still writes a crash dump', existsSync(CRASH_DUMP_DIR));
+
+rmSync(CRASH_DUMP_DIR, { recursive: true, force: true });
 
 // ---------------------------------------------------------------------------------------------
 // A binary built WITHOUT one - the build every release actually makes

--- a/src/butler-sheet-icons.js
+++ b/src/butler-sheet-icons.js
@@ -3,7 +3,8 @@
 // globals.js so that importing library code does not read a dotfile off disk - see issue #1014.
 import 'dotenv/config';
 import { Command } from 'commander';
-import { appVersion } from './globals.js';
+import { appVersion, logger } from './globals.js';
+import { isExpectedFailure } from './lib/util/errors.js';
 import { installFatalHandlers } from './lib/util/fatal-handlers.js';
 import { installSignalHandlers } from './lib/util/signal-handlers.js';
 import { isInterrupted, interruptExitCode } from './lib/util/interrupt.js';
@@ -61,7 +62,33 @@ const program = new Command();
     // and restores what it changed before any handler runs.
     relaxMandatoryOptionsIfInteractive(program, process.argv);
 
-    await program.parseAsync(process.argv);
+    // A run that stops deliberately is reported as a failed command line, not as a crash.
+    //
+    // Without this, anything thrown between the parse and the end of the action handler became a
+    // rejected promise with nobody handling it, so `installFatalHandlers()` did exactly what it is
+    // supposed to do with an error that reaches the top unhandled: logged `FATAL: Unhandled promise
+    // rejection` and wrote a crash dump. That is right for a fault and wrong for a precondition the
+    // operator can fix - and `src/lib/extensions/apply.js` documents throwing as the way a
+    // `beforeAction` hook stops a run, so the contract invited precisely the throw that produced a
+    // crash report. Issue #1150.
+    //
+    // Only errors that mark themselves are treated this way. Everything else is re-thrown
+    // unchanged, which puts it back on the path it took before: the rejection escapes this IIFE,
+    // the safety net catches it, and the dump is written. A bug inside a hook is still a bug.
+    try {
+        await program.parseAsync(process.argv);
+    } catch (err) {
+        if (!isExpectedFailure(err)) {
+            throw err;
+        }
+
+        logger.error(err.message);
+
+        // Set rather than exited on, following the rule the note below records. #1090 will decide
+        // what a deliberately stopped run should exit with; until then it is the generic failure
+        // code, which is what an unhandled throw produced here before.
+        process.exitCode = 1;
+    }
 
     // The one place the interrupted run is allowed to end the process, and the
     // second considered exception to the codebase's "set `process.exitCode`,

--- a/src/butler-sheet-icons.js
+++ b/src/butler-sheet-icons.js
@@ -4,7 +4,7 @@
 import 'dotenv/config';
 import { Command } from 'commander';
 import { appVersion, logger } from './globals.js';
-import { isExpectedFailure } from './lib/util/errors.js';
+import { reportExpectedFailure } from './lib/util/errors.js';
 import { installFatalHandlers } from './lib/util/fatal-handlers.js';
 import { installSignalHandlers } from './lib/util/signal-handlers.js';
 import { isInterrupted, interruptExitCode } from './lib/util/interrupt.js';
@@ -72,22 +72,19 @@ const program = new Command();
     // `beforeAction` hook stops a run, so the contract invited precisely the throw that produced a
     // crash report. Issue #1150.
     //
-    // Only errors that mark themselves are treated this way. Everything else is re-thrown
-    // unchanged, which puts it back on the path it took before: the rejection escapes this IIFE,
-    // the safety net catches it, and the dump is written. A bug inside a hook is still a bug.
+    // Only errors that mark themselves are treated this way. `reportExpectedFailure` re-throws
+    // everything else unchanged, which puts it back on the path it took before: the rejection
+    // escapes this IIFE, the safety net catches it, and the dump is written. A bug inside a hook is
+    // still a bug.
+    //
+    // The decision lives in errors.js rather than inline here because nothing in this file is
+    // instrumented by the test suite - it is reached by spawning a process, not by importing one -
+    // and untestable logic is how this bug survived as long as it did. Exit code set rather than
+    // exited on, following the rule the note below records.
     try {
         await program.parseAsync(process.argv);
     } catch (err) {
-        if (!isExpectedFailure(err)) {
-            throw err;
-        }
-
-        logger.error(err.message);
-
-        // Set rather than exited on, following the rule the note below records. #1090 will decide
-        // what a deliberately stopped run should exit with; until then it is the generic failure
-        // code, which is what an unhandled throw produced here before.
-        process.exitCode = 1;
+        process.exitCode = reportExpectedFailure(err, (message) => logger.error(message));
     }
 
     // The one place the interrupted run is allowed to end the process, and the

--- a/src/lib/extensions/__tests__/apply.test.js
+++ b/src/lib/extensions/__tests__/apply.test.js
@@ -1,6 +1,7 @@
 import { describe, test, expect } from '@jest/globals';
 import { Command, Option } from 'commander';
 import { applyExtensions, runBeforeAction } from '../apply.js';
+import { isExpectedFailure } from '../../util/errors.js';
 
 const SILENT = { writeOut: () => {}, writeErr: () => {} };
 
@@ -310,6 +311,60 @@ describe('the beforeAction hook', () => {
             program.parseAsync(['qseow', 'create-sheet-thumbnails'], { from: 'user' })
         ).rejects.toThrow('refused by the hook');
         expect(runs).toHaveLength(0);
+    });
+
+    // The seam between the hook and the entry point's catch. `parseAsync` has to surface the error
+    // itself rather than a wrapper, or the marker never reaches the classification above it and the
+    // run is reported as a crash - which is what #1150 was. Asserted through a real parse rather
+    // than by calling the hook, because calling the hook directly is exactly the test that stayed
+    // green while the bug shipped.
+    test('an error marked as expected reaches the caller with its marker intact', async () => {
+        const { program, runs } = buildProgram();
+
+        applyExtensions(program, {
+            ...nothing(),
+            hooks: {
+                beforeAction: () => {
+                    throw Object.assign(new Error('this run may not proceed'), { expected: true });
+                },
+            },
+        });
+
+        const err = await program
+            .parseAsync(['qseow', 'create-sheet-thumbnails'], { from: 'user' })
+            .then(
+                () => undefined,
+                (caught) => caught
+            );
+
+        expect(err).toBeDefined();
+        expect(isExpectedFailure(err)).toBe(true);
+        expect(err.message).toBe('this run may not proceed');
+        expect(runs).toHaveLength(0);
+    });
+
+    test('an unmarked error stays unmarked, so a hook bug still takes the crash path', async () => {
+        const { program } = buildProgram();
+
+        applyExtensions(program, {
+            ...nothing(),
+            hooks: {
+                beforeAction: () => {
+                    // The shape a genuine bug takes: nobody meant to stop the run.
+                    throw new TypeError('opts.split is not a function');
+                },
+            },
+        });
+
+        const err = await program
+            .parseAsync(['qseow', 'create-sheet-thumbnails'], { from: 'user' })
+            .then(
+                () => undefined,
+                (caught) => caught
+            );
+
+        expect(err).toBeInstanceOf(TypeError);
+        expect(isExpectedFailure(err)).toBe(false);
     });
 
     // It runs under `parseAsync`, not at module evaluation, so it is allowed to be async - which is

--- a/src/lib/extensions/apply.js
+++ b/src/lib/extensions/apply.js
@@ -63,6 +63,14 @@ const suppliedOptionsOf = (command) =>
  *
  * May be async: it runs under `parseAsync`, not at module evaluation. Throwing aborts the run.
  *
+ * **How that throw is reported depends on one property.** An error carrying `expected: true` is
+ * treated as a run that stopped deliberately: its message is logged and the process exits non-zero,
+ * with no crash dump. Anything else is treated as a fault and takes the crash path, which is what a
+ * bug inside a hook should do. A plain property rather than an error class, because the module
+ * behind `#extensions` is substituted at build time and does not import from this tree, so it has no
+ * class to extend - `isExpectedFailure` in `src/lib/util/errors.js` carries the reasoning. Issue
+ * #1150.
+ *
  * **It can run more than once for a single run, so it must be idempotent.** An interactive run
  * calls it twice, and deliberately: once from the `preAction` hook, where the command line has been
  * parsed but the wizard has not yet asked anything, and again once the wizard has assembled the

--- a/src/lib/util/__tests__/errors.test.js
+++ b/src/lib/util/__tests__/errors.test.js
@@ -1,6 +1,14 @@
 import { describe, test, expect } from '@jest/globals';
 
-import { BsiError, CertError, EnigmaError, CloudError, QseowError } from '../errors.js';
+import {
+    BsiError,
+    CertError,
+    EnigmaError,
+    CloudError,
+    QseowError,
+    ExpectedFailure,
+    isExpectedFailure,
+} from '../errors.js';
 
 describe('BsiError', () => {
     test('is an instance of Error and BsiError', () => {
@@ -63,5 +71,43 @@ describe('Subclasses', () => {
         const err = new QseowError('x');
         expect(typeof err.stack).toBe('string');
         expect(err.stack).toContain('QseowError');
+    });
+});
+
+describe('deliberately stopped runs', () => {
+    test('ExpectedFailure is a BsiError that marks itself', () => {
+        const err = new ExpectedFailure('nothing to do');
+
+        expect(err).toBeInstanceOf(BsiError);
+        expect(err.name).toBe('ExpectedFailure');
+        expect(err.expected).toBe(true);
+        expect(isExpectedFailure(err)).toBe(true);
+    });
+
+    // The marker is duck-typed rather than a class check, because the module behind `#extensions`
+    // is substituted at build time and cannot import this tree to extend anything in it.
+    test('any error carrying the marker counts, whatever its class', () => {
+        const plain = Object.assign(new Error('refused'), { expected: true });
+
+        expect(isExpectedFailure(plain)).toBe(true);
+    });
+
+    test('an ordinary fault does not count, so the crash path is unchanged', () => {
+        expect(isExpectedFailure(new Error('boom'))).toBe(false);
+        expect(isExpectedFailure(new BsiError('boom'))).toBe(false);
+        expect(isExpectedFailure(new QseowError('boom'))).toBe(false);
+    });
+
+    // A truthy-but-not-true value is the shape a careless `expected: 'yes'` would take, and it must
+    // not silently suppress a crash dump.
+    test('only an exact true counts', () => {
+        expect(isExpectedFailure(Object.assign(new Error('x'), { expected: 'yes' }))).toBe(false);
+        expect(isExpectedFailure(Object.assign(new Error('x'), { expected: 1 }))).toBe(false);
+    });
+
+    test('a non-error is handled rather than throwing from the predicate', () => {
+        expect(isExpectedFailure(undefined)).toBe(false);
+        expect(isExpectedFailure(null)).toBe(false);
+        expect(isExpectedFailure('a string')).toBe(false);
     });
 });

--- a/src/lib/util/__tests__/errors.test.js
+++ b/src/lib/util/__tests__/errors.test.js
@@ -8,6 +8,8 @@ import {
     QseowError,
     ExpectedFailure,
     isExpectedFailure,
+    reportExpectedFailure,
+    EXPECTED_FAILURE_EXIT_CODE,
 } from '../errors.js';
 
 describe('BsiError', () => {
@@ -109,5 +111,33 @@ describe('deliberately stopped runs', () => {
         expect(isExpectedFailure(undefined)).toBe(false);
         expect(isExpectedFailure(null)).toBe(false);
         expect(isExpectedFailure('a string')).toBe(false);
+    });
+});
+
+describe('what happens to an error that escaped the parse', () => {
+    test('a deliberately stopped run is reported and given an exit code', () => {
+        const logged = [];
+        const code = reportExpectedFailure(new ExpectedFailure('this run may not proceed'), (m) =>
+            logged.push(m)
+        );
+
+        expect(logged).toEqual(['this run may not proceed']);
+        expect(code).toBe(EXPECTED_FAILURE_EXIT_CODE);
+    });
+
+    // The half that keeps the safety net a safety net. Swallowing this would turn every fault into
+    // a one-line message with no dump and no stack.
+    test('a fault is re-thrown unchanged, so it reaches the crash path', () => {
+        const fault = new TypeError('opts.split is not a function');
+        const logged = [];
+
+        expect(() => reportExpectedFailure(fault, (m) => logged.push(m))).toThrow(fault);
+        expect(logged).toEqual([]);
+    });
+
+    test('the exit code is the generic failure code, so this change moves none', () => {
+        // #1090 defines the graded scheme; until it lands a stopped run exits with what an
+        // unhandled throw already produced.
+        expect(EXPECTED_FAILURE_EXIT_CODE).toBe(1);
     });
 });

--- a/src/lib/util/errors.js
+++ b/src/lib/util/errors.js
@@ -168,3 +168,39 @@ export class ExpectedFailure extends BsiError {
         this.expected = true;
     }
 }
+
+/**
+ * What a deliberately stopped run exits with.
+ *
+ * The generic failure code, which is what an unhandled throw produced here before - so this change
+ * moves no exit code. #1090 defines the graded scheme and is where a distinct value belongs.
+ */
+export const EXPECTED_FAILURE_EXIT_CODE = 1;
+
+/**
+ * Decide what to do with an error that escaped the parse.
+ *
+ * Split out of the entry point rather than written inline there, and the reason is the bug this
+ * exists to fix: `src/butler-sheet-icons.js` is a script, so the test suite reaches it by spawning a
+ * process rather than importing it, and nothing inside it is instrumented. Logic living there is
+ * logic no unit test can see - which is exactly how a contract and a safety net came to disagree for
+ * as long as they did. Issue #1150.
+ *
+ * @param {unknown} err - The error that escaped.
+ * @param {(message: string) => void} log - How to tell the operator. Injected so the decision can be
+ *     asserted without a logger.
+ *
+ * @returns {number} The exit code to set, when the run stopped deliberately.
+ *
+ * @throws {unknown} The original error, unchanged, when it is a fault rather than a stopped run -
+ *     which puts it back on the path to the process-level safety net and its crash dump.
+ */
+export const reportExpectedFailure = (err, log) => {
+    if (!isExpectedFailure(err)) {
+        throw err;
+    }
+
+    log(err.message);
+
+    return EXPECTED_FAILURE_EXIT_CODE;
+};

--- a/src/lib/util/errors.js
+++ b/src/lib/util/errors.js
@@ -121,3 +121,50 @@ export class QseowError extends BsiError {
         this.name = 'QseowError';
     }
 }
+
+/**
+ * Whether an error represents a run that was deliberately stopped, rather than something breaking.
+ *
+ * The two are not the same event and should not read the same way. A run that cannot proceed - a
+ * precondition that was not met, a command line the run refuses to act on - is an ordinary outcome
+ * with a message the operator can act on. A fault is what the crash dump exists for. Before this
+ * predicate there was no way to tell them apart above `parseAsync`, so both took the crash path:
+ * `FATAL: Unhandled promise rejection`, a dump on disk, and a message telling the operator that
+ * something fell out of every `try`/`catch` in the application. Issue #1150.
+ *
+ * **Duck-typed on purpose.** The obvious implementation is `err instanceof SomeClass`, and it would
+ * be wrong here: the module behind `#extensions` is substituted at build time and does not import
+ * from this tree (`src/lib/extensions/apply.js`), so it has no class to extend. A plain property is
+ * the only marker both sides can agree on without a dependency between them.
+ *
+ * Anything not carrying the marker keeps today's behaviour exactly, which is the important half:
+ * the safety net stays a safety net, and a genuine fault - including a bug inside a hook - still
+ * writes its dump.
+ *
+ * @param {unknown} err - The error to classify.
+ *
+ * @returns {boolean} True when the error marks itself as a deliberately stopped run.
+ */
+export const isExpectedFailure = (err) => err?.expected === true;
+
+/**
+ * A run stopped deliberately, with a message the operator can act on.
+ *
+ * Core has no site that throws this yet - it exists so that the convention {@link isExpectedFailure}
+ * recognises has one obvious spelling for code that *can* import from this tree, rather than every
+ * caller hand-setting a property and one of them eventually misspelling it.
+ */
+export class ExpectedFailure extends BsiError {
+    /**
+     * Construct a deliberately stopped run.
+     *
+     * @param {string} message - What to tell the operator, and why the run stopped.
+     * @param {object} [options] - Standard `Error` options.
+     * @param {Error|unknown} [options.cause] - Original error that caused this one.
+     */
+    constructor(message, options = {}) {
+        super(message, options);
+        this.name = 'ExpectedFailure';
+        this.expected = true;
+    }
+}


### PR DESCRIPTION
## What & why

Closes #1150.

`src/lib/extensions/apply.js` documents throwing as the way a `beforeAction` hook stops a run. It did
stop the run — and then reported it as a crash:

```
error: FATAL: Unhandled promise rejection: <the hook's message>
error: CRASH DUMP: Written to ./crash_dumps/crash_dump_….json
error: CRASH DUMP: Written to ./crash_dumps/crash_dump_….txt
```

Nothing caught around `parseAsync`, so the rejection reached the `unhandledRejection` listener
`installFatalHandlers()` installs — which behaved exactly as designed, because an error had reached
the top with nobody handling it. The contract and the safety net were each correct on their own and
disagreed about what the throw meant.

An error carrying `expected: true` is now reported as a failed command line: its message is logged,
the process exits non-zero, and no dump is written. **Everything else is re-thrown unchanged** and
takes the path it took before, so a bug inside a hook is still a bug and the safety net stays a
safety net.

Two things about the shape, since both were forced rather than chosen:

- **The marker is a plain property, not an error class.** The module behind `#extensions` is
  substituted at build time and does not import from this tree, so it has no class to extend. A
  property is the only marker both sides can agree on without a dependency between them.
  `ExpectedFailure` is exported for code that *can* import, so the convention has one spelling rather
  than every caller hand-setting a property and one of them eventually misspelling it.
- **`process.exitCode` is set rather than exited on**, following the rule the surrounding comments
  record. #1090 will decide what a deliberately stopped run should exit with; until then it stays the
  generic failure code, which is what the unhandled throw produced anyway — so no exit code changes
  in this PR.

Note this is not limited to the hook. Any error escaping `parseAsync` took the same path, including
an action handler that throws; the hook is just where the contract explicitly invited it.

## How it was verified

- `npm run lint` exit 0; `npm run test:unit` exit 0 — **3601 tests, 132 suites**, all passing.
- `src/lib/util/__tests__/errors.test.js` covers the predicate, including the cases that must *not*
  suppress a dump: a truthy-but-not-`true` value such as `expected: 'yes'`, an ordinary `BsiError`,
  and a non-error argument.
- `src/lib/extensions/__tests__/apply.test.js` drives a throwing hook **through a real `parseAsync`**
  rather than calling the hook, and asserts the marker survives to the caller. That distinction is
  the point: the existing unit tests were green throughout this bug precisely because they call the
  hook directly, so nothing exercised the path between the throw and the process's reaction to it.
- **`node scripts/extensions-canary.mjs` — run for real on macOS/arm64, all assertions passed**,
  including six new ones inside a packaged SEA binary: the refusal exits non-zero, reports its
  message, does not run the action handler, produces no `Unhandled promise rejection`, and writes no
  crash dump — while an unmarked throw still crashes and still writes one.

That last pair matters together. Without the second, "writes no crash dump" would be satisfiable by
removing the safety net altogether.

CI runs the canary on ubuntu and windows for changes under `src/lib/extensions/**` and
`scripts/extensions-canary.mjs`, so both platforms are covered by this PR.

## Docs

Internal only. No CLI option, environment variable, exit code or documented default changes — the
difference is that one class of failure stops printing a crash report for an outcome that was never a
crash.
