### PR TITLE
Derive the build date so a build stays reproducible

### DIFF
--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -172,14 +172,62 @@ const packageVersionAbove = (fromFile) => {
 };
 
 /**
- * The date stamped into every binary, as ISO yyyy-mm-dd.
+ * Seconds since the epoch, if the string is a plain non-negative integer.
+ *
+ * Deliberately strict. `SOURCE_DATE_EPOCH` is an integer by specification, and `Number('')` is 0
+ * while `Number('   ')` is also 0 - so a loose parse would silently date every binary 1970-01-01
+ * rather than falling through to something usable.
+ *
+ * @param {string|undefined} value - The candidate.
+ *
+ * @returns {number|undefined} The seconds, or undefined when it is not a usable integer.
+ */
+const epochSeconds = (value) => {
+    if (typeof value !== 'string' || !/^\d+$/.test(value.trim())) {
+        return undefined;
+    }
+
+    const seconds = Number(value.trim());
+
+    return Number.isSafeInteger(seconds) ? seconds : undefined;
+};
+
+/**
+ * The commit this tree is at, as seconds since the epoch.
+ *
+ * @returns {number|undefined} The committer date, or undefined outside a usable git checkout.
+ */
+const commitEpochSeconds = () => {
+    const result = spawnSync('git', ['log', '-1', '--format=%ct'], { encoding: 'utf8' });
+
+    return result.status === 0 ? epochSeconds(String(result.stdout)) : undefined;
+};
+
+/**
+ * The date stamped into every binary, as ISO yyyy-mm-dd in UTC.
  *
  * A date rather than a timestamp: it answers "roughly when did this come from?", and a
  * to-the-second value would make two builds of the same commit differ for no reader's benefit.
  *
- * @returns {string} Today, in UTC.
+ * **It is derived, not read off the clock, so that a build stays reproducible.** Stamping
+ * `new Date()` meant two builds of the same commit on different days produced different bytes -
+ * which quietly cost the project the ability to rebuild a published binary and compare it, the
+ * check that distinguishes a benign difference from a tampered artifact. Three sources, in order:
+ *
+ * 1. **`SOURCE_DATE_EPOCH`**, the cross-ecosystem convention for exactly this. An explicit value
+ *    wins, so a caller reproducing an old build can name its date.
+ * 2. **The committer date of `HEAD`**, which makes every build of a given commit identical without
+ *    anyone configuring anything - including the release jobs, which build from a checkout.
+ * 3. **The wall clock**, only when neither is available: an exported tarball with no `.git` and no
+ *    environment variable. Such a build is not reproducible, and nothing here can make it so.
+ *
+ * @returns {string} The date, in UTC.
  */
-const buildDate = () => new Date().toISOString().slice(0, 10);
+const buildDate = () => {
+    const seconds = epochSeconds(process.env.SOURCE_DATE_EPOCH) ?? commitEpochSeconds();
+
+    return new Date((seconds ?? Date.now() / 1000) * 1000).toISOString().slice(0, 10);
+};
 
 /**
  * Bundle the CLI into a single CJS file for the SEA blob.


### PR DESCRIPTION
## What & why

Closes #1156.

#1152 stamped `new Date()` into every binary, community builds included, so two builds of the same
commit on different days produced different bytes. That was a side effect of adding the date rather
than a decision, and it quietly cost the project the ability to rebuild a published binary and
compare it — the check that distinguishes a benign difference from a tampered artifact.

The date is now derived, in this order:

1. **`SOURCE_DATE_EPOCH`** — the cross-ecosystem convention for exactly this. An explicit value wins,
   so a caller reproducing an old build can name its date.
2. **The committer date of `HEAD`** — which makes every build of a given commit identical with
   nothing to configure, including the release jobs, since they build from a checkout.
3. **The wall clock** — only when neither is available, e.g. an exported tarball with no `.git`. Such
   a build is not reproducible and nothing in the bundler can make it so.

The parse is strict deliberately: `SOURCE_DATE_EPOCH` is an integer by specification, and `Number('')`
and `Number('   ')` are both `0`, so a loose parse would date every binary 1970-01-01 rather than
falling through to something usable.

Nothing about the reported format changes — still `yyyy-mm-dd` in UTC, still one line in `--version`.

## How it was verified

- `npm run lint` exit 0; `npm run test:unit` exit 0 — 3615 tests, 133 suites.
- **Two consecutive builds of the same tree produce byte-identical bundles**, sha256
  `c4b78e5308a2b16d9f7778fa3d53a18da07ce2a6ba8336ce15a2929208ea9d67` both times.
- **`SOURCE_DATE_EPOCH=1551398400` stamps 2019-03-01**, so the variable takes precedence.
- **The clock is genuinely not consulted:** on a commit dated 2019-03-01 with the wall clock reading
  2026-08-22, the stamp is 2019-03-01.

That third check is the one that matters. The first two pass just as well against the old code on any
day where the commit and the clock agree — which is every day a change is written, and is why this
was easy to miss.

## Docs

Internal only — build tooling. No CLI option, environment variable read at runtime, exit code or
output format changes; `SOURCE_DATE_EPOCH` is read by the bundler at build time, not by the binary.

## Note for the next release

5.1.0 shipped with the wall-clock date, so its binaries are not reproducible. This does not change
them retrospectively — it makes 5.1.1 onwards reproducible from their tags.
