### PR TITLE
Let a variant build identify itself in --version

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -66,6 +66,13 @@ export default [
         languageOptions: {
             globals: {
                 ...globals.node,
+                // Substituted by esbuild's `--define` at bundle time, so they exist in a built
+                // artifact and nowhere else. Declared here rather than read through `globalThis`,
+                // because `--define` replaces a bare identifier and would not reach a member
+                // expression. `src/lib/util/version-report.js` guards each with `typeof`, which is
+                // what a source run and the test suite take.
+                __BSI_BUILD_DATE__: 'readonly',
+                __BSI_EXTENSIONS_VERSION__: 'readonly',
             },
 
             ecmaVersion: 'latest',

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -132,6 +132,56 @@ const checkCommanderMatch = () => {
 };
 
 /**
+ * The version declared by the nearest `package.json` above a file.
+ *
+ * Used to stamp a variant build with the version of the extensions module it bundled, so that
+ * `--version` can report it. Derived rather than declared on purpose: a description cannot know its
+ * own version without hard-coding a number, and a hard-coded number goes stale silently the first
+ * time somebody forgets it. Issue #1152.
+ *
+ * Walks up rather than assuming the module sits beside its manifest - `src/index.js` is the ordinary
+ * layout, and the manifest is a directory or two above it.
+ *
+ * @param {string} fromFile - Absolute path to the module.
+ *
+ * @returns {string|undefined} The version, or undefined when no manifest declares one.
+ */
+const packageVersionAbove = (fromFile) => {
+    let directory = dirname(fromFile);
+
+    for (;;) {
+        try {
+            const { version } = JSON.parse(readFileSync(join(directory, 'package.json'), 'utf8'));
+
+            if (typeof version === 'string' && version !== '') {
+                return version;
+            }
+        } catch {
+            // No manifest here, or an unreadable one. Keep walking; the caller treats "not found"
+            // as "do not report a variant version", which is the same as a source run.
+        }
+
+        const parent = dirname(directory);
+
+        if (parent === directory) {
+            return undefined;
+        }
+
+        directory = parent;
+    }
+};
+
+/**
+ * The date stamped into every binary, as ISO yyyy-mm-dd.
+ *
+ * A date rather than a timestamp: it answers "roughly when did this come from?", and a
+ * to-the-second value would make two builds of the same commit differ for no reader's benefit.
+ *
+ * @returns {string} Today, in UTC.
+ */
+const buildDate = () => new Date().toISOString().slice(0, 10);
+
+/**
  * Bundle the CLI into a single CJS file for the SEA blob.
  *
  * `format: 'cjs'` is not a preference: Node's SEA blob takes one CommonJS file. It is also why
@@ -149,6 +199,8 @@ const bundle = async () => {
         checkCommanderMatch();
     }
 
+    const extensionsVersion = extensionsModule ? packageVersionAbove(extensionsModule) : undefined;
+
     await build({
         entryPoints: [`src/${distFileName}.js`],
         bundle: true,
@@ -157,7 +209,18 @@ const bundle = async () => {
         platform: 'node',
         target: 'node24',
         inject: ['./src/lib/util/import-meta-url.js'],
-        define: { 'import.meta.url': 'import_meta_url' },
+        define: {
+            'import.meta.url': 'import_meta_url',
+            // Stamped into every binary so `--version` can report when it was built. A source run
+            // has no define and reports no build date, which is why the reader guards on `typeof`.
+            __BSI_BUILD_DATE__: JSON.stringify(buildDate()),
+            // Only a variant build has an extensions version to report. `JSON.stringify(undefined)`
+            // is `undefined` rather than a string, so this spreads to nothing for a stock build and
+            // the identifier stays undeclared - exactly as in a source run.
+            ...(extensionsVersion === undefined
+                ? {}
+                : { __BSI_EXTENSIONS_VERSION__: JSON.stringify(extensionsVersion) }),
+        },
         alias: extensionsModule
             ? { '#extensions': extensionsModule, commander: commanderEntry }
             : undefined,

--- a/scripts/extensions-canary.mjs
+++ b/scripts/extensions-canary.mjs
@@ -231,6 +231,28 @@ const runBinaryExpectingFailure = (label, args) => {
 };
 
 /**
+ * The value on a `--version` detail line, e.g. `core` from `  core    5.0.0`.
+ *
+ * Reads the line rather than matching a pattern built from the value being looked for. Building one
+ * meant escaping the version into a regex, and escaping only the dots is the incomplete-escaping
+ * shape CodeQL flags - correctly, since nothing guarantees a version string carries no other regex
+ * metacharacter. Splitting the line has no such failure mode and reads better besides.
+ *
+ * @param {string} output - What the binary printed.
+ * @param {string} label - The detail label to look for.
+ *
+ * @returns {string|undefined} The value, or undefined when no such line was printed.
+ */
+const detailValue = (output, label) => {
+    const line = output
+        .split('\n')
+        .map((candidate) => candidate.trim())
+        .find((candidate) => candidate.startsWith(`${label} `));
+
+    return line?.slice(label.length).trim();
+};
+
+/**
  * Bundle, package and inject a SEA binary from the current source tree.
  *
  * Mirrors what the release scripts do, minus real code signing: bundle, generate the blob, copy the
@@ -354,19 +376,17 @@ check(
 );
 check(
     'the core version is reported',
-    /\n\s+core\s+/.test(variantVersion.output),
+    detailValue(variantVersion.output, 'core') === canaryVersion,
     variantVersion.output.trim()
 );
 check(
     'the extensions module version is derived and reported',
-    new RegExp(`\\n\\s+canary\\s+${canaryVersion.replace(/\./g, '\\.')}`).test(
-        variantVersion.output
-    ),
+    detailValue(variantVersion.output, 'canary') === canaryVersion,
     variantVersion.output.trim()
 );
 check(
     'the build date is reported',
-    /\n\s+built\s+\d{4}-\d{2}-\d{2}/.test(variantVersion.output),
+    /^\d{4}-\d{2}-\d{2}$/.test(detailValue(variantVersion.output, 'built') ?? ''),
     variantVersion.output.trim()
 );
 
@@ -451,12 +471,12 @@ check(
 );
 check(
     'a stock build still reports its build date',
-    /\n\s+built\s+\d{4}-\d{2}-\d{2}/.test(version.output),
+    /^\d{4}-\d{2}-\d{2}$/.test(detailValue(version.output, 'built') ?? ''),
     version.output.trim()
 );
 check(
     'a stock build reports no core/variant split',
-    !/\n\s+core\s+/.test(version.output),
+    detailValue(version.output, 'core') === undefined,
     version.output.trim()
 );
 

--- a/scripts/extensions-canary.mjs
+++ b/scripts/extensions-canary.mjs
@@ -85,6 +85,7 @@ const cryptoSmoke = () => {
 
 export const extensions = {
     seamVersion: 1,
+    variant: 'canary',
     commands: [
         new Command('canary-check')
             .description('Canary: report what this binary can do.')
@@ -336,6 +337,39 @@ check('node:crypto produces random bytes', cryptoResult.randomBytes === 8);
 check('node:crypto completes a sign/verify round trip', cryptoResult.roundTrip === true);
 check('node:crypto rejects a payload that does not match', cryptoResult.rejectsTampered === true);
 
+// ---------------------------------------------------------------------------------------------
+// What the binary says it is - issue #1152
+// ---------------------------------------------------------------------------------------------
+//
+// A variant build used to report exactly what a stock one did, so an issue filed from one could not
+// say so and could not be told apart. The variant version is derived by the bundler from the
+// extensions module's nearest package.json, which here is this repository's own.
+const variantVersion = runBinary('--version on a variant build', ['--version']);
+const canaryVersion = require('../package.json').version;
+
+check(
+    'the headline names the variant',
+    variantVersion.output.includes(`butler-sheet-icons ${canaryVersion} (canary)`),
+    variantVersion.output.trim()
+);
+check(
+    'the core version is reported',
+    /\n\s+core\s+/.test(variantVersion.output),
+    variantVersion.output.trim()
+);
+check(
+    'the extensions module version is derived and reported',
+    new RegExp(`\\n\\s+canary\\s+${canaryVersion.replace(/\./g, '\\.')}`).test(
+        variantVersion.output
+    ),
+    variantVersion.output.trim()
+);
+check(
+    'the build date is reported',
+    /\n\s+built\s+\d{4}-\d{2}-\d{2}/.test(variantVersion.output),
+    variantVersion.output.trim()
+);
+
 const contributedHelp = runBinary('help for a command carrying a contributed option', [
     'qseow',
     'create-sheet-thumbnails',
@@ -404,7 +438,25 @@ const expectedVersion = require('../package.json').version;
 
 check(
     `--version reports ${expectedVersion}`,
-    version.output.trim() === expectedVersion,
+    version.output.split('\n')[0].trim() === `butler-sheet-icons ${expectedVersion}`,
+    version.output.trim()
+);
+
+// The half that keeps the feature honest: no override, so nothing to name, and the block must not
+// appear at all. A stock binary still says only what it is and when it was built.
+check(
+    'no variant is named on a stock build',
+    !version.output.includes('(') && !version.output.includes('canary'),
+    version.output.trim()
+);
+check(
+    'a stock build still reports its build date',
+    /\n\s+built\s+\d{4}-\d{2}-\d{2}/.test(version.output),
+    version.output.trim()
+);
+check(
+    'a stock build reports no core/variant split',
+    !/\n\s+core\s+/.test(version.output),
     version.output.trim()
 );
 

--- a/src/butler-sheet-icons.js
+++ b/src/butler-sheet-icons.js
@@ -16,6 +16,7 @@ import { buildDoctorCommand } from './lib/commands/doctor/index.js';
 import { buildInteractiveCommand } from './lib/interactive/interactive-command.js';
 import { relaxMandatoryOptionsIfInteractive } from './lib/interactive/mandatory-relaxation.js';
 import { extensions } from '#extensions';
+import { BUILD_DATE, EXTENSIONS_VERSION, describeVersion } from './lib/util/version-report.js';
 import { applyExtensions } from './lib/extensions/apply.js';
 
 // Process-level safety net: catch any error that escapes all try/catch blocks,
@@ -37,7 +38,17 @@ const program = new Command();
  */
 (async () => {
     program
-        .version(appVersion)
+        // Reports which build this is and when it was made, not just what version of core it
+        // bundles - a variant build was otherwise indistinguishable from a stock one. Issue #1152.
+        .version(
+            describeVersion({
+                name: 'butler-sheet-icons',
+                version: appVersion,
+                variant: extensions?.variant,
+                variantVersion: EXTENSIONS_VERSION,
+                buildDate: BUILD_DATE,
+            })
+        )
         .name('butler-sheet-icons')
         .description(
             'This is a tool that creates thumbnail images based on the actual layout of sheets in Qlik Sense applications.\nQlik Sense Cloud and Qlik Sense Enterprise on Windows are both supported.\nThe created thumbnails are saved to disk and uploaded to the Sense app as new sheet thumbnail images.\n\nNew to Butler Sheet Icons? Run "butler-sheet-icons interactive" to be asked for what is needed instead of assembling a command line.'

--- a/src/lib/extensions/apply.js
+++ b/src/lib/extensions/apply.js
@@ -14,6 +14,9 @@
  *
  * @typedef {object} SeamDescription
  * @property {number} seamVersion - The contract version this description targets.
+ * @property {string} [variant] - Optional short name for this build, e.g. `'acme'`. When present,
+ *     `--version` names it and reports the extensions module's own version alongside core's; when
+ *     absent - which is what the committed stub does - `--version` is unchanged. Issue #1152.
  * @property {import('commander').Command[]} commands - Whole commands to add to the root.
  * @property {OptionContribution[]} options - Options to add to commands that already exist.
  * @property {SeamHooks} hooks - Hooks, all of them optional.

--- a/src/lib/util/__tests__/version-report.test.js
+++ b/src/lib/util/__tests__/version-report.test.js
@@ -79,6 +79,46 @@ describe('a variant build', () => {
 });
 
 describe('the detail block', () => {
+    // The bug a fixed pad width hides: `padEnd` does not truncate, so a label as long as the column
+    // was concatenated straight onto its value - `  enterprise2.1.0`, no separator. Every label in
+    // the alignment test below is shorter than the floor, so only an explicitly long one catches it.
+    test('keeps a separator when the variant name is longer than the column', () => {
+        const line = describeVersion({
+            name: NAME,
+            version: '5.1.0',
+            variant: 'enterprise',
+            variantVersion: '2.1.0',
+        })
+            .split('\n')
+            // Past the headline, which also names the variant - in parentheses, not as a label.
+            .slice(1)
+            .find((candidate) => candidate.includes('enterprise'));
+
+        expect(line).toBe('  enterprise 2.1.0');
+        expect(line).not.toContain('enterprise2.1.0');
+    });
+
+    test('still lines up when a long label widens the column', () => {
+        const lines = describeVersion({
+            name: NAME,
+            version: '5.1.0',
+            variant: 'a-very-long-variant-name',
+            variantVersion: '2.1.0',
+            buildDate: '2026-09-14',
+        })
+            .split('\n')
+            .slice(1);
+
+        expect(new Set(lines.map((line) => line.search(/\S+$/))).size).toBe(1);
+    });
+
+    // Short labels must not have moved: this is the output every existing build produces.
+    test('leaves the ordinary case exactly as it was', () => {
+        expect(describeVersion({ name: NAME, version: '5.0.0', buildDate: '2026-09-14' })).toBe(
+            ['butler-sheet-icons 5.0.0', '  built   2026-09-14'].join('\n')
+        );
+    });
+
     test('lines up its values under each other', () => {
         const lines = describeVersion({
             name: NAME,

--- a/src/lib/util/__tests__/version-report.test.js
+++ b/src/lib/util/__tests__/version-report.test.js
@@ -1,0 +1,97 @@
+import { describe, test, expect } from '@jest/globals';
+
+import { describeVersion } from '../version-report.js';
+
+const NAME = 'butler-sheet-icons';
+
+describe('a stock build', () => {
+    // What every build in this repository produces, and what a source run produces too when no
+    // define has been substituted.
+    test('with nothing injected, reports the headline alone', () => {
+        expect(describeVersion({ name: NAME, version: '5.0.0' })).toBe('butler-sheet-icons 5.0.0');
+    });
+
+    test('reports a build date when one was stamped in', () => {
+        expect(describeVersion({ name: NAME, version: '5.0.0', buildDate: '2026-09-14' })).toBe(
+            ['butler-sheet-icons 5.0.0', '  built   2026-09-14'].join('\n')
+        );
+    });
+
+    // "core 5.0.0" under "butler-sheet-icons 5.0.0" would say the same thing twice. The split only
+    // earns its place once there is a second version to distinguish core's from.
+    test('does not split out a core line when there is nothing to distinguish it from', () => {
+        expect(describeVersion({ name: NAME, version: '5.0.0' })).not.toContain('core');
+    });
+});
+
+describe('a variant build', () => {
+    test('names the variant in the headline and reports both versions', () => {
+        expect(
+            describeVersion({
+                name: NAME,
+                version: '5.1.0',
+                variant: 'acme',
+                variantVersion: '2.1.0',
+                buildDate: '2026-09-14',
+            })
+        ).toBe(
+            [
+                'butler-sheet-icons 5.1.0 (acme)',
+                '  core    5.1.0',
+                '  acme    2.1.0',
+                '  built   2026-09-14',
+            ].join('\n')
+        );
+    });
+
+    // The headline stays core's version, so a reader maps the binary onto a public release without
+    // a lookup table. The variant's own version is a detail line, never the headline.
+    test('the headline version is core’s, not the variant’s', () => {
+        const out = describeVersion({
+            name: NAME,
+            version: '5.1.0',
+            variant: 'acme',
+            variantVersion: '2.1.0',
+        });
+
+        expect(out.split('\n')[0]).toBe('butler-sheet-icons 5.1.0 (acme)');
+    });
+
+    // A variant built from a tree with no manifest version: the module is still named, because that
+    // is the fact worth having, and the version line is simply absent rather than `undefined`.
+    test('omits the variant version line when it could not be derived', () => {
+        const out = describeVersion({ name: NAME, version: '5.1.0', variant: 'acme' });
+
+        expect(out).toBe(['butler-sheet-icons 5.1.0 (acme)', '  core    5.1.0'].join('\n'));
+        expect(out).not.toContain('undefined');
+    });
+
+    test('reports the variant without a build date, for a source run', () => {
+        expect(
+            describeVersion({
+                name: NAME,
+                version: '5.1.0',
+                variant: 'acme',
+                variantVersion: '2.1.0',
+            })
+        ).not.toContain('built');
+    });
+});
+
+describe('the detail block', () => {
+    test('lines up its values under each other', () => {
+        const lines = describeVersion({
+            name: NAME,
+            version: '5.1.0',
+            variant: 'a',
+            variantVersion: '2.1.0',
+            buildDate: '2026-09-14',
+        })
+            .split('\n')
+            .slice(1);
+
+        const columns = lines.map((line) => line.search(/\S+$/));
+
+        expect(new Set(columns).size).toBe(1);
+    });
+});

--- a/src/lib/util/version-report.js
+++ b/src/lib/util/version-report.js
@@ -1,0 +1,76 @@
+/**
+ * What `--version` reports.
+ *
+ * Two things a binary could not previously say about itself, both of which turn up in support
+ * threads before anything else does. Issue #1152.
+ *
+ * **Which build this is.** #1135 lets a build substitute the module behind `#extensions` and add
+ * commands, options and a `beforeAction` hook. A binary built that way was indistinguishable from a
+ * stock one at run time, so somebody filing an issue from a variant build had no way to say so and
+ * no way to find out - and the first sign was a report describing a flag that does not exist in this
+ * repository, after both sides had spent time on it.
+ *
+ * **When it was built.** Narrower than it looks, and worth stating so the scope is clear: a tagged
+ * release is determined by its version, and insider builds already rewrite `package.json` to
+ * `<version>-<sha>` before bundling. What is left is the case where one version string covers more
+ * than one artifact - an image rebuilt from the same tag, or a binary that has sat on a server for a
+ * year.
+ *
+ * The variant's own version is **derived at build time, not declared**: a description cannot know
+ * its own version without hard-coding a number that goes stale silently, so `scripts/bundle.mjs`
+ * reads it from that module's nearest `package.json` - the same package tree it already resolves for
+ * the Commander major check - and substitutes it here.
+ */
+
+/**
+ * When this binary was built, injected at bundle time.
+ *
+ * Declared with a `typeof` guard rather than read directly, because esbuild's `--define` substitutes
+ * a bare identifier: in a source run the identifier simply does not exist, and referencing it would
+ * be a ReferenceError rather than `undefined`.
+ */
+export const BUILD_DATE =
+    typeof __BSI_BUILD_DATE__ === 'undefined' ? undefined : __BSI_BUILD_DATE__;
+
+/** The version of the extensions module this binary bundled, injected at bundle time. */
+export const EXTENSIONS_VERSION =
+    typeof __BSI_EXTENSIONS_VERSION__ === 'undefined' ? undefined : __BSI_EXTENSIONS_VERSION__;
+
+/** Width the detail labels are padded to, so the values line up under each other. */
+const LABEL_WIDTH = 8;
+
+/**
+ * Render the string Commander prints for `--version`.
+ *
+ * Pure, and takes every input rather than reading the injected constants itself, so the shape can be
+ * asserted without a build. A detail line appears only when its value is known: a source run knows
+ * neither, and prints the headline alone.
+ *
+ * @param {object} options - What this binary knows about itself.
+ * @param {string} options.name - The program name.
+ * @param {string} options.version - The version from `package.json`, which is core's.
+ * @param {string} [options.variant] - Short name for a variant build, from its description.
+ * @param {string} [options.variantVersion] - That variant's own version, injected at bundle time.
+ * @param {string} [options.buildDate] - When this binary was built, injected at bundle time.
+ *
+ * @returns {string} One line for a stock source run; a headline plus indented detail otherwise.
+ */
+export const describeVersion = ({ name, version, variant, variantVersion, buildDate }) => {
+    const headline = variant ? `${name} ${version} (${variant})` : `${name} ${version}`;
+
+    const details = [
+        // Only worth splitting out when there is a second version to distinguish it from. On a
+        // stock build "core 5.0.0" under "butler-sheet-icons 5.0.0" says nothing twice.
+        ...(variant ? [['core', version]] : []),
+        ...(variant && variantVersion ? [[variant, variantVersion]] : []),
+        ...(buildDate ? [['built', buildDate]] : []),
+    ];
+
+    if (details.length === 0) {
+        return headline;
+    }
+
+    const lines = details.map(([label, value]) => `  ${label.padEnd(LABEL_WIDTH)}${value}`);
+
+    return [headline, ...lines].join('\n');
+};

--- a/src/lib/util/version-report.js
+++ b/src/lib/util/version-report.js
@@ -36,8 +36,14 @@ export const BUILD_DATE =
 export const EXTENSIONS_VERSION =
     typeof __BSI_EXTENSIONS_VERSION__ === 'undefined' ? undefined : __BSI_EXTENSIONS_VERSION__;
 
-/** Width the detail labels are padded to, so the values line up under each other. */
-const LABEL_WIDTH = 8;
+/**
+ * Narrowest the detail label column gets, so short labels keep a readable gutter.
+ *
+ * A floor rather than a fixed width. `padEnd` does not truncate, so a fixed width silently produces
+ * `  enterprise2.1.0` - no separator at all - the moment a variant is named something as long as the
+ * column. The width below grows past this for any label that needs it.
+ */
+const MIN_LABEL_WIDTH = 8;
 
 /**
  * Render the string Commander prints for `--version`.
@@ -70,7 +76,11 @@ export const describeVersion = ({ name, version, variant, variantVersion, buildD
         return headline;
     }
 
-    const lines = details.map(([label, value]) => `  ${label.padEnd(LABEL_WIDTH)}${value}`);
+    // Derived from the labels actually present, never assumed: a variant is named by whoever built
+    // it, so the longest label is not knowable in advance. `+ 1` keeps at least one space after the
+    // longest one, which is the guarantee a fixed width cannot make.
+    const width = Math.max(MIN_LABEL_WIDTH, ...details.map(([label]) => label.length + 1));
+    const lines = details.map(([label, value]) => `  ${label.padEnd(width)}${value}`);
 
     return [headline, ...lines].join('\n');
 };


### PR DESCRIPTION
## What & why

Closes #1152.

#1135 lets a build substitute the module behind `#extensions` and add commands, options and a
`beforeAction` hook. A binary built that way reported exactly what a stock one did:

```console
$ butler-sheet-icons --version
5.0.0
```

So an issue filed from a variant build could not say so, and could not be told apart by whoever read
it. The first sign was a report describing a flag that does not exist in this repository — after both
sides had spent time on it. `--version` is the first thing any support thread asks for, and it was
silent on the fact most likely to explain a confusing report.

A description may now carry an optional `variant` string. **The committed stub omits it**, so nothing
changes for any build here beyond the build date below. Real output from this branch:

```console
$ butler-sheet-icons --version          # variant build
butler-sheet-icons 5.0.0 (acme)
  core    5.0.0
  acme    2.1.0
  built   2026-08-22

$ butler-sheet-icons --version          # stock build
butler-sheet-icons 5.0.0
  built   2026-08-22
```

Two decisions worth surfacing:

- **The variant's version is derived, not declared.** `bundle.mjs` reads it from that module's
  nearest `package.json` — the same package tree it already resolves for the Commander major check —
  and substitutes it as a define. A description cannot know its own version without hard-coding a
  number, and a hard-coded number goes stale silently the first time somebody forgets it. This keeps
  the contract addition to a single optional string.
- **The core/variant split only appears when there is a variant.** `core 5.0.0` printed under
  `butler-sheet-icons 5.0.0` would say the same thing twice, so a stock build gets the headline and
  the build date, nothing more.

The build-date half is narrower in value and deliberately scoped as such: a tagged release is
determined by its version, and insider builds already rewrite `package.json` to `<version>-<sha>`
before bundling. What remains is where one version string covers more than one artifact — an image
rebuilt from the same tag, or a binary that has sat on a server for a year. It shares the define
mechanism with the variant work, which is why it is here rather than in its own change.

## How it was verified

- `npm run lint` exit 0; `npm run test:unit` exit 0 — **3602 tests, 133 suites**.
- `src/lib/util/__tests__/version-report.test.js` covers the renderer as a pure function: both build
  shapes, the alignment of the detail column, and the two cases that must not print `undefined` — a
  variant whose version could not be derived, and a source run with no defines at all.
- **`node scripts/extensions-canary.mjs` — run for real on macOS/arm64, all assertions passed.**
  Seven new ones inside packaged SEA binaries: on an override build the headline names the variant
  and the core version, the derived extensions version and the build date are all reported; on a
  **stock** build no variant is named, no core/variant split appears, and the build date still is.

That last group is what keeps the feature honest — asserting only the variant case would pass just as
well if the block were printed unconditionally.

CI runs the canary on ubuntu and windows for changes under `scripts/bundle.mjs` and
`src/lib/extensions/**`, so both platforms are covered by this PR.

## Docs

Internal only. No CLI option, environment variable, exit code or documented default changes.
`--version` output is text, which #1101 places outside the versioned surface — the headline still
leads with core's version, so anything scraping the first token is unaffected.
